### PR TITLE
Include `memcached` extension in checks for object cache support

### DIFF
--- a/modules/object-cache/persistent-object-cache-health-check/load.php
+++ b/modules/object-cache/persistent-object-cache-health-check/load.php
@@ -231,7 +231,8 @@ function perflab_oc_health_available_object_cache_services() {
 			'APCu'      => 'apcu',
 			'Redis'     => 'redis',
 			'Relay'     => 'relay',
-			'Memcached' => 'memcache', // The `memcached` extension seems unmaintained.
+			'Memcache'  => 'memcache',
+			'Memcached' => 'memcached',
 		)
 	);
 


### PR DESCRIPTION
## Summary

Add `memcached` extension. It looks like Remi is now maintaining it-ish?

https://github.com/php-memcached-dev/php-memcached/issues/495#issuecomment-1060682169

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
