### PR TITLE
Add contribution documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing Guidelines
+Welcome to the Performance plugin project! We're glad you're here. Here's a few things to help you get started.
+
+## How to contribute?
+Check [here](./docs/Getting-started.md) for the complete documentation about how to contribute to the project.

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -25,6 +25,11 @@ First, make sure Docker is installed, up and running on your machine. Then, run 
 The following command will stop the WordPress environment:
 `npm run wp-env stop`
 
+## Open an issue
+Opening an issue is the first step to contributing to the Performance plugin. This allows to discuss, review or validate an idea before implementation. Opening an issue is not strict requirement, but it is highly recommended in most cases, unless the change you are trying to make is really minor or is already covered by an existing issue.
+
+Issues should be labeled to facilitate browsing and filtering. Here are some common labels: `[Type] Feature`, `[Type] Discussion`, `Needs Decision`, `[Focus] Images`. The full list of labels can be found [here](https://github.com/WordPress/performance/labels).
+
 ## Create a pull request
 A pull request must be created to submit changes to the Performance plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance/issues).
 

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -10,11 +10,15 @@ This guide focuses on how to contribute to the Performance plugin, from setting 
 
 ### Clone the repository
 Start by cloning the repository into your local machine. To do this, run the following command in your terminal:
-`git clone https://github.com/WordPress/performance.git`
+```
+git clone https://github.com/WordPress/performance.git
+```
 
 ### Install the local development dependencies
 To install the local development dependencies, run the following command in your terminal:
-`npm install`
+```
+npm install
+```
 
 ### Start the local WordPress environment
 The Performance plugin uses Docker and [the wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env) to start a local WordPress environment.
@@ -23,7 +27,9 @@ First, make sure Docker is installed, up and running on your machine. Then, run 
 
 ### Stop the local WordPress environment
 The following command will stop the WordPress environment:
-`npm run wp-env stop`
+```
+npm run wp-env stop
+```
 
 ## Open an issue
 Opening an issue is the first step to contributing to the Performance plugin. This allows to discuss, review or validate an idea before implementation. It is not a strict requirement, but it is highly recommended in most cases, unless the change you are trying to make is really minor or is already covered by an existing issue.
@@ -51,7 +57,12 @@ npms run format-php
 ```
 
 ## PHPUnit tests
-To execute PHPUnit tests, run the `npm run test-php` in your terminal.
+To execute PHPUnit tests, run this in your terminal:
+```
+npm run test-php
+```
 
 And to execute the tests in multisite, run:
-`npm run test-php-multisite`
+```
+npm run test-php-multisite
+```

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -1,9 +1,9 @@
 # Start contributing to the Performance plugin
-This guide is intended to give details on how to contribute to the Performance plugin. From setting up the development environment to creating pull requests.
+This guide focuses on how to contribute to the Performance plugin, from setting up the development environment to creating pull requests.
 
 ## Prerequisites
-- Node.js
-- Docker
+- [Node.js](https://nodejs.org)
+- [Docker](https://www.docker.com/products/docker-desktop)
 - [Git](https://git-scm.com)
 
 ## Setup the development environment
@@ -17,7 +17,7 @@ To install the local development dependencies, run the following command in your
 `npm install`
 
 ### Start the local WordPress environment
-The Performance plugin uses Docker and `[wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env) to start a local WordPress environment.
+The Performance plugin uses Docker and [the wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env) to start a local WordPress environment.
 
 First, make sure Docker is installed, up and running on your machine. Then, run `npm run wp-env start` to start the WordPress environment. The WordPress development site will be available at `http://localhost:8080`.
 
@@ -26,7 +26,7 @@ The following command will stop the WordPress environment:
 `npm run wp-env stop`
 
 ## Create a pull request
