### PR TITLE
Update Site Health Autoloaded options documentation link

### DIFF
--- a/modules/site-health/audit-autoloaded-options/load.php
+++ b/modules/site-health/audit-autoloaded-options/load.php
@@ -91,7 +91,7 @@ function perflab_aao_autoloaded_options_test() {
 	$result['actions'] = sprintf(
 	/* translators: 1: HelpHub URL. 2: Link description. */
 		'<p><a target="_blank" href="%1$s">%2$s</a></p>',
-		esc_url( __( 'https://wordpress.org/support/article/optimization/', 'performance-lab' ) ),
+		esc_url( __( 'https://wordpress.org/support/article/optimization/#database-tuning', 'performance-lab' ) ),
 		esc_html__( 'More info about performance optimization', 'performance-lab' )
 	);
 


### PR DESCRIPTION
## Summary

Fixes #312 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
