### PR TITLE
Include section on branch name requirements to GitHub workflow documentation

### DIFF
--- a/docs/Github-workflow.md
+++ b/docs/Github-workflow.md
@@ -40,6 +40,13 @@ If you believe you may have discovered a possible bug or have an engineering-rel
 If you have completed initial engineering and want community members to test prior to merge, add the Needs Testing label.
 
 ## Pull requests
+
+### Branch name
+
+Before opening a pull request, you should create a new branch in which you're making your suggested changes. This branch can use almost any name, although it is recommended to include a reference to the issue number in it. Please avoid prefixing your branch with `feature/` or `release/` as those are reserved names for special protected branches in the Performance Lab plugin. If you use one of those names, you will not be able to push code to the branch directly.
+
+### Pull request requirements
+
 All pull requests must:
 
 - Be associated with an issue

--- a/docs/Github-workflow.md
+++ b/docs/Github-workflow.md
@@ -43,7 +43,7 @@ If you have completed initial engineering and want community members to test pri
 
 ### Branch name
 
-Before opening a pull request, you should create a new branch in which you're making your suggested changes. This branch can use almost any name, although it is recommended to include a reference to the issue number in it. Please avoid prefixing your branch with `feature/` or `release/` as those are reserved names for special protected branches in the Performance Lab plugin. If you use one of those names, you will not be able to push code to the branch directly.
+Before opening a pull request, create a new branch for your suggested changes. This branch can use almost any name, although it is recommended to include a reference to the issue number in it. Please avoid prefixing your branch with `feature/` or `release/` as those are reserved names for special protected branches in the Performance Lab plugin. If you use one of those names, you will not be able to push code to the branch directly.
 
 ### Pull request requirements
 


### PR DESCRIPTION
## Summary

Based on the announcement earlier today in the performance chat, specific prefixes like `feature/` and `release/` must not be used for general development branches. This PR adds a relevant section to the documentation.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
