### PR TITLE
Correct usernames for Infrastructure and remove Site Health owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 # Documentation/Infrastructure
-/docs                                       @justinahinon @felixarntz
-/admin                                      @justinahinon @felixarntz
-/tests/admin                                @justinahinon @felixarntz
-/bin                                        @justinahinon @felixarntz
-/.github                                    @justinahinon @felixarntz
+/docs                                       @JustinyAhin @felixarntz
+/admin                                      @JustinyAhin @felixarntz
+/tests/admin                                @JustinyAhin @felixarntz
+/bin                                        @JustinyAhin @felixarntz
+/.github                                    @JustinyAhin @felixarntz
 
 # Focus: Images
 /modules/images                             @adamsilverstein @getsource
@@ -26,6 +26,6 @@
 /tests/testdata/modules/measurement         @AymenLoukil @josephscott
 
 # Focus: Site Health
-/modules/site-health                        @audrasjb
-/tests/modules/site-health                  @audrasjb
-/tests/testdata/modules/site-health         @audrasjb
+/modules/site-health                        
+/tests/modules/site-health                  
+/tests/testdata/modules/site-health         


### PR DESCRIPTION
## Summary

Corrects @JustinyAhin's username for Infrastructure and removes JB as Site Health owner

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
