### PR TITLE
Add/23 codeowners file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -34,3 +34,6 @@ indent_size = 2
 insert_final_newline = false
 indent_style = space
 indent_size = 2
+
+[.github/CODEOWNERS]
+indent_style = space

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Documentation
+/docs
+
+# Infrastructure
+
+# Module: Images
+/modules/webp-uploads
+
+# Module: JavaScript
+
+# Module: Object Caching
+
+# Module: Measurement
+
+# Module: Site Health

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,5 +15,5 @@
 # Focus: Measurement
 
 # Focus: Site Health
-/modules/audit-enqueued-assets				@manuelRod @audrasjb
-/tests/modules/audit-enqueued-assets		@manuelRod @audrasjb
+/modules/audit-enqueued-assets              @manuelRod @audrasjb
+/tests/modules/audit-enqueued-assets        @manuelRod @audrasjb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,19 @@
 # Documentation/Infrastructure
-/docs										@justinahinon @felixarntz	
+/docs                                       @justinahinon @felixarntz
+/admin                                      @justinahinon @felixarntz
+/bin                                        @justinahinon @felixarntz
+/.github                                    @justinahinon @felixarntz
 
-# Module: Images
-/modules/webp-uploads						@adamsilverstein
-/tests/modules/webp-uploads					@adamsilverstein
+# Focus: Images
+/modules/webp-uploads                       @adamsilverstein
+/tests/modules/webp-uploads                 @adamsilverstein
 
-# Module: JavaScript
+# Focus: JavaScript
 
-# Module: Object Caching
+# Focus: Object Caching
 
-# Module: Measurement
+# Focus: Measurement
 
-# Module: Site Health
+# Focus: Site Health
 /modules/audit-enqueued-assets				@manuelRod @audrasjb
 /tests/modules/audit-enqueued-assets		@manuelRod @audrasjb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,9 @@
-# Documentation
-/docs
-
-# Infrastructure
+# Documentation/Infrastructure
+/docs										@justinahinon @felixarntz	
 
 # Module: Images
-/modules/webp-uploads
+/modules/webp-uploads						@adamsilverstein
+/tests/modules/webp-uploads					@adamsilverstein
 
 # Module: JavaScript
 
@@ -13,3 +12,5 @@
 # Module: Measurement
 
 # Module: Site Health
+/modules/audit-enqueued-assets				@manuelRod @audrasjb
+/tests/modules/audit-enqueued-assets		@manuelRod @audrasjb


### PR DESCRIPTION
Fixes #23.

This PR adds the [CODEOWNERS](https://github.com/WordPress/performance/blob/add/23-CODEOWNERS-file/.github/CODEOWNERS) file to the repository.

Right now I've added owner for documentation/infrastructure (me and @felixarntz), images focus (@adamsilverstein) and site health (@audrasjb  and @manuelRod). This is for the code that is already present in the repo.