### PR TITLE
Enhance detection of enqueued frontend assets

### DIFF
--- a/modules/site-health/audit-enqueued-assets/helper.php
+++ b/modules/site-health/audit-enqueued-assets/helper.php
@@ -78,6 +78,8 @@ function perflab_aea_get_total_size_bytes_enqueued_styles() {
 
 /**
  * Convert full URL paths to absolute paths.
+ * Covers Standard WP configuration, wp-content outside WP directories and subdirectories.
+ * Ex: https://example.com/content/themes/, https://example.com/wp/wp-includes/
  *
  * @since 1.0.0
  *
@@ -85,7 +87,20 @@ function perflab_aea_get_total_size_bytes_enqueued_styles() {
  * @return string Returns absolute path to the resource.
  */
 function perflab_aea_get_path_from_resource_url( $resource_url ) {
-	return ABSPATH . wp_make_link_relative( $resource_url );
+
+	// Different content folder ex. /content/.
+	if ( 0 === strpos( $resource_url, content_url() ) ) {
+		return WP_CONTENT_DIR . substr( $resource_url, strlen( content_url() ) );
+	}
+
+	// wp-content in a subdirectory. ex. /blog/wp-content/.
+	$site_url = untrailingslashit( site_url() );
+	if ( 0 === strpos( $resource_url, $site_url ) ) {
+		return untrailingslashit( ABSPATH ) . substr( $resource_url, strlen( $site_url ) );
+	}
+
+	// Standard wp-content configuration.
+	return untrailingslashit( ABSPATH ) . wp_make_link_relative( $resource_url );
 }
 
 /**

--- a/modules/site-health/audit-enqueued-assets/helper.php
+++ b/modules/site-health/audit-enqueued-assets/helper.php
@@ -87,6 +87,9 @@ function perflab_aea_get_total_size_bytes_enqueued_styles() {
  * @return string Returns absolute path to the resource.
  */
 function perflab_aea_get_path_from_resource_url( $resource_url ) {
+	if ( ! $resource_url ) {
+		return '';
+	}
 
 	// Different content folder ex. /content/.
 	if ( 0 === strpos( $resource_url, content_url() ) ) {

--- a/modules/site-health/audit-enqueued-assets/load.php
+++ b/modules/site-health/audit-enqueued-assets/load.php
@@ -28,22 +28,24 @@ function perflab_aea_audit_enqueued_scripts() {
 		foreach ( $wp_scripts->done as $handle ) {
 			$script = $wp_scripts->registered[ $handle ];
 
-			if ( $script->src && ! strpos( $script->src, 'wp-includes' ) ) {
-
-				// Add any extra data (inlined) that was passed with the script.
-				$inline_size = 0;
-				if ( ! empty( $script->extra ) && ! empty( $script->extra['after'] ) ) {
-					foreach ( $script->extra['after'] as $extra ) {
-						$inline_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
-					}
-				}
-
-				$path               = perflab_aea_get_path_from_resource_url( $script->src );
-				$enqueued_scripts[] = array(
-					'src'  => $script->src,
-					'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
-				);
+			if ( ! $script->src || false !== strpos( $script->src, 'wp-includes' ) ) {
+				continue;
 			}
+
+			// Add any extra data (inlined) that was passed with the script.
+			$inline_size = 0;
+			if ( ! empty( $script->extra ) && ! empty( $script->extra['after'] ) ) {
+				foreach ( $script->extra['after'] as $extra ) {
+					$inline_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
+				}
+			}
+
+			$path               = perflab_aea_get_path_from_resource_url( $script->src );
+			$enqueued_scripts[] = array(
+				'src'  => $script->src,
+				'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
+			);
+
 		}
 		set_transient( 'aea_enqueued_front_page_scripts', $enqueued_scripts, 12 * HOUR_IN_SECONDS );
 	}
@@ -63,28 +65,30 @@ function perflab_aea_audit_enqueued_styles() {
 		$enqueued_styles = array();
 		foreach ( $wp_styles->done as $handle ) {
 			$style = $wp_styles->registered[ $handle ];
-			if ( $style->src && ! strpos( $style->src, 'wp-includes' ) ) {
 
-				// Check if we already have the style's path ( part of a refactor for block styles from 5.9 ).
-				if ( ! empty( $style->extra ) && ! empty( $style->extra['path'] ) ) {
-					$path = $style->extra['path'];
-				} else { // Fallback to getting the path from the style's src.
-					$path = perflab_aea_get_path_from_resource_url( $style->src );
-				}
-
-				// Add any extra data (inlined) that was passed with the style.
-				$inline_size = 0;
-				if ( ! empty( $style->extra ) && ! empty( $style->extra['after'] ) ) {
-					foreach ( $style->extra['after'] as $extra ) {
-						$inline_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
-					}
-				}
-
-				$enqueued_styles[] = array(
-					'src'  => $style->src,
-					'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
-				);
+			if ( ! $style->src || false !== strpos( $style->src, 'wp-includes' ) ) {
+				continue;
 			}
+
+			// Check if we already have the style's path ( part of a refactor for block styles from 5.9 ).
+			if ( ! empty( $style->extra ) && ! empty( $style->extra['path'] ) ) {
+				$path = $style->extra['path'];
+			} else { // Fallback to getting the path from the style's src.
+				$path = perflab_aea_get_path_from_resource_url( $style->src );
+			}
+
+			// Add any extra data (inlined) that was passed with the style.
+			$inline_size = 0;
+			if ( ! empty( $style->extra ) && ! empty( $style->extra['after'] ) ) {
+				foreach ( $style->extra['after'] as $extra ) {
+					$inline_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
+				}
+			}
+
+			$enqueued_styles[] = array(
+				'src'  => $style->src,
+				'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
+			);
 		}
 		set_transient( 'aea_enqueued_front_page_styles', $enqueued_styles, 12 * HOUR_IN_SECONDS );
 	}

--- a/modules/site-health/audit-enqueued-assets/load.php
+++ b/modules/site-health/audit-enqueued-assets/load.php
@@ -40,7 +40,11 @@ function perflab_aea_audit_enqueued_scripts() {
 				}
 			}
 
-			$path               = perflab_aea_get_path_from_resource_url( $script->src );
+			$path = perflab_aea_get_path_from_resource_url( $script->src );
+			if ( ! $path ) {
+				continue;
+			}
+
 			$enqueued_scripts[] = array(
 				'src'  => $script->src,
 				'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
@@ -75,6 +79,9 @@ function perflab_aea_audit_enqueued_styles() {
 				$path = $style->extra['path'];
 			} else { // Fallback to getting the path from the style's src.
 				$path = perflab_aea_get_path_from_resource_url( $style->src );
+				if ( ! $path ) {
+					continue;
+				}
 			}
 
 			// Add any extra data (inlined) that was passed with the style.

--- a/modules/site-health/audit-enqueued-assets/load.php
+++ b/modules/site-health/audit-enqueued-assets/load.php
@@ -14,7 +14,7 @@
 require_once __DIR__ . '/helper.php';
 
 /**
- * Audit enqueued scripts in is_front_page(). Ignore /wp-includes scripts.
+ * Audit enqueued and printed scripts in is_front_page(). Ignore /wp-includes scripts.
  *
  * It will save information in a transient for 12 hours.
  *
@@ -25,22 +25,33 @@ function perflab_aea_audit_enqueued_scripts() {
 		global $wp_scripts;
 		$enqueued_scripts = array();
 
-		foreach ( $wp_scripts->queue as $handle ) {
-			$src = $wp_scripts->registered[ $handle ]->src;
-			if ( $src && ! strpos( $src, 'wp-includes' ) ) {
+		foreach ( $wp_scripts->done as $handle ) {
+			$script = $wp_scripts->registered[ $handle ];
+
+			if ( $script->src && ! strpos( $script->src, 'wp-includes' ) ) {
+
+				// Add any extra data (inlined) that was passed with the script.
+				$inline_size = 0;
+				if ( ! empty( $script->extra ) && ! empty( $script->extra['after'] ) ) {
+					foreach ( $script->extra['after'] as $extra ) {
+						$inline_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
+					}
+				}
+
+				$path               = perflab_aea_get_path_from_resource_url( $script->src );
 				$enqueued_scripts[] = array(
-					'src'  => $src,
-					'size' => perflab_aea_get_resource_file_size( perflab_aea_get_path_from_resource_url( $src ) ),
+					'src'  => $script->src,
+					'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
 				);
 			}
 		}
 		set_transient( 'aea_enqueued_front_page_scripts', $enqueued_scripts, 12 * HOUR_IN_SECONDS );
 	}
 }
-add_action( 'wp_print_scripts', 'perflab_aea_audit_enqueued_scripts' );
+add_action( 'wp_footer', 'perflab_aea_audit_enqueued_scripts', PHP_INT_MAX );
 
 /**
- * Audit enqueued styles in the frontend. Ignore /wp-includes styles.
+ * Audit enqueued and printed styles in the frontend. Ignore /wp-includes styles.
  *
  * It will save information in a transient for 12 hours.
  *
@@ -50,19 +61,35 @@ function perflab_aea_audit_enqueued_styles() {
 	if ( ! is_admin() && is_front_page() && current_user_can( 'view_site_health_checks' ) && false === get_transient( 'aea_enqueued_front_page_styles' ) ) {
 		global $wp_styles;
 		$enqueued_styles = array();
-		foreach ( $wp_styles->queue as $handle ) {
-			$src = $wp_styles->registered[ $handle ]->src;
-			if ( $src && ! strpos( $src, 'wp-includes' ) ) {
+		foreach ( $wp_styles->done as $handle ) {
+			$style = $wp_styles->registered[ $handle ];
+			if ( $style->src && ! strpos( $style->src, 'wp-includes' ) ) {
+
+				// Check if we already have the style's path ( part of a refactor for block styles from 5.9 ).
+				if ( ! empty( $style->extra ) && ! empty( $style->extra['path'] ) ) {
+					$path = $style->extra['path'];
+				} else { // Fallback to getting the path from the style's src.
+					$path = perflab_aea_get_path_from_resource_url( $style->src );
+				}
+
+				// Add any extra data (inlined) that was passed with the style.
+				$inline_size = 0;
+				if ( ! empty( $style->extra ) && ! empty( $style->extra['after'] ) ) {
+					foreach ( $style->extra['after'] as $extra ) {
+						$inline_size += ( is_string( $extra ) ) ? mb_strlen( $extra, '8bit' ) : 0;
+					}
+				}
+
 				$enqueued_styles[] = array(
-					'src'  => $src,
-					'size' => perflab_aea_get_resource_file_size( perflab_aea_get_path_from_resource_url( $src ) ),
+					'src'  => $style->src,
+					'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
 				);
 			}
 		}
 		set_transient( 'aea_enqueued_front_page_styles', $enqueued_styles, 12 * HOUR_IN_SECONDS );
 	}
 }
-add_action( 'wp_print_styles', 'perflab_aea_audit_enqueued_styles' );
+add_action( 'wp_footer', 'perflab_aea_audit_enqueued_styles', PHP_INT_MAX );
 
 /**
  * Adds tests to site health.

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -84,6 +84,15 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests perflab_aea_get_path_from_resource_url() functionality empty $url.
+	 */
+	public function test_perflab_aea_get_path_from_resource_url_empty_url() {
+		$test_url      = false;
+		$expected_path = '';
+		$this->assertSame( $expected_path, perflab_aea_get_path_from_resource_url( $test_url ) );
+	}
+
+	/**
 	 * Tests perflab_aea_get_path_from_resource_url() functionality when wp-content outside wp directory.
 	 */
 	public function test_perflab_aea_get_path_from_resource_url_outside_wp_setup() {

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -69,8 +69,32 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 	 * Tests perflab_aea_get_path_from_resource_url() functionality.
 	 */
 	public function test_perflab_aea_get_path_from_resource_url() {
-		$test_url      = 'https://example.com/wp-content/themes/test-theme/style.css';
-		$expected_path = ABSPATH . '/wp-content/themes/test-theme/style.css';
+		$test_url      = site_url() . '/wp-content/themes/test-theme/style.css';
+		$expected_path = ABSPATH . 'wp-content/themes/test-theme/style.css';
+		$this->assertSame( $expected_path, perflab_aea_get_path_from_resource_url( $test_url ) );
+	}
+
+	/**
+	 * Tests perflab_aea_get_path_from_resource_url() functionality when wp-content in subdirectory.
+	 */
+	public function test_perflab_aea_get_path_from_resource_url_subdirectory() {
+		$test_url      = site_url() . '/wp/wp-content/themes/test-theme/style.css';
+		$expected_path = ABSPATH . 'wp/wp-content/themes/test-theme/style.css';
+		$this->assertSame( $expected_path, perflab_aea_get_path_from_resource_url( $test_url ) );
+	}
+
+	/**
+	 * Tests perflab_aea_get_path_from_resource_url() functionality when wp-content outside wp directory.
+	 */
+	public function test_perflab_aea_get_path_from_resource_url_outside_wp_setup() {
+		$test_url      = site_url() . '/content/themes/test-theme/style.css';
+		$expected_path = WP_CONTENT_DIR . '/themes/test-theme/style.css';
+		add_filter(
+			'content_url',
+			function( $url ) {
+				return site_url() . '/content';
+			}
+		);
 		$this->assertSame( $expected_path, perflab_aea_get_path_from_resource_url( $test_url ) );
 	}
 

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -60,6 +60,10 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		wp_enqueue_script( 'script3', 'example3.com', array() );
 		wp_dequeue_script( 'script3' );
 
+		$inline_script = 'console.log("after");';
+		wp_add_inline_script( 'script1', $inline_script );
+
+		get_echo( 'wp_print_scripts' );
 		perflab_aea_audit_enqueued_scripts();
 		$transient = get_transient( 'aea_enqueued_front_page_scripts' );
 		$this->assertNotEmpty( $transient );
@@ -68,7 +72,7 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 			array(
 				array(
 					'src'  => 'example1.com',
-					'size' => 0,
+					'size' => 0 + mb_strlen( $inline_script, '8bit' ),
 				),
 			),
 			$transient
@@ -87,6 +91,9 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		$this->current_user_can_view_site_health_checks_cap();
 
 		Audit_Assets_Transients_Set::set_style_transient_with_data( 3 );
+
+		// Avoids echoing styles.
+		get_echo( 'wp_print_styles' );
 		perflab_aea_audit_enqueued_styles();
 		$transient = get_transient( 'aea_enqueued_front_page_styles' );
 		$this->assertIsArray( $transient );
@@ -126,6 +133,13 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		wp_enqueue_style( 'style3', 'example3.com', array() );
 		wp_dequeue_style( 'style3' );
 
+		// Adding inline style to style1.
+		$style  = ".test {\n";
+		$style .= "\tbackground: red;\n";
+		$style .= '}';
+		wp_add_inline_style( 'style1', $style );
+		get_echo( 'wp_print_styles' );
+
 		perflab_aea_audit_enqueued_styles();
 		$transient = get_transient( 'aea_enqueued_front_page_styles' );
 		$this->assertNotEmpty( $transient );
@@ -134,7 +148,7 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 			array(
 				array(
 					'src'  => 'example1.com',
-					'size' => 0,
+					'size' => 0 + mb_strlen( $style, '8bit' ),
 				),
 			),
 			$transient


### PR DESCRIPTION
## Summary

Enhances for Site Health Enqueued assets module.
Fixes #135

## Relevant technical choices

Follow up of the previous closed PR [#54 ](https://github.com/WordPress/performance/pull/54)

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
