### PR TITLE
[WIP] Generate additional mime types on upload

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -32,7 +32,7 @@ function webp_uploads_filter_image_editor_output_format( $output_format, $filena
 	}
 
 	// Skip conversion when creating the `-scaled` image (for large image uploads).
-	if ( 1 === preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
+	if ( preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
 		return $output_format;
 	}
 

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -11,7 +11,8 @@
 /**
  * Filter the image editor default output format mapping.
  *
- * For uploaded JPEG images, map the default output format to WebP.
+ * Only applies when the image_editor_output_formats filter returns a single mime
+ * type. In that case, the mime type is used as the default output format.
  *
  * @since 1.0.0
  *
@@ -20,22 +21,28 @@
  * @param string $mime_type     The source image mime type.
  * @return string The new output format mapping.
  */
-function webp_uploads_filter_image_editor_output_format( $output_format, $filename, $mime_type ) {
-	// Only enable if the server supports WebP.
-	if ( ! wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {
+function filter_image_editor_output_format( $output_format, $filename, $mime_type ) {
+
+
+	// Only enable if WebP is the only output format.
+	$output_formats = apply_filters( 'image_editor_output_formats', array( 'image/webp', 'image/jpeg' ), $attachment_id, $context );
+	$default_format = $output_formats[0];
+
+	// Only enable if the server supports the output format.
+	if ( ! wp_image_editor_supports( array( 'mime_type' => $default_format ) ) ) {
 		return $output_format;
 	}
 
 	// WebP lossless support is still limited on servers, so only apply to JPEGs.
-	if ( 'image/jpeg' !== $mime_type ) {
+	if ( 'image/webp' === $default_format && 'image/jpeg' !== $mime_type ) {
 		return $output_format;
 	}
 
-	$output_format['image/jpeg'] = 'image/webp';
+	$output_format[ $mime_type ] = $default_format;
 
 	return $output_format;
 }
-add_filter( 'image_editor_output_format', 'webp_uploads_filter_image_editor_output_format', 10, 3 );
+add_filter( 'image_editor_output_format', 'filter_image_editor_output_format', 10, 3 );
 
 /**
  * Create additional mime types with uploaded images by hooking into the 'image_editor_output_formats' filter.

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -23,10 +23,14 @@
  */
 function filter_image_editor_output_format( $output_format, $filename, $mime_type ) {
 
-
-	// Only enable if WebP is the only output format.
-	$output_formats = apply_filters( 'image_editor_output_formats', array( 'image/webp', 'image/jpeg' ), $attachment_id, $context );
+	// Get the default format.
+	$output_formats = apply_filters( 'image_editor_output_formats', array( 'image/webp', 'image/jpeg' ), $filename );
 	$default_format = $output_formats[0];
+
+	// If the file mime and output mime are the same, return the default format.
+	if ( $mime_type === $default_format ) {
+		return $output_format;
+	}
 
 	// Only enable if the server supports the output format.
 	if ( ! wp_image_editor_supports( array( 'mime_type' => $default_format ) ) ) {
@@ -38,11 +42,16 @@ function filter_image_editor_output_format( $output_format, $filename, $mime_typ
 		return $output_format;
 	}
 
-	$output_format[ $mime_type ] = $default_format;
+	// Skip conversion when creating the `-scaled` image (for large image uploads).
+	if ( preg_match( '/-scaled\..{3}.?$/', $filename ) ) {
+		return $output_format;
+	}
+
+	$output_format = array( $mime_type => $default_format );
 
 	return $output_format;
 }
-add_filter( 'image_editor_output_format', 'filter_image_editor_output_format', 10, 3 );
+add_filter( 'image_editor_output_format', 'filter_image_editor_output_format', 9, 3 );
 
 /**
  * Create additional mime types with uploaded images by hooking into the 'image_editor_output_formats' filter.
@@ -55,7 +64,6 @@ add_filter( 'image_editor_output_format', 'filter_image_editor_output_format', 1
  *
  * @since 1.0.0
  *
- *
  * @param array  $metadata      An array of attachment meta data.
  * @param int    $attachment_id Current attachment ID.
  * @param string $context       Additional context. Can be 'create' when metadata was initially created for new attachment
@@ -67,45 +75,99 @@ function filter_wp_generate_attachment_metadata( $metadata, $attachment_id, $con
 	if ( 'create' !== $context ) {
 		return $metadata;
 	}
+	$file = wp_get_original_image_path( $attachment_id );
+
 	/**
 	 * Filter the output image formats.
 	 *
 	 * @since 1.0.0
 	 * @param array  $output_formats The image editor output formats.
- 	 * @param int    $attachment_id  Current attachment ID.
- 	 * @param string $context        Additional context. Can be 'create' when metadata was initially created for new attachment
- 	 *                               or 'update' when the metadata was updated.
+	 * @param string $file           Path to the image.
 	 */
-	$output_formats = apply_filters( 'image_editor_output_formats', array( 'image/webp', 'image/jpeg' ), $attachment_id, $context );
+	$output_formats = apply_filters( 'image_editor_output_formats', array( 'image/webp', 'image/jpeg' ), $file );
+
+	// Create the full sized image in the new format.
+	$editor = wp_get_image_editor( $file );
+	if ( is_wp_error( $editor ) ) {
+		return $metadata;
+	}
+	$upload_mime_type = get_post_mime_type( $attachment_id );
+	$new_sizes        = array();
 
 	// When only a single mime output type is specified, the default mime type will be set
 	// using the 'image_editor_output_format' filter.
 	if ( 1 === sizeof( $output_formats ) ) {
-		return $metadata;
+		// If the output mime type doesn't match the source mime type, convert the
+		// full size image to the new mime type.
+		if ( $upload_mime_type !== $output_formats[0] ) {
+			$extension    = wp_get_default_extension_for_mime_type( $output_formats[0] );
+			$new_metadata = $editor->save( $editor->generate_filename( $extension ) );
+			array_push( $new_sizes, $new_metadata );
+		}
+	} else {
+
+		// Only handle jpeg and webp mime type files.
+		if ( 'image/jpeg' !== $upload_mime_type && 'image/webp' !== $upload_mime_type ) {
+			return $metadata;
+		}
+
+		// Generate the additional mime type images, skipping the first mime type
+		// which has already been created at this point.
+		for ( $i = 1; $i < sizeof( $output_formats ); $i++ ) {
+			$mime_type = $output_formats[ $i ];
+			// If the output mime type doesn't match the source mime type, convert the
+			// full size image to the new mime type.
+			// Generate all sub sizes in the mime type, preventing meta update.
+			$output_use_mime = function() use ( $upload_mime_type, $mime_type ) {
+				return array( $upload_mime_type => $mime_type );
+			};
+
+			// If the mime type doesn't match the original, create a full sized image.
+			if ( $upload_mime_type !== $mime_type ) {
+				// Construct the filename with the format image-{mime-extension}.{mime-extension}.
+				$extension = wp_get_default_extension_for_mime_type( $mime_type );
+				$filename  = $editor->generate_filename( $extension );
+
+				// Output files with the current mime type.
+				add_filter( 'image_editor_output_format', $output_use_mime );
+				$new_metadata = $editor->save( $filename );
+				remove_filter( 'image_editor_output_format', $output_use_mime );
+				array_push( $new_sizes, $new_metadata );
+			}
+
+			// Output files with the current mime type.
+			add_filter( 'image_editor_output_format', $output_use_mime );
+
+			// Don't update meta when creating these images, we will update it later.
+			add_filter( 'wp_update_attachment_metadata', 'use_original_image_meta_data', 10, 2 );
+			$new_metadata = wp_create_image_subsizes( $file, $attachment_id );
+
+			// Remove the filters to set output mime type and prevent meta update.
+			remove_filter( 'image_editor_output_format', $output_use_mime );
+			remove_filter( 'wp_update_attachment_metadata', 'use_original_image_meta_data', 10, 2 );
+
+			array_push( $new_sizes, $new_metadata );
+		}
 	}
 
-	// Only handle jpeg and webp mime type files.
-	$upload_mime_type = get_post_mime_type( $attachment_id );
-	if ( 'image/jpeg' !== $upload_mime_type && 'image/webp' !== $upload_mime_type ) {
-		return $metadata;
+	// Add the additional mime type images to the meta data with the 'sizes->variations' key.
+	if ( ! isset( $metadata['sizes']['variations'] ) ) {
+		$metadata['sizes']['variations'] = array();
 	}
-	$file = wp_get_original_image_path( $attachment_id );
-	$new_sizes = array();
-	// Generate the additional mime type images, skipping the first mime type.
-	for( $i = 1; $i < sizeof( $output_formats ); $i++ ) {
-		$mime_type = $output_formats[ $i ];
-		// Generate all sub sizes in the mime type, preventing meta update.
-		add_filter( 'wp_update_attachment_metadata', 'use_original_image_meta_data', 10, 2 );
-		$metadata = wp_create_image_subsizes( $file, $attachment_id );
-		remove_filter( 'wp_update_attachment_metadata', 'use_original_image_meta_data', 10, 2 );
-		array_push( $new_sizes, $metadata );
-	}
-	error_log( json_encode( $new_sizes, JSON_PRETTY_PRINT));
-	// Add the additional mime type images to the meta data with the 'additional_sizes' key.
+	$metadata['sizes']['variations'] = array_merge( $metadata['sizes']['variations'], $new_sizes );
+
 	return $metadata;
 }
 add_filter( 'wp_generate_attachment_metadata', 'filter_wp_generate_attachment_metadata', 10, 3 );
 
+/**
+ * Shim to prevent core from updating the image meta data when we
+ * create additional mime type images with `wp_create_image_subsizes`.
+ *
+ * @param array $metadata      Array of updated attachment meta data.
+ * @param int   $attachment_id Attachment ID.
+ * @return array $metadata Array of meta data.
+ */
 function use_original_image_meta_data( $metadata, $attachment_id ) {
 	$original_image_meta = wp_get_attachment_metadata( $attachment_id );
 	if ( ! empty( $original_image_meta ) ) {

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -37,3 +37,72 @@ function webp_uploads_filter_image_editor_output_format( $output_format, $filena
 }
 add_filter( 'image_editor_output_format', 'webp_uploads_filter_image_editor_output_format', 10, 3 );
 
+/**
+ * Create additional mime types with uploaded images by hooking into the 'image_editor_output_formats' filter.
+ *
+ * Behavior is filterable with a 'image_editor_output_formats' filter that determines
+ * the mime types to add. The filter returns an array of mime types - the first
+ * mime type is used as the default sub size type and added to the image meta 'sizes'
+ * array. If a large image is uploaded, the '-scaled' version of the image will always
+ * use the same mime type as the original uploaded image.
+ *
+ * @since 1.0.0
+ *
+ *
+ * @param array  $metadata      An array of attachment meta data.
+ * @param int    $attachment_id Current attachment ID.
+ * @param string $context       Additional context. Can be 'create' when metadata was initially created for new attachment
+ *                              or 'update' when the metadata was updated.
+ */
+function filter_wp_generate_attachment_metadata( $metadata, $attachment_id, $context ) {
+
+	// @TODO Handle update context.
+	if ( 'create' !== $context ) {
+		return $metadata;
+	}
+	/**
+	 * Filter the output image formats.
+	 *
+	 * @since 1.0.0
+	 * @param array  $output_formats The image editor output formats.
+ 	 * @param int    $attachment_id  Current attachment ID.
+ 	 * @param string $context        Additional context. Can be 'create' when metadata was initially created for new attachment
+ 	 *                               or 'update' when the metadata was updated.
+	 */
+	$output_formats = apply_filters( 'image_editor_output_formats', array( 'image/webp', 'image/jpeg' ), $attachment_id, $context );
+
+	// When only a single mime output type is specified, the default mime type will be set
+	// using the 'image_editor_output_format' filter.
+	if ( 1 === sizeof( $output_formats ) ) {
+		return $metadata;
+	}
+
+	// Only handle jpeg and webp mime type files.
+	$upload_mime_type = get_post_mime_type( $attachment_id );
+	if ( 'image/jpeg' !== $upload_mime_type && 'image/webp' !== $upload_mime_type ) {
+		return $metadata;
+	}
+	$file = wp_get_original_image_path( $attachment_id );
+	$new_sizes = array();
+	// Generate the additional mime type images, skipping the first mime type.
+	for( $i = 1; $i < sizeof( $output_formats ); $i++ ) {
+		$mime_type = $output_formats[ $i ];
+		// Generate all sub sizes in the mime type, preventing meta update.
+		add_filter( 'wp_update_attachment_metadata', 'use_original_image_meta_data', 10, 2 );
+		$metadata = wp_create_image_subsizes( $file, $attachment_id );
+		remove_filter( 'wp_update_attachment_metadata', 'use_original_image_meta_data', 10, 2 );
+		array_push( $new_sizes, $metadata );
+	}
+	error_log( json_encode( $new_sizes, JSON_PRETTY_PRINT));
+	// Add the additional mime type images to the meta data with the 'additional_sizes' key.
+	return $metadata;
+}
+add_filter( 'wp_generate_attachment_metadata', 'filter_wp_generate_attachment_metadata', 10, 3 );
+
+function use_original_image_meta_data( $metadata, $attachment_id ) {
+	$original_image_meta = wp_get_attachment_metadata( $attachment_id );
+	if ( ! empty( $original_image_meta ) ) {
+		return $original_image_meta;
+	}
+	return $metadata;
+}

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -32,7 +32,7 @@ function webp_uploads_filter_image_editor_output_format( $output_format, $filena
 	}
 
 	// Skip conversion when creating the `-scaled` image (for large image uploads).
-	if ( preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
+	if ( preg_match( '/-scaled\..{3}.?$/', $filename ) ) {
 		return $output_format;
 	}
 

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -31,6 +31,11 @@ function webp_uploads_filter_image_editor_output_format( $output_format, $filena
 		return $output_format;
 	}
 
+	// Skip conversion when creating the `-scaled` image (for large image uploads).
+	if ( 1 === preg_match( '/.*-scaled\..{3}.?$/', $filename ) ) {
+		return $output_format;
+	}
+
 	$output_format['image/jpeg'] = 'image/webp';
 
 	return $output_format;

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -29,7 +29,7 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 	function test_webp_uploads_filter_image_editor_output_format_with_support() {
 		// Mock a system that supports WebP.
 		add_filter( 'wp_image_editors', array( $this, 'mock_wp_image_editor_supports' ) );
-		$output_format = webp_uploads_filter_image_editor_output_format( array(), '', 'image/jpeg' );
+		$output_format = filter_image_editor_output_format( array(), '', 'image/jpeg' );
 		$this->assertEquals( array( 'image/jpeg' => 'image/webp' ), $output_format );
 	}
 
@@ -39,7 +39,7 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 	function test_webp_uploads_filter_image_editor_output_format_without_support() {
 		// Mock a system that doesn't support WebP.
 		add_filter( 'wp_image_editors', array( $this, 'mock_wp_image_editor_doesnt_support' ) );
-		$output_format = webp_uploads_filter_image_editor_output_format( array(), '', 'image/jpeg' );
+		$output_format = filter_image_editor_output_format( array(), '', 'image/jpeg' );
 		$this->assertEquals( array(), $output_format );
 	}
 
@@ -60,7 +60,7 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the webp_uploads_filter_image_editor_output_format callback
+	 * Test that the filter_image_editor_output_format callback
 	 * properly catches filenames ending in `-scaled.{extension}.`.
 	 *
 	 * @dataProvider data_provider_webp_uploads_filter_image_editor_output_format_with_scaled_filename
@@ -68,7 +68,7 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 	function test_webp_uploads_filter_image_editor_output_format_with_scaled_filename( $filename, $mime_type, $expect ) {
 		// Mock a system that supports WebP.
 		add_filter( 'wp_image_editors', array( $this, 'mock_wp_image_editor_supports' ) );
-		$output_format = webp_uploads_filter_image_editor_output_format( array(), $filename, $mime_type );
+		$output_format = filter_image_editor_output_format( array(), $filename, $mime_type );
 		$this->assertEquals( $expect, $output_format );
 	}
 

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -8,11 +8,6 @@
 
 class WebP_Uploads_Tests extends WP_UnitTestCase {
 
-	// Filter callback to limit output to WebP for the single output type tests.
-	function return_webp_array() {
-		return array( 'image/webp' );
-	}
-
 	/**
 	 * Test if webp-uploads applies filter based on system support of WebP.
 	 */
@@ -23,9 +18,6 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 		} else {
 			$expect = array( 'image/jpeg' => 'image/webp' );
 		}
-		// The image_editor_output_format filter is only applied if image_editor_output_format
-		// has fewer than two types.
-		add_filter( 'image_editor_output_formats', array( $this, 'return_webp_array' ) );
 		$output_format = apply_filters( 'image_editor_output_format', array(), '', 'image/jpeg' );
 		$this->assertEquals( $expect, $output_format );
 	}
@@ -36,7 +28,6 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 	function test_webp_uploads_filter_image_editor_output_format_with_support() {
 		// Mock a system that supports WebP.
 		add_filter( 'wp_image_editors', array( $this, 'mock_wp_image_editor_supports' ) );
-		add_filter( 'image_editor_output_formats', array( $this, 'return_webp_array' ) );
 		$output_format = webp_uploads_filter_image_editor_output_format( array(), '', 'image/jpeg' );
 		$this->assertEquals( array( 'image/jpeg' => 'image/webp' ), $output_format );
 	}

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -18,6 +18,7 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 		} else {
 			$expect = array( 'image/jpeg' => 'image/webp' );
 		}
+
 		$output_format = apply_filters( 'image_editor_output_format', array(), '', 'image/jpeg' );
 		$this->assertEquals( $expect, $output_format );
 	}

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -7,8 +7,11 @@
  */
 
 class WebP_Uploads_Tests extends WP_UnitTestCase {
+
+	// Filter callback to limit output to WebP for the single output type tests.
 	function return_webp_array() {
-		return array( 'image/webp' ); }
+		return array( 'image/webp' );
+	}
 
 	/**
 	 * Test if webp-uploads applies filter based on system support of WebP.
@@ -85,8 +88,9 @@ class WebP_Uploads_Tests extends WP_UnitTestCase {
 			// Jpeg images are converted to WebP by default.
 			array( 'image.jpg', 'image/jpeg', array( 'image/jpeg' => 'image/webp' ) ),
 			array( 'another-test-image.jpg', 'image/jpeg', array( 'image/jpeg' => 'image/webp' ) ),
+			array( 'previously-scaled-image.jpg', 'image/jpeg', array( 'image/jpeg' => 'image/webp' ) ),
 
-			// Scaled images are not converted to WebP.
+			// Images with filenames ending in `-scaled.{extension}.` are not converted to WebP.
 			array( 'image-scaled.jpg', 'image/jpeg', array() ),
 			array( 'image-scaled.jpeg', 'image/jpeg', array() ),
 

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -3,6 +3,7 @@
  * Tests for audit-enqueued-assets helper file.
  *
  * @package performance-lab
+ * @group audit-enqueued-assets
  */
 
 class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -3,6 +3,7 @@
  * Tests for audit-enqueued-assets module.
  *
  * @package performance-lab
+ * @group audit-enqueued-assets
  */
 
 class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {


### PR DESCRIPTION
## Summary
* Add a new filter `image_editor_output_formats` that returns the output formats and their order. The first type is used as the default output format
* The default `image_editor_output_format` filter applies for the first mime type, which also creates a full sized image if not the dame mime type as the uploaded image.
* New sub sizes **and** a full sized image are created for each mime type in the returned array

## Usage
By default, this code will generate WebP and jpeg sub sizes for every uploaded image, with WebP as the default.
* Adding add_filter( 'image_editor_output_formats', '__return_false' ); would ensure only the uploaded mime type would be use for sub sizes (current WordPress behavior).
* Adding add_filter( 'image_editor_output_formats', function() { return array( 'image/jpeg', 'image/webp' ); } ); would ensure jpeg and WebP were generated, with jpeg stored in sizes and used as the default output format
* Adding add_filter( 'image_editor_output_formats', function() { return array( 'image/webp' ); } ); would ensure only WebP sub sizes were generated (current behavior of the webp-uploads module).



Fixes #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
