### PR TITLE
Discard WebP image if it is larger than corresponding JPEG image

### DIFF
--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -240,3 +240,36 @@ function webp_uploads_get_attachment_sources( $attachment_id, $size = 'thumbnail
 	// Return an empty array if no sources found.
 	return array();
 }
+
+/**
+ * Check whether the additional image is larger than the original image.
+ *
+ * @since n.e.x.t
+ *
+ * @param array $original An array with the metadata of the attachment.
+ * @param array $additional An array containing the filename and file size for additional mime.
+ * @return bool True if the additional image is larger than the original image, otherwise false.
+ */
+function webp_uploads_should_discard_additional_image_file( array $original, array $additional ) {
+	$original_image_filesize   = isset( $original['filesize'] ) ? (int) $original['filesize'] : 0;
+	$additional_image_filesize = isset( $additional['filesize'] ) ? (int) $additional['filesize'] : 0;
+	if ( $original_image_filesize > 0 && $additional_image_filesize > 0 ) {
+		/**
+		 * Filter whether WebP images that are larger than the matching JPEG should be discarded.
+		 *
+		 * By default the performance lab plugin will use the mime type with the smaller filesize
+		 * rather than defaulting to `webp`.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param bool $preferred_filesize Prioritize file size over mime type. Default true.
+		 */
+		if (
+			apply_filters( 'webp_uploads_discard_larger_generated_images', true )
+			&& $additional_image_filesize >= $original_image_filesize
+		) {
+			return true;
+		}
+	}
+	return false;
+}

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -264,10 +264,9 @@ function webp_uploads_should_discard_additional_image_file( array $original, arr
 		 *
 		 * @param bool $preferred_filesize Prioritize file size over mime type. Default true.
 		 */
-		if (
-			apply_filters( 'webp_uploads_discard_larger_generated_images', true )
-			&& $additional_image_filesize >= $original_image_filesize
-		) {
+		$webp_discard_larger_images = apply_filters( 'webp_uploads_discard_larger_generated_images', true );
+
+		if ( $webp_discard_larger_images && $additional_image_filesize >= $original_image_filesize ) {
 			return true;
 		}
 	}

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -246,7 +246,7 @@ function webp_uploads_get_attachment_sources( $attachment_id, $size = 'thumbnail
  *
  * @since n.e.x.t
  *
- * @param array $original An array with the metadata of the attachment.
+ * @param array $original   An array with the metadata of the attachment.
  * @param array $additional An array containing the filename and file size for additional mime.
  * @return bool True if the additional image is larger than the original image, otherwise false.
  */

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -96,30 +96,9 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 			continue;
 		}
 
-		$original_image_filesize = isset( $metadata['filesize'] ) ? (int) $metadata['filesize'] : 0;
-		$webp_image_filesize     = isset( $image['filesize'] ) ? (int) $image['filesize'] : 0;
-		if ( $original_image_filesize > 0 && $webp_image_filesize > 0 ) {
-			/**
-			 * Filter whether WebP images that are larger than the matching JPEG should be discarded.
-			 *
-			 * By default the performance lab plugin will use the mime type with the smaller filesize
-			 * rather than defaulting to `webp`.
-			 *
-			 * @since n.e.x.t
-			 *
-			 * @param bool $preferred_filesize Prioritize file size over mime type. Default true.
-			 */
-			if (
-				apply_filters( 'webp_uploads_discard_larger_generated_images', true )
-				&& $webp_image_filesize >= $original_image_filesize
-			) {
-				if ( ! file_exists( $destination ) ) {
-					continue;
-				}
-
-				wp_delete_file_from_directory( $destination, $original_directory );
-				continue;
-			}
+		if ( webp_uploads_should_discard_additional_image_file( $metadata, $image ) ) {
+			wp_delete_file_from_directory( $destination, $original_directory );
+			continue;
 		}
 
 		$metadata['sources'][ $targeted_mime ] = $image;
@@ -180,22 +159,10 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 				continue;
 			}
 
-			$original_thumbnail_image_filesize = isset( $properties['filesize'] ) ? (int) $properties['filesize'] : 0;
-			$webp_thumbnail_image_filesize     = isset( $source['filesize'] ) ? (int) $source['filesize'] : 0;
-			if ( $original_thumbnail_image_filesize > 0 && $webp_thumbnail_image_filesize > 0 ) {
-				/** This filter is documented in modules/images/webp-uploads/load.php */
-				if (
-					apply_filters( 'webp_uploads_discard_larger_generated_images', true )
-					&& $webp_thumbnail_image_filesize >= $original_thumbnail_image_filesize
-				) {
-					$destination = path_join( $original_directory, $source['file'] );
-					if ( ! file_exists( $destination ) ) {
-						continue;
-					}
-
-					wp_delete_file_from_directory( $destination, $original_directory );
-					continue;
-				}
+			if ( webp_uploads_should_discard_additional_image_file( $properties, $source ) ) {
+				$destination = path_join( $original_directory, $source['file'] );
+				wp_delete_file_from_directory( $destination, $original_directory );
+				continue;
 			}
 
 			$properties['sources'][ $mime ]  = $source;

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -597,14 +597,21 @@ function webp_uploads_img_tag_update_mime_type( $original_image, $context, $atta
 		}
 	}
 
-	if (
-		! has_action( 'wp_footer', 'webp_uploads_wepb_fallback' ) &&
-		$image !== $original_image &&
-		'the_content' === $context &&
-		'image/jpeg' === $original_mime &&
-		'image/webp' === $target_mime
-	) {
-		add_action( 'wp_footer', 'webp_uploads_wepb_fallback' );
+	foreach ( $target_mimes as $target_mime ) {
+
+		if ( $target_mime === $original_mime ) {
+			continue;
+		}
+
+		if (
+			! has_action( 'wp_footer', 'webp_uploads_wepb_fallback' ) &&
+			$image !== $original_image &&
+			'the_content' === $context &&
+			'image/jpeg' === $original_mime &&
+			'image/webp' === $target_mime
+		) {
+			add_action( 'wp_footer', 'webp_uploads_wepb_fallback' );
+		}
 	}
 
 	return $image;

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -103,7 +103,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 		}
 
 		/**
-		 * Filter whether to prioritize the file type over the mime type.
+		 * Filter whether WebP images that are larger than the matching JPEG should be discarded.
 		 *
 		 * By default the performance lab plugin will use the mime type with the smaller filesize
 		 * rather than defaulting to `webp`.
@@ -113,7 +113,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 		 * @param bool $preferred_filesize Prioritize file size over mime type. Default true.
 		 */
 		if (
-			apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
+			apply_filters( 'webp_uploads_discard_larger_generated_images', true )
 			&& $webp_image_filesize >= $original_image_filesize
 		) {
 			if ( ! file_exists( $destination ) ) {
@@ -190,7 +190,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 
 			/** This filter is documented in modules/images/webp-uploads/load.php */
 			if (
-				apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
+				apply_filters( 'webp_uploads_discard_larger_generated_images', true )
 				&& $webp_thumbnail_image_filesize >= $original_thumbnail_image_filesize
 			) {
 				$destination = trailingslashit( $original_directory ) . "{$source['file']}";

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -192,16 +192,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 			// Remove the WebP image if it is bigger than the original thumbnail image.
 			if (
 				$webp_thumbnail_image_filesize >= $original_thumbnail_image_filesize
-				/**
-				 * Filter whether to prioritize the file type over the mime type.
-				 *
-				 * By default the performance lab plugin will use the mime type with the smaller filesize
-				 * rather than defaulting to `webp`.
-				 *
-				 * @since n.e.x.t
-				 *
-				 * @param bool $perfer_filesize Prioritize file size over mime type. Default true.
-				 */
+				/** This filter is documented in modules/images/webp-uploads/load.php */
 				&& apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
 			) {
 				$destination = trailingslashit( $original_directory ) . "{$source['file']}";

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -102,7 +102,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 			continue;
 		}
 
-		/* Remove WebP image if it bigger then original image */
+		// Remove WebP image if it is bigger than the original image.
 		if (
 			$webp_image_filesize >= $original_image_filesize
 			/**
@@ -113,10 +113,14 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 			 *
 			 * @since n.e.x.t
 			 *
-			 * @param bool $perfer_filesize Prioritize file size over mime type. Default true.
+			 * @param bool $preferred_filesize Prioritize file size over mime type. Default true.
 			 */
 			&& apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
 		) {
+			if ( ! file_exists( $destination ) ) {
+				continue;
+			}
+
 			wp_delete_file_from_directory( $destination, $original_directory );
 			continue;
 		}
@@ -185,7 +189,7 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 				continue;
 			}
 
-			/* Remove WebP image if it bigger then original thumbnail image */
+			// Remove the WebP image if it is bigger than the original thumbnail image.
 			if (
 				$webp_thumbnail_image_filesize >= $original_thumbnail_image_filesize
 				/**
@@ -201,6 +205,10 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 				&& apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
 			) {
 				$destination = trailingslashit( $original_directory ) . "{$source['file']}";
+				if ( ! file_exists( $destination ) ) {
+					continue;
+				}
+
 				wp_delete_file_from_directory( $destination, $original_directory );
 				continue;
 			}

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -102,20 +102,19 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 			continue;
 		}
 
-		// Remove WebP image if it is bigger than the original image.
+		/**
+		 * Filter whether to prioritize the file type over the mime type.
+		 *
+		 * By default the performance lab plugin will use the mime type with the smaller filesize
+		 * rather than defaulting to `webp`.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param bool $preferred_filesize Prioritize file size over mime type. Default true.
+		 */
 		if (
-			$webp_image_filesize >= $original_image_filesize
-			/**
-			 * Filter whether to prioritize the file type over the mime type.
-			 *
-			 * By default the performance lab plugin will use the mime type with the smaller filesize
-			 * rather than defaulting to `webp`.
-			 *
-			 * @since n.e.x.t
-			 *
-			 * @param bool $preferred_filesize Prioritize file size over mime type. Default true.
-			 */
-			&& apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
+			apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
+			&& $webp_image_filesize >= $original_image_filesize
 		) {
 			if ( ! file_exists( $destination ) ) {
 				continue;
@@ -189,11 +188,10 @@ function webp_uploads_create_sources_property( array $metadata, $attachment_id )
 				continue;
 			}
 
-			// Remove the WebP image if it is bigger than the original thumbnail image.
+			/** This filter is documented in modules/images/webp-uploads/load.php */
 			if (
-				$webp_thumbnail_image_filesize >= $original_thumbnail_image_filesize
-				/** This filter is documented in modules/images/webp-uploads/load.php */
-				&& apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
+				apply_filters( 'webp_prioritise_filesize_over_mime_type', true )
+				&& $webp_thumbnail_image_filesize >= $original_thumbnail_image_filesize
 			) {
 				$destination = trailingslashit( $original_directory ) . "{$source['file']}";
 				if ( ! file_exists( $destination ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,7 +54,7 @@ tests_add_filter(
 );
 
 // Remove the filter so that other tests are not impacted.
-tests_add_filter( 'webp_prioritise_filesize_over_mime_type', '__return_false' );
+tests_add_filter( 'webp_uploads_discard_larger_generated_images', '__return_false' );
 
 // Start up the WP testing environment.
 require $_test_root . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,8 +53,5 @@ tests_add_filter(
 	1
 );
 
-// Remove the filter so that other tests are not impacted.
-tests_add_filter( 'webp_uploads_discard_larger_generated_images', '__return_false' );
-
 // Start up the WP testing environment.
 require $_test_root . '/includes/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,5 +53,8 @@ tests_add_filter(
 	1
 );
 
+// Remove the filter so that other tests are not impacted.
+tests_add_filter( 'webp_prioritise_filesize_over_mime_type', '__return_false' );
+
 // Start up the WP testing environment.
 require $_test_root . '/includes/bootstrap.php';

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -410,4 +410,52 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 		$this->assertIsArray( $transforms );
 		$this->assertSame( array( 'image/jpeg' => array( 'image/jpeg', 'image/webp' ) ), $transforms );
 	}
+
+	/**
+	 * Tests the webp_uploads_discard_larger_generated_images filter.
+	 *
+	 * @dataProvider data_provider_image_filesize
+	 *
+	 * @test
+	 */
+	public function it_should_check_if_the_additional_image_is_larger_than_the_original_image( $original_filesize, $additional_filesize, $expected_status ) {
+		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
+
+		$output = webp_uploads_should_discard_additional_image_file( $original_filesize, $additional_filesize );
+		$this->assertSame( $output, $expected_status );
+	}
+
+	public function data_provider_image_filesize() {
+		return array(
+			array(
+				array( 'filesize' => 120101 ),
+				array( 'filesize' => 100101 ),
+				false,
+			),
+			array(
+				array( 'filesize' => 100101 ),
+				array( 'filesize' => 120101 ),
+				true,
+			),
+			array(
+				array( 'filesize' => 10101 ),
+				array( 'filesize' => 10101 ),
+				true,
+			),
+		);
+	}
+
+	/**
+	 * Check the disabled behaviour of the webp_uploads_discard_larger_generated_images filter.
+	 *
+	 * @dataProvider data_provider_image_filesize
+	 *
+	 * @test
+	 */
+	public function it_should_return_an_additional_image_if_it_is_bigger_than_original( $original_filesize, $additional_filesize ) {
+		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_false' );
+
+		$output = webp_uploads_should_discard_additional_image_file( $original_filesize, $additional_filesize );
+		$this->assertSame( $output, false );
+	}
 }

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -412,13 +412,11 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests the webp_uploads_discard_larger_generated_images filter.
-	 *
 	 * @dataProvider data_provider_image_filesize
 	 *
 	 * @test
 	 */
-	public function it_should_check_if_the_additional_image_is_larger_than_the_original_image( $original_filesize, $additional_filesize, $expected_status ) {
+	public function it_should_discard_additional_image_if_larger_than_the_original_image( $original_filesize, $additional_filesize, $expected_status ) {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		$output = webp_uploads_should_discard_additional_image_file( $original_filesize, $additional_filesize );
@@ -446,16 +444,14 @@ class WebP_Uploads_Helper_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check the disabled behaviour of the webp_uploads_discard_larger_generated_images filter.
-	 *
 	 * @dataProvider data_provider_image_filesize
 	 *
 	 * @test
 	 */
-	public function it_should_return_an_additional_image_if_it_is_bigger_than_original( $original_filesize, $additional_filesize ) {
+	public function it_should_never_discard_additional_image_if_filter_is_false( $original_filesize, $additional_filesize ) {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_false' );
 
 		$output = webp_uploads_should_discard_additional_image_file( $original_filesize, $additional_filesize );
-		$this->assertSame( $output, false );
+		$this->assertFalse( $output );
 	}
 }

--- a/tests/modules/images/webp-uploads/image-edit-tests.php
+++ b/tests/modules/images/webp-uploads/image-edit-tests.php
@@ -10,6 +10,12 @@ use PerformanceLab\Tests\TestCase\ImagesTestCase;
 
 class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_false' );
+	}
+
 	/**
 	 * Backup the sources structure alongside the full size
 	 *

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -629,11 +629,10 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 	/**
 	 * The image with the smaller filesize should be used when webp_uploads_discard_larger_generated_images is set to true.
-	 * This test has all WebP smaller than the original size.
 	 *
 	 * @test
 	 */
-	public function it_should_use_smaller_mime_type_image_from_source_for_all_sizes() {
+	public function it_should_create_webp_when_webp_is_smaller_than_jpegs() {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
@@ -669,7 +668,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 *
 	 * @test
 	 */
-	public function it_should_use_smaller_mime_type_image_for_full_size() {
+	public function it_should_create_webp_for_full_size_which_is_smaller_in_webp_format() {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains only full size mime type images.
@@ -692,7 +691,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 *
 	 * @test
 	 */
-	public function it_should_use_smaller_mime_type_image_from_specific_source_for_webp_image() {
+	public function it_should_create_webp_for_some_sizes_which_are_smaller_in_webp_format() {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -621,12 +621,12 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	}
 
 	/**
-	 * The image with the smaller filesize should be used when webp_prioritise_filesize_over_mime_type is set to true.
+	 * The image with the smaller filesize should be used when webp_uploads_discard_larger_generated_images is set to true.
 	 *
 	 * @test
 	 */
 	public function it_should_use_smaller_mime_type_image_from_source() {
-		add_filter( 'webp_prioritise_filesize_over_mime_type', '__return_true' );
+		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
 		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
@@ -651,12 +651,12 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	}
 
 	/**
-	 * The image with the smaller filesize should be used when webp_prioritise_filesize_over_mime_type is set to true.
+	 * The image with the smaller filesize should be used when webp_uploads_discard_larger_generated_images is set to true.
 	 *
 	 * @test
 	 */
 	public function it_should_use_smaller_mime_type_image_from_specific_source() {
-		add_filter( 'webp_prioritise_filesize_over_mime_type', '__return_true' );
+		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
 		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
@@ -673,12 +673,12 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	}
 
 	/**
-	 * The image with the smaller filesize should be used when webp_prioritise_filesize_over_mime_type is set to true.
+	 * The image with the smaller filesize should be used when webp_uploads_discard_larger_generated_images is set to true.
 	 *
 	 * @test
 	 */
 	public function it_should_use_smaller_mime_type_image_from_specific_source_for_webp_image() {
-		add_filter( 'webp_prioritise_filesize_over_mime_type', '__return_true' );
+		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
 		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );

--- a/tests/modules/images/webp-uploads/rest-api-tests.php
+++ b/tests/modules/images/webp-uploads/rest-api-tests.php
@@ -8,6 +8,12 @@
 
 class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 
+	public function set_up() {
+		parent::set_up();
+
+		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_false' );
+	}
+
 	/**
 	 * Checks whether the sources information is added to image sizes details of the REST response object.
 	 *


### PR DESCRIPTION
## Summary

After these changes, it affects many current unit tests because those tests are expecting .webp extensions but the images are bigger, so they end up with .jpg extensions. To handle the tests I use the filter approach to pass tests. thanks, @peterwilsoncc for that review.

After implementing this change we no longer need the smaller file size filter and related code. The filter `$prefer_smaller_image_file = apply_filters('webp_uploads_prefer_smaller_image_file', false);` and code for full size image https://github.com/WordPress/performance/blob/trunk/modules/images/webp-uploads/load.php#L477-L485 and thumbnail size image https://github.com/WordPress/performance/blob/trunk/modules/images/webp-uploads/load.php#L533-L541 because now images have only files that have a smaller size.

### Introduce a new filter `webp_prioritise_filesize_over_mime_type` to handle old unit tests.
The new file size changes affect some old tests to handle it a new filter `webp_prioritise_filesize_over_mime_type` introduce, that allow users to disable to the new behavior. by default its value is `true` in code base. For the unit tests we don't need this filter so added `add tests_add_filter( 'webp_prioritise_filesize_over_mime_type', '__return_false' );` in the tests bootstrap file so old tests don;t affect with new changes. For new tests, we include `add_filter( 'webp_prioritise_filesize_over_mime_type', '__return_true' );`.


<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #372

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
