### PR TITLE
Add Code Of Conduct and security documentations

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+This project comes under the WordPress [Etiquette](https://wordpress.org/about/etiquette/):
+
+In the WordPress open source project, we realize that our biggest asset is the community that we foster. The project, as a whole, follows these basic philosophical principles from The Cathedral and The Bazaar.
+
+- Contributions to the WordPress open source project are for the benefit of the WordPress community as a whole, not specific businesses or individuals. All actions taken as a contributor should be made with the best interests of the community in mind.
+- Participation in the WordPress open source project is open to all who wish to join, regardless of ability, skill, financial status, or any other criteria.
+- The WordPress open source project is a volunteer-run community. Even in cases where contributors are sponsored by companies, that time is donated for the benefit of the entire open source community.
+- Any member of the community can donate their time and contribute to the project in any form including design, code, documentation, community building, etc. For more information, go to make.wordpress.org.
+- The WordPress open source community cares about diversity. We strive to maintain a welcoming environment where everyone can feel included, by keeping communication free of discrimination, incitement to violence, promotion of hate, and unwelcoming behavior.
+
+The team involved will block any user who causes any breach in this.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing Guidelines
+
 Welcome to the Performance plugin project! We're glad you're here. Here's a few things to help you get started.
 
 ## How to contribute?
+
 Check [here](./docs/Getting-started.md) for the complete documentation about how to contribute to the project.
+
+## Guidelines
+
+- As with all WordPress projects, we want to ensure a welcoming environment for everyone. With that in mind, all contributors are expected to follow our [Code of Conduct](/CODE_OF_CONDUCT.md).
+
+- All WordPress projects are [licensed under the GPLv2+](/LICENSE), and all contributions to Gutenberg will be released under the GPLv2+ license. You maintain copyright over any contribution you make, and by submitting a pull request, you are agreeing to release that contribution under the GPLv2+ license.
+
+## Reporting Security Issues
+
+Please see [SECURITY.md](/SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Reporting Security Issues
+
+The Performance team and WordPress community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please visit the [WordPress HackerOne](https://hackerone.com/wordpress) program.


### PR DESCRIPTION
Fixes #48.

This PR adds two new documentations files: [CODE_OF_CONDUCT.md](https://github.com/WordPress/performance/blob/add/48-coc-security-docs/CODE_OF_CONDUCT.md) and [SECURITY.md](https://github.com/WordPress/performance/blob/add/48-coc-security-docs/SECURITY.md). It also updates the [CONTRIBUTING.md](https://github.com/WordPress/performance/blob/add/48-coc-security-docs/CONTRIBUTING.md) file with links to the new docs.