### PR TITLE
Run all relevant GitHub workflows for release branches as well

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - 'release/**'
     # Only run if JS/JSON/Lint/NVM files changed.
     paths:
       - '.github/workflows/js-lint.yml'
@@ -16,6 +17,7 @@ on:
   pull_request:
     branches:
       - trunk
+      - 'release/**'
     # Only run if JS/JSON/Lint/NVM files changed.
     paths:
       - '.github/workflows/js-lint.yml'

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - 'release/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-lint.yml'
@@ -14,6 +15,7 @@ on:
   pull_request:
     branches:
       - trunk
+      - 'release/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-lint.yml'

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - 'release/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test.yml'
@@ -15,6 +16,7 @@ on:
   pull_request:
     branches:
       - trunk
+      - 'release/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test.yml'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - trunk
+      - 'release/**'
     types:
       - labeled
       - unlabeled


### PR DESCRIPTION
## Summary

Our GitHub workflows are currently configured to only run on the `trunk` branch. However, since part of our documented workflows is using `release/{milestoneName}` branches for releases, we should support the workflows as well when working against such branches, e.g. close to a release.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
