### PR TITLE
Avoid overwriting existing WebP files when creating WebP images

### DIFF
--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -142,6 +142,11 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 		$destination_file_name = $editor->generate_filename( null, null, $extension[0] );
 	}
 
+	// Skip creation of duplicate WebP image if an image file already exists in the directory.
+	if ( file_exists( $destination_file_name ) ) {
+		return new WP_Error( 'webp_image_file_present', __( 'The webP image already exists.', 'performance-lab' ) );
+	}
+
 	$image = $editor->save( $destination_file_name, $mime );
 	if ( is_wp_error( $image ) ) {
 		return $image;

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -144,7 +144,7 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 
 	// Skip creation of duplicate WebP image if an image file already exists in the directory.
 	if ( file_exists( $destination_file_name ) ) {
-		return new WP_Error( 'webp_image_file_present', __( 'The webP image already exists.', 'performance-lab' ) );
+		return new WP_Error( 'webp_image_file_present', __( 'The WebP image already exists.', 'performance-lab' ) );
 	}
 
 	$image = $editor->save( $destination_file_name, $mime );

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -90,6 +90,12 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 
 		$extension   = explode( '|', $allowed_mimes[ $targeted_mime ] );
 		$destination = trailingslashit( $original_directory ) . "{$filename}.{$extension[0]}";
+		
+		// Skip creation of duplicate WebP image if a image file has the same name with an extension of jpe, jpg, or jpeg.
+		if ( file_exists( $destination ) ) {
+			continue;
+		}
+
 		$image       = webp_uploads_generate_additional_image_source( $attachment_id, 'full', $original_size_data, $targeted_mime, $destination );
 
 		if ( is_wp_error( $image ) ) {

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -90,13 +90,13 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 
 		$extension   = explode( '|', $allowed_mimes[ $targeted_mime ] );
 		$destination = trailingslashit( $original_directory ) . "{$filename}.{$extension[0]}";
-		
+
 		// Skip creation of duplicate WebP image if a image file has the same name with an extension of jpe, jpg, or jpeg.
 		if ( file_exists( $destination ) ) {
 			continue;
 		}
 
-		$image       = webp_uploads_generate_additional_image_source( $attachment_id, 'full', $original_size_data, $targeted_mime, $destination );
+		$image = webp_uploads_generate_additional_image_source( $attachment_id, 'full', $original_size_data, $targeted_mime, $destination );
 
 		if ( is_wp_error( $image ) ) {
 			continue;

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -90,13 +90,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 
 		$extension   = explode( '|', $allowed_mimes[ $targeted_mime ] );
 		$destination = trailingslashit( $original_directory ) . "{$filename}.{$extension[0]}";
-
-		// Skip creation of duplicate WebP image if a image file has the same name with an extension of jpe, jpg, or jpeg.
-		if ( file_exists( $destination ) ) {
-			continue;
-		}
-
-		$image = webp_uploads_generate_additional_image_source( $attachment_id, 'full', $original_size_data, $targeted_mime, $destination );
+		$image       = webp_uploads_generate_additional_image_source( $attachment_id, 'full', $original_size_data, $targeted_mime, $destination );
 
 		if ( is_wp_error( $image ) ) {
 			continue;


### PR DESCRIPTION
## Summary

This PR skips the creation of duplicate WebP images if anyone uses an image file with the same name with an extension of jpg, jpe, or jpeg.

Please check more detail about the issue and the options for the solution [here](https://github.com/WordPress/performance/issues/358#issuecomment-1150695492)

As @felixarntz suggested we should go with 1st approach.

If you want to generate a WebP image for `.png` images then please add the below code snippet in your current themes functions.php

    add_filter('webp_uploads_upload_image_mime_transforms', function () {

        return [
            'image/jpeg' =>  [ 'image/jpeg', 'image/webp' ],
            'image/png' =>  [ 'image/png', 'image/webp' ],
            'image/webp' =>  [ 'image/webp', 'image/jpeg' ],
        ];
    });

Fixes #358


## Images for testing

If you want to test the different images then please download the zip in which I added all image formats( jpg, jpe, jpeg and png ) - [image.zip](https://github.com/WordPress/performance/files/8876261/image.zip)

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
