### PR TITLE
Remove unnecessary question marks from checkbox labels

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -138,13 +138,13 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 			if ( $module_data['experimental'] ) {
 				printf(
 					/* translators: %s: module name */
-					__( 'Enable %s <strong>(experimental)</strong>?', 'performance-lab' ),
+					__( 'Enable %s <strong>(experimental)</strong>', 'performance-lab' ),
 					esc_html( $module_data['name'] )
 				);
 			} else {
 				printf(
 					/* translators: %s: module name */
-					__( 'Enable %s?', 'performance-lab' ),
+					__( 'Enable %s', 'performance-lab' ),
 					esc_html( $module_data['name'] )
 				);
 			}

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -160,7 +160,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertContains( ' id="module_' . $module_slug . '_enabled"', $output );
 		$this->assertContains( ' name="' . PERFLAB_MODULES_SETTING . '[' . $module_slug . '][enabled]"', $output );
-		$this->assertContains( 'Enable ' . $module_data['name'] . '?', $output );
+		$this->assertContains( 'Enable ' . $module_data['name'], $output );
 		$this->assertNotContains( ' checked', $output );
 
 		// Assert correct 'id' and 'name' attributes, experimental label, and checked checkbox.
@@ -171,7 +171,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		$output = ob_get_clean();
 		$this->assertContains( ' id="module_' . $module_slug . '_enabled"', $output );
 		$this->assertContains( ' name="' . PERFLAB_MODULES_SETTING . '[' . $module_slug . '][enabled]"', $output );
-		$this->assertContains( 'Enable ' . $module_data['name'] . ' <strong>(experimental)</strong>?', $output );
+		$this->assertContains( 'Enable ' . $module_data['name'] . ' <strong>(experimental)</strong>', $output );
 		$this->assertContains( " checked='checked'", $output );
 	}
 


### PR DESCRIPTION
## Summary

It's not really common to add a question mark to checkboxes, in WordPress or elsewhere.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
