### PR TITLE
Fix typo to access to the correct image properties

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -169,14 +169,14 @@ function webp_uploads_generate_image_size( $attachment_id, $size, $mime ) {
 
 	if ( isset( $metadata['sizes'][ $size ]['width'] ) ) {
 		$width = $metadata['sizes'][ $size ]['width'];
-	} elseif ( isset( $sizes[ $size ]['widht'] ) ) {
-		$width = $sizes[ $size ];
+	} elseif ( isset( $sizes[ $size ]['width'] ) ) {
+		$width = $sizes[ $size ]['width'];
 	}
 
 	if ( isset( $metadata['sizes'][ $size ]['height'] ) ) {
 		$height = $metadata['sizes'][ $size ]['height'];
-	} elseif ( isset( $sizes[ $size ]['width'] ) ) {
-		$height = $sizes[ $size ];
+	} elseif ( isset( $sizes[ $size ]['height'] ) ) {
+		$height = $sizes[ $size ]['height'];
 	}
 
 	if ( isset( $sizes[ $size ]['crop'] ) ) {


### PR DESCRIPTION
## Summary

For the most part the `elseif` block won't be reached still in the event that it is, the properties were incorrectly accessed.

Fixes #142 

## Relevant technical choices

- Fixed a typo for the `width` property it was being accessed as `widht` 
- Make sure the right property was accessed for the height
- Make sure the right property was accessed for the width

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
