### PR TITLE
Merge package.json fix back to trunk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "performance",
   "license": "GPL-2.0-or-later",
   "repository": "git+https://github.com/WordPress/performance.git",
   "devDependencies": {


### PR DESCRIPTION
## Summary

Fixes #252 

## Relevant technical choices

* #265 fixed this already, however only in the release branch where it belonged to. Since this is causing JS tests to fail, we need to merge this back into `trunk` to fix it there sooner than later too.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
