### PR TITLE
Correct: Since for webp_uploads_generate_additional_image_source()

### DIFF
--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -55,7 +55,7 @@ function webp_uploads_get_upload_image_mime_transforms() {
  * would be saved in the specified mime and stored in the destination file. If the image can't be saved correctly
  * a WP_Error would be returned otherwise an array with the file and filesize properties.
  *
- * @since n.e.xt
+ * @since 1.0.0
  * @access private
  *
  * @param int    $attachment_id         The ID of the attachment from where this image would be created.


### PR DESCRIPTION
## Summary

`webp_uploads_generate_additional_image_source()` introduce in version `1.0.0` in the plugin but it still shows `@since n.e.xt` because of it has text issue. This version change is part of the release process that happens on the day of the release as per https://github.com/WordPress/performance/blob/trunk/docs/Releasing-the-plugin.md#preparing-the-release document.

This PR set the version number to `1.0.0` 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
