### PR TITLE
Update JS focus code owner per recent change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,9 +11,9 @@
 /tests/testdata/modules/images              @adamsilverstein @getsource
 
 # Focus: JavaScript
-/modules/javascript                         @aristath @gziolo
-/tests/modules/javascript                   @aristath @gziolo
-/tests/testdata/modules/javascript          @aristath @gziolo
+/modules/javascript                         @aristath @sgomes
+/tests/modules/javascript                   @aristath @sgomes
+/tests/testdata/modules/javascript          @aristath @sgomes
 
 # Focus: Object Caching
 /modules/object-caching                     @tillkruss @dustinrue


### PR DESCRIPTION
## Summary

@sgomes is now the new JavaScript focus POC, replacing @gziolo in that role, in accordance with both.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
