### PR TITLE
Add `readme.txt` and related update script

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -31,6 +31,10 @@ const {
 	options: changelogOptions,
 } = require( './commands/changelog' );
 const {
+	handler: readmeHandler,
+	options: readmeOptions,
+} = require( './commands/readme' );
+const {
 	handler: translationsHandler,
 	options: translationsOptions,
 } = require( './commands/translations' );
@@ -39,6 +43,11 @@ withOptions( program.command( 'release-plugin-changelog' ), changelogOptions )
 	.alias( 'changelog' )
 	.description( 'Generates a changelog from merged pull requests' )
 	.action( catchException( changelogHandler ) );
+
+withOptions( program.command( 'plugin-readme' ), readmeOptions )
+	.alias( 'readme' )
+	.description( 'Updates the readme.txt file' )
+	.action( catchException( readmeHandler ) );
 
 withOptions( program.command( 'module-translations' ), translationsOptions )
 	.alias( 'translations' )

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -311,3 +311,6 @@ async function createChangelog( settings ) {
 
 	log( changelog );
 }
+
+// Export getChangelog function to reuse in `readme` command.
+exports.getChangelog = getChangelog;

--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const glob = require( 'fast-glob' );
+const fs = require( 'fs' );
+
+/**
+ * @typedef WPModuleDescription
+ *
+ * @property {string} name        Module name.
+ * @property {string} description Module description.
+ */
+
+/**
+ * Returns a promise resolving to the module description list string for the `readme.txt` file.
+ *
+ * @param {string} modulesDir Modules directory.
+ *
+ * @return {Promise<[]WPModuleDescription>} Promise resolving to module description list.
+ */
+exports.getModuleDescriptions = async ( modulesDir ) => {
+	const moduleFilePattern = path.join( modulesDir, '*/*/load.php' );
+	const moduleFiles = await glob( path.resolve( '.', moduleFilePattern ) );
+
+	return moduleFiles
+		.map( ( moduleFile ) => {
+			// Map of module header => object property.
+			const headers = {
+				'Module Name': 'name',
+				Description: 'description',
+			};
+			const moduleData = {};
+
+			const fileContent = fs.readFileSync( moduleFile, 'utf8' );
+			const regex = new RegExp(
+				`^(?:[ \t]*<?php)?[ \t/*#@]*(${ Object.keys( headers ).join(
+					'|'
+				) }):(.*)$`,
+				'gmi'
+			);
+			let match = regex.exec( fileContent );
+			while ( match ) {
+				const content = match[ 2 ].trim();
+				const prop = headers[ match[ 1 ] ];
+				if ( content && prop ) {
+					moduleData[ prop ] = content;
+				}
+				match = regex.exec( fileContent );
+			}
+
+			return moduleData;
+		} )
+		.filter( ( moduleData ) => moduleData.name && moduleData.description );
+};

