### PR TITLE
Enhance JS replacement mechanism for WebP to JPEG to more reliably replace full file name

### DIFF
--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -8,8 +8,14 @@ window.wpPerfLab = window.wpPerfLab || {};
 					media_details = image.media_details,
 					media_sources = media_details.sources,
 					sizes         = media_details.sizes,
-					sizes_keys    = Object.keys( sizes ),
-					images        = document.querySelectorAll( 'img.wp-image-' + image.id );
+					sizes_keys    = Object.keys( sizes );
+
+				// If the full image has no JPEG version available, no sub-size will have JPEG available either.
+				if ( sizes.full && ! sizes.full.sources['image/jpeg'] ) {
+					continue;
+				}
+
+				var images = document.querySelectorAll( 'img.wp-image-' + image.id );
 
 				for ( var j = 0; j < images.length; j++ ) {
 
@@ -20,11 +26,6 @@ window.wpPerfLab = window.wpPerfLab || {};
 						src = src.replace( media_sources['image/webp'].file, media_sources['image/jpeg'].file );
 						images[ j ].setAttribute( 'src', src );
 						break;
-					}
-
-					// If the full image has no JPEG version available, no sub-size will have JPEG available either.
-					if ( ! sizes.full.sources['image/jpeg'] ) {
-						continue;
 					}
 
 					var srcset = images[ j ].getAttribute( 'srcset' );

--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -21,11 +21,14 @@ window.wpPerfLab = window.wpPerfLab || {};
 
 					var src = images[ j ].src;
 
