### PR TITLE
Remove plugin option network-wide for Multisite during uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -13,7 +13,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 // For a multisite, delete the option for all sites (however limited to 100 sites to avoid memory limit or timeout problems in large scale networks).
 if ( is_multisite() ) {
-
 	$site_ids = get_sites(
 		array(
 			'fields'                 => 'ids',
@@ -26,8 +25,8 @@ if ( is_multisite() ) {
 	foreach ( $site_ids as $site_id ) {
 		switch_to_blog( $site_id );
 		perflab_delete_plugin_option();
+		restore_current_blog();
 	}
-	restore_current_blog();
 }
 
 perflab_delete_plugin_option();

--- a/uninstall.php
+++ b/uninstall.php
@@ -11,4 +11,32 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-delete_option( 'perflab_modules_settings' );
+// For a multisite, delete the option for all sites (however limited to 100 sites to avoid memory limit or timeout problems in large scale networks).
+if ( is_multisite() ) {
+
+	$site_ids = get_sites(
+		array(
+			'fields'                 => 'ids',
+			'number'                 => 100,
+			'update_site_cache'      => false,
+			'update_site_meta_cache' => false,
+		)
+	);
+
+	foreach ( $site_ids as $site_id ) {
+		switch_to_blog( $site_id );
+		perflab_delete_plugin_option();
+	}
+	restore_current_blog();
+}
+
+perflab_delete_plugin_option();
+
+/**
+ * Delete the current site's option.
+ *
+ * @since n.e.x.t
+ */
+function perflab_delete_plugin_option() {
+	delete_option( 'perflab_modules_settings' );
+}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes https://github.com/WordPress/performance/issues/382

## Relevant technical choices

Remove plugin option for Multisite during uninstall execution

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
