### PR TITLE
Do not show admin pointer in multisite Network Admin

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -353,8 +353,8 @@ function perflab_admin_pointer( $hook_suffix ) {
 		return;
 	}
 
-	// Do not show admin pointer in multisite Network Admin.
-	if ( is_network_admin() ) {
+	// Do not show admin pointer in multisite Network admin or User admin UI.
+	if ( is_network_admin() || is_user_admin() ) {
 		return;
 	}
 

--- a/admin/load.php
+++ b/admin/load.php
@@ -353,6 +353,11 @@ function perflab_admin_pointer( $hook_suffix ) {
 		return;
 	}
 
+	// Do not show admin pointer in multisite Network Admin.
+	if ( is_network_admin() ) {
+		return;
+	}
+
 	$current_user = get_current_user_id();
 	$dismissed    = explode( ',', (string) get_user_meta( $current_user, 'dismissed_wp_pointers', true ) );
 


### PR DESCRIPTION
## Summary

PR includes the solution that does not show an admin pointer in the multisite Network Admin.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #387

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
