### PR TITLE
Ensure the `-scaled` image remains in the original uploaded format

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -32,7 +32,7 @@ function webp_uploads_filter_image_editor_output_format( $output_format, $filena
 	}
 
 	// Skip conversion when creating the `-scaled` image (for large image uploads).
-	if ( 1 === preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
+	if ( preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
 		return $output_format;
 	}
 

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -32,7 +32,7 @@ function webp_uploads_filter_image_editor_output_format( $output_format, $filena
 	}
 
 	// Skip conversion when creating the `-scaled` image (for large image uploads).
-	if ( preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
+	if ( preg_match( '/-scaled\..{3}.?$/', $filename ) ) {
 		return $output_format;
 	}
 

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -31,6 +31,11 @@ function webp_uploads_filter_image_editor_output_format( $output_format, $filena
 		return $output_format;
 	}
 
+	// Skip conversion when creating the `-scaled` image (for large image uploads).
+	if ( 1 === preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
+		return $output_format;
+	}
+
 	$output_format['image/jpeg'] = 'image/webp';
 
 	return $output_format;

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -8,11 +8,6 @@
 
 class WebP_Uploads_Tests extends WP_UnitTestCase {
 
-	// Filter callback to limit output to WebP for the single output type tests.
-	function return_webp_array() {
-		return array( 'image/webp' );
-	}
-
 	/**
 	 * Test if webp-uploads applies filter based on system support of WebP.
 	 */
@@ -23,9 +18,6 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 		} else {
 			$expect = array( 'image/jpeg' => 'image/webp' );
 		}
-		// The image_editor_output_format filter is only applied if image_editor_output_format
-		// has fewer than two types.
-		add_filter( 'image_editor_output_formats', array( $this, 'return_webp_array' ) );
 		$output_format = apply_filters( 'image_editor_output_format', array(), '', 'image/jpeg' );
 		$this->assertEquals( $expect, $output_format );
 	}
@@ -36,7 +28,6 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 	function test_webp_uploads_filter_image_editor_output_format_with_support() {
 		// Mock a system that supports WebP.
 		add_filter( 'wp_image_editors', array( $this, 'mock_wp_image_editor_supports' ) );
-		add_filter( 'image_editor_output_formats', array( $this, 'return_webp_array' ) );
 		$output_format = webp_uploads_filter_image_editor_output_format( array(), '', 'image/jpeg' );
 		$this->assertEquals( array( 'image/jpeg' => 'image/webp' ), $output_format );
 	}

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -18,6 +18,7 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 		} else {
 			$expect = array( 'image/jpeg' => 'image/webp' );
 		}
+
 		$output_format = apply_filters( 'image_editor_output_format', array(), '', 'image/jpeg' );
 		$this->assertEquals( $expect, $output_format );
 	}

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -7,8 +7,11 @@
  */
 
 class WebP_Uploads_Tests extends WP_UnitTestCase {
+
+	// Filter callback to limit output to WebP for the single output type tests.
 	function return_webp_array() {
-		return array( 'image/webp' ); }
+		return array( 'image/webp' );
+	}
 
 	/**
 	 * Test if webp-uploads applies filter based on system support of WebP.
@@ -85,8 +88,9 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 			// Jpeg images are converted to WebP by default.
 			array( 'image.jpg', 'image/jpeg', array( 'image/jpeg' => 'image/webp' ) ),
 			array( 'another-test-image.jpg', 'image/jpeg', array( 'image/jpeg' => 'image/webp' ) ),
+			array( 'previously-scaled-image.jpg', 'image/jpeg', array( 'image/jpeg' => 'image/webp' ) ),
 
-			// Scaled images are not converted to WebP.
+			// Images with filenames ending in `-scaled.{extension}.` are not converted to WebP.
 			array( 'image-scaled.jpg', 'image/jpeg', array() ),
 			array( 'image-scaled.jpeg', 'image/jpeg', array() ),
 

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -3,6 +3,7 @@
  * Tests for audit-enqueued-assets helper file.
  *
  * @package performance-lab
+ * @group audit-enqueued-assets
  */
 
 class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -3,6 +3,7 @@
  * Tests for audit-enqueued-assets module.
  *
  * @package performance-lab
+ * @group audit-enqueued-assets
  */
 
 class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {


### PR DESCRIPTION
## Summary

When uploading very large images (over the `big_image_size_threshold` filter threshold), WordPress creates a scaled version of the image with the word`-scaled` appended to the file name. It stores a reference to the original image in the image meta `original_image` field, see [this make post](https://make.wordpress.org/core/2019/10/09/introducing-handling-of-big-images-in-wordpress-5-3/#:~:text=The%20default%20threshold%20value%20is,as%20the%20largest%20available%20size.) for more details.

WordPress subsequently uses the "scaled" image as if it were the original in most use cases (only going back to the true original image when editing the image). This causes the mime type shown in the media library for a large jpeg upload to show as image/webp because the scaled image is a WebP.

To fix that, in this PR I skip the `-scaled` image, leaving it in the original format of the uploaded image.

This matches the behavior of uploading a smaller image that isn't over the `big_image_size_threshold`, improving consistency.

Fixes https://github.com/WordPress/performance/issues/67

## Relevant technical choices

* Makes sense that the `scaled` image, which WordPress largely treats as the "original" would remain in the mime type of the upload
* Ensure the behavior is consistent between large and smaller image uploads.
 
## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