-					// If there are no sizes, then replace src through sources, there is nothing more to replace.
-					if ( media_sources && ! sizes.full ) {
-						src = src.replace( media_sources['image/webp'].file, media_sources['image/jpeg'].file );
-						images[ j ].setAttribute( 'src', src );
-						break;
+					// If there are sources but no sizes, then attempt to replace src through sources. In that case, there is nothing more to replace.
+					if ( media_sources && ! sizes_keys.length ) {
+						// Only modify src if available and the relevant sources are set.
+						if ( src && media_sources['image/webp'] && media_sources['image/jpeg'] ) {
+							src = src.replace( media_sources['image/webp'].file, media_sources['image/jpeg'].file );
+							images[ j ].setAttribute( 'src', src );
+						}
+						continue;
 					}
 
 					var srcset = images[ j ].getAttribute( 'srcset' );

--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -4,46 +4,49 @@ window.wpPerfLab = window.wpPerfLab || {};
 	window.wpPerfLab.webpUploadsFallbackWebpImages = function( media ) {
 		for ( var i = 0; i < media.length; i++ ) {
 			try {
-				var images = document.querySelectorAll( 'img.wp-image-' + media[i].id );
+
+				var images = document.querySelectorAll( 'img.wp-image-' + media[ i ].id ),
+					media_sources = media[ i ].media_details.sources;
 				for ( var j = 0; j < images.length; j++ ) {
 
-					if ( ! media[i].media_details.sources || ! media[i].media_details.sources['image/jpeg'] ) {
+					if ( ! media_sources || ! media_sources['image/jpeg'] ) {
 						continue;
 					}
 
-					var sizes = media[i].media_details.sizes;
-					var sizes_keys = Object.keys( sizes );
-					var srcset = images[j].getAttribute( 'srcset' );
+					var srcset = images[ j ].getAttribute( 'srcset' ),
+						sizes = media[ i ].media_details.sizes,
+						sizes_keys = Object.keys( sizes ),
+						flag = true;
 
 					// If a full image is present in srcset, it should be updated.
-					if( srcset && media[i].media_details.sources['image/webp'] ) {
-						srcset = srcset.replace( media[i].media_details.sources['image/webp'].file, media[i].media_details.sources['image/jpeg'].file );
+					if ( srcset && media_sources['image/webp'] ) {
+						srcset = srcset.replace( media_sources['image/webp'].file, media_sources['image/jpeg'].file );
 					}
 
-					var flag = true;
 					for ( var k = 0; k < sizes_keys.length; k++ ) {
-						if( ! media[i].media_details.sizes[sizes_keys[k]].sources || ! media[i].media_details.sizes[sizes_keys[k]].sources['image/webp'] || ! media[i].media_details.sizes[sizes_keys[k]].sources['image/jpeg'] ) {
+						var media_sizes_sources = media[ i ].media_details.sizes[ sizes_keys[ k ] ].sources;
+						if ( ! media_sizes_sources || ! media_sizes_sources['image/webp'] || ! media_sizes_sources['image/jpeg'] ) {
 							continue;
 						}
 
 						// Check to see if the image src has any size set, then update it.
-						if( flag && media[i].media_details.sizes[sizes_keys[k]].sources['image/webp'].source_url === images[j].src ) {
-							images[j].src = media[i].media_details.sizes[sizes_keys[k]].sources['image/jpeg'].source_url;
+						if ( flag && media_sizes_sources['image/webp'].source_url === images[ j ].src ) {
+							images[ j ].src = media_sizes_sources['image/jpeg'].source_url;
 							flag = false;
 						}
 
-						if( srcset && media[i].media_details.sizes[sizes_keys[k]].sources['image/webp'] ) {
-							srcset = srcset.replace( media[i].media_details.sizes[sizes_keys[k]].sources['image/webp'].source_url, media[i].media_details.sizes[sizes_keys[k]].sources['image/jpeg'].source_url );
+						if ( srcset && media_sizes_sources['image/webp'] ) {
+							srcset = srcset.replace( media_sizes_sources['image/webp'].source_url, media_sizes_sources['image/jpeg'].source_url );
 						}
 					}
 
-					if( srcset ) {
-						images[j].setAttribute( 'srcset', srcset );
+					if ( srcset ) {
+						images[ j ].setAttribute( 'srcset', srcset );
 					}
 
 					// If the src has not been updated, then update the image src with the sources.
-					if( flag && media[i].media_details.sources['image/webp'] ) {
-						images[j].src = images[j].src.replace( media[i].media_details.sources['image/webp'].file, media[i].media_details.sources['image/jpeg'].file );
+					if ( flag && media_sources['image/webp'] ) {
+						images[ j ].src = images[ j ].src.replace( media_sources['image/webp'].file, media_sources['image/jpeg'].file );
 					}
 				}
 			} catch ( e ) {
@@ -56,7 +59,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 	var loadMediaDetails = function( nodes ) {
 		var ids = [];
 		for ( var i = 0; i < nodes.length; i++ ) {
-			var node = nodes[i];
+			var node = nodes[ i ];
 			var srcset = node.getAttribute( 'srcset' ) || '';
 
 			if (
@@ -91,7 +94,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 		// Start the mutation observer to update images added dynamically.
 		var observer = new MutationObserver( function( mutationList ) {
 			for ( var i = 0; i < mutationList.length; i++ ) {
-				loadMediaDetails( mutationList[i].addedNodes );
+				loadMediaDetails( mutationList[ i ].addedNodes );
 			}
 		} );
 	

--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -9,7 +9,6 @@ window.wpPerfLab = window.wpPerfLab || {};
 
 				var images = document.querySelectorAll( 'img.wp-image-' + media[i].id );
 				for ( var j = 0; j < images.length; j++ ) {
-					console.log( media[i] );
 					var srcset = images[j].getAttribute( 'srcset' );
 					if ( srcset ) {
 						// Update full image in srcset.

--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -4,21 +4,32 @@ window.wpPerfLab = window.wpPerfLab || {};
 	window.wpPerfLab.webpUploadsFallbackWebpImages = function( media ) {
 		for ( var i = 0; i < media.length; i++ ) {
 			try {
-				if ( ! media[i].media_details.sources || ! media[i].media_details.sources['image/jpeg'] ) {
-					continue;
-				}
-
-				var ext = media[i].media_details.sources['image/jpeg'].file.match( /\.\w+$/i );
-				if ( ! ext || ! ext[0] ) {
-					continue;
-				}
+				var webp_sizes = window.wpPerfLabWebpSizes;
+				var size_keys = Object.keys( webp_sizes );
 
 				var images = document.querySelectorAll( 'img.wp-image-' + media[i].id );
 				for ( var j = 0; j < images.length; j++ ) {
-					images[j].src = images[j].src.replace( /\.webp$/i, ext[0] );
+					console.log( media[i] );
 					var srcset = images[j].getAttribute( 'srcset' );
 					if ( srcset ) {
-						images[j].setAttribute( 'srcset', srcset.replace( /\.webp(\s)/ig, ext[0] + '$1' ) );
+						// Update full image in srcset.
+						srcset = srcset.replace( images[j].src, media[i].media_details.sizes.full.source_url );
+						images[j].setAttribute( 'srcset', srcset );
+
+						// Update full image in src.
+						images[j].src = media[i].media_details.sizes.full.source_url;
+
+						// Update thumbnail images.
+						for ( var k = 0; k < size_keys.length; k++ ) {
+
+							if( ! media[i].media_details.sizes[size_keys[k]].sources['image/webp'] ) {
+								continue;
+							}
+
+							srcset = srcset.replace( media[i].media_details.sizes[size_keys[k]].sources['image/webp'].source_url, media[i].media_details.sizes[size_keys[k]].sources['image/jpeg'].source_url );
+							images[j].setAttribute( 'srcset', srcset );
+						}
+
 					}
 				}
 			} catch ( e ) {

--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -13,11 +13,10 @@ window.wpPerfLab = window.wpPerfLab || {};
 
 				for ( var j = 0; j < images.length; j++ ) {
 
-					var src    = images[ j ].src,
-						srcset = images[ j ].getAttribute( 'srcset' );
+					var src = images[ j ].src;
 
 					// If there are no sizes, then replace src through sources, there is nothing more to replace.
-					if ( media_sources ) {
+					if ( media_sources && ! sizes.full ) {
 						src = src.replace( media_sources['image/webp'].file, media_sources['image/jpeg'].file );
 						images[ j ].setAttribute( 'src', src );
 						break;
@@ -27,6 +26,8 @@ window.wpPerfLab = window.wpPerfLab || {};
 					if ( ! sizes.full.sources['image/jpeg'] ) {
 						continue;
 					}
+
+					var srcset = images[ j ].getAttribute( 'srcset' );
 
 					for ( var k = 0; k < sizes_keys.length; k++ ) {
 						var media_sizes_sources = sizes[ sizes_keys[ k ] ].sources;
@@ -44,7 +45,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 							}
 						}
 
-						if ( srcset && media_sizes_sources['image/webp'] ) {
+						if ( srcset ) {
 							srcset = srcset.replace( media_sizes_sources['image/webp'].source_url, media_sizes_sources['image/jpeg'].source_url );
 						}
 					}

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -675,10 +675,7 @@ function webp_uploads_wepb_fallback() {
 	<?php
 	$javascript = ob_get_clean();
 
-	$sizes_with_mime_type_support = webp_uploads_get_image_sizes_additional_mime_type_support();
-
 	wp_print_inline_script_tag(
-		sprintf( 'window.wpPerfLabWebpSizes = %s;', wp_json_encode( array_filter( $sizes_with_mime_type_support ) ) ) . "\n" .
 		preg_replace( '/\s+/', '', $javascript ),
 		array(
 			'id'            => 'webpUploadsFallbackWebpImages',

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -675,7 +675,10 @@ function webp_uploads_wepb_fallback() {
 	<?php
 	$javascript = ob_get_clean();
 
+	$sizes_with_mime_type_support = webp_uploads_get_image_sizes_additional_mime_type_support();
+
 	wp_print_inline_script_tag(
+		sprintf( 'window.wpPerfLabWebpSizes = %s;', wp_json_encode( array_filter( $sizes_with_mime_type_support ) ) ) . "\n" .
 		preg_replace( '/\s+/', '', $javascript ),
 		array(
 			'id'            => 'webpUploadsFallbackWebpImages',

--- a/modules/images/webp-uploads/rest-api.php
+++ b/modules/images/webp-uploads/rest-api.php
@@ -22,27 +22,23 @@ function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Pos
 		return $response;
 	}
 
-	$metadata = wp_get_attachment_metadata( $post->ID );
 	foreach ( $data['media_details']['sizes'] as $size => &$details ) {
-		if ( empty( $metadata['sizes'][ $size ]['sources'] ) || ! is_array( $metadata['sizes'][ $size ]['sources'] ) ) {
+
+		if ( empty( $details['sources'] ) || ! is_array( $details['sources'] ) ) {
 			continue;
 		}
-		$sources   = array();
+
 		$directory = dirname( $details['source_url'] );
-		foreach ( $metadata['sizes'][ $size ]['sources'] as $mime => $mime_details ) {
-			$source_url                  = "{$directory}/{$mime_details['file']}";
-			$mime_details['source_url']  = $source_url;
-			$details['sources'][ $mime ] = $mime_details;
+		foreach ( $details['sources'] as $mime => &$mime_details ) {
+			$mime_details['source_url'] = "{$directory}/{$mime_details['file']}";
 		}
 	}
 
 	$full_src = wp_get_attachment_image_src( $post->ID, 'full' );
-
-	if ( ! empty( $full_src ) ) {
-		$directory = dirname( $full_src[0] );
+	if ( ! empty( $full_src ) && ! empty( $data['media_details']['sources'] ) && ! empty( $data['media_details']['sizes']['full'] ) ) {
+		$full_url_basename = wp_basename( $full_src[0] );
 		foreach ( $data['media_details']['sources'] as $mime => &$mime_details ) {
-			$source_url                 = "{$directory}/{$mime_details['file']}";
-			$mime_details['source_url'] = $source_url;
+			$mime_details['source_url'] = str_replace( $full_url_basename, $mime_details['file'], $full_src[0] );
 		}
 
 		$data['media_details']['sizes']['full']['sources'] = $data['media_details']['sources'];

--- a/modules/images/webp-uploads/rest-api.php
+++ b/modules/images/webp-uploads/rest-api.php
@@ -28,9 +28,9 @@ function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Pos
 			continue;
 		}
 
-		$directory = dirname( $details['source_url'] );
+		$image_url_basename = wp_basename( $details['source_url'] );
 		foreach ( $details['sources'] as $mime => &$mime_details ) {
-			$mime_details['source_url'] = "{$directory}/{$mime_details['file']}";
+			$mime_details['source_url'] = str_replace( $image_url_basename, $mime_details['file'], $details['source_url'] );
 		}
 	}
 

--- a/tests/modules/images/webp-uploads/rest-api-tests.php
+++ b/tests/modules/images/webp-uploads/rest-api-tests.php
@@ -30,13 +30,14 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 		$controller = new WP_REST_Attachments_Controller( 'attachment' );
 		$response   = $controller->get_item( $request );
 
-		$this->assertInstanceOf( 'WP_REST_Response', $response );
+		$this->assertNotWPError( $response );
 
 		$data       = $response->get_data();
-		$mime_types = array(
-			'image/jpeg',
-			'image/webp',
-		);
+		$mime_types = array( 'image/jpeg' );
+
+		if ( wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {
+			array_push( $mime_types, 'image/webp' );
+		}
 
 		foreach ( $data['media_details']['sizes'] as $size_name => $properties ) {
 			if ( ! isset( $metadata['sizes'][ $size_name ]['sources'] ) ) {
@@ -56,5 +57,6 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 				$this->assertNotFalse( filter_var( $properties['sources'][ $mime_type ]['source_url'], FILTER_VALIDATE_URL ) );
 			}
 		}
+		$this->assertArrayNotHasKey( 'sources', $data['media_details'] );
 	}
 }


### PR DESCRIPTION
## Summary

In this PR I use `media[i].media_details.sizes` to check if the image size has an additional mime type or not. I also use `webp_uploads_get_image_sizes_additional_mime_type_support()` to get only allowed sizes, so we don't need to check for other sizes.

The `console.log` for the image data.

![image](https://user-images.githubusercontent.com/10103365/179894881-bc5e0bd6-759b-42e9-bdc3-9e5b881e697f.png)

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #426

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
