### PR TITLE
Ensure default modules are loaded regardless of setting registration

### DIFF
--- a/load.php
+++ b/load.php
@@ -26,28 +26,43 @@ define( 'PERFLAB_MODULES_SCREEN', 'perflab-modules' );
  * @since 1.0.0
  */
 function perflab_register_modules_setting() {
-	// To set the default value for which modules are enabled, rely on this generated file.
-	$default_enabled_modules = require plugin_dir_path( __FILE__ ) . 'default-enabled-modules.php';
-	$default_option          = array_reduce(
-		$default_enabled_modules,
-		function( $module_settings, $module_dir ) {
-			$module_settings[ $module_dir ] = array( 'enabled' => true );
-			return $module_settings;
-		},
-		array()
-	);
-
 	register_setting(
 		PERFLAB_MODULES_SCREEN,
 		PERFLAB_MODULES_SETTING,
 		array(
 			'type'              => 'object',
 			'sanitize_callback' => 'perflab_sanitize_modules_setting',
-			'default'           => $default_option,
+			'default'           => perflab_get_modules_setting_default(),
 		)
 	);
 }
 add_action( 'init', 'perflab_register_modules_setting' );
+
+/**
+ * Gets the default value for the performance modules setting.
+ *
+ * @since n.e.x.t
+ */
+function perflab_get_modules_setting_default() {
+	// Since the default relies on some minimal logic that includes requiring an additional file,
+	// the result is "cached" in a static variable.
+	static $default_option = null;
+
+	if ( null === $default_option ) {
+		// To set the default value for which modules are enabled, rely on this generated file.
+		$default_enabled_modules = require plugin_dir_path( __FILE__ ) . 'default-enabled-modules.php';
+		$default_option          = array_reduce(
+			$default_enabled_modules,
+			function( $module_settings, $module_dir ) {
+				$module_settings[ $module_dir ] = array( 'enabled' => true );
+				return $module_settings;
+			},
+			array()
+		);
+	}
+
+	return $default_option;
+}
 
 /**
  * Sanitizes the performance modules setting.
@@ -87,7 +102,10 @@ function perflab_sanitize_modules_setting( $value ) {
  * @return array Associative array of module settings keyed by module slug.
  */
 function perflab_get_module_settings() {
-	return (array) get_option( PERFLAB_MODULES_SETTING );
+	// Even though a default value is registered for this setting, the default must be explicitly
+	// passed here, to support scenarios where this function is called before the 'init' action,
+	// for example when loading the active modules.
+	return (array) get_option( PERFLAB_MODULES_SETTING, perflab_get_modules_setting_default() );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #247

## Relevant technical choices

* By passing the default as second parameter to `get_option()` in `perflab_get_module_settings()`, it is ensured the default value is always used, even when the setting is not registered yet.
* Since the plugin consistently relies on the `perflab_get_module_settings()` function to get the setting value, this ensures the default is also taken into consideration early (e.g. when the active modules are being loaded).
* The default is still _also_ being registered, which is still necessary to support potential other plugins that may need it, e.g. when calling `get_option()` directly.
* Tests are included to verify the expected behavior.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
