### PR TITLE
Select image editor based on WebP support instead of always using the default one

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -304,19 +304,6 @@ function webp_uploads_get_upload_image_mime_transforms() {
  * @return array|WP_Error An array with the file and filesize if the image was created correctly otherwise a WP_Error
  */
 function webp_uploads_generate_additional_image_source( $attachment_id, array $size_data, $mime, $destination_file_name = null ) {
-	$image_path = wp_get_original_image_path( $attachment_id );
-
-	// File does not exist.
-	if ( ! file_exists( $image_path ) ) {
-		return new WP_Error( 'original_image_file_not_found', __( 'The original image file does not exists, subsizes are created out of the original image.', 'performance-lab' ) );
-	}
-
-	$editor = wp_get_image_editor( $image_path );
-
-	if ( is_wp_error( $editor ) ) {
-		return $editor;
-	}
-
 	$allowed_mimes = array_flip( wp_get_mime_types() );
 	if ( ! isset( $allowed_mimes[ $mime ] ) || ! is_string( $allowed_mimes[ $mime ] ) ) {
 		return new WP_Error( 'image_mime_type_invalid', __( 'The provided mime type is not allowed.', 'performance-lab' ) );
@@ -324,6 +311,19 @@ function webp_uploads_generate_additional_image_source( $attachment_id, array $s
 
 	if ( ! wp_image_editor_supports( array( 'mime_type' => $mime ) ) ) {
 		return new WP_Error( 'image_mime_type_not_supported', __( 'The provided mime type is not supported.', 'performance-lab' ) );
+	}
+
+	$image_path = wp_get_original_image_path( $attachment_id );
+
+	// File does not exist.
+	if ( ! file_exists( $image_path ) ) {
+		return new WP_Error( 'original_image_file_not_found', __( 'The original image file does not exists, subsizes are created out of the original image.', 'performance-lab' ) );
+	}
+
+	$editor = wp_get_image_editor( $image_path, array( 'mime_type' => $mime ) );
+
+	if ( is_wp_error( $editor ) ) {
+		return $editor;
 	}
 
 	$height = isset( $size_data['height'] ) ? (int) $size_data['height'] : 0;

--- a/tests/modules/images/webp-uploads/webp-uploads-test.php
+++ b/tests/modules/images/webp-uploads/webp-uploads-test.php
@@ -200,7 +200,7 @@ class WebP_Uploads_Tests extends ImagesTestCase {
 		add_filter( 'wp_image_editors', '__return_empty_array' );
 		$result = webp_uploads_generate_image_size( $attachment_id, 'medium', 'image/webp' );
 		$this->assertTrue( is_wp_error( $result ) );
-		$this->assertSame( 'image_no_editor', $result->get_error_code() );
+		$this->assertSame( 'image_mime_type_not_supported', $result->get_error_code() );
 	}
 
 	/**
@@ -807,5 +807,33 @@ class WebP_Uploads_Tests extends ImagesTestCase {
 			$this->assertImageHasSizeSource( $attachment_id, $size_name, 'image/webp' );
 			$this->assertImageNotHasSizeSource( $attachment_id, $size_name, 'image/jpeg' );
 		}
+	}
+
+	/**
+	 * Allow the upload of a WebP image if at least one editor supports the format
+	 *
+	 * @test
+	 */
+	public function it_should_allow_the_upload_of_a_web_p_image_if_at_least_one_editor_supports_the_format() {
+		add_filter(
+			'wp_image_editors',
+			function () {
+				return array( 'WP_Image_Doesnt_Support_WebP', 'WP_Image_Editor_GD' );
+			}
+		);
+
+		$this->assertTrue( wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) );
+
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$metadata      = wp_get_attachment_metadata( $attachment_id );
+
+		$this->assertArrayHasKey( 'sources', $metadata );
+		$this->assertIsArray( $metadata['sources'] );
+
+		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
+		$this->assertImageHasSource( $attachment_id, 'image/webp' );
+
+		$this->assertImageHasSizeSource( $attachment_id, 'thumbnail', 'image/jpeg' );
+		$this->assertImageHasSizeSource( $attachment_id, 'thumbnail', 'image/webp' );
 	}
 }

--- a/tests/testdata/modules/images/webp-uploads/class-wp-image-doesnt-support-webp.php
+++ b/tests/testdata/modules/images/webp-uploads/class-wp-image-doesnt-support-webp.php
@@ -11,7 +11,7 @@
  *
  * @since 1.0.0
  */
-class WP_Image_Doesnt_Support_WebP {
+class WP_Image_Doesnt_Support_WebP extends WP_Image_Editor_Imagick {
 	/**
 	 * Checks to see if editor supports the mime-type specified.
 	 *

--- a/tests/testdata/modules/images/webp-uploads/class-wp-image-doesnt-support-webp.php
+++ b/tests/testdata/modules/images/webp-uploads/class-wp-image-doesnt-support-webp.php
@@ -21,17 +21,4 @@ class WP_Image_Doesnt_Support_WebP extends WP_Image_Editor_Imagick {
 	public static function supports_mime_type( $mime_type ) {
 		return 'image/webp' !== $mime_type;
 	}
-
-	/**
-	 * Set support true.
-	 *
-	 * @return bool
-	 */
-	public static function test( $args = array() ) {
-		return true;
-	}
-
-	public function load() {
-		// TODO: Implement load() method.
-	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #258

## Relevant technical choices

The update uses WP internals to allow for a more appropriate editor instead of the default one based only on the image file when the provided mime type would make a difference as the provided mime type might be supported for other editors besides the default one.

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
