### PR TITLE
Update documentation with minor tweaks around plugin name and branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Performance Lab
+![banner-1544x500](https://user-images.githubusercontent.com/3531426/159084476-af352db4-192e-4927-a383-7f76bb3641df.png)
 
 Monorepo for the [WordPress Performance Group](https://make.wordpress.org/core/tag/performance/), primarily for the Performance Lab plugin, which is a collection of standalone performance modules.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# WordPress Performance
+# Performance Lab
 
-Monorepo for the [WordPress Performance Group](https://make.wordpress.org/core/tag/performance/), primarily for the overall performance plugin, which is a collection of standalone performance modules.
+Monorepo for the [WordPress Performance Group](https://make.wordpress.org/core/tag/performance/), primarily for the Performance Lab plugin, which is a collection of standalone performance modules.
 
 ## Useful commands
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Performance Lab
-![banner-1544x500](https://user-images.githubusercontent.com/3531426/159084476-af352db4-192e-4927-a383-7f76bb3641df.png)
+![Performance Lab plugin banner with icon](https://user-images.githubusercontent.com/3531426/159084476-af352db4-192e-4927-a383-7f76bb3641df.png)
 
 Monorepo for the [WordPress Performance Group](https://make.wordpress.org/core/tag/performance/), primarily for the Performance Lab plugin, which is a collection of standalone performance modules.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Monorepo for the [WordPress Performance Group](https://make.wordpress.org/core/tag/performance/), primarily for the Performance Lab plugin, which is a collection of standalone performance modules.
 
+[Learn more about the Performance Lab plugin.](https://make.wordpress.org/core/2022/03/07/the-performance-lab-plugin-has-been-released/)
+
 ## Useful commands
 
 In order to run the following commands, you need to have [Node.js](https://nodejs.org) (including `npm`) and [Docker](https://www.docker.com) installed, and Docker needs to be up and running. The Docker configuration used relies on the [`@wordpress/env` package](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/).

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -1,7 +1,7 @@
 [Back to overview](./README.md)
 
-# Start contributing to the Performance plugin
-This guide focuses on how to contribute to the Performance plugin, from setting up the development environment to creating pull requests.
+# Start contributing to the Performance Lab plugin
+This guide focuses on how to contribute to the Performance Lab plugin, from setting up the development environment to creating pull requests.
 
 ## Prerequisites
 - [Node.js](https://nodejs.org)
@@ -23,7 +23,7 @@ npm install
 ```
 
 ### Start the local WordPress environment
-The Performance plugin uses Docker and [the wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env) to start a local WordPress environment.
+The Performance Lab plugin uses Docker and [the wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env) to start a local WordPress environment.
 
 First, make sure Docker is installed, up and running on your machine. Then, run `npm run wp-env start` to start the WordPress environment. The WordPress development site will be available at `http://localhost:8080`.
 
@@ -34,20 +34,20 @@ npm run wp-env stop
 ```
 
 ## Open an issue
-Opening an issue is the first step to contributing to the Performance plugin. This allows to discuss, review or validate an idea before implementation. It is not a strict requirement, but it is highly recommended in most cases, unless the change you are trying to make is really minor or is already covered by an existing issue.
+Opening an issue is the first step to contributing to the Performance Lab plugin. This allows to discuss, review or validate an idea before implementation. It is not a strict requirement, but it is highly recommended in most cases, unless the change you are trying to make is really minor or is already covered by an existing issue.
 
 Issues should be labeled to facilitate browsing and filtering. Here are some common labels: `[Type] Feature`, `[Type] Discussion`, `Needs Decision`, `[Focus] Images`. The full list of labels can be found [here](https://github.com/WordPress/performance/labels).
 
 ## Create a pull request
-A pull request must be created to submit changes to the Performance plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance/issues).
+A pull request must be created to submit changes to the Performance Lab plugin. Pull requests should refer to an issue in the [repository issue tracker](https://github.com/WordPress/performance/issues).
 
 Every pull-request should receive both a `[Type] xyz` label and either a `[Focus] xyz` or `Infrastructure` label.
 
 ## Coding standards
-In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). For a complete documentation about Performance plugin modules specifications, read this [documentation](./Writing-a-module.md).
+In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). For a complete documentation about Performance Lab plugin modules specifications, read this [documentation](./Writing-a-module.md).
 
 ### WordPress and PHP compatibility
-All code in the Performance plugin must follow theses requirements:
+All code in the Performance Lab plugin must follow theses requirements:
 - **WordPress**: the latest release is the minimum required version. Right now, the plugin is compatible with WordPress 5.8.
 - **PHP**: always match the latest WordPress version. The minimum required version right now is 5.6.
 

--- a/docs/Releasing-the-plugin.md
+++ b/docs/Releasing-the-plugin.md
@@ -1,8 +1,8 @@
 [Back to overview](./README.md)
 
-# Releasing the performance plugin
+# Releasing the Performance Lab plugin
 
-This document describes the steps to release the Performance plugin.
+This document describes the steps to release the Performance Lab plugin.
 
 ## Branching off `trunk`
 

--- a/docs/Writing-a-module.md
+++ b/docs/Writing-a-module.md
@@ -2,23 +2,23 @@
 
 # Writing a module
 
-Modules in the performance plugin share various similarities with WordPress plugins:
+Modules in the Performance Lab plugin share various similarities with WordPress plugins:
 
 * They must have a slug, a name, and a short description.
 * They must function 100% standalone.
 * They must have an entry point file that initializes the module.
 * Their entry point file must contain a specific header comment with meta information about the module.
 
-Every module surfaces on the admin settings page of the performance plugin, where it can be enabled or disabled.
+Every module surfaces on the admin settings page of the Performance Lab plugin, where it can be enabled or disabled.
 
 ## Module requirements
 
-* The production code for a module must all be located in a directory `/modules/{focus}/{module-slug}` where `{module-slug}` is the module's slug and `{focus}` is the focus area: an identifier of a single focus (e.g. `images`). This should correspond to a section on the performance plugin's settings page. [See the `perflab_get_focus_areas()` function for the currently available focus areas.](../admin/load.php#L161)
+* The production code for a module must all be located in a directory `/modules/{focus}/{module-slug}` where `{module-slug}` is the module's slug and `{focus}` is the focus area: an identifier of a single focus (e.g. `images`). This should correspond to a section on the Performance Lab plugin's settings page. [See the `perflab_get_focus_areas()` function for the currently available focus areas.](../admin/load.php#L161)
 * The entry point file must be called `load.php` and per the above be located at `/modules/{focus}/{module-slug}/load.php`.
 * The `load.php` entry point file must contain a module header with the following fields:
-    * `Module Name`: Name of the module (comparable to `Plugin Name` for plugins). It will be displayed on the performance plugin's settings page.
-    * `Description`: Brief description of the module (comparable to `Description` for plugins). It will be displayed next to the module name on the performance plugin's settings page.
-    * `Experimental`: Either `Yes` or `No`. If `Yes`, the module will be marked as explicitly experimental on the performance plugin's settings page. While all modules are somewhat experimental (similar to feature plugins), for some that may apply more than for others. For example, certain modules we would encourage limited testing in production for, where we've already established a certain level of reliability/quality, in other cases modules shouldn't be used in production at all.
+    * `Module Name`: Name of the module (comparable to `Plugin Name` for plugins). It will be displayed on the Performance Lab plugin's settings page.
+    * `Description`: Brief description of the module (comparable to `Description` for plugins). It will be displayed next to the module name on the Performance Lab plugin's settings page.
+    * `Experimental`: Either `Yes` or `No`. If `Yes`, the module will be marked as explicitly experimental on the Performance Lab plugin's settings page. While all modules are somewhat experimental (similar to feature plugins), for some that may apply more than for others. For example, certain modules we would encourage limited testing in production for, where we've already established a certain level of reliability/quality, in other cases modules shouldn't be used in production at all.
 * The module must neither rely on any PHP code from outside its directory nor on any external PHP code. If relying on an external PHP dependency is essential for a module, the approach should be evaluated and discussed with the wider team.
 * The module must use the `performance-lab` text domain for all of its localizable strings.
 * All global code structures in the module PHP codebase must be prefixed (e.g. with a string based on the module slug) to avoid conflicts with other modules or plugins.
@@ -30,7 +30,7 @@ Every module surfaces on the admin settings page of the performance plugin, wher
 
 * Modules should be written with a future WordPress core merge in mind and therefore use coding patterns already established in WordPress core. For this reason, using PHP language features like autoloaders, interfaces, or traits is discouraged unless they are truly needed for the respective module.
 * Modules should always be accompanied by tests, preferably covering every function and class method.
-* Modules should refrain from including infrastructure tooling such as build scripts, Docker containers etc. When such functionalities are needed, they should be implemented in a central location in the performance plugin, in a way that they can be reused by other modules as well - one goal of the performance plugin is to minimize the infrastructure code duplication that is often seen between different projects today.
+* Modules should refrain from including infrastructure tooling such as build scripts, Docker containers etc. When such functionalities are needed, they should be implemented in a central location in the Performance Lab plugin, in a way that they can be reused by other modules as well - one goal of the Performance Lab plugin is to minimize the infrastructure code duplication that is often seen between different projects today.
 
 ## Example
 


### PR DESCRIPTION
## Summary

This PR makes a couple of small documentation tweaks since we now have branding and a plugin name.

* Refer to the plugin as "Performance Lab" throughout the documentation.
* Add a link to the plugin announcement post to `README.md` as a way to learn more.
* Add the plugin banner to `README.md`.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
