### PR TITLE
Avoid unnecessarily early escape of Site Health check labels

### DIFF
--- a/modules/site-health/audit-autoloaded-options/load.php
+++ b/modules/site-health/audit-autoloaded-options/load.php
@@ -18,7 +18,7 @@
  */
 function perflab_aao_add_autoloaded_options_test( $tests ) {
 	$tests['direct']['autoloaded_options'] = array(
-		'label' => esc_html__( 'Autoloaded options', 'performance-lab' ),
+		'label' => __( 'Autoloaded options', 'performance-lab' ),
 		'test'  => 'perflab_aao_autoloaded_options_test',
 	);
 	return $tests;

--- a/modules/site-health/audit-enqueued-assets/load.php
+++ b/modules/site-health/audit-enqueued-assets/load.php
@@ -112,11 +112,11 @@ add_action( 'wp_footer', 'perflab_aea_audit_enqueued_styles', PHP_INT_MAX );
  */
 function perflab_aea_add_enqueued_assets_test( $tests ) {
 	$tests['direct']['enqueued_js_assets']  = array(
-		'label' => esc_html__( 'JS assets', 'performance-lab' ),
+		'label' => __( 'JS assets', 'performance-lab' ),
 		'test'  => 'perflab_aea_enqueued_js_assets_test',
 	);
 	$tests['direct']['enqueued_css_assets'] = array(
-		'label' => esc_html__( 'CSS assets', 'performance-lab' ),
+		'label' => __( 'CSS assets', 'performance-lab' ),
 		'test'  => 'perflab_aea_enqueued_css_assets_test',
 	);
 

--- a/modules/site-health/webp-support/load.php
+++ b/modules/site-health/webp-support/load.php
@@ -18,7 +18,7 @@
  */
 function webp_uploads_add_is_webp_supported_test( $tests ) {
 	$tests['direct']['webp_supported'] = array(
-		'label' => esc_html__( 'WebP Support', 'performance-lab' ),
+		'label' => __( 'WebP Support', 'performance-lab' ),
 		'test'  => 'webp_uploads_check_webp_supported_test',
 	);
 	return $tests;


### PR DESCRIPTION
As suggested by @felixarntz in the #329 ticket.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
