### PR TITLE
Correct docblock for `wp_get_attachment_file_path()`

### DIFF
--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -319,7 +319,7 @@ function _dominant_color_get_dominant_color_data( $attachment_id ) {
  * @param string $size          Optional. Image size. Default 'thumbnail'.
  * @return false|string Path to an image or false if not found.
  */
-function wp_get_attachment_file_path( $attachment_id, $size = 'medium' ) {
+function wp_get_attachment_file_path( $attachment_id, $size = 'thumbnail' ) {
 	$imagedata = wp_get_attachment_metadata( $attachment_id );
 	if ( ! is_array( $imagedata ) ) {
 		return false;

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -316,10 +316,10 @@ function _dominant_color_get_dominant_color_data( $attachment_id ) {
  * @since 1.2.0
  *
  * @param int    $attachment_id Attachment ID for image.
- * @param string $size          Optional. Image size. Default 'thumbnail'.
+ * @param string $size          Optional. Image size. Default 'medium'.
  * @return false|string Path to an image or false if not found.
  */
-function wp_get_attachment_file_path( $attachment_id, $size = 'thumbnail' ) {
+function wp_get_attachment_file_path( $attachment_id, $size = 'medium' ) {
 	$imagedata = wp_get_attachment_metadata( $attachment_id );
 	if ( ! is_array( $imagedata ) ) {
 		return false;


### PR DESCRIPTION
Fixes #499
## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
