### PR TITLE
Rely on `wp_get_image_editor()` methods argument to check whether it supports dominant color methods

### DIFF
--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -259,7 +259,7 @@ function dominant_color_set_image_editors() {
  */
 function _dominant_color_get_dominant_color_data( $attachment_id ) {
 	$mime_type = get_post_mime_type( $attachment_id );
-	if( 'application/pdf' === $mime_type ){
+	if ( 'application/pdf' === $mime_type ) {
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'performance-lab' ) );
 	}
 	$file = wp_get_attachment_file_path( $attachment_id );
@@ -267,12 +267,15 @@ function _dominant_color_get_dominant_color_data( $attachment_id ) {
 		$file = get_attached_file( $attachment_id );
 	}
 	add_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
-	$editor = wp_get_image_editor( $file, array(
-		'methods' => array(
-			'get_dominant_color',
-			'has_transparency'
+	$editor = wp_get_image_editor(
+		$file,
+		array(
+			'methods' => array(
+				'get_dominant_color',
+				'has_transparency',
+			),
 		)
-	) );
+	);
 	remove_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
 
 	if ( is_wp_error( $editor ) ) {

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -258,7 +258,8 @@ function dominant_color_set_image_editors() {
  * @return array|WP_Error Array with the dominant color and has transparency values or WP_Error on error.
  */
 function _dominant_color_get_dominant_color_data( $attachment_id ) {
-	if ( ! wp_attachment_is_image( $attachment_id ) ) {
+	$mime_type = get_post_mime_type( $attachment_id );
+	if( 'application/pdf' === $mime_type ){
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'performance-lab' ) );
 	}
 	$file = wp_get_attachment_file_path( $attachment_id );
@@ -266,25 +267,23 @@ function _dominant_color_get_dominant_color_data( $attachment_id ) {
 		$file = get_attached_file( $attachment_id );
 	}
 	add_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
-	$editor = wp_get_image_editor( $file );
+	$editor = wp_get_image_editor( $file, array(
+		'methods' => array(
+			'get_dominant_color',
+			'has_transparency'
+		)
+	) );
 	remove_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
 
 	if ( is_wp_error( $editor ) ) {
 		return $editor;
 	}
 
-	if ( ! method_exists( $editor, 'has_transparency' ) ) {
-		return new WP_Error( 'unable_to_find_method', __( 'Unable to find has_transparency method', 'performance-lab' ) );
-	}
 	$has_transparency = $editor->has_transparency();
 	if ( is_wp_error( $has_transparency ) ) {
 		return $has_transparency;
 	}
 	$dominant_color_data['has_transparency'] = $has_transparency;
-
-	if ( ! method_exists( $editor, 'get_dominant_color' ) ) {
-		return new WP_Error( 'unable_to_find_method', __( 'Unable to find get_dominant_color method', 'performance-lab' ) );
-	}
 
 	$dominant_color = $editor->get_dominant_color();
 	if ( is_wp_error( $dominant_color ) ) {

--- a/tests/modules/images/dominant-color/dominant-color-image-editor-gd-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-image-editor-gd-test.php
@@ -74,6 +74,5 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
-		$this->assertStringContainsString( 'no_image_found', $dominant_color_data->get_error_code() );
 	}
 }

--- a/tests/modules/images/dominant-color/dominant-color-image-editor-imageick-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-image-editor-imageick-test.php
@@ -79,6 +79,5 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
-		$this->assertStringContainsString( 'no_image_found', $dominant_color_data->get_error_code() );
 	}
 }


### PR DESCRIPTION
## Summary

`wp_get_image_editor` has a method to allow to check to see if method exists. Also editors to workout if mime type is supported. 

Fixes #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
