### PR TITLE
PHPCS: Use a period at the end

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -385,7 +385,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 add_action( 'admin_enqueue_scripts', 'perflab_admin_pointer' );
 
 /**
- * Renders the Admin Pointer
+ * Renders the Admin Pointer.
  *
  * Handles the rendering of the admin pointer.
  *

--- a/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
+++ b/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * WordPress Image Editor Class for Image Manipulation through GD
- * with dominant color detection.
+ * with dominant color detection
  *
  * @package performance-lab
  * @group dominant-color

--- a/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
+++ b/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * WordPress Image Editor Class for Image Manipulation through GD
- * with dominant color detection
+ * with dominant color detection.
  *
  * @package performance-lab
  * @group dominant-color
@@ -11,7 +11,7 @@
 
 /**
  * WordPress Image Editor Class for Image Manipulation through GD
- * with dominant color detection
+ * with dominant color detection.
  *
  * @since 1.2.0
  *

--- a/modules/images/dominant-color/class-dominant-color-image-editor-imagick.php
+++ b/modules/images/dominant-color/class-dominant-color-image-editor-imagick.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * WordPress Image Editor Class for Image Manipulation through Imagick
- * with dominant color detection.
+ * with dominant color detection
  *
  * @package performance-lab
  * @group dominant-color

--- a/modules/images/dominant-color/class-dominant-color-image-editor-imagick.php
+++ b/modules/images/dominant-color/class-dominant-color-image-editor-imagick.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * WordPress Image Editor Class for Image Manipulation through Imagick
- * with dominant color detection
+ * with dominant color detection.
  *
  * @package performance-lab
  * @group dominant-color
@@ -11,7 +11,7 @@
 
 /**
  * WordPress Image Editor Class for Image Manipulation through Imagick
- * with dominant color detection
+ * with dominant color detection.
  *
  * @since 1.2.0
  *

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -34,7 +34,7 @@ function dominant_color_metadata( $metadata, $attachment_id ) {
 add_filter( 'wp_generate_attachment_metadata', 'dominant_color_metadata', 10, 2 );
 
 /**
- * Filter various image attributes to add the dominant color to the image.
+ * Filters various image attributes to add the dominant color to the image.
  *
  * @since 1.2.0
  *
@@ -145,9 +145,9 @@ if ( version_compare( '6', $GLOBALS['wp_version'], '>=' ) ) {
 	 *
 	 * @since 1.2.0
 	 *
-	 * @param string $content the content to filter.
-	 * @param string $context the context of the content.
-	 * @return string content.
+	 * @param string $content The content to filter.
+	 * @param string $context The context of the content.
+	 * @return string The updated $content.
 	 */
 	function dominant_color_filter_content_tags( $content, $context = null ) {
 		if ( null === $context ) {

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -34,7 +34,7 @@ function dominant_color_metadata( $metadata, $attachment_id ) {
 add_filter( 'wp_generate_attachment_metadata', 'dominant_color_metadata', 10, 2 );
 
 /**
- * Filter various image attributes to add the dominant color to the image
+ * Filter various image attributes to add the dominant color to the image.
  *
  * @since 1.2.0
  *
@@ -147,7 +147,7 @@ if ( version_compare( '6', $GLOBALS['wp_version'], '>=' ) ) {
 	 *
 	 * @param string $content the content to filter.
 	 * @param string $context the context of the content.
-	 * @return string content
+	 * @return string content.
 	 */
 	function dominant_color_filter_content_tags( $content, $context = null ) {
 		if ( null === $context ) {

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -64,7 +64,7 @@ function webp_uploads_get_upload_image_mime_transforms() {
  * @param string $mime                  The target mime in which the image should be created.
  * @param string $destination_file_name The path where the file would be stored, including the extension. If empty, `generate_filename` is used to create the destination file name.
  *
- * @return array|WP_Error An array with the file and filesize if the image was created correctly otherwise a WP_Error.
+ * @return array|WP_Error An array with the file and filesize if the image was created correctly, otherwise a WP_Error.
  */
 function webp_uploads_generate_additional_image_source( $attachment_id, $image_size, array $size_data, $mime, $destination_file_name = null ) {
 	/**
@@ -80,7 +80,7 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 	 * @param string              $image_size    The size name that would be used to create this image, out of the registered subsizes.
 	 * @param array               $size_data     An array with the dimensions of the image: height, width and crop {'height'=>int, 'width'=>int, 'crop'}.
 	 * @param string              $mime          The target mime in which the image should be created.
-	 * @return array|null|WP_Error An array with the file and filesize if the image was created correctly otherwise a WP_Error.
+	 * @return array|null|WP_Error array|null|WP_Error An array with the file and filesize if the image was created correctly, otherwise a WP_Error.
 	 */
 	$image = apply_filters( 'webp_uploads_pre_generate_additional_image_source', null, $attachment_id, $image_size, $size_data, $mime );
 	if ( is_wp_error( $image ) ) {

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -64,7 +64,7 @@ function webp_uploads_get_upload_image_mime_transforms() {
  * @param string $mime                  The target mime in which the image should be created.
  * @param string $destination_file_name The path where the file would be stored, including the extension. If empty, `generate_filename` is used to create the destination file name.
  *
- * @return array|WP_Error An array with the file and filesize if the image was created correctly otherwise a WP_Error
+ * @return array|WP_Error An array with the file and filesize if the image was created correctly otherwise a WP_Error.
  */
 function webp_uploads_generate_additional_image_source( $attachment_id, $image_size, array $size_data, $mime, $destination_file_name = null ) {
 	/**
@@ -80,7 +80,7 @@ function webp_uploads_generate_additional_image_source( $attachment_id, $image_s
 	 * @param string              $image_size    The size name that would be used to create this image, out of the registered subsizes.
 	 * @param array               $size_data     An array with the dimensions of the image: height, width and crop {'height'=>int, 'width'=>int, 'crop'}.
 	 * @param string              $mime          The target mime in which the image should be created.
-	 * @return array|null|WP_Error An array with the file and filesize if the image was created correctly otherwise a WP_Error
+	 * @return array|null|WP_Error An array with the file and filesize if the image was created correctly otherwise a WP_Error.
 	 */
 	$image = apply_filters( 'webp_uploads_pre_generate_additional_image_source', null, $attachment_id, $image_size, $size_data, $mime );
 	if ( is_wp_error( $image ) ) {

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -497,7 +497,7 @@ add_filter( 'the_content', 'webp_uploads_update_image_references', 10 );
  * for the specified image sizes, the *.webp references are stored inside of each size.
  *
  * @since 1.0.0
- * @since n.e.x.t Remove `webp_uploads_prefer_smaller_image_file` filter
+ * @since n.e.x.t Remove `webp_uploads_prefer_smaller_image_file` filter.
  *
  * @param string $original_image An <img> tag where the urls would be updated.
  * @param string $context        The context where this is function is being used.

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -497,7 +497,7 @@ add_filter( 'the_content', 'webp_uploads_update_image_references', 10 );
  * for the specified image sizes, the *.webp references are stored inside of each size.
  *
  * @since 1.0.0
- * @since n.e.x.t Remove `webp_uploads_prefer_smaller_image_file` filter.
+ * @since 1.3.0 Remove `webp_uploads_prefer_smaller_image_file` filter.
  *
  * @param string $original_image An <img> tag where the urls would be updated.
  * @param string $context        The context where this is function is being used.


### PR DESCRIPTION
## Summary

As per [PHP Documentation Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/), we should add a period at the end of inline documents.

### Document summary:
 
`Summary:` A brief, one sentence explanation of the purpose of the function spanning a maximum of two lines. **Use a period at the end.**
`Description:` A supplement to the summary, providing a more detailed description. **Use a period at the end of sentences.**
`@since`: PHPDoc supports multiple `@since` versions in DocBlocks for this explicit reason. When adding changelog entries to the `@since` block, a version should be cited, and a description should be added in sentence case and form and **end with a period**:
`@param:` Note if the parameter is Optional before the description, and **include a period at the end**. The description should mention accepted values as well as the default. For example: Optional. This value does something. Accepts ‘post’, ‘term’, or empty. Default empty.
`@return:` Should contain all possible return types, and a description for each. **Use a period at the end**. Note: @return void should not be used outside of the default bundled themes.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
