### PR TITLE
Added support for attachment image html markup

### DIFF
--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -628,6 +628,8 @@ add_filter( 'post_thumbnail_html', 'webp_uploads_update_featured_image', 10, 3 )
  * Updates the references of the attachment image to the a new image format if available, in the same way it
  * occurs in the_content of a post.
  *
+ * @since n.e.x.t
+ *
  * @param string $html          The current HTML markup of the image.
  * @param int    $attachment_id The ID of the attachment image.
  * @return string The updated HTML markup.

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -628,8 +628,6 @@ add_filter( 'post_thumbnail_html', 'webp_uploads_update_featured_image', 10, 3 )
  * Updates the references of the attachment image to the a new image format if available, in the same way it
  * occurs in the_content of a post.
  *
- * @since n.e.x.t
- *
  * @param string $html          The current HTML markup of the image.
  * @param int    $attachment_id The ID of the attachment image.
  * @return string The updated HTML markup.

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -625,6 +625,19 @@ function webp_uploads_update_featured_image( $html, $post_id, $attachment_id ) {
 add_filter( 'post_thumbnail_html', 'webp_uploads_update_featured_image', 10, 3 );
 
 /**
+ * Updates the references of the attachment image to the a new image format if available, in the same way it
+ * occurs in the_content of a post.
+ *
+ * @param string $html          The current HTML markup of the featured image.
+ * @param int    $attachment_id The ID of the attachment image.
+ * @return string The updated HTML markup.
+ */
+function webp_uploads_update_attachment_image( $html, $attachment_id ) {
+	return webp_uploads_img_tag_update_mime_type( $html, 'the_content', $attachment_id );
+}
+add_filter( 'wp_get_attachment_image', 'webp_uploads_update_attachment_image', 10, 2 );
+
+/**
  * Adds a fallback mechanism to replace webp images with jpeg alternatives on older browsers.
  *
  * @since 1.3.0

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -628,7 +628,7 @@ add_filter( 'post_thumbnail_html', 'webp_uploads_update_featured_image', 10, 3 )
  * Updates the references of the attachment image to the a new image format if available, in the same way it
  * occurs in the_content of a post.
  *
- * @param string $html          The current HTML markup of the featured image.
+ * @param string $html          The current HTML markup of the image.
  * @param int    $attachment_id The ID of the attachment image.
  * @return string The updated HTML markup.
  */


### PR DESCRIPTION
## Summary

After enabling the SVG image support when we use the function `wp_get_attachment_image()` used as:

```php
$html = wp_get_attachment_image( $image_id, $size );
```

Then the HTML is generated as:

```html
<img width="150" height="150" src="http://example.com/wp-content/uploads/2022/09/dummy-150x150.jpg" class="alignright not-transparent" alt="" loading="lazy" data-has-transparency="false" data-dominant-color="a26fd1" style="--dominant-color: #a26fd1;">
```

It keep serve the `.jpg` image version instead of `.webp`

This PR add the support with filter `wp_get_attachment_image` same as added support for `post_thumbnail_html`.

After adding the support the HTML markup generated as:

```html
<img width="150" height="150" src="http://example.com/wp-content/uploads/2022/09/dummy-150x150-jpg.webp" class="alignright not-transparent" alt="" loading="lazy" data-has-transparency="false" data-dominant-color="a26fd1" style="--dominant-color: #a26fd1;">
```

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
