### PR TITLE
Fix incorrect usage of badge colors in all Site Health checks

### DIFF
--- a/modules/object-cache/persistent-object-cache-health-check/load.php
+++ b/modules/object-cache/persistent-object-cache-health-check/load.php
@@ -107,10 +107,9 @@ function perflab_oc_health_persistent_object_cache() {
 	 */
 	$notes = apply_filters( 'perflab_oc_site_status_persistent_object_cache_notes', $notes, $available_services );
 
-	$result['status']         = 'recommended';
-	$result['label']          = __( 'You should use a persistent object cache', 'performance-lab' );
-	$result['badge']['color'] = 'orange';
-	$result['description']   .= sprintf(
+	$result['status']       = 'recommended';
+	$result['label']        = __( 'You should use a persistent object cache', 'performance-lab' );
+	$result['description'] .= sprintf(
 		'<p>%s</p>',
 		wp_kses(
 			$notes,

--- a/modules/site-health/audit-autoloaded-options/load.php
+++ b/modules/site-health/audit-autoloaded-options/load.php
@@ -43,7 +43,7 @@ function perflab_aao_autoloaded_options_test() {
 		'label'       => esc_html__( 'Autoloaded options are acceptable', 'performance-lab' ),
 		'status'      => 'good',
 		'badge'       => array(
-			'label' => esc_html__( 'Performance', 'performance-lab' ),
+			'label' => __( 'Performance', 'performance-lab' ),
 			'color' => 'blue',
 		),
 		'description' => sprintf(
@@ -69,10 +69,9 @@ function perflab_aao_autoloaded_options_test() {
 		return $result;
 	}
 
-	$result['status']         = 'critical';
-	$result['badge']['color'] = 'red';
-	$result['label']          = esc_html__( 'Autoloaded options could affect performance', 'performance-lab' );
-	$result['description']    = sprintf(
+	$result['status']      = 'critical';
+	$result['label']       = esc_html__( 'Autoloaded options could affect performance', 'performance-lab' );
+	$result['description'] = sprintf(
 		/* translators: 1. Number of autoloaded options. 2. Autoloaded options size. */
 		'<p>' . esc_html( $base_description ) . ' ' . esc_html__( 'Your site has %1$s autoloaded options (size: %2$s) in the options table, which could cause your site to be slow. You can reduce the number of autoloaded options by cleaning up your site\'s options table.', 'performance-lab' ) . '</p>',
 		$autoloaded_options_count,

--- a/modules/site-health/audit-autoloaded-options/load.php
+++ b/modules/site-health/audit-autoloaded-options/load.php
@@ -40,7 +40,7 @@ function perflab_aao_autoloaded_options_test() {
 	$base_description = __( 'Autoloaded options are configuration settings for plugins and themes that are automatically loaded with every page load in WordPress. Having too many autoloaded options can slow down your site.', 'performance-lab' );
 
 	$result = array(
-		'label'       => esc_html__( 'Autoloaded options are acceptable', 'performance-lab' ),
+		'label'       => __( 'Autoloaded options are acceptable', 'performance-lab' ),
 		'status'      => 'good',
 		'badge'       => array(
 			'label' => __( 'Performance', 'performance-lab' ),
@@ -48,7 +48,7 @@ function perflab_aao_autoloaded_options_test() {
 		),
 		'description' => sprintf(
 			/* translators: 1. Number of autoloaded options. 2. Autoloaded options size. */
-			'<p>' . esc_html( $base_description ) . ' ' . esc_html__( 'Your site has %1$s autoloaded options (size: %2$s) in the options table, which is acceptable.', 'performance-lab' ) . '</p>',
+			'<p>' . esc_html( $base_description ) . ' ' . __( 'Your site has %1$s autoloaded options (size: %2$s) in the options table, which is acceptable.', 'performance-lab' ) . '</p>',
 			$autoloaded_options_count,
 			size_format( $autoloaded_options_size )
 		),
@@ -70,10 +70,10 @@ function perflab_aao_autoloaded_options_test() {
 	}
 
 	$result['status']      = 'critical';
-	$result['label']       = esc_html__( 'Autoloaded options could affect performance', 'performance-lab' );
+	$result['label']       = __( 'Autoloaded options could affect performance', 'performance-lab' );
 	$result['description'] = sprintf(
 		/* translators: 1. Number of autoloaded options. 2. Autoloaded options size. */
-		'<p>' . esc_html( $base_description ) . ' ' . esc_html__( 'Your site has %1$s autoloaded options (size: %2$s) in the options table, which could cause your site to be slow. You can reduce the number of autoloaded options by cleaning up your site\'s options table.', 'performance-lab' ) . '</p>',
+		'<p>' . esc_html( $base_description ) . ' ' . __( 'Your site has %1$s autoloaded options (size: %2$s) in the options table, which could cause your site to be slow. You can reduce the number of autoloaded options by cleaning up your site\'s options table.', 'performance-lab' ) . '</p>',
 		$autoloaded_options_count,
 		size_format( $autoloaded_options_size )
 	);
@@ -91,7 +91,7 @@ function perflab_aao_autoloaded_options_test() {
 	/* translators: 1: HelpHub URL. 2: Link description. */
 		'<p><a target="_blank" href="%1$s">%2$s</a></p>',
 		esc_url( __( 'https://wordpress.org/support/article/optimization/#autoloaded-options', 'performance-lab' ) ),
-		esc_html__( 'More info about performance optimization', 'performance-lab' )
+		__( 'More info about performance optimization', 'performance-lab' )
 	);
 
 	/**

--- a/modules/site-health/audit-enqueued-assets/load.php
+++ b/modules/site-health/audit-enqueued-assets/load.php
@@ -144,7 +144,7 @@ function perflab_aea_enqueued_js_assets_test() {
 		'label'       => esc_html__( 'Enqueued scripts', 'performance-lab' ),
 		'status'      => 'good',
 		'badge'       => array(
-			'label' => esc_html__( 'Performance', 'performance-lab' ),
+			'label' => __( 'Performance', 'performance-lab' ),
 			'color' => 'blue',
 		),
 		'description' => sprintf(
@@ -186,8 +186,7 @@ function perflab_aea_enqueued_js_assets_test() {
 	$scripts_size_treshold = apply_filters( 'perflab_aea_enqueued_scripts_byte_size_threshold', 300000 );
 
 	if ( $enqueued_scripts > $scripts_treshold || perflab_aea_get_total_size_bytes_enqueued_scripts() > $scripts_size_treshold ) {
-		$result['status']         = 'recommended';
-		$result['badge']['color'] = 'orange';
+		$result['status'] = 'recommended';
 
 		$result['description'] = sprintf(
 			'<p>%s</p>',
@@ -238,7 +237,7 @@ function perflab_aea_enqueued_css_assets_test() {
 		'label'       => esc_html__( 'Enqueued styles', 'performance-lab' ),
 		'status'      => 'good',
 		'badge'       => array(
-			'label' => esc_html__( 'Performance', 'performance-lab' ),
+			'label' => __( 'Performance', 'performance-lab' ),
 			'color' => 'blue',
 		),
 		'description' => sprintf(
@@ -279,8 +278,7 @@ function perflab_aea_enqueued_css_assets_test() {
 	 */
 	$styles_size_threshold = apply_filters( 'perflab_aea_enqueued_styles_byte_size_threshold', 100000 );
 	if ( $enqueued_styles > $styles_threshold || perflab_aea_get_total_size_bytes_enqueued_styles() > $styles_size_threshold ) {
-		$result['status']         = 'recommended';
-		$result['badge']['color'] = 'orange';
+		$result['status'] = 'recommended';
 
 		$result['description'] = sprintf(
 			'<p>%s</p>',

--- a/modules/site-health/audit-enqueued-assets/load.php
+++ b/modules/site-health/audit-enqueued-assets/load.php
@@ -141,7 +141,7 @@ function perflab_aea_enqueued_js_assets_test() {
 	}
 
 	$result = array(
-		'label'       => esc_html__( 'Enqueued scripts', 'performance-lab' ),
+		'label'       => __( 'Enqueued scripts', 'performance-lab' ),
 		'status'      => 'good',
 		'badge'       => array(
 			'label' => __( 'Performance', 'performance-lab' ),
@@ -209,9 +209,9 @@ function perflab_aea_enqueued_js_assets_test() {
 			/* translators: 1: HelpHub URL. 2: Link description. 3.URL to clean cache. 4. Clean Cache text. */
 			'<p><a target="_blank" href="%1$s">%2$s</a></p><p><a href="%3$s">%4$s</a></p>',
 			esc_url( __( 'https://wordpress.org/support/article/optimization/', 'performance-lab' ) ),
-			esc_html__( 'More info about performance optimization', 'performance-lab' ),
+			__( 'More info about performance optimization', 'performance-lab' ),
 			esc_url( add_query_arg( 'action', 'clean_aea_audit', wp_nonce_url( admin_url( 'site-health.php' ), 'clean_aea_audit' ) ) ),
-			esc_html__( 'Clean Test Cache', 'performance-lab' )
+			__( 'Clean Test Cache', 'performance-lab' )
 		);
 	}
 
@@ -234,7 +234,7 @@ function perflab_aea_enqueued_css_assets_test() {
 		return array();
 	}
 	$result = array(
-		'label'       => esc_html__( 'Enqueued styles', 'performance-lab' ),
+		'label'       => __( 'Enqueued styles', 'performance-lab' ),
 		'status'      => 'good',
 		'badge'       => array(
 			'label' => __( 'Performance', 'performance-lab' ),
@@ -301,9 +301,9 @@ function perflab_aea_enqueued_css_assets_test() {
 			/* translators: 1: HelpHub URL. 2: Link description. 3.URL to clean cache. 4. Clean Cache text. */
 			'<p><a target="_blank" href="%1$s">%2$s</a></p><p><a href="%3$s">%4$s</a></p>',
 			esc_url( __( 'https://wordpress.org/support/article/optimization/', 'performance-lab' ) ),
-			esc_html__( 'More info about performance optimization', 'performance-lab' ),
+			__( 'More info about performance optimization', 'performance-lab' ),
 			esc_url( add_query_arg( 'action', 'clean_aea_audit', wp_nonce_url( admin_url( 'site-health.php' ), 'clean_aea_audit' ) ) ),
-			esc_html__( 'Clean Test Cache', 'performance-lab' )
+			__( 'Clean Test Cache', 'performance-lab' )
 		);
 	}
 

--- a/modules/site-health/audit-full-page-cache/load.php
+++ b/modules/site-health/audit-full-page-cache/load.php
@@ -47,7 +47,7 @@ function perflab_afpc_page_cache_test() {
 	$result = array(
 		'badge'       => array(
 			'label' => __( 'Performance', 'performance-lab' ),
-			'color' => 'green',
+			'color' => 'blue',
 		),
 		'description' => wp_kses_post( $description ),
 		'test'        => 'perflab_page_cache',
@@ -65,10 +65,9 @@ function perflab_afpc_page_cache_test() {
 	$page_cache_detail = perflab_afpc_get_page_cache_detail();
 
 	if ( is_wp_error( $page_cache_detail ) ) {
-		$result['badge']['color'] = 'orange';
-		$result['label']          = __( 'Unable to detect the presence of page caching', 'performance-lab' );
-		$result['status']         = 'recommended';
-		$error_info               = sprintf(
+		$result['label']  = __( 'Unable to detect the presence of page caching', 'performance-lab' );
+		$result['status'] = 'recommended';
+		$error_info       = sprintf(
 			/* translators: 1 is error message, 2 is error code */
 			__( 'Unable to detect page caching due to possible loopback request problem. Please verify that the loopback request test is passing. Error: %1$s (Code: %2$s)', 'performance-lab' ),
 			$page_cache_detail->get_error_message(),
@@ -82,15 +81,12 @@ function perflab_afpc_page_cache_test() {
 
 	switch ( $page_cache_detail['status'] ) {
 		case 'recommended':
-			$result['badge']['color'] = 'orange';
-			$result['label']          = __( 'Page caching is not detected but the server response time is OK', 'performance-lab' );
+			$result['label'] = __( 'Page caching is not detected but the server response time is OK', 'performance-lab' );
 			break;
 		case 'good':
-			$result['badge']['color'] = 'green';
-			$result['label']          = __( 'Page caching is detected and the server response time is good', 'performance-lab' );
+			$result['label'] = __( 'Page caching is detected and the server response time is good', 'performance-lab' );
 			break;
 		default:
-			$result['badge']['color'] = 'red';
 			if ( empty( $page_cache_detail['headers'] ) && ! $page_cache_detail['advanced_cache_present'] ) {
 				$result['label'] = __( 'Page caching is not detected and the server response time is slow', 'performance-lab' );
 			} else {

--- a/tests/modules/site-health/audit-full-page-cache/audit-full-page-cache-test.php
+++ b/tests/modules/site-health/audit-full-page-cache/audit-full-page-cache-test.php
@@ -42,16 +42,10 @@ class Audit_Full_Page_Cache_Tests extends WP_UnitTestCase {
 	 * @covers ::perflab_afpc_check_for_page_caching()
 	 */
 	public function test_perflab_afpc_page_cache_test( $responses, $expected_status, $expected_label, $good_basic_auth = null, $delay_the_response = false ) {
-		$badge_color = array(
-			'critical'    => 'red',
-			'recommended' => 'orange',
-			'good'        => 'green',
-		);
-
 		$expected_props = array(
 			'badge'  => array(
 				'label' => __( 'Performance', 'performance-lab' ),
-				'color' => $badge_color[ $expected_status ],
+				'color' => 'blue',
 			),
 			'test'   => 'perflab_page_cache',
 			'status' => $expected_status,

--- a/tests/testdata/modules/site-health/audit-enqueued-assets/class-site-health-mock-responses.php
+++ b/tests/testdata/modules/site-health/audit-enqueued-assets/class-site-health-mock-responses.php
@@ -74,10 +74,9 @@ class Site_Health_Mock_Responses {
 	 * @return array
 	 */
 	public static function return_aea_enqueued_js_assets_test_callback_more_than_threshold( $enqueued_scripts ) {
-		$result                   = self::return_aea_enqueued_js_assets_test_callback_less_than_threshold();
-		$result['status']         = 'recommended';
-		$result['badge']['color'] = 'orange';
-		$result['description']    = sprintf(
+		$result                = self::return_aea_enqueued_js_assets_test_callback_less_than_threshold();
+		$result['status']      = 'recommended';
+		$result['description'] = sprintf(
 			'<p>%s</p>',
 			esc_html(
 				sprintf(
@@ -149,10 +148,9 @@ class Site_Health_Mock_Responses {
 	 * @return array
 	 */
 	public static function return_aea_enqueued_css_assets_test_callback_more_than_threshold( $enqueued_styles ) {
-		$result                   = self::return_aea_enqueued_css_assets_test_callback_less_than_threshold();
-		$result['status']         = 'recommended';
-		$result['badge']['color'] = 'orange';
-		$result['description']    = sprintf(
+		$result                = self::return_aea_enqueued_css_assets_test_callback_less_than_threshold();
+		$result['status']      = 'recommended';
+		$result['description'] = sprintf(
 			'<p>%s</p>',
 			esc_html(
 				sprintf(


### PR DESCRIPTION
## Summary

Fixes #471

## Relevant technical choices

* All badges should always be "Performance" and use the color `blue`.
* Setting the badge color based on check result status is incorrect.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
