### PR TITLE
Use `wp_filesize` instead of `filesize` if available

### DIFF
--- a/load.php
+++ b/load.php
@@ -197,3 +197,47 @@ perflab_load_active_modules();
 if ( is_admin() ) {
 	require_once plugin_dir_path( __FILE__ ) . 'admin/load.php';
 }
+
+// WP Filesize function.
+if ( ! function_exists( 'wp_filesize' ) ) {
+	/**
+	 * Wrapper for PHP filesize with filters and casting the result as an integer.
+	 *
+	 * This function is introduced in WP 6.0, to support backward compatibility
+	 * function is added as backup here.
+	 *
+	 * @param string $path Path to the file.
+	 *
+	 * @return int The size of the file in bytes, or 0 in the event of an error.
+	 * @since n.e.x.t
+	 *
+	 * @link https://www.php.net/manual/en/function.filesize.php
+	 */
+	function wp_filesize( $path ) {
+		/**
+		 * Filters the result of wp_filesize before the PHP function is run.
+		 *
+		 * @param null|int $size The unfiltered value. Returning an int from the callback bypasses the filesize call.
+		 * @param string $path Path to the file.
+		 *
+		 * @since n.e.x.t
+		 */
+		$size = apply_filters( 'pre_wp_filesize', null, $path );
+
+		if ( is_int( $size ) ) {
+			return $size;
+		}
+
+		$size = file_exists( $path ) ? (int) filesize( $path ) : 0;
+
+		/**
+		 * Filters the size of the file.
+		 *
+		 * @param int $size The result of PHP filesize on the file.
+		 * @param string $path Path to the file.
+		 *
+		 * @since n.e.x.t
+		 */
+		return (int) apply_filters( 'wp_filesize', $size, $path );
+	}
+}

--- a/load.php
+++ b/load.php
@@ -198,46 +198,5 @@ if ( is_admin() ) {
 	require_once plugin_dir_path( __FILE__ ) . 'admin/load.php';
 }
 
-// WP Filesize function.
-if ( ! function_exists( 'wp_filesize' ) ) {
-	/**
-	 * Wrapper for PHP filesize with filters and casting the result as an integer.
-	 *
-	 * This function is introduced in WP 6.0, to support backward compatibility
-	 * function is added as backup here.
-	 *
-	 * @param string $path Path to the file.
-	 *
-	 * @return int The size of the file in bytes, or 0 in the event of an error.
-	 * @since n.e.x.t
-	 *
-	 * @link https://www.php.net/manual/en/function.filesize.php
-	 */
-	function wp_filesize( $path ) {
-		/**
-		 * Filters the result of wp_filesize before the PHP function is run.
-		 *
-		 * @param null|int $size The unfiltered value. Returning an int from the callback bypasses the filesize call.
-		 * @param string $path Path to the file.
-		 *
-		 * @since n.e.x.t
-		 */
-		$size = apply_filters( 'pre_wp_filesize', null, $path );
-
-		if ( is_int( $size ) ) {
-			return $size;
-		}
-
-		$size = file_exists( $path ) ? (int) filesize( $path ) : 0;
-
-		/**
-		 * Filters the size of the file.
-		 *
-		 * @param int $size The result of PHP filesize on the file.
-		 * @param string $path Path to the file.
-		 *
-		 * @since n.e.x.t
-		 */
-		return (int) apply_filters( 'wp_filesize', $size, $path );
-	}
-}
+// Polyfills.
+require_once plugin_dir_path( __FILE__ ) . 'polyfills.php';

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -99,7 +99,7 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 			'file'     => $image['file'],
 			'filesize' => array_key_exists( 'filesize', $image )
 				? $image['filesize']
-				: filesize( $image['path'] ),
+				: wp_filesize( $image['path'] ),
 		);
 	}
 
@@ -153,7 +153,7 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 
 	return array(
 		'file'     => $image['file'],
-		'filesize' => isset( $image['path'] ) ? filesize( $image['path'] ) : 0,
+		'filesize' => isset( $image['path'] ) ? wp_filesize( $image['path'] ) : 0,
 	);
 }
 

--- a/modules/images/webp-uploads/image-edit.php
+++ b/modules/images/webp-uploads/image-edit.php
@@ -25,7 +25,7 @@ function webp_uploads_update_sources( $metadata, $valid_mime_transforms, $main_i
 			// Add sources to original image metadata.
 			$metadata['sources'][ $targeted_mime ] = array(
 				'file'     => $main_images[ $targeted_mime ]['file'],
-				'filesize' => filesize( $main_images[ $targeted_mime ]['path'] ),
+				'filesize' => wp_filesize( $main_images[ $targeted_mime ]['path'] ),
 			);
 			$image_directory                       = pathinfo( $main_images[ $targeted_mime ]['path'], PATHINFO_DIRNAME );
 		}
@@ -68,7 +68,7 @@ function webp_uploads_update_sources( $metadata, $valid_mime_transforms, $main_i
 
 			$metadata['sizes'][ $size_name ]['sources'][ $targeted_mime ] = array(
 				'file'     => $subsized_images[ $targeted_mime ][ $size_name ]['file'],
-				'filesize' => filesize( $subsize_path ),
+				'filesize' => wp_filesize( $subsize_path ),
 			);
 		}
 	}

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -61,7 +61,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 	) {
 		$metadata['sources'][ $mime_type ] = array(
 			'file'     => wp_basename( $file ),
-			'filesize' => filesize( $file ),
+			'filesize' => wp_filesize( $file ),
 		);
 		wp_update_attachment_metadata( $attachment_id, $metadata );
 	}
