### PR TITLE
Ensure incorrect usage of `webp_uploads_upload_image_mime_transforms` filter is treated correctly

### DIFF
--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -32,7 +32,7 @@ function webp_uploads_get_upload_image_mime_transforms() {
 	 *
 	 * @param array $default_transforms A map with the valid mime transforms.
 	 */
-	$transforms = (array) apply_filters( 'webp_uploads_upload_image_mime_transforms', $default_transforms );
+	$transforms = apply_filters( 'webp_uploads_upload_image_mime_transforms', $default_transforms );
 
 	// Return the default mime transforms if a non-array result is returned from the filter.
 	if ( ! is_array( $transforms ) ) {

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -340,8 +340,7 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 	 *
 	 * @test
 	 */
-	public function it_should_return_empty_array_when_filter_returns_empty_array()
-	{
+	public function it_should_return_empty_array_when_filter_returns_empty_array() {
 		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
 
 		$transforms = webp_uploads_get_upload_image_mime_transforms();
@@ -355,8 +354,7 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 	 *
 	 * @test
 	 */
-	public function it_should_return_default_transforms_when_filter_returns_non_array_type()
-	{
+	public function it_should_return_default_transforms_when_filter_returns_non_array_type() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
 			function () {
@@ -380,8 +378,7 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 	 *
 	 * @test
 	 */
-	public function it_should_return_fallback_transforms_when_overwritten_invalid_transforms()
-	{
+	public function it_should_return_fallback_transforms_when_overwritten_invalid_transforms() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
 			function () {
@@ -400,8 +397,7 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 	 *
 	 * @test
 	 */
-	public function it_should_return_custom_transforms_when_overwritten_by_filter()
-	{
+	public function it_should_return_custom_transforms_when_overwritten_by_filter() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
 			function () {

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -335,4 +335,83 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 		$this->assertSame( 'image_additional_generated_error', $result->get_error_code() );
 	}
 
+	/**
+	 * Returns an empty array when the overwritten with empty array by webp_uploads_upload_image_mime_transforms filter.
+	 *
+	 * @test
+	 */
+	public function it_should_return_empty_array_when_filter_returns_empty_array()
+	{
+		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
+
+		$transforms = webp_uploads_get_upload_image_mime_transforms();
+
+		$this->assertIsArray( $transforms );
+		$this->assertSame( array(), $transforms );
+	}
+
+	/**
+	 * Returns default transforms when the overwritten with non array type by webp_uploads_upload_image_mime_transforms filter.
+	 *
+	 * @test
+	 */
+	public function it_should_return_default_transforms_when_filter_returns_non_array_type()
+	{
+		add_filter(
+			'webp_uploads_upload_image_mime_transforms',
+			function () {
+				return;
+			}
+		);
+
+		$default_transforms = array(
+			'image/jpeg' => array( 'image/jpeg', 'image/webp' ),
+			'image/webp' => array( 'image/webp', 'image/jpeg' ),
+		);
+
+		$transforms = webp_uploads_get_upload_image_mime_transforms();
+
+		$this->assertIsArray( $transforms );
+		$this->assertSame( $default_transforms, $transforms );
+	}
+
+	/**
+	 * Returns transforms array with fallback to original mime with invalid transforms array.
+	 *
+	 * @test
+	 */
+	public function it_should_return_fallback_transforms_when_overwritten_invalid_transforms()
+	{
+		add_filter(
+			'webp_uploads_upload_image_mime_transforms',
+			function () {
+				return array( 'image/jpeg' => array() );
+			}
+		);
+
+		$transforms = webp_uploads_get_upload_image_mime_transforms();
+
+		$this->assertIsArray( $transforms );
+		$this->assertSame( array( 'image/jpeg' => array( 'image/jpeg' ) ), $transforms );
+	}
+
+	/**
+	 * Returns custom transforms array when overwritten by webp_uploads_upload_image_mime_transforms filter.
+	 *
+	 * @test
+	 */
+	public function it_should_return_custom_transforms_when_overwritten_by_filter()
+	{
+		add_filter(
+			'webp_uploads_upload_image_mime_transforms',
+			function () {
+				return array( 'image/jpeg' => array( 'image/jpeg', 'image/webp' ) );
+			}
+		);
+
+		$transforms = webp_uploads_get_upload_image_mime_transforms();
+
+		$this->assertIsArray( $transforms );
+		$this->assertSame( array( 'image/jpeg' => array( 'image/jpeg', 'image/webp' ) ), $transforms );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #361

## Relevant technical choices

* Removes casting the value returned by the `webp_uploads_upload_image_mime_transforms` to an array.
* Add tests to confirm behaviour works as expected based on `webp_uploads_get_upload_image_mime_transforms` comments.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
