### PR TITLE
Correct label for persistent object cache Site Health check

### DIFF
--- a/modules/object-cache/persistent-object-cache-health-check/load.php
+++ b/modules/object-cache/persistent-object-cache-health-check/load.php
@@ -19,7 +19,7 @@
 function perflab_oc_health_add_tests( $tests ) {
 	if ( wp_get_environment_type() === 'production' ) {
 		$tests['direct']['persistent_object_cache'] = array(
-			'label' => 'persistent_object_cache',
+			'label' => esc_html__( 'Persistent object cache', 'performance-lab' ),
 			'test'  => 'perflab_oc_health_persistent_object_cache',
 		);
 	}

--- a/modules/object-cache/persistent-object-cache-health-check/load.php
+++ b/modules/object-cache/persistent-object-cache-health-check/load.php
@@ -19,7 +19,7 @@
 function perflab_oc_health_add_tests( $tests ) {
 	if ( wp_get_environment_type() === 'production' ) {
 		$tests['direct']['persistent_object_cache'] = array(
-			'label' => esc_html__( 'Persistent object cache', 'performance-lab' ),
+			'label' => __( 'Persistent object cache', 'performance-lab' ),
 			'test'  => 'perflab_oc_health_persistent_object_cache',
 		);
 	}


### PR DESCRIPTION
<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #328

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
