### PR TITLE
Include generated module-i18n.php file in repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,6 @@ nbproject/
 ############
 
 build
-module-i18n.php
 
 ############
 ## Vendor

--- a/module-i18n.php
+++ b/module-i18n.php
@@ -3,11 +3,11 @@
 $generated_i18n_strings = array(
 	_x( 'WebP Uploads', 'module name', 'performance-lab' ),
 	_x( 'Creates WebP versions for new JPEG image uploads if supported by the server.', 'module description', 'performance-lab' ),
-	_x( 'Web Support', 'module name', 'performance-lab' ),
-	_x( 'Adds a WebP support check in Site Health status.', 'module description', 'performance-lab' ),
-	_x( 'Audit Enqueued Assets', 'module name', 'performance-lab' ),
-	_x( 'Adds a CSS and JS resource check in Site Health status.', 'module description', 'performance-lab' ),
 	_x( 'Persistent Object Cache Health Check', 'module name', 'performance-lab' ),
 	_x( 'Adds a persistent object cache check for sites with non-trivial amounts of data in Site Health status.', 'module description', 'performance-lab' ),
+	_x( 'Audit Enqueued Assets', 'module name', 'performance-lab' ),
+	_x( 'Adds a CSS and JS resource check in Site Health status.', 'module description', 'performance-lab' ),
+	_x( 'WebP Support', 'module name', 'performance-lab' ),
+	_x( 'Adds a WebP support check in Site Health status.', 'module description', 'performance-lab' ),
 );
 /* THIS IS THE END OF THE GENERATED FILE */

--- a/module-i18n.php
+++ b/module-i18n.php
@@ -1,0 +1,13 @@
+<?php
+/* THIS IS A GENERATED FILE. DO NOT EDIT DIRECTLY. */
+$generated_i18n_strings = array(
+	_x( 'WebP Uploads', 'module name', 'performance-lab' ),
+	_x( 'Creates WebP versions for new JPEG image uploads if supported by the server.', 'module description', 'performance-lab' ),
+	_x( 'Web Support', 'module name', 'performance-lab' ),
+	_x( 'Adds a WebP support check in Site Health status.', 'module description', 'performance-lab' ),
+	_x( 'Audit Enqueued Assets', 'module name', 'performance-lab' ),
+	_x( 'Adds a CSS and JS resource check in Site Health status.', 'module description', 'performance-lab' ),
+	_x( 'Persistent Object Cache Health Check', 'module name', 'performance-lab' ),
+	_x( 'Adds a persistent object cache check for sites with non-trivial amounts of data in Site Health status.', 'module description', 'performance-lab' ),
+);
+/* THIS IS THE END OF THE GENERATED FILE */

--- a/modules/site-health/webp-support/load.php
+++ b/modules/site-health/webp-support/load.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Web Support
+ * Module Name: WebP Support
  * Description: Adds a WebP support check in Site Health status.
  * Experimental: No
  *


### PR DESCRIPTION
## Summary

#59 introduced a generated `module-i18n.php` file that contains all the available module names and descriptions so that these are recognized as translatable strings in the plugin repository. This file was originally `.gitignore`d, however that was not fully thought through.

The [release instructions](https://github.com/WordPress/performance/blob/trunk/docs/Releasing-the-plugin.md#update-translation-strings) state that updating these strings is part of the release tasks, and our automated deployment task relies on all relevant files being part of the repository.

So, while this is a generated file, we should still include it in the repository. This makes deployment straightforward, as without this PR the plugin would be missing the file. The change furthermore ensures that the plugin still works even when somebody downloads it manually from GitHub as a ZIP file.

## Relevant technical choices

* Remove `module-i18n.php` from `.gitignore`.
* Fix typo in `Web Support` module name (should be `WebP Support`).
* Make sure all strings in the file are their latest versions (by running `npm run translations`).

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
