### PR TITLE
Avoid including .husky directory in plugin ZIP

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 /.git export-ignore
 /.github export-ignore
 /.wordpress-org export-ignore
+/.husky export-ignore
 /node_modules export-ignore
 /vendor export-ignore
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #386 

## Relevant technical choices

<!-- Please describe your changes. -->
This PR adds the `.husky` folder to the `.gitattributes` file so that it's not copied over during build time.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