@@ -137,7 +137,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 			// Set the filesize from the current mime image.
 			$file_location = path_join( $original_directory, $properties['file'] );
 			if ( file_exists( $file_location ) ) {
-				$properties['sources'][ $current_mime ]['filesize'] = filesize( $file_location );
+				$properties['sources'][ $current_mime ]['filesize'] = wp_filesize( $file_location );
 			}
 			$metadata['sizes'][ $size_name ] = $properties;
 			wp_update_attachment_metadata( $attachment_id, $metadata );

--- a/modules/site-health/audit-enqueued-assets/helper.php
+++ b/modules/site-health/audit-enqueued-assets/helper.php
@@ -115,6 +115,6 @@ function perflab_aea_get_path_from_resource_url( $resource_url ) {
  * @return int Returns size if file exists, 0 if it doesn't.
  */
 function perflab_aea_get_resource_file_size( $file_src ) {
-	return file_exists( $file_src ) ? filesize( $file_src ) : 0;
+	return file_exists( $file_src ) ? wp_filesize( $file_src ) : 0;
 }
 

--- a/modules/site-health/audit-enqueued-assets/helper.php
+++ b/modules/site-health/audit-enqueued-assets/helper.php
@@ -115,6 +115,6 @@ function perflab_aea_get_path_from_resource_url( $resource_url ) {
  * @return int Returns size if file exists, 0 if it doesn't.
  */
 function perflab_aea_get_resource_file_size( $file_src ) {
-	return file_exists( $file_src ) ? wp_filesize( $file_src ) : 0;
+	return wp_filesize( $file_src );
 }
 

--- a/polyfills.php
+++ b/polyfills.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * These functions are either introduced in WP Core in latest version or
+ * available in different versions. For simplicity for future, we can remove them
+ * if they are supported in WP Core versions which this plugin supports.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+// WP Filesize function.
+if ( ! function_exists( 'wp_filesize' ) ) {
+	/**
+	 * Wrapper for PHP filesize with filters and casting the result as an integer.
+	 *
+	 * This function is introduced in WP 6.0, to support backward compatibility
+	 * function is added as backup here.
+	 *
+	 * @param string $path Path to the file.
+	 *
+	 * @return int The size of the file in bytes, or 0 in the event of an error.
+	 * @since n.e.x.t
+	 *
+	 * @link https://www.php.net/manual/en/function.filesize.php
+	 */
+	function wp_filesize( $path ) {
+		/**
+		 * Filters the result of wp_filesize before the PHP function is run.
+		 *
+		 * @param null|int $size The unfiltered value. Returning an int from the callback bypasses the filesize call.
+		 * @param string $path Path to the file.
+		 *
+		 * @since n.e.x.t
+		 */
+		$size = apply_filters( 'pre_wp_filesize', null, $path );
+
+		if ( is_int( $size ) ) {
+			return $size;
+		}
+
+		$size = file_exists( $path ) ? (int) filesize( $path ) : 0;
+
+		/**
+		 * Filters the size of the file.
+		 *
+		 * @param int $size The result of PHP filesize on the file.
+		 * @param string $path Path to the file.
+		 *
+		 * @since n.e.x.t
+		 */
+		return (int) apply_filters( 'wp_filesize', $size, $path );
+	}
+}

--- a/polyfills.php
+++ b/polyfills.php
@@ -13,7 +13,7 @@ if ( ! function_exists( 'wp_filesize' ) ) {
 	/**
 	 * Wrapper for PHP filesize with filters and casting the result as an integer.
 	 *
-	 * This function is introduced in WP 6.0, to support backward compatibility
+	 * This function was introduced in WP 6.0, for backward compatibility the
 	 * function is added as backup here.
 	 *
 	 * @param string $path Path to the file.

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -141,11 +141,11 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
 		$this->assertStringEndsWith( $metadata['sources']['image/jpeg']['file'], $file );
 		$this->assertFileExists( path_join( $dirname, $metadata['sources']['image/jpeg']['file'] ) );
-		$this->assertSame( $metadata['sources']['image/jpeg']['filesize'], filesize( path_join( $dirname, $metadata['sources']['image/jpeg']['file'] ) ) );
+		$this->assertSame( $metadata['sources']['image/jpeg']['filesize'], wp_filesize( path_join( $dirname, $metadata['sources']['image/jpeg']['file'] ) ) );
 
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 		$this->assertFileExists( path_join( $dirname, $metadata['sources']['image/webp']['file'] ) );
-		$this->assertSame( $metadata['sources']['image/webp']['filesize'], filesize( path_join( $dirname, $metadata['sources']['image/webp']['file'] ) ) );
+		$this->assertSame( $metadata['sources']['image/webp']['filesize'], wp_filesize( path_join( $dirname, $metadata['sources']['image/webp']['file'] ) ) );
 
 		$this->assertImageHasSizeSource( $attachment_id, 'thumbnail', 'image/jpeg' );
 		$this->assertImageHasSizeSource( $attachment_id, 'thumbnail', 'image/webp' );

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -119,7 +119,7 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 		$filename = __FUNCTION__ . '.css';
 		$contents = __FUNCTION__ . '_contents';
 		$file     = wp_upload_bits( $filename, null, $contents );
-		$this->assertEquals( filesize( $file['file'] ), perflab_aea_get_resource_file_size( $file['file'] ) );
+		$this->assertEquals( wp_filesize( $file['file'] ), perflab_aea_get_resource_file_size( $file['file'] ) );
 	}
 
 }


### PR DESCRIPTION
## Summary
WordPress 6.0 introduced the wp_filesize() function which should be used in favor of PHP's filesize() going forward.

Fixes #344 

## Relevant technical choices

This PR changes `filesize` function to `wp_filesize` everywhere it was used in the plugin. Code and test cases.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
