### PR TITLE
Introduce `webp_uploads_prefer_smaller_image_file` filter allowing to opt in to preferring the smaller image file

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -599,6 +599,23 @@ function webp_uploads_img_tag_update_mime_type( $image, $context, $attachment_id
 	 */
 	$target_mimes = apply_filters( 'webp_uploads_content_image_mimes', array( 'image/webp', 'image/jpeg' ), $attachment_id, $context );
 
+	/**
+	 * Filters whether the smaller image should be used regardless of which MIME type is preferred overall.
+	 *
+	 * This is disabled by default only because it is not part of the current WordPress core feature proposal, as it
+	 * requires storing the file sizes, which the plugin implementation does but the core implementation does not.
+	 *
+	 * By enabling this, the plugin will compare the image file sizes and prefer the smaller file regardless of MIME
+	 * type.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param bool $prefer_smaller_image_file Whether to prefer the smaller image file.
+	 */
+	if ( apply_filters( 'webp_uploads_prefer_smaller_image_file', false ) ) {
+		$target_mimes = webp_uploads_get_mime_types_by_filesize( $target_mimes, $attachment_id );
+	}
+
 	$target_mime = null;
 	foreach ( $target_mimes as $mime ) {
 		if ( isset( $metadata['sources'][ $mime ] ) ) {
@@ -933,4 +950,3 @@ function webp_uploads_get_mime_types_by_filesize( $mime_types, $attachment_id ) 
 	// Create an array of available mime types ordered by smallest filesize.
 	return array_keys( $sources );
 }
-add_filter( 'webp_uploads_content_image_mimes', 'webp_uploads_get_mime_types_by_filesize', 10, 2 );

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -602,8 +602,7 @@ function webp_uploads_img_tag_update_mime_type( $image, $context, $attachment_id
 	/**
 	 * Filters whether the smaller image should be used regardless of which MIME type is preferred overall.
 	 *
-	 * This is disabled by default only because it is not part of the current WordPress core feature proposal, as it
-	 * requires storing the file sizes, which the plugin implementation does but the core implementation does not.
+	 * This is disabled by default only because it is not part of the current WordPress core feature proposal.
 	 *
 	 * By enabling this, the plugin will compare the image file sizes and prefer the smaller file regardless of MIME
 	 * type.


### PR DESCRIPTION
## Summary

Fixes #286

## Relevant technical choices

* A simpler solution would have been to just remove the `add_filter` call to the new function, but that would make it much less intuitive for developers, and they would need to use this "generic" filter, and remember the name of our "internal" function.
* A dedicated filter is much more intuitive and easy to use.
* I chose `webp_uploads_prefer_smaller_image_file` for the filter name for now.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