--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -1,0 +1,177 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+/**
+ * Internal dependencies
+ */
+const { log, formats } = require( '../lib/logger' );
+const config = require( '../config' );
+const { getModuleDescriptions } = require( './common' );
+const { getChangelog } = require( './changelog' );
+
+/**
+ * @typedef WPReadmeCommandOptions
+ *
+ * @property {string=} directory Optional directory, default is the root `/modules` directory.
+ * @property {string=} milestone Optional milestone title, to update the changelog in the readme.
+ * @property {string=} token     Optional personal GitHub access token, only relevant for changelog updates.
+ */
+
+/**
+ * @typedef WPReadmeSettings
+ *
+ * @property {string}  owner     GitHub repository owner.
+ * @property {string}  repo      GitHub repository name.
+ * @property {string}  directory Modules directory.
+ * @property {string=} milestone Optional milestone title, to update the changelog in the readme.
+ * @property {string=} token     Optional personal GitHub access token, only relevant for changelog updates.
+ */
+
+exports.options = [
+	{
+		argname: '-d, --directory <directory>',
+		description: 'Modules directory',
+	},
+	{
+		argname: '-m, --milestone <milestone>',
+		description: 'Milestone title, to update the changelog',
+	},
+	{
+		argname: '-t, --token <token>',
+		description: 'GitHub token',
+	},
+];
+
+/**
+ * Command that updates the `readme.txt` file.
+ *
+ * @param {WPReadmeCommandOptions} opt
+ */
+exports.handler = async ( opt ) => {
+	await updateReadme( {
+		owner: config.githubRepositoryOwner,
+		repo: config.githubRepositoryName,
+		directory: opt.directory || 'modules',
+		milestone: opt.milestone,
+		token: opt.token,
+	} );
+};
+
+/**
+ * Returns a promise resolving to the module description list string for the `readme.txt` file.
+ *
+ * @param {WPReadmeSettings} settings Readme settings.
+ *
+ * @return {Promise<string>} Promise resolving to module description list in markdown, with trailing newline.
+ */
+async function getModuleDescriptionList( settings ) {
+	const moduleDescriptions = await getModuleDescriptions(
+		settings.directory
+	);
+
+	return moduleDescriptions
+		.map( ( moduleData ) => {
+			return `* **${ moduleData.name }:** ${ moduleData.description }`;
+		} )
+		.join( '\n' )
+		.concat( '\n' );
+}
+
+/**
+ * Updates the `readme.txt` file with the given module description list.
+ *
+ * @param {string} moduleList Module description list in markdown, with trailing newline.
+ */
+function updateReadmeModuleDescriptionList( moduleList ) {
+	const readmeFile = path.join( '.', 'readme.txt' );
+	const fileContent = fs.readFileSync( readmeFile, 'utf8' );
+	const newContent = fileContent.replace(
+		/(the following performance modules:\s+)((\*.*\n)+)/,
+		( match, prefix ) => {
+			return `${ prefix }${ moduleList }`;
+		}
+	);
+	fs.writeFileSync( readmeFile, newContent );
+}
+
+/**
+ * Updates the `readme.txt` file with the given changelog.
+ *
+ * @param {string}           changelog Changelog in markdown, with trailing newline.
+ * @param {WPReadmeSettings} settings  Readme settings.
+ */
+function updateReadmeChangelog( changelog, settings ) {
+	const regex = new RegExp( `= ${ settings.milestone } =[^=]+` );
+
+	const readmeFile = path.join( '.', 'readme.txt' );
+	const fileContent = fs.readFileSync( readmeFile, 'utf8' );
+
+	let newContent;
+	if ( fileContent.match( regex ) ) {
+		newContent = fileContent
+			.replace( regex, changelog )
+			.trim()
+			.concat( '\n' );
+	} else {
+		newContent = fileContent.replace(
+			/(== Changelog ==\n\n)/,
+			( match ) => {
+				return `${ match }${ changelog }`;
+			}
+		);
+	}
+	fs.writeFileSync( readmeFile, newContent );
+}
+
+/**
+ * Updates the `readme.txt` file with latest module description list and optionally a specific release changelog.
+ *
+ * @param {WPReadmeSettings} settings Readme settings.
+ */
+async function updateReadme( settings ) {
+	if ( ! settings.milestone ) {
+		log(
+			formats.title(
+				`\n💃Updating readme.txt for "${ settings.directory }"\n\n`
+			)
+		);
+	} else {
+		log(
+			formats.title(
+				`\n💃Updating readme.txt for "${ settings.directory }" and changelog for milestone "${ settings.milestone }"\n\n`
+			)
+		);
+	}
+
+	try {
+		const moduleList = await getModuleDescriptionList( settings );
+		updateReadmeModuleDescriptionList( moduleList );
+	} catch ( error ) {
+		if ( error instanceof Error ) {
+			log( formats.error( error.stack ) );
+			return;
+		}
+	}
+
+	if ( settings.milestone ) {
+		try {
+			const changelog = await getChangelog( {
+				owner: settings.owner,
+				repo: settings.repo,
+				milestone: settings.milestone,
+				token: settings.token,
+			} );
+			updateReadmeChangelog( changelog, settings );
+		} catch ( error ) {
+			if ( error instanceof Error ) {
+				log( formats.error( error.stack ) );
+				return;
+			}
+		}
+	}
+
+	log( formats.success( `\n💃readme.txt successfully updated\n\n` ) );
+}

--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -73,9 +73,10 @@ async function getModuleDescriptionList( settings ) {
 	);
 
 	return moduleDescriptions
