### PR TITLE
Add image regeneration module

### DIFF
--- a/modules/images/regenerate-existing-images/can-load.php
+++ b/modules/images/regenerate-existing-images/can-load.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Can load function to determine if image regenaration module is already merged in WordPress core.
+ *
+ * @todo Adjust the returned value with appropriate condition.
+ * @since   n.e.x.t
+ * @package performance-lab
+ */
+
+return function() {
+	return true;
+};

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Module Name: Regenarate Existing Images
+ * Description: Regenerate existing images when the image sizes changes during plugin/theme
+ * activation/deactivation or for any other reasons.
+ * Experimental: No
+ *
+ * @since   n.e.x.t
+ * @package performance-lab
+ */


### PR DESCRIPTION
## Summary

This PR adds the `regenerate-existing-images` module in the plugin. This shall be the first thing to get merged for image regeneration work.

All of the subsequent work related to image regeneration would reside in this module.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #489 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
