### PR TITLE
Background Process: Create perflab_create_background_job function

### DIFF
--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Functions used by the background process API.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * Create a new background job.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $job_name The name of job.
+ * @param array  $job_data Data for the job.
+ *
+ * @return Perflab_Background_Job|WP_Error The Background Job object on success, else WP_Error.
+ */
+function perflab_create_background_job( $job_name, array $job_data = array() ) {
+	return Perflab_Background_Job::create( $job_name, $job_data );
+}

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -9,6 +9,11 @@
  */
 
 /**
+ * Require helper functions and specific integrations.
+ */
+require_once __DIR__ . '/helper.php';
+
+/**
  * Registers the background job taxonomy.
  *
  * Intentionally on lower priority, so that other post types can be


### PR DESCRIPTION
## Summary

* Adds the `perflab_create_background_job()` function to the background processing API

Fixes #479 

## Relevant technical choices

* Makes use of the `Perlab_Background_Job` class to encapsulate the job creation logic.
* Dependent on PR #507

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
