### PR TITLE
Add WebP support in site health

### DIFF
--- a/modules/site-health/webp-support/load.php
+++ b/modules/site-health/webp-support/load.php
@@ -48,7 +48,7 @@ function webp_uploads_check_webp_supported_test() {
 		'test'        => 'is_webp_uploads_enabled',
 	);
 
-	$webp_supported = wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ;
+	$webp_supported = wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) );
 
 	if ( ! $webp_supported ) {
 		$result['status']  = 'critical';

--- a/modules/site-health/webp-support/load.php
+++ b/modules/site-health/webp-support/load.php
@@ -42,7 +42,7 @@ function webp_uploads_check_webp_supported_test() {
 		),
 		'description' => sprintf(
 			'<p>%s</p>',
-			__( 'WebP image format is used by WordPress to improve the performance of your site by generating smaller images than it usually could with JPEG format. This means your pages will load faster and consume less bandwidth from users.', 'performance-lab' )
+			__( 'WebP image format is used by WordPress to improve the performance of your site by generating smaller images than it usually could with the JPEG format. This means your pages will load faster and consume less bandwidth.', 'performance-lab' )
 		),
 		'actions'     => '',
 		'test'        => 'is_webp_uploads_enabled',

--- a/modules/site-health/webp-support/load.php
+++ b/modules/site-health/webp-support/load.php
@@ -51,7 +51,7 @@ function webp_uploads_check_webp_supported_test() {
 	$webp_supported = wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) );
 
 	if ( ! $webp_supported ) {
-		$result['status']  = 'critical';
+		$result['status']  = 'recommended';
 		$result['label']   = __( 'Your site does not support WebP', 'performance-lab' );
 		$result['actions'] = sprintf(
 			'<p>%s</p>',

--- a/modules/site-health/webp-support/load.php
+++ b/modules/site-health/webp-support/load.php
@@ -56,7 +56,7 @@ function webp_uploads_check_webp_supported_test() {
 		$result['actions'] = sprintf(
 			'<p>%s</p>',
 			/* translators: Accessibility text. */
-			__( 'Please contact your host and ask them to add WebP support', 'performance-lab' )
+			__( 'Please contact your host and ask them to add WebP support.', 'performance-lab' )
 		);
 	}
 

--- a/modules/site-health/webp-support/load.php
+++ b/modules/site-health/webp-support/load.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Web Uploads Support
+ * Module Name: Web Support
  * Description: Add WebP support check in Site Health checks.
  * Experimental: No
  *

--- a/modules/site-health/webp-uploads-enabled/load.php
+++ b/modules/site-health/webp-uploads-enabled/load.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Module Name: Web Uploads Support
+ * Description: Add WebP support check in Site Health checks.
+ * Experimental: No
+ *
+ * @package performance-lab
+ * @since 1.0.0
+ */
+
+/**
+ * Adds tests to site health.
+ *
+ * @since 1.0.0
+ *
+ * @param array $tests Site Health Tests.
+ * @return array
+ */
+function webp_uploads_add_is_webp_supported_test( $tests )
+{
+	$tests['direct']['webp_supported']  = array(
+		'label' => esc_html__( 'WebP Support', 'performance-lab' ),
+		'test'  => 'webp_uploads_check_webp_supported_test',
+	);
+	return $tests;
+}
+add_filter( 'site_status_tests', 'webp_uploads_add_is_webp_supported_test' );
+
+/**
+ * Callback for webp_enabled test.
+ *
+ * @since 1.0.0
+ *
+ * @return array
+ */
+function webp_uploads_check_webp_supported_test() {
+	$result = array(
+		'label'       => __( 'Your site supports WebP' ),
+		'status'      => 'good',
+		'badge'       => array(
+			'label' => __( 'Performance' ),
+			'color' => 'blue',
+		),
+		'description' => sprintf(
+			'<p>%s</p>',
+			__( 'WebP image format is used by WordPress to boost performance of your site by generating smaller images than it usually could with default JPEG format. This means your pages will load faster and consume less data from users.' )
+		),
+		'actions'     => '',
+		'test'        => 'is_webp_uploads_enabled',
+	);
+
+	$gd_supported = false;
+	if ( function_exists( 'gd_info' ) ) {
+		$gd = gd_info();
+		if ( isset( $gd[ 'WebP Support' ] ) && $gd[ 'WebP Support' ] ) {
+			$gd_supported = true;
+		}
+	}
+
+	try {
+		$formats = Imagick::queryFormats( '*' );
+
+		if( in_array('WEBP', $formats ) ) {
+			$gd_supported = true;
+		}
+	} catch (Exception $e) {
+	}
+
+	if ( ! $gd_supported ) {
+		$result['status'] = 'critical';
+		$result['label']  = __( 'Your site does not support WebP' );
+		$result['actions'] = sprintf(
+			'<p>%s</p>',
+			/* translators: Accessibility text. */
+			__( 'Please contact your host and ask them to add WebP support' )
+		);
+	}
+
+	return $result;
+}

--- a/modules/site-health/webp-uploads-enabled/load.php
+++ b/modules/site-health/webp-uploads-enabled/load.php
@@ -48,24 +48,9 @@ function webp_uploads_check_webp_supported_test() {
 		'test'        => 'is_webp_uploads_enabled',
 	);
 
-	$gd_supported = false;
-	if ( function_exists( 'gd_info' ) ) {
-		$gd = gd_info();
-		if ( isset( $gd['WebP Support'] ) && $gd['WebP Support'] ) {
-			$gd_supported = true;
-		}
-	}
+	$webp_supported = wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ;
 
-	try {
-		$formats = Imagick::queryFormats( '*' );
-
-		if ( in_array( 'WEBP', $formats ) ) {
-			$gd_supported = true;
-		}
-	} catch ( Exception $e ) {
-	}
-
-	if ( $gd_supported ) {
+	if ( ! $webp_supported ) {
 		$result['status']  = 'critical';
 		$result['label']   = __( 'Your site does not support WebP', 'performance-lab' );
 		$result['actions'] = sprintf(

--- a/modules/site-health/webp-uploads-enabled/load.php
+++ b/modules/site-health/webp-uploads-enabled/load.php
@@ -16,9 +16,8 @@
  * @param array $tests Site Health Tests.
  * @return array
  */
-function webp_uploads_add_is_webp_supported_test( $tests )
-{
-	$tests['direct']['webp_supported']  = array(
+function webp_uploads_add_is_webp_supported_test( $tests ) {
+	$tests['direct']['webp_supported'] = array(
 		'label' => esc_html__( 'WebP Support', 'performance-lab' ),
 		'test'  => 'webp_uploads_check_webp_supported_test',
 	);
@@ -35,15 +34,15 @@ add_filter( 'site_status_tests', 'webp_uploads_add_is_webp_supported_test' );
  */
 function webp_uploads_check_webp_supported_test() {
 	$result = array(
-		'label'       => __( 'Your site supports WebP' ),
+		'label'       => __( 'Your site supports WebP', 'performance-lab' ),
 		'status'      => 'good',
 		'badge'       => array(
-			'label' => __( 'Performance' ),
+			'label' => __( 'Performance', 'performance-lab' ),
 			'color' => 'blue',
 		),
 		'description' => sprintf(
 			'<p>%s</p>',
-			__( 'WebP image format is used by WordPress to boost performance of your site by generating smaller images than it usually could with default JPEG format. This means your pages will load faster and consume less data from users.' )
+			__( 'WebP image format is used by WordPress to boost performance of your site by generating smaller images than it usually could with default JPEG format. This means your pages will load faster and consume less data from users.', 'performance-lab' )
 		),
 		'actions'     => '',
 		'test'        => 'is_webp_uploads_enabled',
@@ -52,7 +51,7 @@ function webp_uploads_check_webp_supported_test() {
 	$gd_supported = false;
 	if ( function_exists( 'gd_info' ) ) {
 		$gd = gd_info();
-		if ( isset( $gd[ 'WebP Support' ] ) && $gd[ 'WebP Support' ] ) {
+		if ( isset( $gd['WebP Support'] ) && $gd['WebP Support'] ) {
 			$gd_supported = true;
 		}
 	}
@@ -60,19 +59,19 @@ function webp_uploads_check_webp_supported_test() {
 	try {
 		$formats = Imagick::queryFormats( '*' );
 
-		if( in_array('WEBP', $formats ) ) {
+		if ( in_array( 'WEBP', $formats ) ) {
 			$gd_supported = true;
 		}
-	} catch (Exception $e) {
+	} catch ( Exception $e ) {
 	}
 
-	if ( ! $gd_supported ) {
-		$result['status'] = 'critical';
-		$result['label']  = __( 'Your site does not support WebP' );
+	if ( $gd_supported ) {
+		$result['status']  = 'critical';
+		$result['label']   = __( 'Your site does not support WebP', 'performance-lab' );
 		$result['actions'] = sprintf(
 			'<p>%s</p>',
 			/* translators: Accessibility text. */
-			__( 'Please contact your host and ask them to add WebP support' )
+			__( 'Please contact your host and ask them to add WebP support', 'performance-lab' )
 		);
 	}
 

--- a/modules/site-health/webp-uploads-enabled/load.php
+++ b/modules/site-health/webp-uploads-enabled/load.php
@@ -43,7 +43,7 @@ function webp_uploads_check_webp_supported_test() {
 		),
 		'description' => sprintf(
 			'<p>%s</p>',
-			__( 'WebP image format is used by WordPress to boost performance of your site by generating smaller images than it usually could with default JPEG format. This means your pages will load faster and consume less data from users.' )
+			__( 'WebP image format is used by WordPress to improve the performance of your site by generating smaller images than it usually could with JPEG format. This means your pages will load faster and consume less bandwidth from users.' )
 		),
 		'actions'     => '',
 		'test'        => 'is_webp_uploads_enabled',


### PR DESCRIPTION
## Summary
Fixes #130. 

## Relevant technical choices

Adds a module in site health to check for WebP support and shows a warning if support is not present. 
If either GD or Imagick has WebP support, the WebP support warning is not shown.

The code of checking support in GD and Imagick is same as how it's shown in site health info's media handling section.

## Screenshots
![Screenshot from 2022-02-03 18-19-09](https://user-images.githubusercontent.com/8456197/152346010-7020fa2e-10f4-4271-8333-1805fc6bbd4e.png)