-		.map( ( moduleData ) => {
-			return `* **${ moduleData.name }:** ${ moduleData.description }`;
-		} )
+		.map(
+			( moduleData ) =>
+				`* **${ moduleData.name }:** ${ moduleData.description }`
+		)
 		.join( '\n' )
 		.concat( '\n' );
 }
@@ -90,9 +91,7 @@ function updateReadmeModuleDescriptionList( moduleList ) {
 	const fileContent = fs.readFileSync( readmeFile, 'utf8' );
 	const newContent = fileContent.replace(
 		/(the following performance modules:\s+)((\*.*\n)+)/,
-		( match, prefix ) => {
-			return `${ prefix }${ moduleList }`;
-		}
+		( match, prefix ) => `${ prefix }${ moduleList }`
 	);
 	fs.writeFileSync( readmeFile, newContent );
 }
@@ -132,16 +131,16 @@ function updateReadmeChangelog( changelog, settings ) {
  * @param {WPReadmeSettings} settings Readme settings.
  */
 async function updateReadme( settings ) {
-	if ( ! settings.milestone ) {
+	if ( settings.milestone ) {
 		log(
 			formats.title(
-				`\n💃Updating readme.txt for "${ settings.directory }"\n\n`
+				`\n💃Updating readme.txt for "${ settings.directory }" and changelog for milestone "${ settings.milestone }"\n\n`
 			)
 		);
 	} else {
 		log(
 			formats.title(
-				`\n💃Updating readme.txt for "${ settings.directory }" and changelog for milestone "${ settings.milestone }"\n\n`
+				`\n💃Updating readme.txt for "${ settings.directory }"\n\n`
 			)
 		);
 	}

--- a/load.php
+++ b/load.php
@@ -5,14 +5,14 @@
  * Description: Performance plugin from the WordPress Performance Group, which is a collection of standalone performance modules.
  * Requires at least: 5.8
  * Requires PHP: 5.6
- * Version: 1.0.0
+ * Version: 1.0.0-beta.1
  * Author: WordPress Performance Group
  * Text Domain: performance-lab
  *
  * @package performance-lab
  */
 
-define( 'PERFLAB_VERSION', '1.0.0' );
+define( 'PERFLAB_VERSION', '1.0.0-beta.1' );
 define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );
 define( 'PERFLAB_MODULES_SCREEN', 'perflab-modules' );
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "scripts": {
     "changelog": "./bin/plugin/cli.js changelog",
+    "readme": "./bin/plugin/cli.js readme",
     "translations": "./bin/plugin/cli.js translations",
     "format-js": "wp-scripts format ./bin",
     "lint-js": "wp-scripts lint-js ./bin",

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,84 @@
+=== Performance Lab ===
+
+Contributors:      wordpressdotorg
+Requires at least: 5.8
+Tested up to:      5.9
+Requires PHP:      5.6
+Stable tag:        1.0.0-beta.1
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              performance, images, javascript, site health, measurement, object caching
+
+Performance plugin from the WordPress Performance Group, which is a collection of standalone performance modules.
+
+== Description ==
+
+The Performance Lab plugin is a collection of modules focused on enhancing performance of your site, most of which should eventually be merged into WordPress core. The plugin allows to individually enable and test the modules to get their benefits before they become available in WordPress core, and to provide feedback to further improve the solutions.
+
+Currently the plugin includes the following performance modules:
+
+* **WebP Uploads:** Uses WebP as the default format for new JPEG image uploads if the server supports it.
+
+== Installation ==
+
+= Installation from within WordPress =
+
+1. Visit **Plugins > Add New**.
+2. Search for **Performance Lab**.
+3. Install and activate the Performance Lab plugin.
+
+= Manual installation =
+
+1. Upload the entire `performance-lab` folder to the `/wp-content/plugins/` directory.
+2. Visit **Plugins**.
+3. Activate the Performance Lab plugin.
+
+= After activation =
+
+1. Visit the new **Settings > Performance** menu.
+2. Enable the individual modules you would like to use.
+
+== Frequently Asked Questions ==
+
+= What is the purpose of this plugin? =
+
+The primary purpose of the Performance Lab plugin is to allow testing of various performance modules for which the goal is to eventually land in WordPress core. It is essentially a collection of "feature plugins", which makes it different from other performance plugins that offer performance features which are not targeted at WordPress core and potentially rely on functionality that would not be feasible to use in WordPress core. The list of available modules will regularly change: Existing modules may be removed after they have been released in WordPress core, while new modules may be added in any release.
+
+= Can I use this plugin on my production site? =
+
+Per the primary purpose of the plugin (see above), it can mostly be considered a beta testing plugin for the various performance modules it includes. However, unless a module is explicitly marked as "experimental", it has been tested and established to a degree where it should be okay to use in production. Still, as with every plugin, you are doing so at your own risk.
+
+= Where can I submit my plugin feedback? =
+
+Especially since this is a collection of WordPress core feature plugins, providing feedback is encouraged and much appreciated! You can submit your feedback either in the [plugin support forum](https://wordpress.org/support/plugin/performance-lab/) or, if you have a specific issue to report, in its [GitHub repository](https://github.com/WordPress/performance).
+
+= How can I contribute to the plugin? =
+
+Contributions welcome! There are several ways to contribute:
+
+* Raise an issue or submit a pull request in the [Github repository for the plugin](https://github.com/WordPress/performance)
+* Translate the plugin into your language at [translate.wordpress.org](https://translate.wordpress.org/projects/wp-plugins/performance-lab)
+* Join the weekly chat (Tuesdays at 16:00 UTC) in the [#performance channel on Slack](https://wordpress.slack.com/archives/performance)
+
+== Changelog ==
+
+= 1.0.0-beta.1 =
+
+**Features**
+
+* Images: Add WebP for uploads module. ([32](https://github.com/WordPress/performance/pull/32))
+* Infrastructure: Add settings screen to toggle modules. ([30](https://github.com/WordPress/performance/pull/30))
+
+**Enhancements**
+
+* Images: Update module directories to be within their focus directory. ([58](https://github.com/WordPress/performance/pull/58))
+
+**Bug Fixes**
+
+* Infrastructure: Ensure that module header fields can be translated. ([60](https://github.com/WordPress/performance/pull/60))
+
+**Documentation**
+
+* Infrastructure: Add changelog generator script. ([51](https://github.com/WordPress/performance/pull/51))
+* Infrastructure: Add contribution documentation. ([47](https://github.com/WordPress/performance/pull/47))
+* Infrastructure: Define module specification in documentation. ([26](https://github.com/WordPress/performance/pull/26))


### PR DESCRIPTION
Fixes #40

This PR is a starting point for the plugin's `readme.txt` file. It is a first content **proposal** for the readme itself, but in addition to that the PR includes a new related script callable via `npm run readme` that will help automate `readme.txt` updates in the future. Here's what that script does:

* Since the readme should contain an up-to-date list of all the available modules in the plugin description, the script automatically parses all module names and descriptions from the codebase and updates that bulleted list in the readme accordingly. This way we can easily always keep the readme up to date without double-maintaining these descriptions.
    * Of course we can always add more detailed information about a module somewhere else in the readme, but IMO having a quick overview list somewhere in the beginning of the plugin description is helpful, and for that purpose this script simplifies maintenance.
* The script also optionally updates the changelog for a given milestone within the readme, relying on the `npm run changelog` logic that was previously implemented in #51.

Here's how to use the script:
* `npm run readme`: This way it'll only update the module list. Try changing it to something else in the `readme.txt` file and then run this command, to see how it will always update the content to the names and descriptions of all modules within the codebase.
* `npm run readme -- -m "1.0.0-beta.1"`: This way it'll _also_ (in addition to the module list, see above) update the changelog section for the given milestone (right now we only have `1.0.0-beta.1`). If that changelog section doesn't exist yet, it'll add it right below `== Changelog ==`, otherwise it'll replace the existing section with the latest content. Try changing the content for that release to something else or add some dummy changelogs for other (non-existing) versions and then run the script to see how it always puts the latest changelog into `readme.txt`.

This PR needs two types of reviews: On the one hand, it needs engineering review and testing for the new `npm run readme` script. On the other hand, it needs content review for the initial proposal for the readme itself. Let's keep in mind that this doesn't need to be perfect or the final state of the readme (we can always add more details later), but it should at least be good for a start and a minimum foundation with which we _could_ potentially release a first version of the plugin.