### PR TITLE
Replace the featured image with WebP version when available

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -502,3 +502,20 @@ function webp_uploads_img_tag_update_mime_type( $image, $context, $attachment_id
 
 	return $image;
 }
+
+/**
+ * Updates the references of the featured image to the a new image format if available, in the same way it
+ * occurs in the_content of a post.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $html          The current HTML markup of the featured image.
+ * @param int    $post_id       The current post ID where the featured image is requested.
+ * @param int    $attachment_id The ID of the attachment image.
+ * @return string The updated HTML markup.
+ */
+function webp_uploads_update_featured_image( $html, $post_id, $attachment_id ) {
+	return webp_uploads_img_tag_update_mime_type( $html, 'post_thumbnail_html', $attachment_id );
+}
+
+add_filter( 'post_thumbnail_html', 'webp_uploads_update_featured_image', 10, 3 );

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -517,5 +517,4 @@ function webp_uploads_img_tag_update_mime_type( $image, $context, $attachment_id
 function webp_uploads_update_featured_image( $html, $post_id, $attachment_id ) {
 	return webp_uploads_img_tag_update_mime_type( $html, 'post_thumbnail_html', $attachment_id );
 }
-
 add_filter( 'post_thumbnail_html', 'webp_uploads_update_featured_image', 10, 3 );

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -662,4 +662,21 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		$this->assertNotContains( 'image/invalid', $mime_types );
 		$this->assertSame( array( 'image/jpeg', 'image/webp' ), $mime_types );
 	}
+
+	/**
+	 * Replace the featured image to WebP when requesting the featured image
+	 *
+	 * @test
+	 */
+	public function it_should_replace_the_featured_image_to_web_p_when_requesting_the_featured_image() {
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
+		$post_id       = $this->factory()->post->create();
+		set_post_thumbnail( $post_id, $attachment_id );
+
+		$featured_image = get_the_post_thumbnail( $post_id );
+
+		$this->assertTrue( has_post_thumbnail( $post_id ) );
+		$this->assertStringContainsString( '.webp', $featured_image );
+		$this->assertStringNotContainsString( '.jpeg', $featured_image );
+	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
When a modern format is available to render the featured image make sure that the replacement image uses the same logic used to replace the images in the content in order to be consistent
with the rest of rendered format.

Fixes #288

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
