### PR TITLE
Introduce plugin uninstaller routine

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Plugin uninstaller logic.
+ *
+ * @package performance-lab
+ * @since 1.2.0
+ */
+
+// If uninstall.php is not called by WordPress, bail.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+delete_option( 'perflab_modules_settings' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Cleanup `wp_options` table after plugin uninstall.

Currently, if we uninstall `performance-lab` plugin - it leaves `wp_options` entries with AUTOLOAD = yes values.
![download (6)](https://user-images.githubusercontent.com/16621855/171601721-3b7c7ce9-4c0c-40c2-b49d-9bf3f18de528.png)


## Relevant technical choices

Introduce Uninstall method referenced at https://developer.wordpress.org/plugins/plugin-basics/uninstall-methods/

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
