### PR TITLE
Enable all non-experimental modules on plugin activation

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -344,7 +344,7 @@ function perflab_get_module_data( $module_file ) {
  */
 function perflab_activation_hook() {
 	// Bail if option is already set with any value.
-	if ( false !== get_option( PERFLAB_MODULES_SETTING, false ) ) {
+	if ( get_option( PERFLAB_MODULES_SETTING, false ) ) {
 		return;
 	}
 

--- a/admin/load.php
+++ b/admin/load.php
@@ -336,3 +336,23 @@ function perflab_get_module_data( $module_file ) {
 
 	return $module_data;
 }
+
+/**
+ * Enable all non-experimental modules on plugin activation.
+ *
+ * @since 1.0.0
+ */
+function perflab_activation_hook() {
+	$modules          = perflab_get_modules();
+	$modules_settings = perflab_get_module_settings();
+
+	foreach ( $modules as $module_name => $module_data ) {
+		if ( ! $module_data['experimental'] ) {
+			$modules_settings[ $module_name ]['enabled'] = true;
+		}
+	}
+
+	update_option( PERFLAB_MODULES_SETTING, $modules_settings );
+}
+
+register_activation_hook( __FILE__, 'perflab_activation_hook' );

--- a/admin/load.php
+++ b/admin/load.php
@@ -344,7 +344,7 @@ function perflab_get_module_data( $module_file ) {
  */
 function perflab_activation_hook() {
 	// Bail if option is already set with any value.
-	if ( get_option( PERFLAB_MODULES_SETTING, false ) ) {
+	if ( false !== get_option( PERFLAB_MODULES_SETTING, false ) ) {
 		return;
 	}
 

--- a/admin/load.php
+++ b/admin/load.php
@@ -343,6 +343,11 @@ function perflab_get_module_data( $module_file ) {
  * @since 1.0.0
  */
 function perflab_activation_hook() {
+	// Bail if option is already set with any value.
+	if ( false !== get_option( PERFLAB_MODULES_SETTING, false ) ) {
+		return;
+	}
+
 	$modules          = perflab_get_modules();
 	$modules_settings = perflab_get_module_settings();
 

--- a/admin/load.php
+++ b/admin/load.php
@@ -348,11 +348,11 @@ function perflab_activation_hook() {
 
 	foreach ( $modules as $module_name => $module_data ) {
 		if ( ! $module_data['experimental'] ) {
-			$modules_settings[ $module_name ]['enabled'] = true;
+			$modules_settings[ $module_name ] = array( 'enabled' => true );
 		}
 	}
 
 	update_option( PERFLAB_MODULES_SETTING, $modules_settings );
 }
 
-register_activation_hook( __FILE__, 'perflab_activation_hook' );
+register_activation_hook( dirname( __DIR__ ) . '/load.php', 'perflab_activation_hook' );


### PR DESCRIPTION
## Summary

Fixes #61. Enable all non-experimental modules on plugin activation.

Fix is quiet simple so there isn't much to explain here.