### PR TITLE
Add missing release instructions reference to docs TOC.

### DIFF
--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -1,3 +1,5 @@
+[Back to overview](./README.md)
+
 # Start contributing to the Performance plugin
 This guide focuses on how to contribute to the Performance plugin, from setting up the development environment to creating pull requests.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,5 @@
 # Documentation
 
-* [Getting Started](./Getting-started.md)
+* [Getting started](./Getting-started.md)
 * [Writing a module](./Writing-a-module.md)
+* [Releasing the plugin](./Releasing-the-plugin.md)

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -1,3 +1,5 @@
+[Back to overview](./README.md)
+
 # Releasing the performance plugin
 
 This document describes the steps to release the Performance plugin.


### PR DESCRIPTION
## Summary

* Adds a link to the "Releasing the plugin" documentation to the `/docs` table of contents, which has been missing.
* Adds links back to the `/docs` table of contents from the two documentation entries which were missing that.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
