### PR TITLE
Fix REST API support for plain permalinks.

### DIFF
--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -54,7 +54,11 @@ window.wpPerfLab = window.wpPerfLab || {};
 			}
 
 			var jsonp = document.createElement( 'script' );
-			jsonp.src = restApi + 'wp/v2/media/?_fields=id,media_details&_jsonp=wpPerfLab.webpUploadsFallbackWebpImages&per_page=100&include=' + pageIds.join( ',' );
+			var restPath = 'wp/v2/media/?_fields=id,media_details&_jsonp=wpPerfLab.webpUploadsFallbackWebpImages&per_page=100&include=' + pageIds.join( ',' );
+			if ( -1 !== restApi.indexOf( '?' ) ) {
+				restPath = restPath.replace( '?', '&' );
+			}
+			jsonp.src = restApi + restPath;
 			document.body.appendChild( jsonp );
 		}
 	};
@@ -69,7 +73,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 				loadMediaDetails( mutationList[i].addedNodes );
 			}
 		} );
-	
+
 		observer.observe( document.body, {
 			subtree: true,
 			childList: true,


### PR DESCRIPTION
## Summary

Ensure the WebP fallback JavaScript works with sites using plain permalinks.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #456.

## Relevant technical choices

I decided to copy the approach used in the `@wordpress/apiFetch` [`rootUrl` middleware](https://github.com/WordPress/gutenberg/blob/f84d26e41a6b253b853d591eb040219a11c042cb/packages/api-fetch/src/middlewares/root-url.js) that handles this exact issue. It seems to work. 

<!-- Please describe your changes. -->

Ensures that the querystring does not have a double `?` if the site is configured using plain permalinks. 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.

