### PR TITLE
Always recommend object cache on multisite

### DIFF
--- a/modules/object-cache/persistent-object-cache-health-check/load.php
+++ b/modules/object-cache/persistent-object-cache-health-check/load.php
@@ -138,6 +138,10 @@ function perflab_oc_health_persistent_object_cache() {
 function perflab_oc_health_should_persistent_object_cache() {
 	global $wpdb;
 
+	if ( is_multisite() ) {
+		return true;
+	}
+
 	/**
 	 * Filter to force suggestion to use a persistent object cache and bypass threshold checks.
 	 *

--- a/modules/object-cache/persistent-object-cache-health-check/load.php
+++ b/modules/object-cache/persistent-object-cache-health-check/load.php
@@ -74,7 +74,7 @@ function perflab_oc_health_persistent_object_cache() {
 		return $result;
 	}
 
-	if ( ! perflab_oc_health_should_persistent_object_cache() ) {
+	if ( ! perflab_oc_health_should_suggest_persistent_object_cache() ) {
 		$result['label'] = __( 'A persistent object cache is not required', 'performance-lab' );
 
 		return $result;
@@ -135,7 +135,7 @@ function perflab_oc_health_persistent_object_cache() {
  *
  * @return bool Whether to suggest using a persistent object cache.
  */
-function perflab_oc_health_should_persistent_object_cache() {
+function perflab_oc_health_should_suggest_persistent_object_cache() {
 	global $wpdb;
 
 	if ( is_multisite() ) {

--- a/tests/modules/object-cache/persistent-object-cache-health-check/health-check-test.php
+++ b/tests/modules/object-cache/persistent-object-cache-health-check/health-check-test.php
@@ -13,7 +13,7 @@ class Object_Cache_Health_Check_Tests extends WP_UnitTestCase {
 	 */
 	function test_object_cache_default_thresholds() {
 		$this->assertFalse(
-			perflab_oc_health_should_persistent_object_cache()
+			perflab_oc_health_should_suggest_persistent_object_cache()
 		);
 	}
 
@@ -22,7 +22,7 @@ class Object_Cache_Health_Check_Tests extends WP_UnitTestCase {
 	 */
 	function test_object_cache_default_thresholds_on_multisite() {
 		$this->assertTrue(
-			perflab_oc_health_should_persistent_object_cache()
+			perflab_oc_health_should_suggest_persistent_object_cache()
 		);
 	}
 
@@ -30,7 +30,7 @@ class Object_Cache_Health_Check_Tests extends WP_UnitTestCase {
 		add_filter( 'perflab_oc_site_status_suggest_persistent_object_cache', '__return_true' );
 
 		$this->assertTrue(
-			perflab_oc_health_should_persistent_object_cache()
+			perflab_oc_health_should_suggest_persistent_object_cache()
 		);
 	}
 
@@ -46,7 +46,7 @@ class Object_Cache_Health_Check_Tests extends WP_UnitTestCase {
 		);
 
 		$this->assertTrue(
-			perflab_oc_health_should_persistent_object_cache()
+			perflab_oc_health_should_suggest_persistent_object_cache()
 		);
 	}
 

--- a/tests/modules/object-cache/persistent-object-cache-health-check/health-check-test.php
+++ b/tests/modules/object-cache/persistent-object-cache-health-check/health-check-test.php
@@ -20,7 +20,7 @@ class Object_Cache_Health_Check_Tests extends WP_UnitTestCase {
 	/**
 	 * @group ms-required
 	 */
-	function test_object_cache_default_thresholds() {
+	function test_object_cache_default_thresholds_on_multisite() {
 		$this->assertTrue(
 			perflab_oc_health_should_persistent_object_cache()
 		);

--- a/tests/modules/object-cache/persistent-object-cache-health-check/health-check-test.php
+++ b/tests/modules/object-cache/persistent-object-cache-health-check/health-check-test.php
@@ -8,8 +8,20 @@
 
 class Object_Cache_Health_Check_Tests extends WP_UnitTestCase {
 
+	/**
+	 * @group ms-excluded
+	 */
 	function test_object_cache_default_thresholds() {
 		$this->assertFalse(
+			perflab_oc_health_should_persistent_object_cache()
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	function test_object_cache_default_thresholds() {
+		$this->assertTrue(
 			perflab_oc_health_should_persistent_object_cache()
 		);
 	}


### PR DESCRIPTION
## Summary

This is a followup to #111 and resolves #161.

A @spacedmonkey suggested, multisite greatly benefits from object caching, due to the extra queries to bootstrap WordPress.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
