### PR TITLE
Fix dominant color upload process to not override potential third-party editors

### DIFF
--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -235,6 +235,8 @@ add_filter( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
  *
  * @since 1.2.0
  *
+ * @param string[] $editors Array of available image editor class names. Defaults are 'WP_Image_Editor_Imagick', 'WP_Image_Editor_GD'.
+ *
  * @return string[] Registered image editors class names.
  */
 function dominant_color_set_image_editors( $editors ) {

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -236,7 +236,6 @@ add_filter( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
  * @since 1.2.0
  *
  * @param string[] $editors Array of available image editor class names. Defaults are 'WP_Image_Editor_Imagick', 'WP_Image_Editor_GD'.
- *
  * @return string[] Registered image editors class names.
  */
 function dominant_color_set_image_editors( $editors ) {

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -237,7 +237,7 @@ add_filter( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
  *
  * @return string[] Registered image editors class names.
  */
-function dominant_color_set_image_editors() {
+function dominant_color_set_image_editors( $editors ) {
 	if ( ! class_exists( 'Dominant_Color_Image_Editor_GD' ) ) {
 		require_once __DIR__ . '/class-dominant-color-image-editor-gd.php';
 	}
@@ -245,7 +245,19 @@ function dominant_color_set_image_editors() {
 		require_once __DIR__ . '/class-dominant-color-image-editor-imagick.php';
 	}
 
-	return array( 'Dominant_Color_Image_Editor_GD', 'Dominant_Color_Image_Editor_Imagick' );
+	$replaces = array(
+		'WP_Image_Editor_GD'      => 'Dominant_Color_Image_Editor_GD',
+		'WP_Image_Editor_Imagick' => 'Dominant_Color_Image_Editor_Imagick',
+	);
+
+	foreach ( $replaces as $old => $new ) {
+		$key = array_search( $old, $editors, true );
+		if ( false !== $key ) {
+			$editors[ $key ] = $new;
+		}
+	}
+
+	return $editors;
 }
 
 /**

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -58,6 +58,9 @@ class Dominant_Color_Test extends DominantColorTestCase {
 		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$transparency_metadata = dominant_color_metadata( array(), $attachment_id );
+		if ( strpos( $image_path, '.gif' ) ) {
+			$expected_transparency = true; // all gif have alpha.
+		}
 		$this->assertArrayHasKey( 'has_transparency', $transparency_metadata );
 		$this->assertSame( $expected_transparency, $transparency_metadata['has_transparency'] );
 	}
@@ -72,6 +75,9 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	public function test_dominant_color_has_transparency( $image_path, $expected_color, $expected_transparency ) {
 		// Creating attachment.
 		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		if ( strpos( $image_path, '.gif' ) ) {
+			$expected_transparency = true; // all gif have alpha.
+		}
 		$this->assertSame( $expected_transparency, dominant_color_has_transparency( $attachment_id ) );
 	}
 
@@ -92,6 +98,9 @@ class Dominant_Color_Test extends DominantColorTestCase {
 
 		$filtered_image_tags_added = dominant_color_img_tag_add_dominant_color( $filtered_image_mock_lazy_load, 'the_content', $attachment_id );
 
+		if ( strpos( $image_path, '.gif' ) ) {
+			$expected_transparency = true; // all gif have alpha.
+		}
 		$this->assertStringContainsString( 'data-has-transparency="' . json_encode( $expected_transparency ) . '"', $filtered_image_tags_added );
 
 		foreach ( $expected_color as $color ) {

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -110,6 +110,60 @@ class Dominant_Color_Test extends DominantColorTestCase {
 
 
 	/**
+	 * Tests dominant_color_set_image_editors().
+	 *
+	 * @dataProvider provider_dominant_color_set_image_editors
+	 *
+	 * @covers ::dominant_color_set_image_editors
+	 */
+	public function test_dominant_color_set_image_editors( $existing, $expected ) {
+		$this->assertEqualSets( dominant_color_set_image_editors( $existing ), $expected );
+	}
+
+	public function provider_dominant_color_set_image_editors() {
+		return array(
+			'default'  => array(
+				'existing' => array(
+					'WP_Image_Editor_GD',
+					'WP_Image_Editor_Imagick',
+				),
+				'expected' => array(
+					'Dominant_Color_Image_Editor_GD',
+					'Dominant_Color_Image_Editor_Imagick',
+				),
+			),
+			'filtered' => array(
+				'existing' => array(
+					'WP_Image_Editor_Filered_GD',
+					'WP_Image_Editor_Filered_Imagick',
+				),
+				'expected' => array(
+					'WP_Image_Editor_Filered_GD',
+					'WP_Image_Editor_Filered_Imagick',
+				),
+			),
+			'added'    => array(
+				'existing' => array(
+					'WP_Image_Editor_Filered_GD',
+					'WP_Image_Editor_Filered_Imagick',
+					'WP_Image_Editor_GD',
+					'WP_Image_Editor_Imagick',
+				),
+				'expected' => array(
+					'WP_Image_Editor_Filered_GD',
+					'WP_Image_Editor_Filered_Imagick',
+					'Dominant_Color_Image_Editor_GD',
+					'Dominant_Color_Image_Editor_Imagick',
+				),
+			),
+			'empty'    => array(
+				'existing' => array(),
+				'expected' => array(),
+			),
+		);
+	}
+
+	/**
 	 * Tests dominant_color_rgb_to_hex().
 	 *
 	 * @dataProvider provider_get_hex_color


### PR DESCRIPTION
## Summary

Replace editor in a cleaner way.

Fixes #374

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
