### PR TITLE
Define module owners and add them to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,20 +15,20 @@
 /tests/modules/javascript                   @aristath @sgomes
 /tests/testdata/modules/javascript          @aristath @sgomes
 
-# Focus: Object Cache
-/modules/object-cache                       @tillkruss @spacedmonkey
-/tests/modules/object-cache                 @tillkruss @spacedmonkey
-/tests/testdata/modules/object-cache        @tillkruss @spacedmonkey
+# Focus: Site Health
+/modules/site-health
+/tests/modules/site-health
+/tests/testdata/modules/site-health
 
 # Focus: Measurement
 /modules/measurement
 /tests/modules/measurement
 /tests/testdata/modules/measurement
 
-# Focus: Site Health
-/modules/site-health
-/tests/modules/site-health
-/tests/testdata/modules/site-health
+# Focus: Object Cache
+/modules/object-cache                       @tillkruss @spacedmonkey
+/tests/modules/object-cache                 @tillkruss @spacedmonkey
+/tests/testdata/modules/object-cache        @tillkruss @spacedmonkey
 
 # Module: WebP Uploads
 /modules/images/webp-uploads                                                @adamsilverstein @felixarntz

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,14 +31,14 @@
 /tests/testdata/modules/object-cache        @tillkruss @spacedmonkey
 
 # Module: WebP Uploads
-/modules/images/webp-uploads                                                @adamsilverstein @felixarntz
-/tests/modules/images/webp-uploads                                          @adamsilverstein @felixarntz
-/tests/testdata/modules/images/webp-uploads                                 @adamsilverstein @felixarntz
+/modules/images/webp-uploads                                                @adamsilverstein @felixarntz @mitogh
+/tests/modules/images/webp-uploads                                          @adamsilverstein @felixarntz @mitogh
+/tests/testdata/modules/images/webp-uploads                                 @adamsilverstein @felixarntz @mitogh
 
 # Module: WebP Support
-/modules/site-health/webp-support                                           @adamsilverstein @kirtangajjar
-/tests/modules/site-health/webp-support                                     @adamsilverstein @kirtangajjar
-/tests/testdata/modules/site-health/webp-support                            @adamsilverstein @kirtangajjar
+/modules/site-health/webp-support                                           @adamsilverstein @kirtangajjar @mitogh
+/tests/modules/site-health/webp-support                                     @adamsilverstein @kirtangajjar @mitogh
+/tests/testdata/modules/site-health/webp-support                            @adamsilverstein @kirtangajjar @mitogh
 
 # Module: Audit Autoloaded Options
 /modules/site-health/audit-autoloaded-options                               @manuelRod

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,11 +21,36 @@
 /tests/testdata/modules/object-cache        @tillkruss @spacedmonkey
 
 # Focus: Measurement
-/modules/measurement                        
-/tests/modules/measurement                  
-/tests/testdata/modules/measurement         
+/modules/measurement
+/tests/modules/measurement
+/tests/testdata/modules/measurement
 
 # Focus: Site Health
-/modules/site-health                        
-/tests/modules/site-health                  
-/tests/testdata/modules/site-health         
+/modules/site-health
+/tests/modules/site-health
+/tests/testdata/modules/site-health
+
+# Module: WebP Uploads
+/modules/images/webp-uploads                                                @adamsilverstein @felixarntz
+/tests/modules/images/webp-uploads                                          @adamsilverstein @felixarntz
+/tests/testdata/modules/images/webp-uploads                                 @adamsilverstein @felixarntz
+
+# Module: WebP Support
+/modules/site-health/webp-support                                           @adamsilverstein @kirtangajjar
+/tests/modules/site-health/webp-support                                     @adamsilverstein @kirtangajjar
+/tests/testdata/modules/site-health/webp-support                            @adamsilverstein @kirtangajjar
+
+# Module: Audit Autoloaded Options
+/modules/site-health/audit-autoloaded-options                               @manuelRod
+/tests/modules/site-health/audit-autoloaded-options                         @manuelRod
+/tests/testdata/modules/site-health/audit-autoloaded-options                @manuelRod
+
+# Module: Audit Enqueued Assets
+/modules/site-health/audit-enqueued-assets                                  @manuelRod
+/tests/modules/site-health/audit-enqueued-assets                            @manuelRod
+/tests/testdata/modules/site-health/audit-enqueued-assets                   @manuelRod
+
+# Module: Persistent Object Cache Health Check
+/modules/object-cache/persistent-object-cache-health-check                  @tillkruss @spacedmonkey
+/tests/modules/object-cache/persistent-object-cache-health-check            @tillkruss @spacedmonkey
+/tests/testdata/modules/object-cache/persistent-object-cache-health-check   @tillkruss @spacedmonkey


### PR DESCRIPTION
## Summary

Fixes #310

## Relevant technical choices

* Defines the owner(s) for each module, based on replies to the issue #310.
* Everyone mentioned here as a code owner, please review and approve this PR if you agree. @adamsilverstein @kirtangajjar @manuelRod @tillkruss @spacedmonkey 
* It would be preferable to have at least two code owners for every module. Anybody willing to support @manuelRod one one or both of the Site Health modules around autoloaded options and enqueued assets?
* Feel free to directly update this PR and add or remove yourselves.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
