### PR TITLE
Run GitHub workflows also for feature branches

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - trunk
       - 'release/**'
-      - 'feature/**'
     # Only run if JS/JSON/Lint/NVM files changed.
     paths:
       - '.github/workflows/js-lint.yml'

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - trunk
       - 'release/**'
+      - 'feature/**'
     # Only run if JS/JSON/Lint/NVM files changed.
     paths:
       - '.github/workflows/js-lint.yml'
@@ -18,6 +19,7 @@ on:
     branches:
       - trunk
       - 'release/**'
+      - 'feature/**'
     # Only run if JS/JSON/Lint/NVM files changed.
     paths:
       - '.github/workflows/js-lint.yml'

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - trunk
       - 'release/**'
+      - 'feature/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-lint.yml'
@@ -16,6 +17,7 @@ on:
     branches:
       - trunk
       - 'release/**'
+      - 'feature/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-lint.yml'

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - trunk
       - 'release/**'
-      - 'feature/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-lint.yml'

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - trunk
       - 'release/**'
-      - 'feature/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test.yml'

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - trunk
       - 'release/**'
+      - 'feature/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test.yml'
@@ -17,6 +18,7 @@ on:
     branches:
       - trunk
       - 'release/**'
+      - 'feature/**'
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test.yml'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - trunk
       - 'release/**'
+      - 'feature/**'
     types:
       - labeled
       - unlabeled


### PR DESCRIPTION
## Summary

As noted in e.g. #497, the new `feature/regenerate-existing-images` branch does not run our GitHub workflows. This PR adds that, generally for all `feature/*` branches, which should only be used for broader features (i.e. not PR branches in which you're actually coding).

Once this is merged into `trunk`, we can merge it back into `feature/regenerate-existing-images` to apply it there.

## Relevant technical choices

* Add `feature/**` to the allowlist of branches.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
