### PR TITLE
Fix PHP notice and bug in logic for when `webp_uploads_prefer_smaller_image_file` filter is set to `true`

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -481,7 +481,7 @@ function webp_uploads_img_tag_update_mime_type( $image, $context, $attachment_id
 			$metadata['sources'][ $original_mime ]['filesize'] < $metadata['sources'][ $target_mime ]['filesize']
 		) {
 			// Set the original source file as the replacement if smaller.
-			$replacement_source = $size_data['sources'][ $original_mime ]['file'];
+			$replacement_source = $metadata['sources'][ $original_mime ]['file'];
 		}
 
 		$basename = wp_basename( $metadata['file'] );


### PR DESCRIPTION
## Summary

When I work on [#372](https://github.com/WordPress/performance/issues/372) bug I found this bug that needs to fix.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #396 

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
