### PR TITLE
Adding LiteSpeed Cache and QUIC.cloud CDN

### DIFF
--- a/modules/site-health/audit-full-page-cache/helper.php
+++ b/modules/site-health/audit-full-page-cache/helper.php
@@ -39,6 +39,8 @@ function perflab_afpc_get_page_cache_headers() {
 		'cf-cache-status'        => $cache_hit_callback,
 		'x-kinsta-cache'         => $cache_hit_callback,
 		'x-aruba-cache'          => $cache_hit_callback,
+		'x-litespeed-cache'      => $cache_hit_callback,
+		'x-qc-cache'             => $cache_hit_callback,
 		'x-cache-enabled'        => static function ( $header_value ) {
 			return 'true' === strtolower( $header_value );
 		},


### PR DESCRIPTION
## Summary

Add support for:
- LiteSpeed Cache: https://litespeedtech.com/products/cache-plugins/wordpress-acceleration
- QUIC.cloud CDN: https://quic.cloud/quic-cloud-services-and-features/litespeed-cache-service/

## Checklist
* [x]  PR has either `[Focus]` or `Infrastructure` label.
* [x]  PR has a `[Type]` label.
* [ ]  PR has a milestone or the `no milestone` label.