-A pull request must be created to submit changes to the Performance plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance).
+A pull request must be created to submit changes to the Performance plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance/issues).
 
 For better triaging, it is recommended that each pull request receive a `[Type] xyz`, `[Focus] xyz` or `[Infrastructure]` labels.
 

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -1,0 +1,52 @@
+# Start contributing to the Performance plugin
+This guide is intended to give details on how to contribute to the Performance plugin. From setting up the development environment to creating pull requests.
+
+## Prerequisites
+- Node.js
+- Docker
+- [Git](https://git-scm.com)
+
+## Setup the development environment
+
+### Clone the repository
+Start by cloning the repository into your local machine. To do this, run the following command in your terminal:
+`git clone https://github.com/WordPress/performance.git`
+
+### Install the local development dependencies
+To install the local development dependencies, run the following command in your terminal:
+`npm install`
+
+### Start the local WordPress environment
+The Performance plugin uses Docker and `[wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env) to start a local WordPress environment.
+
+First, make sure Docker is installed, up and running on your machine. Then, run `npm run wp-env start` to start the WordPress environment. The WordPress development site will be available at `http://localhost:8080`.
+
+### Stop the local WordPress environment
+The following command will stop the WordPress environment:
+`npm run wp-env stop`
+
+## Create a pull request
+A pull request must be created to submit changes to the Performance plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance).
+
+For better triaging, it is recommended that each pull request receive a `[Type] xyz` and `[Focus] xyz` or `[Infrastructure]` labels.
+
+## Coding standards
+In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). For a complete documentation about Performance plugin modules specifications, read this [documentation](./Writing-a-module.md).
+
+### WordPress and PHP compatibility
+All code in the Performance plugin must follow theses requirements:
+- **WordPress**: the latest release is the minimum required version. Right now, the plugin is compatible with WordPress 5.8.
+- **PHP**: always match the latest WordPress version. The minimum required version right now is 5.6.
+
+### Linting and formatting
+After adding new code to the repository, make sure to run this command to lint and format PHP code:
+```
+npm run lint-php
+npms run format-php
+```
+
+## PHPUnit tests
+To execute PHPUnit tests, run the `npm run test-php` in your terminal.
+
+And to execute the tests in multisite, run:
+`npm run test-php-multisite`

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -26,7 +26,7 @@ The following command will stop the WordPress environment:
 `npm run wp-env stop`
 
 ## Open an issue
-Opening an issue is the first step to contributing to the Performance plugin. This allows to discuss, review or validate an idea before implementation. Opening an issue is not strict requirement, but it is highly recommended in most cases, unless the change you are trying to make is really minor or is already covered by an existing issue.
+Opening an issue is the first step to contributing to the Performance plugin. This allows to discuss, review or validate an idea before implementation. It is not a strict requirement, but it is highly recommended in most cases, unless the change you are trying to make is really minor or is already covered by an existing issue.
 
 Issues should be labeled to facilitate browsing and filtering. Here are some common labels: `[Type] Feature`, `[Type] Discussion`, `Needs Decision`, `[Focus] Images`. The full list of labels can be found [here](https://github.com/WordPress/performance/labels).
 

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -39,7 +39,7 @@ Issues should be labeled to facilitate browsing and filtering. Here are some com
 ## Create a pull request
 A pull request must be created to submit changes to the Performance plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance/issues).
 
-For better triaging, it is recommended that each pull request receive a `[Type] xyz`, `[Focus] xyz` or `[Infrastructure]` labels.
+Every pull-request should receive both a `[Type] xyz` label and either a `[Focus] xyz` or `Infrastructure` label.
 
 ## Coding standards
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). For a complete documentation about Performance plugin modules specifications, read this [documentation](./Writing-a-module.md).

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -28,7 +28,7 @@ The following command will stop the WordPress environment:
 ## Create a pull request
 A pull request must be created to submit changes to the Performance plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance).
 
-For better triaging, it is recommended that each pull request receive a `[Type] xyz` and `[Focus] xyz` or `[Infrastructure]` labels.
+For better triaging, it is recommended that each pull request receive a `[Type] xyz`, `[Focus] xyz` or `[Infrastructure]` labels.
 
 ## Coding standards
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). For a complete documentation about Performance plugin modules specifications, read this [documentation](./Writing-a-module.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,4 @@
 # Documentation
 
+* [Getting Started](./getting-started.md)
 * [Writing a module](./Writing-a-module.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
 # Documentation
 
-* [Getting Started](./getting-started.md)
+* [Getting Started](./Getting-started.md)
 * [Writing a module](./Writing-a-module.md)


### PR DESCRIPTION
This PR adds the documentation to get start with contribution to the performance plugin. It also adds the new documentation page to the `/docs/README.md` file.

See https://github.com/WordPress/performance/blob/add/39-contributing-documentation/docs/Getting-started.md for the new doc.

Fixes #39.