### PR TITLE
Fix typos and Coding standard

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -408,7 +408,7 @@ function perflab_render_pointer() {
 	?>
 	<script id="perflab-admin-pointer" type="text/javascript">
 		jQuery( function() {
-			// Pointer Options
+			// Pointer Options.
 			var options = {
 				content: '<h3><?php echo esc_js( $heading ); ?></h3><p><?php echo wp_kses( $content, $wp_kses_options ); ?></p>',
 				position: {

--- a/tests/testdata/modules/images/webp-uploads/class-wp-image-edit.php
+++ b/tests/testdata/modules/images/webp-uploads/class-wp-image-edit.php
@@ -136,7 +136,7 @@ class WP_Image_Edit {
 
 	/**
 	 * Setup the $_REQUEST global so `wp_save_image` can process the image with the same editions
-	 * performend into an image as it was performed from the editor.
+	 * performed into an image as it was performed from the editor.
 	 *
 	 * @see wp_save_image
 	 *
@@ -158,7 +158,7 @@ class WP_Image_Edit {
 	/**
 	 * Determine if the last operation executed to edit the image was successfully or not.
 	 *
-	 * @return bool whether the operation to save the image was succesfully or not.
+	 * @return bool whether the operation to save the image was successfully or not.
 	 */
 	public function success() {
 		if ( ! is_object( $this->result ) ) {


### PR DESCRIPTION
fix some typos and coding standards

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.