### PR TITLE
Add release documentation

### DIFF
--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -34,7 +34,7 @@ Push your local release branch to the GitHub repository and open a pull request 
 
 If this is a major or minor release, please keep the release branch around since that branch can be used to later create patch releases from the same state of the codebase.
 
-## Create a new GitHub release
+## Publishing the release
 
 Once the above pull request has been merged, let the other maintainers know on [Slack](https://wordpress.slack.com/archives/performance) that no new commits or pull requests must be added to the branch due to the release process. Then, make sure that all GitHub actions successfully pass for the target branch (e.g. [for `trunk`](https://github.com/WordPress/performance/actions?query=branch%3Atrunk)).
 

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -18,8 +18,8 @@ The version number needs to be updated in the following files:
 
 Run `npm run readme -- -m "X.Y.Z"` to update the readme.txt file with the release changelog, with X.Y.Z as the release milestone name.
 
-### Create a new GitHub release
+## Create a new GitHub release
 
 Go to https://github.com/WordPress/performance/releases/new to create a new release for the plugin. The release tag should be in the format `X.Y.Z`. Finally, add the changelog (it can be found in the readme.txt file) to the release description and create the release.
 
-## Post-release steps
+Once a new version is released on GitHub, the plugin will be deployed to the WordPress.org repository using this [action](../.github/workflows/deploy-dotorg.yml).

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -16,7 +16,7 @@ The version number needs to be updated in the following files:
 - load.php
 - readme.txt
 
-In addition to those locations, do a global search and replace across the entire codebase to replace any occurrence of `n.e.x.t` with the version number. This ensures any code annotated with the "next" release will now have its proper version number on it.
+In addition to those locations, do a global search and replace across the entire codebase to replace any occurrence of `n.e.x.t` with the version number. This ensures any code annotated with the "next" release will now have its proper version number on it. The only exception to this are pre-releases, such as a beta or RC: For those, the stable version number should be used. For example, if the milestone is `1.2.0-beta.2`, the version in e.g. `@since` annotations in the codebase should still be `1.2.0`.
 
 ### Update translation strings
 

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -30,4 +30,6 @@ After running the command, check the readme.txt file to ensure the new changelog
 
 Go to https://github.com/WordPress/performance/releases/new to create a new release for the plugin. The release tag should be in the format `X.Y.Z`. Finally, add the changelog (it can be found in the readme.txt file) to the release description and create the release.
 
-Once a new version is released on GitHub, the plugin will be deployed to the WordPress.org repository using this [action](../.github/workflows/deploy-dotorg.yml).
+Once a new version is released on GitHub, the plugin will be deployed to the [WordPress.org repository](https://wordpress.org/plugins/performance-lab/) using [this action](../.github/workflows/deploy-dotorg.yml).
+
+At this point, test the update process from your WordPress site, getting the plugin from wordpress.org. You can then share on [Slack](https://wordpress.slack.com/archives/performance) that the new release has been published and that committing may continue.

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -28,6 +28,12 @@ Run `npm run readme -- -m "{milestoneName}"` to update the readme.txt file with 
 
 After running the command, check the readme.txt file to ensure the new changelog for the release has been added. Also review its changelog entries for whether they make sense and are understandable.
 
+### Open a pull request
+
+Push your local release branch to the GitHub repository and open a pull request against `trunk`. Make sure to tag at least 2 plugin maintainers to request a review. Once the pull request is approved by at least 2 plugin maintainers, the pull request can be merged.
+
+If this is a major or minor release, please keep the release branch around since that branch can be used to later create patch releases from the same state of the codebase.
+
 ## Create a new GitHub release
 
 Go to https://github.com/WordPress/performance/releases/new to create a new release for the plugin. The release tag should be in the format `X.Y.Z`. Finally, add the changelog (it can be found in the readme.txt file) to the release description and create the release.

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -1,0 +1,11 @@
+# Releasing the performance plugin
+
+This document describes the steps to release the Performance plugin.
+
+## Preparing the release
+
+- Update version number
+  - package.json
+  - composer.json
+  - load.php
+- 

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -14,6 +14,10 @@ The version number needs to be updated in the following files:
 - load.php
 - readme.txt
 
+### Update translation strings
+
+The module headers from the plugin have to be translated using a separate `module-i18n.php` file which can be automatically generated and updated. Run `npm run translations` to update the file to reflect the latest available modules.
+
 ### Update readme.txt
 
 Run `npm run readme -- -m "X.Y.Z"` to update the readme.txt file with the release changelog, with X.Y.Z as the release milestone name.

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -4,7 +4,9 @@ This document describes the steps to release the Performance plugin.
 
 ## Preparing the release
 
-> The following changes need to be made through a pull request.
+### Create a local release branch
+
+Before making any changes, create a local branch `release/{milestoneName}` from latest `trunk`, where `{milestoneName}` is the name of the milestone (which should match the release version). For example, if the milestone is `1.2.0`, name the branch `release/1.2.0`.
 
 ### Update the version number
 

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -4,8 +4,15 @@ This document describes the steps to release the Performance plugin.
 
 ## Preparing the release
 
-- Update version number
-  - package.json
-  - composer.json
-  - load.php
-- 
+### Update the version number
+
+- package.json
+- composer.json
+- load.php
+- readme.txt
+
+### Update readme.txt
+
+`npm run readme -- -m "version"`
+
+### Create a new GitHub release

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -4,15 +4,22 @@ This document describes the steps to release the Performance plugin.
 
 ## Preparing the release
 
+> The following changes need to be made through a pull request.
+
 ### Update the version number
 
+The version number needs to be updated in the following files:
+
 - package.json
-- composer.json
 - load.php
 - readme.txt
 
 ### Update readme.txt
 
-`npm run readme -- -m "version"`
+Run `npm run readme -- -m "X.Y.Z"` to update the readme.txt file with the release changelog, with X.Y.Z as the release milestone name.
 
 ### Create a new GitHub release
+
+Go to https://github.com/WordPress/performance/releases/new to create a new release for the plugin. The release tag should be in the format `X.Y.Z`. Finally, add the changelog (it can be found in the readme.txt file) to the release description and create the release.
+
+## Post-release steps

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -16,6 +16,8 @@ The version number needs to be updated in the following files:
 - load.php
 - readme.txt
 
+In addition to those locations, do a global search and replace across the entire codebase to replace any occurrence of `n.e.x.t` with the version number. This ensures any code annotated with the "next" release will now have its proper version number on it.
+
 ### Update translation strings
 
 The module headers from the plugin have to be translated using a separate `module-i18n.php` file which can be automatically generated and updated. Run `npm run translations` to update the file to reflect the latest available modules.

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -20,7 +20,9 @@ The module headers from the plugin have to be translated using a separate `modul
 
 ### Update readme.txt
 
-Run `npm run readme -- -m "X.Y.Z"` to update the readme.txt file with the release changelog, with X.Y.Z as the release milestone name.
+Run `npm run readme -- -m "{milestoneName}"` to update the readme.txt file with the release changelog, where `{milestoneName}` is the name of the milestone. For example, if the milestone is `1.2.0`, the command needs to be `npm run readme -- -m "1.2.0"`.
+
+After running the command, check the readme.txt file to ensure the new changelog for the release has been added. Also review its changelog entries for whether they make sense and are understandable.
 
 ## Create a new GitHub release
 

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -36,7 +36,9 @@ If this is a major or minor release, please keep the release branch around since
 
 ## Create a new GitHub release
 
-Go to https://github.com/WordPress/performance/releases/new to create a new release for the plugin. The release tag should be in the format `X.Y.Z`. Finally, add the changelog (it can be found in the readme.txt file) to the release description and create the release.
+Once the above pull request has been merged, let the other maintainers know on [Slack](https://wordpress.slack.com/archives/performance) that no new commits or pull requests must be added to the branch due to the release process. Then, make sure that all GitHub actions successfully pass for the target branch (e.g. [for `trunk`](https://github.com/WordPress/performance/actions?query=branch%3Atrunk)).
+
+After that, [create a new release tag for the plugin on GitHub](https://github.com/WordPress/performance/releases/new). The release tag should have the same name as the corresponding milestone used earlier, and it should be created from the `trunk` branch (unless this is for a patch release, in which case it should be created from the corresponding `release/...` branch). Finally, add the changelog (it can be found in the readme.txt file) to the release description and create the release.
 
 Once a new version is released on GitHub, the plugin will be deployed to the [WordPress.org repository](https://wordpress.org/plugins/performance-lab/) using [this action](../.github/workflows/deploy-dotorg.yml).
 


### PR DESCRIPTION
## Summary
This PR adds a new file [Releasing-the-plugin.md](https://github.com/WordPress/performance/blob/add/131-release-documentation/docs/Releasing-the-plugin.md) with the release steps.

Fixes #131. 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
