### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,7 +50,7 @@
 /tests/modules/site-health/audit-enqueued-assets                            @manuelRod
 /tests/testdata/modules/site-health/audit-enqueued-assets                   @manuelRod
 
-# Module: Persistent Object Cache Health Check
+# Module: Persistent Object Cache
 /modules/object-cache/persistent-object-cache-health-check                  @tillkruss @spacedmonkey
 /tests/modules/object-cache/persistent-object-cache-health-check            @tillkruss @spacedmonkey
 /tests/testdata/modules/object-cache/persistent-object-cache-health-check   @tillkruss @spacedmonkey


### PR DESCRIPTION
Removed "Health Check" from the Persistent Object Cache title, since we don't use that title elsewhere

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
