### PR TITLE
Remove `perflab_aea_get_resource_file_size()` in favor of `wp_filesize()`

### DIFF
--- a/modules/site-health/audit-enqueued-assets/helper.php
+++ b/modules/site-health/audit-enqueued-assets/helper.php
@@ -105,16 +105,3 @@ function perflab_aea_get_path_from_resource_url( $resource_url ) {
 	// Standard wp-content configuration.
 	return untrailingslashit( ABSPATH ) . wp_make_link_relative( $resource_url );
 }
-
-/**
- * If file exists, returns its size.
- *
- * @since 1.0.0
- *
- * @param string $file_src Path to the file.
- * @return int Returns size if file exists, 0 if it doesn't.
- */
-function perflab_aea_get_resource_file_size( $file_src ) {
-	return wp_filesize( $file_src );
-}
-

--- a/modules/site-health/audit-enqueued-assets/load.php
+++ b/modules/site-health/audit-enqueued-assets/load.php
@@ -47,7 +47,7 @@ function perflab_aea_audit_enqueued_scripts() {
 
 			$enqueued_scripts[] = array(
 				'src'  => $script->src,
-				'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
+				'size' => wp_filesize( $path ) + $inline_size,
 			);
 
 		}
@@ -94,7 +94,7 @@ function perflab_aea_audit_enqueued_styles() {
 
 			$enqueued_styles[] = array(
 				'src'  => $style->src,
-				'size' => perflab_aea_get_resource_file_size( $path ) + $inline_size,
+				'size' => wp_filesize( $path ) + $inline_size,
 			);
 		}
 		set_transient( 'aea_enqueued_front_page_styles', $enqueued_styles, 12 * HOUR_IN_SECONDS );

--- a/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -108,19 +108,5 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 		$this->assertSame( $expected_path, perflab_aea_get_path_from_resource_url( $test_url ) );
 	}
 
-	/**
-	 * Tests perflab_aea_get_resource_file_size() functionality.
-	 */
-	public function test_perflab_aea_get_resource_file_size() {
-		$non_existing_resource = ABSPATH . '/wp-content/themes/test-theme/style.css';
-		$this->assertEquals( 0, perflab_aea_get_resource_file_size( $non_existing_resource ) );
-
-		// Upload a fake resource file.
-		$filename = __FUNCTION__ . '.css';
-		$contents = __FUNCTION__ . '_contents';
-		$file     = wp_upload_bits( $filename, null, $contents );
-		$this->assertEquals( wp_filesize( $file['file'] ), perflab_aea_get_resource_file_size( $file['file'] ) );
-	}
-
 }
 


### PR DESCRIPTION
## Summary

We already have `wp_filesize()` function in WP and polifile function in Performance so we don't need `perflab_aea_get_resource_file_size()` function because it returns `wp_filesize()`.

This PR completely remove `perflab_aea_get_resource_file_size()` function and use `wp_filesize()` instead of `perflab_aea_get_resource_file_size()` in code base. It also remove unit test for `perflab_aea_get_resource_file_size()` function.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #378

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
