### PR TITLE
Background Process: Create perflab_start_background_job function 

### DIFF
--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Functions used by the background process API.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * Start a job in the background process.
+ *
+ * @since n.e.x.t
+ *
+ * @param int $job_id The job ID to run.
+ *
+ * @return boolean|WP_Error True on success, WP_Error om failure.
+ */
+function perflab_start_background_job( $job_id ) {
+	$args = array(
+		'blocking'  => false,
+		'body'      => array(
+			'action' => 'wp_ajax_background_process_handle_request',
+			'job_id' => $job_id,
+			'nonce'  => wp_create_nonce( 'wp_ajax_background_process_handle_request' ),
+		),
+		'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+		'timeout'   => 0.1,
+	);
+
+	$response = wp_remote_post( admin_url( 'admin-ajax.php' ), $args );
+
+	if ( ! is_wp_error( $response ) ) {
+		return true;
+	}
+
+	return $response;
+}

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -9,6 +9,11 @@
  */
 
 /**
+ * Require helper functions and specific integrations.
+ */
+require_once __DIR__ . '/helper.php';
+
+/**
  * Registers the background job taxonomy.
  *
  * Intentionally on lower priority, so that other post types can be


### PR DESCRIPTION
## Summary

* Adds the `perflab_start_background_job()` function

Fixes #480 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
