### PR TITLE
Add an additional code owner for the image focus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,9 +6,9 @@
 /.github                                    @justinahinon @felixarntz
 
 # Focus: Images
-/modules/images                             @adamsilverstein
-/tests/modules/images                       @adamsilverstein
-/tests/testdata/modules/images              @adamsilverstein
+/modules/images                             @adamsilverstein @getsource
+/tests/modules/images                       @adamsilverstein @getsource
+/tests/testdata/modules/images              @adamsilverstein @getsource
 
 # Focus: JavaScript
 /modules/javascript                         @aristath @gziolo


### PR DESCRIPTION
Fixes #103.

This adds @getsource as the second code owner for the images focus.