### PR TITLE
Update the plugin contributors

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Performance Lab ===
 
-Contributors:      wordpressdotorg
+Contributors:      performanceteam
 Requires at least: 5.8
 Tested up to:      5.9
 Requires PHP:      5.6


### PR DESCRIPTION
## Summary

Following https://github.com/WordPress/performance/issues/42#issuecomment-1024067465, this PR updates the contributor to the plugin to use https://profiles.wordpress.org/performanceteam handle.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
