### PR TITLE
Rename `object-caching` to `object-cache`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,10 +15,10 @@
 /tests/modules/javascript                   @aristath @gziolo
 /tests/testdata/modules/javascript          @aristath @gziolo
 
-# Focus: Object Caching
-/modules/object-caching                     @tillkruss @dustinrue
-/tests/modules/object-caching               @tillkruss @dustinrue
-/tests/testdata/modules/object-caching      @tillkruss @dustinrue
+# Focus: Object Cache
+/modules/object-cache                       @tillkruss @spacedmonkey
+/tests/modules/object-cache                 @tillkruss @spacedmonkey
+/tests/testdata/modules/object-cache        @tillkruss @spacedmonkey
 
 # Focus: Measurement
 /modules/measurement                        @AymenLoukil @josephscott

--- a/admin/load.php
+++ b/admin/load.php
@@ -179,8 +179,8 @@ function perflab_get_focus_areas() {
 		'measurement'    => array(
 			'name' => __( 'Measurement', 'performance-lab' ),
 		),
-		'object-caching' => array(
-			'name' => __( 'Object caching', 'performance-lab' ),
+		'object-cache' => array(
+			'name' => __( 'Object Cache', 'performance-lab' ),
 		),
 	);
 }

--- a/admin/load.php
+++ b/admin/load.php
@@ -167,16 +167,16 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
  */
 function perflab_get_focus_areas() {
 	return array(
-		'images'         => array(
+		'images'       => array(
 			'name' => __( 'Images', 'performance-lab' ),
 		),
-		'javascript'     => array(
+		'javascript'   => array(
 			'name' => __( 'JavaScript', 'performance-lab' ),
 		),
-		'site-health'    => array(
+		'site-health'  => array(
 			'name' => __( 'Site Health', 'performance-lab' ),
 		),
-		'measurement'    => array(
+		'measurement'  => array(
 			'name' => __( 'Measurement', 'performance-lab' ),
 		),
 		'object-cache' => array(

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -32,16 +32,16 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 	);
 
 	private static $demo_focus_areas = array(
-		'images'         => array(
+		'images'       => array(
 			'name' => 'Images',
 		),
-		'javascript'     => array(
+		'javascript'   => array(
 			'name' => 'JavaScript',
 		),
-		'site-health'    => array(
+		'site-health'  => array(
 			'name' => 'Site Health',
 		),
-		'measurement'    => array(
+		'measurement'  => array(
 			'name' => 'Measurement',
 		),
 		'object-cache' => array(

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -44,8 +44,8 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		'measurement'    => array(
 			'name' => 'Measurement',
 		),
-		'object-caching' => array(
-			'name' => 'Object caching',
+		'object-cache' => array(
+			'name' => 'Object Cache',
 		),
 	);
 
@@ -181,7 +181,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 			'javascript',
 			'site-health',
 			'measurement',
-			'object-caching',
+			'object-cache',
 		);
 		$this->assertSame( $expected_focus_areas, array_keys( perflab_get_focus_areas() ) );
 	}


### PR DESCRIPTION
## Summary

WordPress core calls it "Object Cache" not "Object Caching".

Also replaced @dustinrue with @spacedmonkey as code owner, if that's cool?

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
