### PR TITLE
Ensure regenerating an image also regenerates WebP while not conflicting with other attachments

### DIFF
--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -144,7 +144,13 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 
 	// Skip creation of duplicate WebP image if an image file already exists in the directory.
 	if ( file_exists( $destination_file_name ) ) {
-		return new WP_Error( 'webp_image_file_present', __( 'The WebP image already exists.', 'performance-lab' ) );
+		$extension = explode( '|', $allowed_mimes[ $mime ] );
+		$filename  = pathinfo( $destination_file_name, PATHINFO_FILENAME );
+		$filename  = "{$filename}.{$extension[0]}";
+		return array(
+			'file'     => $filename,
+			'filesize' => wp_filesize( $destination_file_name ),
+		);
 	}
 
 	$image = $editor->save( $destination_file_name, $mime );

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -144,11 +144,8 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 
 	// Skip creation of duplicate WebP image if an image file already exists in the directory.
 	if ( file_exists( $destination_file_name ) ) {
-		$extension = explode( '|', $allowed_mimes[ $mime ] );
-		$filename  = pathinfo( $destination_file_name, PATHINFO_FILENAME );
-		$filename  = "{$filename}.{$extension[0]}";
 		return array(
-			'file'     => $filename,
+			'file'     => wp_basename( $destination_file_name ),
 			'filesize' => wp_filesize( $destination_file_name ),
 		);
 	}


### PR DESCRIPTION
## Summary

This issue is related to #359. 

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #395

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
