### PR TITLE
Update CODEOWNERS to use the new module naming convention

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Documentation/Infrastructure
 /docs                                       @justinahinon @felixarntz
 /admin                                      @justinahinon @felixarntz
+/tests/admin                                @justinahinon @felixarntz
 /bin                                        @justinahinon @felixarntz
 /.github                                    @justinahinon @felixarntz
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,15 +5,21 @@
 /.github                                    @justinahinon @felixarntz
 
 # Focus: Images
-/modules/webp-uploads                       @adamsilverstein
-/tests/modules/webp-uploads                 @adamsilverstein
+/modules/images                             @adamsilverstein
+/tests/modules/images                       @adamsilverstein
 
 # Focus: JavaScript
+/modules/javascript                         @aristath @gziolo
+/tests/modules/javascript                   @aristath @gziolo
 
 # Focus: Object Caching
+/modules/object-caching                     @tillkruss @dustinrue
+/tests/modules/object-caching               @tillkruss @dustinrue
 
 # Focus: Measurement
+/modules/measurement                        @AymenLoukil @josephscott
+/tests/modules/measurement                  @AymenLoukil @josephscott
 
 # Focus: Site Health
-/modules/audit-enqueued-assets              @manuelRod @audrasjb
-/tests/modules/audit-enqueued-assets        @manuelRod @audrasjb
+/modules/site-health                        @audrasjb
+/tests/modules/site-health                  @audrasjb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,19 +7,24 @@
 # Focus: Images
 /modules/images                             @adamsilverstein
 /tests/modules/images                       @adamsilverstein
+/tests/testdata/modules/images              @adamsilverstein
 
 # Focus: JavaScript
 /modules/javascript                         @aristath @gziolo
 /tests/modules/javascript                   @aristath @gziolo
+/tests/testdata/modules/javascript          @aristath @gziolo
 
 # Focus: Object Caching
 /modules/object-caching                     @tillkruss @dustinrue
 /tests/modules/object-caching               @tillkruss @dustinrue
+/tests/testdata/modules/object-caching      @tillkruss @dustinrue
 
 # Focus: Measurement
 /modules/measurement                        @AymenLoukil @josephscott
 /tests/modules/measurement                  @AymenLoukil @josephscott
+/tests/testdata/modules/measurement         @AymenLoukil @josephscott
 
 # Focus: Site Health
 /modules/site-health                        @audrasjb
 /tests/modules/site-health                  @audrasjb
+/tests/testdata/modules/site-health         @audrasjb


### PR DESCRIPTION
Fixes #23. Follows up on https://github.com/WordPress/performance/issues/23#issuecomment-1013140822.

This PR update the CODEOWNERS file to reflect the module naming convention. It also updates the code owners based on the latest changes on [the focus spreadsheet](https://docs.google.com/spreadsheets/d/16N5oZ9wE6AkiqMz7b_707eh24vvpjMwsEG67XFAbxy8/).