### PR TITLE
Fix wrong version from the previous release

### DIFF
--- a/load.php
+++ b/load.php
@@ -15,7 +15,7 @@
  * @package performance-lab
  */
 
-define( 'PERFLAB_VERSION', '1.0.0-beta.3' );
+define( 'PERFLAB_VERSION', '1.0.0-rc.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );
 define( 'PERFLAB_MODULES_SCREEN', 'perflab-modules' );


### PR DESCRIPTION
Update the version to the correct version associated with this relase

## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #274 

## Relevant technical choices

The following PR updates the wrong version number used to release the plugin.

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
