### PR TITLE
Add plugin author URI pointing to relevant make.wordpress.org blog

### DIFF
--- a/load.php
+++ b/load.php
@@ -8,6 +8,8 @@
  * Version: 1.0.0-beta.1
  * Author: WordPress Performance Group
  * Author URI: https://make.wordpress.org/core/tag/performance/
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: performance-lab
  *
  * @package performance-lab

--- a/load.php
+++ b/load.php
@@ -7,6 +7,7 @@
  * Requires PHP: 5.6
  * Version: 1.0.0-beta.1
  * Author: WordPress Performance Group
+ * Author URI: https://make.wordpress.org/core/tag/performance/
  * Text Domain: performance-lab
  *
  * @package performance-lab


### PR DESCRIPTION
## Summary

This PR adds an `Author URI` link to the plugin main file that points to https://make.wordpress.org/core/tag/performance/. Right now there is no link there, and providing one like this will allow interested parties to find out more on the performance team.

The PR also adds license information to the plugin header, which had been missing so far.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
