### PR TITLE
Add link to Settings screen to the plugin's entry in plugins list table

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -24,8 +24,10 @@ function perflab_add_modules_page() {
 		'perflab_render_modules_page'
 	);
 
+	// Add the following hooks only if the screen was successfully added.
 	if ( false !== $hook_suffix ) {
 		add_action( "load-{$hook_suffix}", 'perflab_load_modules_page', 10, 0 );
+		add_action( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ), 'perflab_plugin_action_links_add_settings' );
 	}
 
 	return $hook_suffix;
@@ -335,4 +337,27 @@ function perflab_get_module_data( $module_file ) {
 	}
 
 	return $module_data;
+}
+
+/**
+ * Adds a link to the modules page to the plugin's entry in the plugins list table.
+ *
+ * This function is only used if the modules page exists and is accessible.
+ *
+ * @since 1.0.0
+ * @see perflab_add_modules_page()
+ *
+ * @param array $links List of plugin action links HTML.
+ * @return array Modified list of plugin action links HTML.
+ */
+function perflab_plugin_action_links_add_settings( $links ) {
+	// Add link as the first plugin action link.
+	$settings_link = sprintf(
+		'<a href="%s">%s</a>',
+		esc_url( add_query_arg( 'page', PERFLAB_MODULES_SCREEN, admin_url( 'options-general.php' ) ) ),
+		esc_html__( 'Settings', 'performance-lab' )
+	);
+	array_unshift( $links, $settings_link );
+
+	return $links;
 }

--- a/load.php
+++ b/load.php
@@ -13,6 +13,7 @@
  */
 
 define( 'PERFLAB_VERSION', '1.0.0-beta.1' );
+define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );
 define( 'PERFLAB_MODULES_SCREEN', 'perflab-modules' );
 


### PR DESCRIPTION
## Summary

Fixes #192

## Relevant technical choices

* Add link to Settings / module screen _if_ it is available.
* To do that reliably, the new action is only added if the screen was added successfully.

Screenshot:
<img width="1062" alt="Screen Shot 2022-02-28 at 2 31 53 PM" src="https://user-images.githubusercontent.com/3531426/156069720-9ea04535-acc3-403f-88ac-f46c8fc29587.png">

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
