### PR TITLE
Remove experimental label from Dominant Color module and turn on by default for new installs

### DIFF
--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -2,7 +2,7 @@
 /**
  * Module Name: Dominant Color
  * Description: Adds support to store dominant color for an image and create a placeholder background with that color.
- * Experimental: Yes
+ * Experimental: No
  *
  * @package performance-lab
  * @since 1.2.0


### PR DESCRIPTION
## Summary

Enable dominant color module by default and remove experiemently flag.

Fixes #402

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
