### PR TITLE
Ensure that module header fields can be translated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ nbproject/
 ############
 
 build
+module-i18n.php
 
 ############
 ## Vendor

--- a/admin/load.php
+++ b/admin/load.php
@@ -262,6 +262,7 @@ function perflab_get_modules( $modules_root = null ) {
  * Parses the module main file to get the module's metadata.
  *
  * This is similar to how plugin data is parsed in the WordPress core function `get_plugin_data()`.
+ * The user-facing strings will be translated.
  *
  * @since 1.0.0
  *
@@ -289,6 +290,14 @@ function perflab_get_module_data( $module_file ) {
 		$module_data['experimental'] = true;
 	} else {
 		$module_data['experimental'] = false;
+	}
+
+	// Translate fields using low-level function since they come from PHP comments.
+	// See the generated `/module-i18n.php` file.
+	$translatable_fields = array( 'name', 'description' );
+	foreach ( $translatable_fields as $field ) {
+		// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
+		$module_data[ $field ] = translate( $module_data[ $field ], 'performance-lab' );
 	}
 
 	return $module_data;

--- a/admin/load.php
+++ b/admin/load.php
@@ -292,12 +292,15 @@ function perflab_get_module_data( $module_file ) {
 		$module_data['experimental'] = false;
 	}
 
-	// Translate fields using low-level function since they come from PHP comments.
-	// See the generated `/module-i18n.php` file.
-	$translatable_fields = array( 'name', 'description' );
-	foreach ( $translatable_fields as $field ) {
-		// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralText
-		$module_data[ $field ] = translate( $module_data[ $field ], 'performance-lab' );
+	// Translate fields using low-level function since they come from PHP comments, including the necessary context for
+	// `_x()`. This must match how these are translated in the generated `/module-i18n.php` file.
+	$translatable_fields = array(
+		'name'        => 'module name',
+		'description' => 'module description',
+	);
+	foreach ( $translatable_fields as $field => $context ) {
+		// phpcs:ignore WordPress.WP.I18n.LowLevelTranslationFunction,WordPress.WP.I18n.NonSingularStringLiteralContext,WordPress.WP.I18n.NonSingularStringLiteralText
+		$module_data[ $field ] = translate_with_gettext_context( $module_data[ $field ], $context, 'performance-lab' );
 	}
 
 	return $module_data;

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -30,10 +30,21 @@ const {
 	handler: changelogHandler,
 	options: changelogOptions,
 } = require( './commands/changelog' );
+const {
+	handler: translationsHandler,
+	options: translationsOptions,
+} = require( './commands/translations' );
 
 withOptions( program.command( 'release-plugin-changelog' ), changelogOptions )
 	.alias( 'changelog' )
 	.description( 'Generates a changelog from merged pull requests' )
 	.action( catchException( changelogHandler ) );
+
+withOptions( program.command( 'module-translations' ), translationsOptions )
+	.alias( 'translations' )
+	.description(
+		'Generates a PHP file from module header translation strings'
+	)
+	.action( catchException( translationsHandler ) );
 
 program.parse( process.argv );

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -33,7 +33,7 @@ const config = require( '../config' );
  * @property {string=} token     Optional personal access token.
  */
 
-const options = [
+exports.options = [
 	{
 		argname: '-m, --milestone <milestone>',
 		description: 'Milestone',
@@ -49,18 +49,13 @@ const options = [
  *
  * @param {WPChangelogCommandOptions} opt
  */
-async function handler( opt ) {
+exports.handler = async ( opt ) => {
 	await createChangelog( {
 		owner: config.githubRepositoryOwner,
 		repo: config.githubRepositoryName,
 		milestone: opt.milestone,
 		token: opt.token,
 	} );
-}
-
-module.exports = {
-	options,
-	handler,
 };
 
 const MISSING_TYPE = 'MISSING_TYPE';

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -14,6 +14,18 @@ const {
 } = require( '../lib/milestone' );
 const config = require( '../config' );
 
+const MISSING_TYPE = 'MISSING_TYPE';
+const MISSING_FOCUS = 'MISSING_FOCUS';
+const TYPE_PREFIX = '[Type] ';
+const FOCUS_PREFIX = '[Focus] ';
+const INFRASTRUCTURE_LABEL = 'Infrastructure';
+const PRIMARY_TYPE_LABELS = {
+	'[Type] Feature': 'Features',
+	'[Type] Enhancement': 'Enhancements',
+	'[Type] Bug': 'Bug Fixes',
+};
+const PRIMARY_TYPE_ORDER = Object.values( PRIMARY_TYPE_LABELS );
+
 /** @typedef {import('@octokit/rest')} GitHub */
 /** @typedef {import('@octokit/rest').IssuesListForRepoResponseItem} IssuesListForRepoResponseItem */
 
@@ -57,18 +69,6 @@ exports.handler = async ( opt ) => {
 		token: opt.token,
 	} );
 };
-
-const MISSING_TYPE = 'MISSING_TYPE';
-const MISSING_FOCUS = 'MISSING_FOCUS';
-const TYPE_PREFIX = '[Type] ';
-const FOCUS_PREFIX = '[Focus] ';
-const INFRASTRUCTURE_LABEL = 'Infrastructure';
-const PRIMARY_TYPE_LABELS = {
-	'[Type] Feature': 'Features',
-	'[Type] Enhancement': 'Enhancements',
-	'[Type] Bug': 'Bug Fixes',
-};
-const PRIMARY_TYPE_ORDER = Object.values( PRIMARY_TYPE_LABELS );
 
 /**
  * Returns a promise resolving to an array of pull requests associated with the

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -63,7 +63,8 @@ const FILE_HEADER = `<?php
 $generated_i18n_strings = array(
 `;
 const FILE_FOOTER = `
-'/* THIS IS THE END OF THE GENERATED FILE */'
+);
+/* THIS IS THE END OF THE GENERATED FILE */
 `;
 
 /**

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-const { flatten } = require( 'lodash' );
 const path = require( 'path' );
 const glob = require( 'fast-glob' );
 const fs = require( 'fs' );
@@ -113,7 +112,7 @@ async function getTranslations( settings ) {
 		} )
 	);
 
-	return flatten( moduleTranslations );
+	return moduleTranslations.flat();
 }
 
 /**

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -62,9 +62,7 @@ module.exports = {
  */
 async function getTranslations( settings ) {
 	const moduleFilePattern = path.join( settings.directory, '*/load.php' );
-	const moduleFiles = await glob(
-		path.resolve( '../../..', moduleFilePattern )
-	);
+	const moduleFiles = await glob( path.resolve( '.', moduleFilePattern ) );
 
 	const moduleTranslations = await Promise.all(
 		moduleFiles.map( async ( moduleFile ) => {
@@ -110,17 +108,20 @@ async function getTranslations( settings ) {
  * @param {WPTranslationsSettings} settings Translations settings.
  */
 async function createTranslations( settings ) {
-	const directory = settings.directory || 'modules';
-	const output = settings.output || 'module-i18n.php';
+	const fullSettings = {
+		...settings,
+		directory: settings.directory || 'modules',
+		output: settings.output || 'module-i18n.php',
+	};
 
 	log(
 		formats.title(
-			`\n💃Preparing module translations for "${ directory }" in "${ output }"\n\n`
+			`\n💃Preparing module translations for "${ fullSettings.directory }" in "${ fullSettings.output }"\n\n`
 		)
 	);
 
 	try {
-		const translations = await getTranslations( settings );
+		const translations = await getTranslations( fullSettings );
 		log( translations );
 	} catch ( error ) {
 		if ( error instanceof Error ) {
@@ -130,7 +131,7 @@ async function createTranslations( settings ) {
 
 	log(
 		formats.success(
-			`\n💃Module translations successfully set in "${ output }"\n\n`
+			`\n💃Module translations successfully set in "${ fullSettings.output }"\n\n`
 		)
 	);
 }

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -59,16 +59,13 @@ module.exports = {
 
 const TAB = '\t';
 const NEWLINE = '\n';
-const FILE_HEADER =
-	[
-		'<?php',
-		'/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */',
-		'$generated_i18n_strings = array(',
-	].join( NEWLINE ) + NEWLINE;
-const FILE_FOOTER =
-	NEWLINE +
-	[ ');', '/* THIS IS THE END OF THE GENERATED FILE */' ].join( NEWLINE ) +
-	NEWLINE;
+const FILE_HEADER = `<?php
+/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
+$generated_i18n_strings = array(
+`;
+const FILE_FOOTER = `
+'/* THIS IS THE END OF THE GENERATED FILE */'
+`;
 
 /**
  * Parses module header translation strings.

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -1,0 +1,136 @@
+/**
+ * External dependencies
+ */
+const { flatten } = require( 'lodash' );
+const path = require( 'path' );
+const glob = require( 'fast-glob' );
+const fs = require( 'fs' );
+const readline = require( 'readline' );
+
+/**
+ * Internal dependencies
+ */
+const { log, formats } = require( '../lib/logger' );
+
+/**
+ * @typedef WPTranslationsCommandOptions
+ *
+ * @property {string=} directory Optional directory, default is the root `/modules` directory.
+ * @property {string=} output    Optional output file, default is the root `/module-i18n.php` file.
+ */
+
+/**
+ * @typedef WPTranslationsSettings
+ *
+ * @property {string=} directory Optional directory, default is the root `/modules` directory.
+ * @property {string=} output    Optional output file, default is the root `/module-i18n.php` file.
+ */
+
+const options = [
+	{
+		argname: '-d, --directory <directory>',
+		description: 'Modules directory',
+	},
+	{
+		argname: '-d, --output <output>',
+		description: 'Output file',
+	},
+];
+
+/**
+ * Command that generates a PHP file from module header translation strings.
+ *
+ * @param {WPTranslationsCommandOptions} opt
+ */
+async function handler( opt ) {
+	await createTranslations( {
+		directory: opt.directory,
+	} );
+}
+
+module.exports = {
+	options,
+	handler,
+};
+
+/**
+ * Parses module header translation strings.
+ *
+ * @param {WPTranslationsSettings} settings Translations settings.
+ *
+ * @return {[]string} List of translation strings.
+ */
+async function getTranslations( settings ) {
+	const moduleFilePattern = path.join( settings.directory, '*/load.php' );
+	const moduleFiles = await glob(
+		path.resolve( '../../..', moduleFilePattern )
+	);
+
+	const moduleTranslations = await Promise.all(
+		moduleFiles.map( async ( moduleFile ) => {
+			const fileStream = fs.createReadStream( moduleFile );
+
+			const rl = readline.createInterface( {
+				input: fileStream,
+			} );
+
+			const headers = [ 'Module Name', 'Description' ];
+			const translationStrings = [];
+
+			for await ( const line of rl ) {
+				headers.forEach( ( header, index ) => {
+					const regex = new RegExp(
+						'^(?:[ \t]*<?php)?[ \t/*#@]*' + header + ':(.*)$',
+						'i'
+					);
+					const match = regex.exec( line );
+
+					if ( match ) {
+						const headerValue = match[ 1 ]
+							.replace( /\s*(?:\*\/|\?>).*/, '' )
+							.trim();
+						if ( headerValue ) {
+							headers.splice( index, 1 );
+							translationStrings.push( headerValue );
+						}
+					}
+				} );
+			}
+
+			return translationStrings;
+		} )
+	);
+
+	return flatten( moduleTranslations );
+}
+
+/**
+ * Parses module header translation strings and generates a PHP file with them.
+ *
+ * @param {WPTranslationsSettings} settings Translations settings.
+ */
+async function createTranslations( settings ) {
+	const directory = settings.directory || 'modules';
+	const output = settings.output || 'module-i18n.php';
+
+	log(
+		formats.title(
+			`\n💃Preparing module translations for "${ directory }" in "${ output }"\n\n`
+		)
+	);
+
+	try {
+		const translations = await getTranslations( settings );
+		log( translations );
+	} catch ( error ) {
+		if ( error instanceof Error ) {
+			log( formats.error( error.stack ) );
+		}
+	}
+
+	log(
+		formats.success(
+			`\n💃Module translations successfully set in "${ output }"\n\n`
+		)
+	);
+}

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -5,6 +5,7 @@ const path = require( 'path' );
 const glob = require( 'fast-glob' );
 const fs = require( 'fs' );
 const readline = require( 'readline' );
+const { EOL } = require( 'os' );
 
 /**
  * Internal dependencies
@@ -13,7 +14,7 @@ const { log, formats } = require( '../lib/logger' );
 const config = require( '../config' );
 
 const TAB = '\t';
-const NEWLINE = '\n';
+const NEWLINE = EOL;
 const FILE_HEADER = `<?php
 /* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
 $generated_i18n_strings = array(

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -133,7 +133,7 @@ function createTranslationsPHPFile( translations, settings ) {
 		);
 	} );
 
-	const fileOutput = FILE_HEADER + output.join( NEWLINE ) + FILE_FOOTER;
+	const fileOutput = `${ FILE_HEADER }${ output.join( NEWLINE ) }${ FILE_FOOTER }`;
 	fs.writeFileSync( path.join( '.', settings.output ), fileOutput );
 }
 

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -27,7 +27,7 @@ const config = require( '../config' );
  * @property {string} output     Output PHP file.
  */
 
-const options = [
+exports.options = [
 	{
 		argname: '-d, --directory <directory>',
 		description: 'Modules directory',
@@ -43,17 +43,12 @@ const options = [
  *
  * @param {WPTranslationsCommandOptions} opt
  */
-async function handler( opt ) {
+exports.handler = async ( opt ) => {
 	await createTranslations( {
 		textDomain: config.textDomain,
 		directory: opt.directory || 'modules',
 		output: opt.output || 'module-i18n.php',
 	} );
-}
-
-module.exports = {
-	options,
-	handler,
 };
 
 const TAB = '\t';

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -4,7 +4,6 @@
 const path = require( 'path' );
 const glob = require( 'fast-glob' );
 const fs = require( 'fs' );
-const readline = require( 'readline' );
 const { EOL } = require( 'os' );
 
 /**

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -12,6 +12,17 @@ const readline = require( 'readline' );
 const { log, formats } = require( '../lib/logger' );
 const config = require( '../config' );
 
+const TAB = '\t';
+const NEWLINE = '\n';
+const FILE_HEADER = `<?php
+/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
+$generated_i18n_strings = array(
+`;
+const FILE_FOOTER = `
+);
+/* THIS IS THE END OF THE GENERATED FILE */
+`;
+
 /**
  * @typedef WPTranslationsCommandOptions
  *
@@ -50,17 +61,6 @@ exports.handler = async ( opt ) => {
 		output: opt.output || 'module-i18n.php',
 	} );
 };
-
-const TAB = '\t';
-const NEWLINE = '\n';
-const FILE_HEADER = `<?php
-/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
-$generated_i18n_strings = array(
-`;
-const FILE_FOOTER = `
-);
-/* THIS IS THE END OF THE GENERATED FILE */
-`;
 
 /**
  * Parses module header translation strings.

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -23,7 +23,7 @@ const config = require( '../config' );
 /**
  * @typedef WPTranslationsSettings
  *
- * @property {string} textdomain Plugin textdomain.
+ * @property {string} textDomain Plugin text domain.
  * @property {string} directory  Modules directory.
  * @property {string} output     Output PHP file.
  */
@@ -46,7 +46,7 @@ const options = [
  */
 async function handler( opt ) {
 	await createTranslations( {
-		textdomain: config.textdomain,
+		textDomain: config.textDomain,
 		directory: opt.directory || 'modules',
 		output: opt.output || 'module-i18n.php',
 	} );
@@ -131,7 +131,7 @@ function createTranslationsPHPFile( translations, settings ) {
 		return (
 			TAB +
 			`__( '${ translation.replace( /'/g, "\\'" ) }', '${
-				settings.textdomain
+				settings.textDomain
 			}' ),`
 		);
 	} );

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -133,7 +133,9 @@ function createTranslationsPHPFile( translations, settings ) {
 		);
 	} );
 
-	const fileOutput = `${ FILE_HEADER }${ output.join( NEWLINE ) }${ FILE_FOOTER }`;
+	const fileOutput = `${ FILE_HEADER }${ output.join(
+		NEWLINE
+	) }${ FILE_FOOTER }`;
 	fs.writeFileSync( path.join( '.', settings.output ), fileOutput );
 }
 

--- a/bin/plugin/commands/translations.js
+++ b/bin/plugin/commands/translations.js
@@ -155,6 +155,7 @@ async function createTranslations( settings ) {
 	} catch ( error ) {
 		if ( error instanceof Error ) {
 			log( formats.error( error.stack ) );
+			return;
 		}
 	}
 

--- a/bin/plugin/config.js
+++ b/bin/plugin/config.js
@@ -11,6 +11,7 @@
 const config = {
 	githubRepositoryOwner: 'WordPress',
 	githubRepositoryName: 'performance',
+	textdomain: 'performance-lab',
 };
 
 module.exports = config;

--- a/bin/plugin/config.js
+++ b/bin/plugin/config.js
@@ -11,7 +11,7 @@
 const config = {
 	githubRepositoryOwner: 'WordPress',
 	githubRepositoryName: 'performance',
-	textdomain: 'performance-lab',
+	textDomain: 'performance-lab',
 };
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
     "@wordpress/scripts": "^19.0",
     "chalk": "4.1.1",
     "commander": "4.1.0",
+    "fast-glob": "^3.2.7",
     "lodash": "4.17.21"
   },
   "scripts": {
     "changelog": "./bin/plugin/cli.js changelog",
+    "translations": "./bin/plugin/cli.js translations",
     "format-js": "wp-scripts format ./bin",
     "lint-js": "wp-scripts lint-js ./bin",
     "format-php": "wp-env run composer run-script format",


### PR DESCRIPTION
Fixes #59

This PR implements an `npm run translations` command (via the JS infrastructure introduced in #51), which makes the two module header fields `Module Name` and `Description` translatable by extracting the values from all module files and putting them into a generated `module-i18n.php` file. This file allows wordpress.org to recognize these translations as if they were normally used in the plugin. The PR then uses a similar approach to WordPress core when it comes to the headers themselves in the production code: By calling `translate` it will technically go through the same function, which in combination with the generated file ensures that those are translatable in GlotPress.

The implementation of the script is heavily based on a combination of https://github.com/WordPress/gutenberg/pull/5310 and https://github.com/wp-pot/wp-pot/commit/c46b8cbc2c8f494405a71dd8ebaee2e7ce8bd79b, both of which do in parts similar tasks.

The generated file is `.gitignore`d, since it doesn't need to be in the repository (it isn't even `require`d anywhere, it just needs to "exist" when the plugin is deployed to wordpress.org).

To test the script locally, run `npm run translations`.