### PR TITLE
Add plugin name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"license": "GPL-2.0-or-later",
 	"description": "Performance plugin from the WordPress Performance Group, which is a collection of standalone performance modules.",
-	"homepage": "https://wordpress.org/plugins/TODO-SLUG/",
+	"homepage": "https://wordpress.org/plugins/performance-lab/",
 	"keywords": [
 		"performance",
 		"wordpress"

--- a/load.php
+++ b/load.php
@@ -1,38 +1,38 @@
 <?php
 /**
- * Plugin Name: TODO-NAME
+ * Plugin Name: Performance Lab
  * Plugin URI: https://github.com/WordPress/performance
  * Description: Performance plugin from the WordPress Performance Group, which is a collection of standalone performance modules.
  * Requires at least: 5.8
  * Requires PHP: 5.6
  * Version: 1.0.0
  * Author: WordPress Performance Group
- * Text Domain: TODO-SLUG
+ * Text Domain: performance-lab
  *
- * @package TODO-SLUG
+ * @package performance-lab
  */
 
-define( 'TODO_CONSTANTSLUG_VERSION', '1.0.0' );
-define( 'TODO_CONSTANTSLUG_MODULES_SETTING', 'todo_snakecaseslug_modules_settings' );
-define( 'TODO_CONSTANTSLUG_MODULES_SCREEN', 'TODO-SLUG-modules' );
+define( 'PERFLAB_VERSION', '1.0.0' );
+define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );
+define( 'PERFLAB_MODULES_SCREEN', 'perflab-modules' );
 
 /**
  * Registers the performance modules setting.
  *
  * @since 1.0.0
  */
-function todo_snakecaseslug_register_modules_setting() {
+function perflab_register_modules_setting() {
 	register_setting(
-		TODO_CONSTANTSLUG_MODULES_SCREEN,
-		TODO_CONSTANTSLUG_MODULES_SETTING,
+		PERFLAB_MODULES_SCREEN,
+		PERFLAB_MODULES_SETTING,
 		array(
 			'type'              => 'object',
-			'sanitize_callback' => 'todo_snakecaseslug_sanitize_modules_setting',
+			'sanitize_callback' => 'perflab_sanitize_modules_setting',
 			'default'           => array(),
 		)
 	);
 }
-add_action( 'init', 'todo_snakecaseslug_register_modules_setting' );
+add_action( 'init', 'perflab_register_modules_setting' );
 
 /**
  * Sanitizes the performance modules setting.
@@ -42,7 +42,7 @@ add_action( 'init', 'todo_snakecaseslug_register_modules_setting' );
  * @param mixed $value Modules setting value.
  * @return array Sanitized modules setting value.
  */
-function todo_snakecaseslug_sanitize_modules_setting( $value ) {
+function perflab_sanitize_modules_setting( $value ) {
 	// TODO: Make this more error-proof.
 	if ( ! is_array( $value ) ) {
 		return array();
@@ -58,8 +58,8 @@ function todo_snakecaseslug_sanitize_modules_setting( $value ) {
  *
  * @return array Associative array of module settings keyed by module slug.
  */
-function todo_snakecaseslug_get_module_settings() {
-	return (array) get_option( TODO_CONSTANTSLUG_MODULES_SETTING, array() );
+function perflab_get_module_settings() {
+	return (array) get_option( PERFLAB_MODULES_SETTING, array() );
 }
 
 /**
@@ -69,10 +69,10 @@ function todo_snakecaseslug_get_module_settings() {
  *
  * @return array List of active module slugs.
  */
-function todo_snakecaseslug_get_active_modules() {
+function perflab_get_active_modules() {
 	return array_keys(
 		array_filter(
-			todo_snakecaseslug_get_module_settings(),
+			perflab_get_module_settings(),
 			function( $module_settings ) {
 				return isset( $module_settings['enabled'] ) && $module_settings['enabled'];
 			}
@@ -85,8 +85,8 @@ function todo_snakecaseslug_get_active_modules() {
  *
  * @since 1.0.0
  */
-function todo_snakecaseslug_load_active_modules() {
-	$active_modules = todo_snakecaseslug_get_active_modules();
+function perflab_load_active_modules() {
+	$active_modules = perflab_get_active_modules();
 
 	if ( empty( $active_modules ) ) {
 		return;
@@ -103,4 +103,4 @@ function todo_snakecaseslug_load_active_modules() {
 	}
 }
 
-todo_snakecaseslug_load_active_modules();
+perflab_load_active_modules();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,7 +8,7 @@
 	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress.WP.I18n"/>
-	<config name="text_domain" value="TODO-SLUG,default"/>
+	<config name="text_domain" value="performance-lab,default"/>
 
 	<arg value="ps"/>
 	<arg name="extensions" value="php"/>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,7 +2,7 @@
 /**
  * PHPUnit bootstrap file
  *
- * @package TODO-SLUG
+ * @package performance-lab
  */
 
 define( 'TESTS_PLUGIN_DIR', dirname( __DIR__ ) );


### PR DESCRIPTION
Addresses issue #1 based on the vote from the majority to name the plugin `Performance Lab`.

I went for `perflab` for CONSTANTS and prefixes which may still be debatable, to me it is still readable and considerably shorter.