### PR TITLE
Remove additional image backup sources & sizes files when attachment deleted

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -387,6 +387,30 @@ function webp_uploads_remove_sources_files( $attachment_id ) {
 			wp_delete_file_from_directory( $backup_intermediate_file, $intermediate_dir );
 		}
 	}
+
+	$backup_sources = get_post_meta( $attachment_id, '_wp_attachment_backup_sources', true );
+	$backup_sources = is_array( $backup_sources ) ? $backup_sources : array();
+
+	// Delete full sizes backup mime types.
+	foreach ( $backup_sources as $backup_mimes ) {
+
+		foreach ( $backup_mimes as $backup_mime_properties ) {
+			if ( ! is_array( $backup_mime_properties ) || empty( $backup_mime_properties['file'] ) ) {
+				continue;
+			}
+
+			$full_size = str_replace( $basename, $backup_mime_properties['file'], $file );
+			if ( empty( $full_size ) ) {
+				continue;
+			}
+
+			$full_size_file = path_join( $upload_path['basedir'], $full_size );
+			if ( ! file_exists( $full_size_file ) ) {
+				continue;
+			}
+			wp_delete_file_from_directory( $full_size_file, $intermediate_dir );
+		}
+	}
 }
 add_action( 'delete_attachment', 'webp_uploads_remove_sources_files', 10, 1 );
 

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -347,6 +347,46 @@ function webp_uploads_remove_sources_files( $attachment_id ) {
 		}
 		wp_delete_file_from_directory( $full_size_file, $intermediate_dir );
 	}
+
+	$backup_sizes = get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true );
+	$backup_sizes = is_array( $backup_sizes ) ? $backup_sizes : array();
+
+	foreach ( $backup_sizes as $backup_size ) {
+		if ( ! isset( $backup_size['sources'] ) || ! is_array( $backup_size['sources'] ) ) {
+			continue;
+		}
+
+		$original_backup_size_mime = empty( $backup_size['mime-type'] ) ? '' : $backup_size['mime-type'];
+
+		foreach ( $backup_size['sources'] as $backup_mime => $backup_properties ) {
+			/**
+			 * When we face the same mime type as the original image, we ignore this file as this file
+			 * would be removed when the size is removed by WordPress itself. The meta information as well
+			 * would be deleted as soon as the image is removed.
+			 *
+			 * @see wp_delete_attachment
+			 */
+			if ( $original_backup_size_mime === $backup_mime ) {
+				continue;
+			}
+
+			if ( ! is_array( $backup_properties ) || empty( $backup_properties['file'] ) ) {
+				continue;
+			}
+
+			$backup_intermediate_file = str_replace( $basename, $backup_properties['file'], $file );
+			if ( empty( $backup_intermediate_file ) ) {
+				continue;
+			}
+
+			$backup_intermediate_file = path_join( $upload_path['basedir'], $backup_intermediate_file );
+			if ( ! file_exists( $backup_intermediate_file ) ) {
+				continue;
+			}
+
+			wp_delete_file_from_directory( $backup_intermediate_file, $intermediate_dir );
+		}
+	}
 }
 add_action( 'delete_attachment', 'webp_uploads_remove_sources_files', 10, 1 );
 

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -332,20 +332,16 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		$backup_sources = get_post_meta( $attachment_id, '_wp_attachment_backup_sources', true );
 		$this->assertNotEmpty( $backup_sources );
+		$this->assertIsArray( $backup_sources );
 
 		$backup_sizes = get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true );
+		$this->assertNotEmpty( $backup_sizes );
 		$this->assertIsArray( $backup_sizes );
 
 		wp_delete_attachment( $attachment_id, true );
 
 		$this->assertFileDoesNotExist( path_join( $dirname, $backup_sources['full-orig']['image/webp']['file'] ) );
 		$this->assertFileDoesNotExist( path_join( $dirname, $backup_sizes['thumbnail-orig']['sources']['image/webp']['file'] ) );
-
-		$backup_sources = get_post_meta( $attachment_id, '_wp_attachment_backup_sources', true );
-		$this->assertEmpty( $backup_sources );
-
-		$backup_sizes = get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true );
-		$this->assertEmpty( $backup_sizes );
 	}
 
 	/**

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -312,7 +312,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	}
 
 	/**
-	 * Remove the attached WebP version if the attachment is force deleted but empty trash day is not defined
+	 * Remove the attached WebP version if the attachment is force deleted after edit.
 	 *
 	 * @test
 	 */

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -312,6 +312,43 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	}
 
 	/**
+	 * Remove the attached WebP version if the attachment is force deleted but empty trash day is not defined
+	 *
+	 * @test
+	 */
+	public function it_should_remove_the_backup_sizes_and_sources_if_the_attachment_is_deleted_after_edit() {
+		$attachment_id = $this->factory->attachment->create_upload_object(
+			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
+		);
+
+		$file    = get_attached_file( $attachment_id, true );
+		$dirname = pathinfo( $file, PATHINFO_DIRNAME );
+
+		$this->assertIsString( $file );
+		$this->assertFileExists( $file );
+
+		$editor = new WP_Image_Edit( $attachment_id );
+		$editor->rotate_right()->save();
+
+		$backup_sources = get_post_meta( $attachment_id, '_wp_attachment_backup_sources', true );
+		$this->assertNotEmpty( $backup_sources );
+
+		$backup_sizes = get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true );
+		$this->assertIsArray( $backup_sizes );
+
+		wp_delete_attachment( $attachment_id, true );
+
+		$this->assertFileDoesNotExist( path_join( $dirname, $backup_sources['full-orig']['image/webp']['file'] ) );
+		$this->assertFileDoesNotExist( path_join( $dirname, $backup_sizes['thumbnail-orig']['sources']['image/webp']['file'] ) );
+
+		$backup_sources = get_post_meta( $attachment_id, '_wp_attachment_backup_sources', true );
+		$this->assertEmpty( $backup_sources );
+
+		$backup_sizes = get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true );
+		$this->assertEmpty( $backup_sizes );
+	}
+
+	/**
 	 * Avoid the change of URLs of images that are not part of the media library
 	 *
 	 * @group webp_uploads_update_image_references


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #375 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
