### PR TITLE
Fixed infinit loop in the fallback mechanism for webp images.

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -664,6 +664,7 @@ function webp_uploads_wepb_fallback() {
 		i = d.createElement( i );
 		i.src = p + 'jIAAABXRUJQVlA4ICYAAACyAgCdASoCAAEALmk0mk0iIiIiIgBoSygABc6zbAAA/v56QAAAAA==';
 		i.onload = function() {
+			i.onload = undefined;
 			i.src = p + 'h4AAABXRUJQVlA4TBEAAAAvAQAAAAfQ//73v/+BiOh/AAA=';
 		};
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
