### PR TITLE
Status check cron for background job

### DIFF
--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -17,80 +17,80 @@ class Perflab_Background_Job {
 	/**
 	 * Meta key for storing job name/action.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job name meta key.
 	 */
 	const JOB_NAME_META_KEY = 'perflab_job_name';
 
 	/**
 	 * Meta key for storing job data.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job data meta key.
 	 */
 	const JOB_DATA_META_KEY = 'perflab_job_data';
 
 	/**
 	 * Meta key for storing job data.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job attempts meta key.
 	 */
 	const JOB_ATTEMPTS_META_KEY = 'perflab_job_attempts';
 
 	/**
 	 * Meta key for storing job lock.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job lock meta key.
 	 */
 	const JOB_LOCK_META_KEY = 'perflab_job_lock';
 
 	/**
 	 * Meta key for storing job errors.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job errors meta key.
 	 */
 	const JOB_ERRORS_META_KEY = 'perflab_job_errors';
 
 	/**
 	 * Job status meta key.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job status meta key.
 	 */
 	const JOB_STATUS_META_KEY = 'perflab_job_status';
 
 	/**
 	 * Job status for queued jobs.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job status queued.
 	 */
 	const JOB_STATUS_QUEUED = 'perflab_job_queued';
 
 	/**
 	 * Job status for running jobs.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job status running.
 	 */
 	const JOB_STATUS_RUNNING = 'perflab_job_running';
 
 	/**
 	 * Job status for completed jobs.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job status commplete.
 	 */
 	const JOB_STATUS_COMPLETE = 'perflab_job_complete';
 
 	/**
 	 * Job status for failed jobs.
 	 *
-	 * @const string
 	 * @since n.e.x.t
+	 * @var string Job status failed.
 	 */
 	const JOB_STATUS_FAILED = 'perflab_job_failed';
 
@@ -155,8 +155,6 @@ class Perflab_Background_Job {
 		 * @since n.e.x.t
 		 *
 		 * @param int $attempts Number of attempts allowed for a job to run.
-		 *
-		 * @return int
 		 */
 		$max_attempts = apply_filters( 'perflab_job_max_attempts_allowed', 3 );
 
@@ -282,8 +280,8 @@ class Perflab_Background_Job {
 			 * @since n.e.x.t
 			 *
 			 * @param int    $job_id Job ID.
-			 * @param string $name Job name.
-			 * @param array  $data Job data.
+			 * @param string $name   Job name.
+			 * @param array  $data   Job data.
 			 */
 			do_action( 'perflab_job_created', $this->job_id, $this->name, $this->data );
 		}
@@ -315,8 +313,6 @@ class Perflab_Background_Job {
 		 * @param int    $job_id Background job ID.
 		 * @param string $name   Job identifier or name.
 		 * @param array  $data   Job data.
-		 *
-		 * @return array Array of items to process.
 		 */
 		$items = apply_filters( 'perflab_job_batch_items', $items, $this->job_id, $this->name, $this->data );
 
@@ -340,7 +336,7 @@ class Perflab_Background_Job {
 		 *
 		 * @since n.e.x.t
 		 *
-		 * @param mixed $item Batch item for the job.
+		 * @param mixed $item   Batch item for the job.
 		 * @param int   $job_id Job ID.
 		 * @param array $data   Job data.
 		 */
@@ -368,9 +364,7 @@ class Perflab_Background_Job {
 	 * @return void
 	 */
 	public function lock() {
-		$time = time();
-
-		update_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, $time );
+		update_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, time() );
 		$this->set_status( self::JOB_STATUS_RUNNING );
 	}
 

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -223,9 +223,7 @@ class Perflab_Background_Job {
 	 * @return array|null
 	 */
 	public function data() {
-		/**
-		 * If we have cached data, return it.
-		 */
+		// If we have cached data, return it.
 		if ( ! is_null( $this->data ) ) {
 			return $this->data;
 		}

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -289,7 +289,7 @@ class Perflab_Background_Job {
 	 */
 	public static function create( $name, array $data = array() ) {
 		// Insert the new job in queue.
-		$term_data = wp_insert_term( 'job_' . time(), 'background_job' );
+		$term_data = wp_insert_term( 'job_' . time(), BACKGROUND_JOB_TAXONOMY_SLUG );
 
 		if ( ! is_wp_error( $term_data ) ) {
 			update_term_meta( $term_data['term_id'], self::JOB_DATA_META_KEY, $data );
@@ -375,8 +375,7 @@ class Perflab_Background_Job {
 	 * @return array|null
 	 */
 	private function exists() {
-		// @todo Replace taxonomy name with constant.
-		return term_exists( $this->job_id, 'background_job' );
+		return term_exists( $this->job_id, BACKGROUND_JOB_TAXONOMY_SLUG );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -252,16 +252,8 @@ class Perflab_Background_Job {
 			return new WP_Error( __( 'Cannot create the job as it exists already.', 'performance-lab' ) );
 		}
 
-		$term_name = 'job_' . microtime();
-
 		// Insert the new job in queue.
-		$term_data = wp_insert_term(
-			$term_name,
-			'background_job',
-			array(
-				'slug' => $term_name,
-			)
-		);
+		$term_data = wp_insert_term( 'job_' . time(), 'background_job' );
 
 		if ( ! is_wp_error( $term_data ) ) {
 			// Set object properties for instance as soon as job is created.

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -39,6 +39,22 @@ class Perflab_Background_Job {
 	const JOB_RETRY_META_KEY = 'perflab_job_retries';
 
 	/**
+	 * Meta key for storing job lock.
+	 *
+	 * @const string
+	 * @since n.e.x.t
+	 */
+	const JOB_LOCK_META_KEY = 'perflab_job_lock';
+
+	/**
+	 * Meta key for storing job errors.
+	 *
+	 * @const string
+	 * @since n.e.x.t
+	 */
+	const JOB_ERRORS_META_KEY = 'perflab_job_errors';
+
+	/**
 	 * Job ID.
 	 *
 	 * @var int
@@ -310,7 +326,7 @@ class Perflab_Background_Job {
 	 * @return int
 	 */
 	public function get_retries() {
-		$retries = get_term_meta( $this->job_id, 'perflab_job_retries', true );
+		$retries = get_term_meta( $this->job_id, self::JOB_RETRY_META_KEY, true );
 		$retries = absint( $retries );
 
 		return $retries;
@@ -326,7 +342,7 @@ class Perflab_Background_Job {
 	public function lock() {
 		$time = time();
 
-		update_term_meta( $this->job->job_id, 'job_lock', $time );
+		update_term_meta( $this->job->job_id, self::JOB_LOCK_META_KEY, $time );
 		$this->job->set_status( 'running' );
 	}
 
@@ -338,7 +354,7 @@ class Perflab_Background_Job {
 	 * @return void
 	 */
 	public function unlock() {
-		delete_term_meta( $this->job->job_id, 'job_lock' );
+		delete_term_meta( $this->job->job_id, self::JOB_LOCK_META_KEY );
 	}
 
 	/**
@@ -358,7 +374,7 @@ class Perflab_Background_Job {
 		if ( ! empty( $job_failure_data ) ) {
 			$this->job->set_status( 'failed' );
 
-			update_term_meta( $this->job_id, 'job_errors', $job_failure_data );
+			update_term_meta( $this->job_id, self::JOB_ERRORS_META_KEY, $job_failure_data );
 			update_term_meta( $this->job_id, self::JOB_RETRY_META_KEY, ( $this->get_retries() + 1 ) );
 		}
 	}

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -151,7 +151,7 @@ class Perflab_Background_Job {
 	 *
 	 * @param string $status Status to set for current job.
 	 *
-	 * @return void
+	 * @return bool Returns true if status is updated, false otherwise.
 	 */
 	public function set_status( $status ) {
 		$valid_statuses = array(
@@ -167,7 +167,11 @@ class Perflab_Background_Job {
 			if ( 'complete' === $status ) {
 				update_term_meta( $this->job_id, 'job_completed_at', time() );
 			}
+
+			return true;
 		}
+
+		return false;
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -1,0 +1,285 @@
+<?php
+/**
+ * Background job class.
+ *
+ * @since n.e.x.t
+ * @package performance-lab
+ */
+
+/**
+ * Class Perflab_Background_Job.
+ *
+ * Runs the heavy lifting tasks in background in separate process.
+ */
+final class Perflab_Background_Job {
+	/**
+	 * Meta key for storing job name/action.
+	 *
+	 * @const string
+	 */
+	const JOB_NAME_META_KEY = 'job_name';
+
+	/**
+	 * Meta key for storing job data.
+	 *
+	 * @const string
+	 */
+	const JOB_DATA_META_KEY = 'job_data';
+
+	/**
+	 * Job ID.
+	 *
+	 * @var int
+	 */
+	public $job_id;
+
+	/**
+	 * Job name.
+	 *
+	 * @var string
+	 */
+	public $name;
+
+	/**
+	 * Job data.
+	 *
+	 * @var array
+	 */
+	public $data;
+
+	/**
+	 * Perflab_Background_Job constructor.
+	 *
+	 * @param int $job_id job ID.
+	 */
+	public function __construct( $job_id = 0 ) {
+		$this->job_id = absint( $job_id );
+
+		// @todo Replace taxonomy name with constant.
+		if ( term_exists( $this->job_id, 'background_job' ) ) {
+			$this->name = get_term_meta( $this->job_id, Perflab_Background_Job::JOB_NAME_META_KEY, true );
+			$this->data = get_term_meta( $this->job_id, Perflab_Background_Job::JOB_DATA_META_KEY, true );
+		}
+	}
+
+	/**
+	 * Checks that the job term exist.
+	 *
+	 * @return array|null
+	 */
+	public function exists() {
+		// @todo Replace taxonomy name with constant.
+		return term_exists( $this->job_id, 'background_job' );
+	}
+
+	/**
+	 * Checks if the job is running.
+	 *
+	 * If the job lock is present, it means job is running.
+	 *
+	 * @return int
+	 */
+	public function is_running() {
+		$lock = get_term_meta( $this->job_id, 'job_lock', true );
+		$lock = empty( $lock ) ? 0 : $lock;
+
+		return absint( $lock );
+	}
+
+	/**
+	 * Checks if the background job is completed.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return (bool) get_term_meta( $this->job_id, 'job_completed_at', true );
+	}
+
+	/**
+	 * Sets the status of the current job.
+	 *
+	 * @param string $status Status to set for current job.
+	 *
+	 * @return void
+	 */
+	public function set_status( $status ) {
+		$valid_statuses = array(
+			'running',
+			'failed',
+			'complete',
+		);
+
+		if ( in_array( $status, $valid_statuses, true ) ) {
+			update_term_meta( $this->job_id, 'job_status', $status );
+
+			// If job is complete, set the timestamp at which it was completed.
+			if ( 'complete' === $status ) {
+				update_term_meta( $this->job_id, 'job_completed_at', time() );
+			}
+		}
+	}
+
+	/**
+	 * Retrieves the job data.
+	 *
+	 * @return array|null
+	 */
+	public function data() {
+		/**
+		 * If we have cached data, return it.
+		 */
+		if ( ! is_null( $this->data ) ) {
+			return $this->data;
+		}
+
+		$this->data = get_term_meta( $this->job_id, 'job_data', true );
+
+		return $this->data;
+	}
+
+	/**
+	 * Creates a new job in the queue.
+	 *
+	 * Job refers to the term and queue refers to the `background_job` taxonomy.
+	 *
+	 * @param string $name Name of job identifier.
+	 * @param array  $data Data for the job.
+	 *
+	 * @return int|WP_Error
+	 */
+	public function create( $name, array $data ) {
+		// @todo Replace taxonomy name with constant.
+		// Create job only when job ID for current instance is non-zero and term doesn't exist.
+		if ( $this->job_id > 0 && term_exists( $this->job_id, 'background_job' ) ) {
+			return new WP_Error( __( 'Cannot create the job as it exists already.', 'performance-lab' ) );
+		}
+
+		$term_name = 'job_' . microtime();
+
+		// Insert the new job in queue.
+		$term_data = wp_insert_term(
+			$term_name,
+			'background_job',
+			array(
+				'slug' => $term_name,
+			)
+		);
+
+		if ( ! is_wp_error( $term_data ) ) {
+			// Set object properties for instance as soon as job is created.
+			$this->job_id = $term_data['term_id'];
+			$this->name   = sanitize_text_field( $name );
+			$this->data   = $data;
+
+			update_term_meta( $this->job_id, Perflab_Background_Job::JOB_DATA_META_KEY, $this->data );
+			update_term_meta( $this->job_id, Perflab_Background_Job::JOB_NAME_META_KEY, $this->name );
+
+			/**
+			 * Fires when the job has been created successfully.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param int    $job_id Job ID.
+			 * @param string $name Job name.
+			 * @param array  $data Job data.
+			 */
+			do_action( 'perflab_job_created', $this->job_id, $this->name, $this->data );
+		}
+
+		return $term_data;
+	}
+
+	/**
+	 * Get the batch for current run.
+	 *
+	 * This will return the items to process in the current batch.
+	 *
+	 * @return array
+	 */
+	public function batch() {
+		$items = array();
+
+		/**
+		 * Filters the items for the current batch of job.
+		 *
+		 * By default this will be empty array. Consumer code will need to use this filter in
+		 * order to return the list of items which needs to be processed in current batch.
+		 *
+		 * @param array  $items  Items for the current batch.
+		 * @param int    $job_id Background job ID.
+		 * @param string $name   Job identifier or name.
+		 * @param array  $data   Job data.
+		 *
+		 * @since n.e.x.t
+		 */
+		$items = apply_filters( 'perflab_job_batch_items', $items, $this->job_id, $this->name, $this->data );
+
+		return (array) $items;
+	}
+
+	/**
+	 * Process the batch item.
+	 *
+	 * @param mixed $item Batch item for the job.
+	 *
+	 * @return void
+	 */
+	public function process( $item ) {
+		/**
+		 * Hook to this action to run the job.
+		 *
+		 * Concrete implementations would add the logic to run this job.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param mixed $item Batch item for the job.
+		 * @param int   $job_id Job ID.
+		 * @param array $data   Job data.
+		 */
+		do_action( 'perflab_process_' . $this->name . '_job_item', $item, $this->job_id, $this->data );
+	}
+
+	/**
+	 * Locks the process. It tells that process is running.
+	 *
+	 * @return void
+	 */
+	public function lock() {
+		$time = time();
+
+		update_term_meta( $this->job->job_id, 'job_lock', $time );
+		$this->job->set_status( 'running' );
+	}
+
+	/**
+	 * Unlocks the process.
+	 *
+	 * @return void
+	 */
+	public function unlock() {
+		delete_term_meta( $this->job->job_id, 'job_lock' );
+	}
+
+	/**
+	 * Records the error for the current process run.
+	 *
+	 * @param WP_Error $error Error instance.
+	 *
+	 * @todo Implement the error recording activity.
+	 *
+	 * @return void
+	 */
+	public function record_error( WP_Error $error ) {
+		$job_failure_data = $error->get_error_data( 'perflab_job_failure' );
+
+		if ( ! empty( $job_failure_data ) ) {
+			$retries = get_term_meta( $this->job_id, 'perflab_job_retries', true );
+			$retries = empty( $retries ) ? 0 : ( absint( $retries ) + 1 ); // Increment retry count.
+
+			$this->job->set_status( 'failed' );
+
+			update_term_meta( $this->job_id, 'job_errors', $job_failure_data );
+			update_term_meta( $this->job_id, 'perflab_job_retries', $$retries );
+		}
+	}
+}

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -97,6 +97,7 @@ class Perflab_Background_Job {
 	/**
 	 * Job ID.
 	 *
+	 * @since n.e.x.t
 	 * @var int
 	 */
 	public $job_id;
@@ -104,6 +105,7 @@ class Perflab_Background_Job {
 	/**
 	 * Job name.
 	 *
+	 * @since n.e.x.t
 	 * @var string
 	 */
 	private $name;
@@ -111,6 +113,7 @@ class Perflab_Background_Job {
 	/**
 	 * Job data.
 	 *
+	 * @since n.e.x.t
 	 * @var array
 	 */
 	private $data;

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -276,46 +276,6 @@ class Perflab_Background_Job {
 	}
 
 	/**
-	 * Creates a new job in the queue.
-	 *
-	 * Job refers to the term and queue refers to the `background_job` taxonomy.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param string $name Name of job identifier.
-	 * @param array  $data Data for the job.
-	 *
-	 * @return Perflab_Background_Job|WP_Error Job object if created successfully, else WP_Error.
-	 */
-	public static function create( $name, array $data = array() ) {
-		// Insert the new job in queue.
-		$term_name = 'job_' . time() . rand();
-		$term_data = wp_insert_term( $term_name, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
-
-		if ( ! is_wp_error( $term_data ) ) {
-			update_term_meta( $term_data['term_id'], self::META_KEY_JOB_DATA, $data );
-			update_term_meta( $term_data['term_id'], self::META_KEY_JOB_NAME, $name );
-
-			/**
-			 * Create a fresh instance to return.
-			 *
-			 * @var Perflab_Background_Job
-			 */
-			$job = new self( $term_data['term_id'] );
-
-			$job->name = $name;
-			$job->data = $data;
-
-			// Set the queued status for freshly created jobs.
-			$job->set_status( self::JOB_STATUS_QUEUED );
-
-			return $job;
-		}
-
-		return $term_data;
-	}
-
-	/**
 	 * Returns the number of attempts executed for a job.
 	 *
 	 * @since n.e.x.t
@@ -386,7 +346,7 @@ class Perflab_Background_Job {
 	 *
 	 * @return array|null
 	 */
-	private function exists() {
+	public function exists() {
 		return term_exists( $this->id, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 	}
 
@@ -399,7 +359,7 @@ class Perflab_Background_Job {
 	 *
 	 * @return bool
 	 */
-	private function is_running() {
+	public function is_running() {
 		return ( self::JOB_STATUS_RUNNING === $this->get_status() );
 	}
 }

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -135,11 +135,6 @@ class Perflab_Background_Job {
 	 */
 	public function __construct( $job_id ) {
 		$this->id = absint( $job_id );
-
-		if ( $this->exists() ) {
-			$this->name = get_term_meta( $this->id, self::META_KEY_JOB_NAME, true );
-			$this->data = get_term_meta( $this->id, self::META_KEY_JOB_DATA, true );
-		}
 	}
 
 	/**
@@ -148,7 +143,6 @@ class Perflab_Background_Job {
 	 * @return int Job ID. Technically this is a term id for `background_job` taxonomy.
 	 */
 	public function get_id() {
-
 		return $this->id;
 	}
 
@@ -160,11 +154,6 @@ class Perflab_Background_Job {
 	 * @return array|null Job data.
 	 */
 	public function get_data() {
-		// If we have cached data, return it.
-		if ( ! is_null( $this->data ) ) {
-			return $this->data;
-		}
-
 		$this->data = get_term_meta( $this->id, self::META_KEY_JOB_DATA, true );
 
 		return $this->data;
@@ -178,7 +167,9 @@ class Perflab_Background_Job {
 	 * @return string Job name.
 	 */
 	public function get_name() {
-		return (string) $this->name;
+		$this->name = get_term_meta( $this->id, self::META_KEY_JOB_NAME, true );
+
+		return $this->name;
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -367,6 +367,17 @@ class Perflab_Background_Job {
 	}
 
 	/**
+	 * Checks if the background job is completed.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool
+	 */
+	public function is_completed() {
+		return ( self::JOB_STATUS_COMPLETE === $this->get_status() );
+	}
+
+	/**
 	 * Checks that the job term exist.
 	 *
 	 * @since n.e.x.t
@@ -388,16 +399,5 @@ class Perflab_Background_Job {
 	 */
 	private function is_running() {
 		return ( self::JOB_STATUS_RUNNING === $this->get_status() );
-	}
-
-	/**
-	 * Checks if the background job is completed.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return bool
-	 */
-	private function is_completed() {
-		return ( self::JOB_STATUS_COMPLETE === $this->get_status() );
 	}
 }

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -18,7 +18,7 @@ class Perflab_Background_Job {
 	 * Meta key for storing job name/action.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job name meta key.
+	 * @var string
 	 */
 	const META_KEY_JOB_NAME = 'perflab_job_name';
 
@@ -26,7 +26,7 @@ class Perflab_Background_Job {
 	 * Meta key for storing job data.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job data meta key.
+	 * @var string
 	 */
 	const META_KEY_JOB_DATA = 'perflab_job_data';
 
@@ -34,7 +34,7 @@ class Perflab_Background_Job {
 	 * Meta key for storing job data.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job attempts meta key.
+	 * @var string
 	 */
 	const META_KEY_JOB_ATTEMPTS = 'perflab_job_attempts';
 
@@ -42,7 +42,7 @@ class Perflab_Background_Job {
 	 * Meta key for storing job lock.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job lock meta key.
+	 * @var string
 	 */
 	const META_KEY_JOB_LOCK = 'perflab_job_lock';
 
@@ -50,7 +50,7 @@ class Perflab_Background_Job {
 	 * Meta key for storing job errors.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job errors meta key.
+	 * @var string
 	 */
 	const META_KEY_JOB_ERRORS = 'perflab_job_errors';
 
@@ -58,7 +58,7 @@ class Perflab_Background_Job {
 	 * Job status meta key.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job status meta key.
+	 * @var string
 	 */
 	const META_KEY_JOB_STATUS = 'perflab_job_status';
 
@@ -66,7 +66,7 @@ class Perflab_Background_Job {
 	 * Job status for queued jobs.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job status queued.
+	 * @var string
 	 */
 	const JOB_STATUS_QUEUED = 'perflab_job_queued';
 
@@ -74,7 +74,7 @@ class Perflab_Background_Job {
 	 * Job status for running jobs.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job status running.
+	 * @var string
 	 */
 	const JOB_STATUS_RUNNING = 'perflab_job_running';
 
@@ -82,7 +82,7 @@ class Perflab_Background_Job {
 	 * Job status for partially executed jobs.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job status partial.
+	 * @var string
 	 */
 	const JOB_STATUS_PARTIAL = 'perflab_job_partial';
 
@@ -90,7 +90,7 @@ class Perflab_Background_Job {
 	 * Job status for completed jobs.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job status commplete.
+	 * @var string
 	 */
 	const JOB_STATUS_COMPLETE = 'perflab_job_complete';
 
@@ -98,7 +98,7 @@ class Perflab_Background_Job {
 	 * Job status for failed jobs.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job status failed.
+	 * @var string
 	 */
 	const JOB_STATUS_FAILED = 'perflab_job_failed';
 
@@ -106,7 +106,7 @@ class Perflab_Background_Job {
 	 * Job ID.
 	 *
 	 * @since n.e.x.t
-	 * @var int Job ID. Technically this is a term id for `background_job` taxonomy.
+	 * @var int
 	 */
 	private $id;
 
@@ -114,7 +114,7 @@ class Perflab_Background_Job {
 	 * Job name.
 	 *
 	 * @since n.e.x.t
-	 * @var string Job name.
+	 * @var string
 	 */
 	private $name;
 
@@ -122,7 +122,7 @@ class Perflab_Background_Job {
 	 * Job data.
 	 *
 	 * @since n.e.x.t
-	 * @var array Job data.
+	 * @var array
 	 */
 	private $data;
 

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -174,7 +174,7 @@ class Perflab_Background_Job {
 		$max_attempts = apply_filters( 'perflab_job_max_attempts_allowed', 3 );
 
 		// If number of attempts have been exhausted, return false.
-		if ( $this->get_attempts() >= $max_attempts ) {
+		if ( $this->get_attempts() >= absint( $max_attempts ) ) {
 			return false;
 		}
 

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -133,7 +133,7 @@ class Perflab_Background_Job {
 	 *
 	 * @param int $job_id Job ID. Technically this is the ID of a term in the 'background_job' taxonomy.
 	 */
-	public function __construct( $job_id = 0 ) {
+	public function __construct( $job_id ) {
 		$this->id = absint( $job_id );
 
 		if ( $this->exists() ) {
@@ -298,7 +298,8 @@ class Perflab_Background_Job {
 	 */
 	public static function create( $name, array $data = array() ) {
 		// Insert the new job in queue.
-		$term_data = wp_insert_term( 'job_' . time(), PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
+		$term_name = 'job_' . time() . rand();
+		$term_data = wp_insert_term( $term_name, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 
 		if ( ! is_wp_error( $term_data ) ) {
 			update_term_meta( $term_data['term_id'], self::META_KEY_JOB_DATA, $data );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -132,42 +132,6 @@ class Perflab_Background_Job {
 	}
 
 	/**
-	 * Checks that the job term exist.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return array|null
-	 */
-	public function exists() {
-		// @todo Replace taxonomy name with constant.
-		return term_exists( $this->job_id, 'background_job' );
-	}
-
-	/**
-	 * Checks if the job is running.
-	 *
-	 * If the job lock is present, it means job is running.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return bool
-	 */
-	public function is_running() {
-		return ( self::JOB_STATUS_RUNNING === $this->get_status() );
-	}
-
-	/**
-	 * Checks if the background job is completed.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return bool
-	 */
-	public function is_complete() {
-		return ( self::JOB_STATUS_COMPLETE === $this->get_status() );
-	}
-
-	/**
 	 * Determines whether a job should run for current request or not.
 	 *
 	 * It determines by checking if job is already running or completed.
@@ -180,7 +144,7 @@ class Perflab_Background_Job {
 	 */
 	public function should_run() {
 		// If job doesn't exist or completed, return false.
-		if ( ! $this->exists() || $this->is_complete() ) {
+		if ( ! $this->exists() || $this->is_completed() ) {
 			return false;
 		}
 
@@ -442,5 +406,41 @@ class Perflab_Background_Job {
 			update_term_meta( $this->job_id, self::JOB_ERRORS_META_KEY, $job_failure_data );
 			update_term_meta( $this->job_id, self::JOB_RETRY_META_KEY, ( $this->get_retries() + 1 ) );
 		}
+	}
+
+	/**
+	 * Checks that the job term exist.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array|null
+	 */
+	private function exists() {
+		// @todo Replace taxonomy name with constant.
+		return term_exists( $this->job_id, 'background_job' );
+	}
+
+	/**
+	 * Checks if the job is running.
+	 *
+	 * If the job lock is present, it means job is running.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool
+	 */
+	private function is_running() {
+		return ( self::JOB_STATUS_RUNNING === $this->get_status() );
+	}
+
+	/**
+	 * Checks if the background job is completed.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool
+	 */
+	private function is_completed() {
+		return ( self::JOB_STATUS_COMPLETE === $this->get_status() );
 	}
 }

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -11,6 +11,17 @@
  *
  * Manage and run the background jobs.
  *
+ * Following fields are being stored for a background job.
+ *
+ * 1. Job ID: Identifies the job; stored as the term ID.
+ * 2. Job name: Unique identifier for different types of jobs. Stored as term meta `perflab_job_name`.
+ * 3. Job data: Job related data. Stored in term meta in serialised format `perflab_job_data`.
+ * 4. Job status: Background job status like running, failed etc. Stored as term meta `perflab_job_status`.
+ * 5. Job errors: Errors related to a job. Stored as term meta in serialized format `perflab_job_errors`.
+ * 6. Job attempts: Number of times this job has been attempted to run after failure. Stored as term meta `perflab_job_attempts`.
+ * 7. Job lock: Timestamp in seconds at which the job has started. Stored as term meta `perflab_job_lock`.
+ * 8. Job completed at: Timestamp at which the job has been marked as completed. Stored as term meta `job_completed_at`
+ *
  * @since n.e.x.t
  */
 class Perflab_Background_Job {
@@ -31,7 +42,7 @@ class Perflab_Background_Job {
 	const META_KEY_JOB_DATA = 'perflab_job_data';
 
 	/**
-	 * Meta key for storing job data.
+	 * Meta key for storing number of attempts for a job.
 	 *
 	 * @since n.e.x.t
 	 * @var string
@@ -233,7 +244,7 @@ class Perflab_Background_Job {
 
 			// If job is complete, set the timestamp at which it was completed.
 			if ( self::JOB_STATUS_COMPLETE === $status ) {
-				update_term_meta( $this->id, 'job_completed_at', time() );
+				update_term_meta( $this->id, 'perflab_job_completed_at', time() );
 			}
 
 			return true;

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -79,6 +79,14 @@ class Perflab_Background_Job {
 	const JOB_STATUS_RUNNING = 'perflab_job_running';
 
 	/**
+	 * Job status for partially executed jobs.
+	 *
+	 * @since n.e.x.t
+	 * @var string Job status partial.
+	 */
+	const JOB_STATUS_PARTIAL = 'perflab_job_partial';
+
+	/**
 	 * Job status for completed jobs.
 	 *
 	 * @since n.e.x.t

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -131,7 +131,7 @@ class Perflab_Background_Job {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param int $job_id job ID.
+	 * @param int $job_id Job ID. Technically this is the ID of a term in the 'background_job' taxonomy.
 	 */
 	public function __construct( $job_id = 0 ) {
 		$this->id = absint( $job_id );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -151,6 +151,10 @@ class Perflab_Background_Job {
 			return false;
 		}
 
+		if ( $this->is_running() ) {
+			return false;
+		}
+
 		/**
 		 * Number of attempts to try to run a job.
 		 * Repeated attempts may be required to run a failed job. Default 3 attempts.
@@ -163,10 +167,6 @@ class Perflab_Background_Job {
 
 		// If number of attempts have been exhausted, return false.
 		if ( $this->get_attempts() >= $max_attempts ) {
-			return false;
-		}
-
-		if ( $this->is_running() ) {
 			return false;
 		}
 

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -20,7 +20,7 @@ class Perflab_Background_Job {
 	 * @since n.e.x.t
 	 * @var string Job name meta key.
 	 */
-	const JOB_NAME_META_KEY = 'perflab_job_name';
+	const META_KEY_JOB_NAME = 'perflab_job_name';
 
 	/**
 	 * Meta key for storing job data.
@@ -28,7 +28,7 @@ class Perflab_Background_Job {
 	 * @since n.e.x.t
 	 * @var string Job data meta key.
 	 */
-	const JOB_DATA_META_KEY = 'perflab_job_data';
+	const META_KEY_JOB_DATA = 'perflab_job_data';
 
 	/**
 	 * Meta key for storing job data.
@@ -36,7 +36,7 @@ class Perflab_Background_Job {
 	 * @since n.e.x.t
 	 * @var string Job attempts meta key.
 	 */
-	const JOB_ATTEMPTS_META_KEY = 'perflab_job_attempts';
+	const META_KEY_JOB_ATTEMPTS = 'perflab_job_attempts';
 
 	/**
 	 * Meta key for storing job lock.
@@ -44,7 +44,7 @@ class Perflab_Background_Job {
 	 * @since n.e.x.t
 	 * @var string Job lock meta key.
 	 */
-	const JOB_LOCK_META_KEY = 'perflab_job_lock';
+	const META_KEY_JOB_LOCK = 'perflab_job_lock';
 
 	/**
 	 * Meta key for storing job errors.
@@ -52,7 +52,7 @@ class Perflab_Background_Job {
 	 * @since n.e.x.t
 	 * @var string Job errors meta key.
 	 */
-	const JOB_ERRORS_META_KEY = 'perflab_job_errors';
+	const META_KEY_JOB_ERRORS = 'perflab_job_errors';
 
 	/**
 	 * Job status meta key.
@@ -60,7 +60,7 @@ class Perflab_Background_Job {
 	 * @since n.e.x.t
 	 * @var string Job status meta key.
 	 */
-	const JOB_STATUS_META_KEY = 'perflab_job_status';
+	const META_KEY_JOB_STATUS = 'perflab_job_status';
 
 	/**
 	 * Job status for queued jobs.
@@ -137,8 +137,8 @@ class Perflab_Background_Job {
 		$this->job_id = absint( $job_id );
 
 		if ( $this->exists() ) {
-			$this->name = get_term_meta( $this->job_id, self::JOB_NAME_META_KEY, true );
-			$this->data = get_term_meta( $this->job_id, self::JOB_DATA_META_KEY, true );
+			$this->name = get_term_meta( $this->job_id, self::META_KEY_JOB_NAME, true );
+			$this->data = get_term_meta( $this->job_id, self::META_KEY_JOB_DATA, true );
 		}
 	}
 
@@ -199,7 +199,7 @@ class Perflab_Background_Job {
 		);
 
 		if ( in_array( $status, $valid_statuses, true ) ) {
-			update_term_meta( $this->job_id, self::JOB_STATUS_META_KEY, $status );
+			update_term_meta( $this->job_id, self::META_KEY_JOB_STATUS, $status );
 
 			// If job is complete, set the timestamp at which it was completed.
 			if ( self::JOB_STATUS_COMPLETE === $status ) {
@@ -229,8 +229,8 @@ class Perflab_Background_Job {
 		if ( ! empty( $job_failure_data ) ) {
 			$this->set_status( self::JOB_STATUS_FAILED );
 
-			update_term_meta( $this->job_id, self::JOB_ERRORS_META_KEY, $job_failure_data );
-			update_term_meta( $this->job_id, self::JOB_ATTEMPTS_META_KEY, ( $this->get_attempts() + 1 ) );
+			update_term_meta( $this->job_id, self::META_KEY_JOB_ERRORS, $job_failure_data );
+			update_term_meta( $this->job_id, self::META_KEY_JOB_ATTEMPTS, ( $this->get_attempts() + 1 ) );
 		}
 	}
 
@@ -242,7 +242,7 @@ class Perflab_Background_Job {
 	 * @return string Job status.
 	 */
 	public function get_status() {
-		return (string) get_term_meta( $this->job_id, self::JOB_STATUS_META_KEY, true );
+		return (string) get_term_meta( $this->job_id, self::META_KEY_JOB_STATUS, true );
 	}
 
 	/**
@@ -258,7 +258,7 @@ class Perflab_Background_Job {
 			return $this->data;
 		}
 
-		$this->data = get_term_meta( $this->job_id, self::JOB_DATA_META_KEY, true );
+		$this->data = get_term_meta( $this->job_id, self::META_KEY_JOB_DATA, true );
 
 		return $this->data;
 	}
@@ -291,8 +291,8 @@ class Perflab_Background_Job {
 		$term_data = wp_insert_term( 'job_' . time(), PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 
 		if ( ! is_wp_error( $term_data ) ) {
-			update_term_meta( $term_data['term_id'], self::JOB_DATA_META_KEY, $data );
-			update_term_meta( $term_data['term_id'], self::JOB_NAME_META_KEY, $name );
+			update_term_meta( $term_data['term_id'], self::META_KEY_JOB_DATA, $data );
+			update_term_meta( $term_data['term_id'], self::META_KEY_JOB_NAME, $name );
 
 			/**
 			 * Create a fresh instance to return.
@@ -321,7 +321,7 @@ class Perflab_Background_Job {
 	 * @return int
 	 */
 	public function get_attempts() {
-		$attempts = get_term_meta( $this->job_id, self::JOB_ATTEMPTS_META_KEY, true );
+		$attempts = get_term_meta( $this->job_id, self::META_KEY_JOB_ATTEMPTS, true );
 
 		return absint( $attempts );
 	}
@@ -338,7 +338,7 @@ class Perflab_Background_Job {
 	 */
 	public function lock( $time = null ) {
 		$time = empty( $time ) ? time() : $time;
-		update_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, $time );
+		update_term_meta( $this->job_id, self::META_KEY_JOB_LOCK, $time );
 		$this->set_status( self::JOB_STATUS_RUNNING );
 	}
 
@@ -350,7 +350,7 @@ class Perflab_Background_Job {
 	 * @return int Start time of the job.
 	 */
 	public function get_start_time() {
-		$time = get_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, true );
+		$time = get_term_meta( $this->job_id, self::META_KEY_JOB_LOCK, true );
 
 		return absint( $time );
 	}
@@ -363,7 +363,7 @@ class Perflab_Background_Job {
 	 * @return void
 	 */
 	public function unlock() {
-		delete_term_meta( $this->job_id, self::JOB_LOCK_META_KEY );
+		delete_term_meta( $this->job_id, self::META_KEY_JOB_LOCK );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -106,7 +106,7 @@ class Perflab_Background_Job {
 	 * Job ID.
 	 *
 	 * @since n.e.x.t
-	 * @var int
+	 * @var int Job ID.
 	 */
 	public $job_id;
 
@@ -127,7 +127,7 @@ class Perflab_Background_Job {
 	private $data;
 
 	/**
-	 * Perflab_Background_Job constructor.
+	 * Constructor.
 	 *
 	 * @since n.e.x.t
 	 *
@@ -187,7 +187,6 @@ class Perflab_Background_Job {
 	 * @since n.e.x.t
 	 *
 	 * @param string $status Status to set for current job.
-	 *
 	 * @return bool Returns true if status is updated, false otherwise.
 	 */
 	public function set_status( $status ) {
@@ -289,7 +288,7 @@ class Perflab_Background_Job {
 	 */
 	public static function create( $name, array $data = array() ) {
 		// Insert the new job in queue.
-		$term_data = wp_insert_term( 'job_' . time(), BACKGROUND_JOB_TAXONOMY_SLUG );
+		$term_data = wp_insert_term( 'job_' . time(), PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 
 		if ( ! is_wp_error( $term_data ) ) {
 			update_term_meta( $term_data['term_id'], self::JOB_DATA_META_KEY, $data );
@@ -348,7 +347,7 @@ class Perflab_Background_Job {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return int
+	 * @return int Start time of the job.
 	 */
 	public function get_start_time() {
 		$time = get_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, true );
@@ -375,7 +374,7 @@ class Perflab_Background_Job {
 	 * @return array|null
 	 */
 	private function exists() {
-		return term_exists( $this->job_id, BACKGROUND_JOB_TAXONOMY_SLUG );
+		return term_exists( $this->job_id, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -320,12 +320,16 @@ class Perflab_Background_Job {
 	/**
 	 * Unlocks the process.
 	 *
+	 * Mark job status as partial as the unlock implies that job has run
+	 * atleast partially.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return void
 	 */
 	public function unlock() {
 		delete_term_meta( $this->id, self::META_KEY_JOB_LOCK );
+		$this->set_status( self::JOB_STATUS_PARTIAL );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -57,8 +57,8 @@ final class Perflab_Background_Job {
 
 		// @todo Replace taxonomy name with constant.
 		if ( term_exists( $this->job_id, 'background_job' ) ) {
-			$this->name = get_term_meta( $this->job_id, Perflab_Background_Job::JOB_NAME_META_KEY, true );
-			$this->data = get_term_meta( $this->job_id, Perflab_Background_Job::JOB_DATA_META_KEY, true );
+			$this->name = get_term_meta( $this->job_id, self::JOB_NAME_META_KEY, true );
+			$this->data = get_term_meta( $this->job_id, self::JOB_DATA_META_KEY, true );
 		}
 	}
 
@@ -171,8 +171,8 @@ final class Perflab_Background_Job {
 			$this->name   = sanitize_text_field( $name );
 			$this->data   = $data;
 
-			update_term_meta( $this->job_id, Perflab_Background_Job::JOB_DATA_META_KEY, $this->data );
-			update_term_meta( $this->job_id, Perflab_Background_Job::JOB_NAME_META_KEY, $this->name );
+			update_term_meta( $this->job_id, self::JOB_DATA_META_KEY, $this->data );
+			update_term_meta( $this->job_id, self::JOB_NAME_META_KEY, $this->name );
 
 			/**
 			 * Fires when the job has been created successfully.

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -360,15 +360,32 @@ class Perflab_Background_Job {
 	}
 
 	/**
-	 * Locks the process. It tells that process is running.
+	 * Set the start time of job.
+	 * It tells at what point of time the job has been started.
 	 *
 	 * @since n.e.x.t
 	 *
+	 * @param int $time Timestamp (in seconds) at which job has been started.
+	 *
 	 * @return void
 	 */
-	public function lock() {
-		update_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, time() );
+	public function lock( $time = null ) {
+		$time = empty( $time ) ? time() : $time;
+		update_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, $time );
 		$this->set_status( self::JOB_STATUS_RUNNING );
+	}
+
+	/**
+	 * Get the timestamp (in seconds) when the job was started.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return int
+	 */
+	public function get_start_time() {
+		$time = get_term_meta( $this->job_id, self::JOB_LOCK_META_KEY, true );
+
+		return absint( $time );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -214,6 +214,28 @@ class Perflab_Background_Job {
 	}
 
 	/**
+	 * Records the error for the current process run.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param WP_Error $error Error instance.
+	 *
+	 * @todo Implement the error recording activity.
+	 *
+	 * @return void
+	 */
+	public function set_error( WP_Error $error ) {
+		$job_failure_data = $error->get_error_data( 'perflab_job_failure' );
+
+		if ( ! empty( $job_failure_data ) ) {
+			$this->set_status( self::JOB_STATUS_FAILED );
+
+			update_term_meta( $this->job_id, self::JOB_ERRORS_META_KEY, $job_failure_data );
+			update_term_meta( $this->job_id, self::JOB_ATTEMPTS_META_KEY, ( $this->get_attempts() + 1 ) );
+		}
+	}
+
+	/**
 	 * Retrieves the job status from its meta information.
 	 *
 	 * @since n.e.x.t
@@ -293,60 +315,6 @@ class Perflab_Background_Job {
 	}
 
 	/**
-	 * Get the batch for current run.
-	 *
-	 * This will return the items to process in the current batch.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return array List of batch items.
-	 */
-	public function batch() {
-		$items = array();
-
-		/**
-		 * Filters the items for the current batch of job.
-		 *
-		 * By default this will be empty array. Consumer code will need to use this filter in
-		 * order to return the list of items which needs to be processed in current batch.
-		 *
-		 * @since n.e.x.t
-		 *
-		 * @param array  $items  Items for the current batch.
-		 * @param int    $job_id Background job ID.
-		 * @param string $name   Job identifier or name.
-		 * @param array  $data   Job data.
-		 */
-		$items = apply_filters( 'perflab_job_batch_items', $items, $this->job_id, $this->name, $this->data );
-
-		return (array) $items;
-	}
-
-	/**
-	 * Process the batch item.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param mixed $item Batch item for the job.
-	 *
-	 * @return void
-	 */
-	public function process( $item ) {
-		/**
-		 * Hook to this action to run the job.
-		 *
-		 * Concrete implementations would add the logic to run this job.
-		 *
-		 * @since n.e.x.t
-		 *
-		 * @param mixed $item   Batch item for the job.
-		 * @param int   $job_id Job ID.
-		 * @param array $data   Job data.
-		 */
-		do_action( 'perflab_process_' . $this->name . '_job_item', $item, $this->job_id, $this->data );
-	}
-
-	/**
 	 * Returns the number of attempts executed for a job.
 	 *
 	 * @since n.e.x.t
@@ -397,28 +365,6 @@ class Perflab_Background_Job {
 	 */
 	public function unlock() {
 		delete_term_meta( $this->job_id, self::JOB_LOCK_META_KEY );
-	}
-
-	/**
-	 * Records the error for the current process run.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param WP_Error $error Error instance.
-	 *
-	 * @todo Implement the error recording activity.
-	 *
-	 * @return void
-	 */
-	public function record_error( WP_Error $error ) {
-		$job_failure_data = $error->get_error_data( 'perflab_job_failure' );
-
-		if ( ! empty( $job_failure_data ) ) {
-			$this->set_status( self::JOB_STATUS_FAILED );
-
-			update_term_meta( $this->job_id, self::JOB_ERRORS_META_KEY, $job_failure_data );
-			update_term_meta( $this->job_id, self::JOB_ATTEMPTS_META_KEY, ( $this->get_attempts() + 1 ) );
-		}
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php
@@ -196,6 +196,7 @@ class Perflab_Background_Job {
 			self::JOB_STATUS_FAILED,
 			self::JOB_STATUS_QUEUED,
 			self::JOB_STATUS_RUNNING,
+			self::JOB_STATUS_PARTIAL,
 		);
 
 		if ( in_array( $status, $valid_statuses, true ) ) {

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -118,9 +118,6 @@ class Perflab_Background_Process {
 			 */
 			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
 		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! $this->job->is_completed() );
-
-		// Once job ran successfully, change its status to queued.
-		$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );
 	}
 
 	/**
@@ -141,7 +138,7 @@ class Perflab_Background_Process {
 		}
 
 		$nonce  = wp_create_nonce( self::BG_PROCESS_ACTION );
-		$job_id = $this->job->job_id;
+		$job_id = $this->job->get_id();
 
 		$url    = admin_url( 'admin-ajax.php' );
 		$params = array(

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -86,7 +86,7 @@ class Perflab_Background_Process {
 		} catch ( Exception $e ) {
 			if ( $this->job instanceof Perflab_Background_Job ) {
 				$error = new WP_Error( 'perflab_job_failure', $e->getMessage() );
-				$this->job->record_error( $error );
+				$this->job->set_error( $error );
 			}
 		} finally {
 			if ( $this->job instanceof Perflab_Background_Job ) {
@@ -109,23 +109,14 @@ class Perflab_Background_Process {
 	 * @return void
 	 */
 	private function run() {
-		$iterator    = 0;
-		$batch_items = array_values( $this->job->batch() ); // Ensure array is numerically indexed.
-
-		if ( ! empty( $batch_items ) ) {
-			do {
-				$this->job->process( $batch_items[ $iterator ] );
-
-				unset( $batch_items[ $iterator ] );
-				// Increment the count.
-				$iterator += 1;
-			} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! empty( $batch_items ) );
-
-			return;
-		}
-
-		// If we are here, means there are no batch items to process, so mark job as complete.
-		$this->job->set_status( 'complete' );
+		do {
+			/**
+			 * Consumer code will hook to this action to perform necessary tasks.
+			 *
+			 * @param array $data Job data.
+			 */
+			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
+		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! empty( $batch_items ) );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -138,20 +138,7 @@ class Perflab_Background_Process {
 			return;
 		}
 
-		$nonce  = wp_create_nonce( self::BG_PROCESS_ACTION );
-		$url    = admin_url( 'admin-ajax.php' );
-		$params = array(
-			'blocking'  => false,
-			'body'      => array(
-				'action' => self::BG_PROCESS_ACTION,
-				'job_id' => $job_id,
-				'nonce'  => $nonce,
-			),
-			'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
-			'timeout'   => 0.1,
-		);
-
-		wp_remote_post( $url, $params );
+		perflab_dispatch_background_process_request( $job_id );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Background process runner class.
+ *
+ * @since n.e.x.t
+ * @package performance-lab
+ */
+
+/**
+ * Class Perflab_Background_Process.
+ *
+ * Runs the heavy lifting tasks in background in separate process.
+ */
+class Perflab_Background_Process {
+	/**
+	 * Name of the action which will trigger background
+	 * process to run the job.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var string Background process action name.
+	 */
+	const BG_PROCESS_ACTION = 'background_process_handle_request';
+
+	/**
+	 * Job instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var Perflab_Background_Job Background job instance.
+	 */
+	private $job;
+
+	/**
+	 * Perflab_Background_Process constructor.
+	 *
+	 * Adds the necessary hooks to trigger process handling.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
+		add_action( 'wp_ajax_nopriv' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
+	}
+
+	/**
+	 * Handle incoming request to run the batch of job.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @throws Exception Invalid request for background process.
+	 *
+	 * @return void
+	 */
+	public function handle_request() {
+		try {
+
+			// Exit if nonce varification fails.
+			check_ajax_referer( Perflab_Background_Process::BG_PROCESS_ACTION, 'nonce' );
+
+			$job_id = isset( $_POST['job_id'] ) ? absint( sanitize_text_field( $_POST['job_id'] ) ) : 0;
+
+			// Job ID is mandatory to be specified.
+			if ( empty( $job_id ) ) {
+				throw new Exception( 'empty_background_job_id', __( 'No job specified to execute.', 'performance-lab' ) );
+			}
+
+			$this->job = new Perflab_Background_Job( $job_id );
+
+			// Silently exit if the job is not ready to run.
+			if ( $this->job->should_run() ) {
+				return;
+			}
+
+			$this->job->lock(); // Lock the process for this job before running.
+			$this->run(); // Run the job.
+
+		} catch ( Exception $e ) {
+
+			$error = new WP_Error( 'perflab_job_failure', $e->getMessage() );
+			$this->job->record_error( $error );
+
+		} finally {
+			// Unlock the process once everything is done.
+			$this->job->unlock();
+		}
+	}
+
+	/**
+	 * Runs the process over a batch of job.
+	 *
+	 * As of now, it won't fetch the next batch if memory or time
+	 * is not exceeded, but this can be introduced later.
+	 *
+	 * Consumer code can fine-tune the batch size according to requirement.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return void
+	 */
+	private function run() {
+		$iterator    = 0;
+		$batch_items = array_values( $this->job->batch() ); // Ensure array is numerically indexed.
+
+		if ( ! empty( $batch_items ) ) {
+			do {
+				$this->job->process( $batch_items[ $iterator ] );
+
+				unset( $batch_items[ $iterator ] );
+				// Increment the count.
+				$iterator += 1;
+			} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! empty( $batch_items ) );
+
+			return;
+		}
+
+		// If we are here, means there are no batch items to process, so mark job as complete.
+		$this->job->set_status( 'complete' );
+	}
+
+	/**
+	 * Checks whether the memory is exceeded for the current process.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool
+	 */
+	private function memory_exceeded() {
+		return false;
+	}
+
+	/**
+	 * Checks if current execution time is exceeded for the process.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool
+	 */
+	private function time_exceeded() {
+		$current_time       = time();
+		$run_start_time     = $this->job->get_start_time();
+		$min_execution_time = 20; // Default to 20 seconds. Almost, all servers will have this much of time.
+
+		if ( function_exists( 'ini_get' ) ) {
+			$time               = ini_get( 'max_execution_time' );
+			$max_execution_time = ( ! empty( $time ) && ( $time > $min_execution_time ) ) ? $time - 10 : $min_execution_time;
+		}
+
+		return ( $current_time >= ( $run_start_time + $max_execution_time ) );
+	}
+}

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -81,7 +81,7 @@ class Perflab_Background_Process {
 			$this->run(); // Run the job.
 
 			// Once job ran successfully, change its status to queued.
-			$this->job->set_status( Perflab_Background_Job::JOB_STATUS_QUEUED );
+			$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );
 
 		} catch ( Exception $e ) {
 			if ( $this->job instanceof Perflab_Background_Job ) {

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -325,6 +325,7 @@ class Perflab_Background_Process {
 	 */
 	private function get_max_execution_time() {
 		$min_execution_time = 20; // Default to 20 seconds. Almost, all servers will have this much of time.
+		$max_execution_time = $min_execution_time;
 
 		if ( function_exists( 'ini_get' ) ) {
 			$time               = ini_get( 'max_execution_time' );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -131,6 +131,9 @@ class Perflab_Background_Process {
 	/**
 	 * Checks whether the memory is exceeded for the current process.
 	 *
+	 * Keep memory limit to 90% of the values assigned to PHP config,
+	 * it will prevent the error and help run the memory exhaustion check.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return bool
@@ -158,6 +161,9 @@ class Perflab_Background_Process {
 	/**
 	 * Get the memory limit allotted for PHP.
 	 *
+	 * Keep the default memory limit of 128M which
+	 * is there on most of the hosts.
+	 *
 	 * @return int
 	 */
 	private function get_memory_limit() {
@@ -177,6 +183,11 @@ class Perflab_Background_Process {
 
 	/**
 	 * Checks if current execution time is exceeded for the process.
+	 *
+	 * A sensible default of 20 seconds has been taken in case ini_get does not
+	 * work. Keep max_execution_time to 10 seconds less than whatever is set in PHP
+	 * configuration, so that those 10 seconds can be used to cleanup everything and
+	 * call the next batch of job.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -42,7 +42,7 @@ class Perflab_Background_Process {
 	 */
 	public function __construct() {
 		add_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
-		add_action( 'wp_ajax_nopriv' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
+		add_action( 'wp_ajax_nopriv_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -117,7 +117,7 @@ class Perflab_Background_Process {
 			 * @param array $data Job data.
 			 */
 			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
-		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() );
+		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && $this->job->is_completed() );
 
 		// Once job ran successfully, change its status to queued.
 		$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -80,6 +80,9 @@ class Perflab_Background_Process {
 			$this->job->lock(); // Lock the process for this job before running.
 			$this->run(); // Run the job.
 
+			// Once job ran successfully, change its status to queued.
+			$this->job->set_status( Perflab_Background_Job::JOB_STATUS_QUEUED );
+
 		} catch ( Exception $e ) {
 			if ( $this->job instanceof Perflab_Background_Job ) {
 				$error = new WP_Error( 'perflab_job_failure', $e->getMessage() );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -128,7 +128,43 @@ class Perflab_Background_Process {
 	 * @return bool
 	 */
 	private function memory_exceeded() {
-		return false;
+		$memory_limit     = $this->get_memory_limit() * 0.9; // Use 90% of memory limit.
+		$memmory_usage    = memory_get_usage( true ); // Memory allotted to php.
+		$memory_exhausted = false;
+
+		// Check if memory usage has reached the memory limit (90%).
+		if ( $memmory_usage >= $memory_limit ) {
+			$memory_exhausted = true;
+		}
+
+		/**
+		 * Filters the memory exceeded flag.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param bool $memory_exhausted Whether the memory limit has been reached.
+		 */
+		return apply_filters( 'perflab_background_process_memory_exceeded', $memory_exhausted );
+	}
+
+	/**
+	 * Get the memory limit allotted for PHP.
+	 *
+	 * @return int
+	 */
+	private function get_memory_limit() {
+		$default_memory_limit = '128M';
+
+		if ( function_exists( 'memory_limit' ) ) {
+			$memory_limit = ini_get( 'memory_limit' );
+		}
+
+		if ( empty( $memory_limit ) || -1 === $memory_limit ) {
+			$memory_limit = $default_memory_limit;
+		}
+
+		// Convert memory to bytes in integer format.
+		return wp_convert_hr_to_bytes( $memory_limit );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -41,8 +41,12 @@ class Perflab_Background_Process {
 	 * @return void
 	 */
 	public function __construct() {
+		// Handle job execution request.
 		add_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
 		add_action( 'wp_ajax_nopriv_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
+
+		// Handle status check cron.
+		add_action( 'perflab_background_process_status_check', array( $this, 'status_check' ) );
 	}
 
 	/**
@@ -95,6 +99,89 @@ class Perflab_Background_Process {
 	}
 
 	/**
+	 * Status check cron handler.
+	 *
+	 * 1. Cron will be schedule if it does not exist already.
+	 * 2. It will restart any job which is halted due to failure.
+	 * 3. Remove old completed jobs.
+	 *
+	 * @return void
+	 */
+	public function status_check() {
+		$this->status_check_running_jobs();
+		$this->status_check_completed_jobs();
+	}
+
+	/**
+	 * Check the running jobs.
+	 *
+	 * If they are still running, bail it.
+	 *
+	 * If the execution has been stopped by exceeding maximum execution
+	 * time, restart the job.
+	 *
+	 * @return void
+	 */
+	private function status_check_running_jobs() {
+		$jobs_args = array(
+			'taxonomy'   => PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG,
+			'meta_key'   => Perflab_Background_Job::META_KEY_JOB_STATUS,
+			'meta_value' => Perflab_Background_Job::JOB_STATUS_RUNNING,
+			'fields'     => 'ids',
+		);
+
+		// Fetch all the running jobs.
+		$running_jobs = get_terms( $jobs_args );
+
+		if ( ! empty( $running_jobs ) && ! is_wp_error( $running_jobs ) ) {
+			foreach ( $running_jobs as $running_job ) {
+				$job_lock = get_term_meta( $running_job, Perflab_Background_Job::META_KEY_JOB_LOCK, true );
+				$job_lock = absint( $job_lock );
+
+				// If job lock is not present, trigger the job again.
+				if ( empty( $job_lock ) || $this->time_exceeded( $running_job ) ) {
+					perflab_dispatch_background_process_request( $running_job );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Check the completed jobs.
+	 *
+	 * If the job has been marked as completed and completed
+	 * time has been over 7 days, remove that job from job queue (history).
+	 *
+	 * @return void
+	 */
+	private function status_check_completed_jobs() {
+		$jobs_args = array(
+			'taxonomy'   => PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG,
+			'meta_key'   => Perflab_Background_Job::META_KEY_JOB_STATUS,
+			'meta_value' => Perflab_Background_Job::JOB_STATUS_COMPLETE,
+			'fields'     => 'ids',
+		);
+
+		$completed_jobs = get_terms( $jobs_args );
+
+		if ( ! empty( $completed_jobs ) && ! is_wp_error( $completed_jobs ) ) {
+			$expiry_days  = 7 * DAY_IN_SECONDS;
+			$current_time = time();
+
+			foreach ( $completed_jobs as $completed_job ) {
+				$job_completed_at = get_term_meta( $completed_job, 'perflab_job_completed_at', true );
+				$job_completed_at = absint( $job_completed_at );
+				$valid_till       = $job_completed_at + $expiry_days;
+
+				// If completed job has more than 7 days, delete/remove it.
+				if ( $current_time > $valid_till ) {
+					wp_delete_term( $completed_job, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
+				}
+			}
+		}
+	}
+
+	/**
 	 * Runs the process over a batch of job.
 	 *
 	 * As of now, it won't fetch the next batch if memory or time
@@ -117,7 +204,7 @@ class Perflab_Background_Process {
 			 * @param array $data Job data.
 			 */
 			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
-		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! $this->job->is_completed() );
+		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded( $this->job->get_id() ) && ! $this->job->is_completed() );
 	}
 
 	/**
@@ -204,17 +291,14 @@ class Perflab_Background_Process {
 	 *
 	 * @since n.e.x.t
 	 *
+	 * @param int $job_id Job ID. Term ID for `background_job` taxonomy.
 	 * @return bool
 	 */
-	private function time_exceeded() {
+	private function time_exceeded( $job_id ) {
+		$job                = new Perflab_Background_Job( $job_id );
 		$current_time       = time();
-		$run_start_time     = $this->job->get_start_time();
-		$min_execution_time = 20; // Default to 20 seconds. Almost, all servers will have this much of time.
-
-		if ( function_exists( 'ini_get' ) ) {
-			$time               = ini_get( 'max_execution_time' );
-			$max_execution_time = ( ! empty( $time ) && ( $time > $min_execution_time ) ) ? $time - 10 : $min_execution_time;
-		}
+		$run_start_time     = $job->get_start_time();
+		$max_execution_time = $this->get_max_execution_time();
 
 		$time_exceeded = ( $current_time >= ( $run_start_time + $max_execution_time ) );
 
@@ -226,5 +310,27 @@ class Perflab_Background_Process {
 		 * @param bool $time_exceeded Time exceeded flag.
 		 */
 		return apply_filters( 'perflab_background_process_time_exceeded', $time_exceeded );
+	}
+
+	/**
+	 * Get the maximum execution time for php script.
+	 *
+	 * By default this will be 20 seconds.
+	 *
+	 * If init_get returns the time, max execution time will be 10 seconds less than
+	 * what has been returned. These 10 seconds will be utilised to perform cleanup actions
+	 * like unlocking the job and making new request for background process.
+	 *
+	 * @return int
+	 */
+	private function get_max_execution_time() {
+		$min_execution_time = 20; // Default to 20 seconds. Almost, all servers will have this much of time.
+
+		if ( function_exists( 'ini_get' ) ) {
+			$time               = ini_get( 'max_execution_time' );
+			$max_execution_time = ( ! empty( $time ) && ( $time > $min_execution_time ) ) ? $time - 10 : $min_execution_time;
+		}
+
+		return $max_execution_time;
 	}
 }

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -117,7 +117,7 @@ class Perflab_Background_Process {
 			 * @param array $data Job data.
 			 */
 			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
-		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && $this->job->is_completed() );
+		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! $this->job->is_completed() );
 
 		// Once job ran successfully, change its status to queued.
 		$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -89,7 +89,7 @@ class Perflab_Background_Process {
 			if ( $this->job instanceof Perflab_Background_Job ) {
 				// Unlock the process once everything is done.
 				$this->job->unlock();
-				$this->next_batch();
+				$this->next_batch( $this->job->get_id() );
 			}
 		}
 	}
@@ -126,9 +126,10 @@ class Perflab_Background_Process {
 	 * This will send a POST request to admin-ajax.php with background
 	 * process specific action to continue executing the job in a new process.
 	 *
+	 * @param int $job_id Job ID. This is the term id from `background_job` taxonomy.
 	 * @return void
 	 */
-	private function next_batch() {
+	private function next_batch( $job_id ) {
 		/**
 		 * Do not call the background process from within the script if the
 		 * real cron has been setup to do so.
@@ -138,8 +139,6 @@ class Perflab_Background_Process {
 		}
 
 		$nonce  = wp_create_nonce( self::BG_PROCESS_ACTION );
-		$job_id = $this->job->get_id();
-
 		$url    = admin_url( 'admin-ajax.php' );
 		$params = array(
 			'blocking'  => false,

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -19,7 +19,9 @@
  * @since n.e.x.t
  */
 function perflab_register_background_job_taxonomy() {
-
+	/**
+	 * Require background job class.
+	 */
 	require_once __DIR__ . '/background-process/class-perflab-background-job.php';
 
 	// Labels for the background job taxonomy.

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -87,3 +87,56 @@ function perflab_get_background_job_capabilities() {
 		'assign_terms' => 'assign_jobs', // To assign background_job terms to posts.
 	);
 }
+
+/**
+ * Creates a background job.
+ *
+ * Job refers to the term and queue refers to the `background_job` taxonomy.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $name Name of job identifier.
+ * @param array  $data Data for the job.
+ * @return Perflab_Background_Job|WP_Error Job object if created successfully, else WP_Error.
+ */
+function perflab_create_background_job( $name, array $data = array() ) {
+	// Insert the new job in queue.
+	$term_name = 'job_' . time() . rand();
+	$term_data = wp_insert_term( $term_name, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
+
+	if ( ! is_wp_error( $term_data ) ) {
+		update_term_meta( $term_data['term_id'], Perflab_Background_Job::META_KEY_JOB_DATA, $data );
+		update_term_meta( $term_data['term_id'], Perflab_Background_Job::META_KEY_JOB_NAME, $name );
+
+		// Create a fresh instance to return.
+		$job = new Perflab_Background_Job( $term_data['term_id'] );
+		// Set the queued status for freshly created jobs.
+		$job->set_status( Perflab_Background_Job::JOB_STATUS_QUEUED );
+
+		return $job;
+	}
+
+	return $term_data;
+}
+
+/**
+ * Deletes a background job.
+ *
+ * Technically it is equivalent of deleting a term in
+ * `background_job` taxonomy and all its associated meta.
+ *
+ * @since n.e.x.t
+ *
+ * @param int $job_id Job ID. Technically the term id for `background_job` taxonomy.
+ * @return bool|WP_Error
+ */
+function perflab_delete_background_job( $job_id ) {
+	$job_id = absint( $job_id );
+	$job    = new Perflab_Background_Job( $job_id );
+
+	if ( ! $job->exists() ) {
+		return false;
+	}
+
+	return wp_delete_term( $job_id, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
+}

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -19,6 +19,9 @@
  * @since n.e.x.t
  */
 function perflab_register_background_job_taxonomy() {
+
+	require_once __DIR__ . '/background-process/class-perflab-background-job.php';
+
 	// Labels for the background job taxonomy.
 	$labels = array(
 		'name'                  => _x( 'Background Jobs', 'taxonomy general name', 'performance-lab' ),

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -9,6 +9,17 @@
  */
 
 /**
+ * Define the background job taxonomy constant.
+ *
+ * @since n.e.x.t
+ *
+ * @var Background job taxonomy slug.
+ */
+if ( ! defined( 'BACKGROUND_JOB_TAXONOMY_SLUG' ) ) {
+	define( 'BACKGROUND_JOB_TAXONOMY_SLUG', 'background_job' );
+}
+
+/**
  * Registers the background job taxonomy.
  *
  * Intentionally on lower priority, so that other post types can be
@@ -59,7 +70,7 @@ function perflab_register_background_job_taxonomy() {
 	 * `wp_set_object_terms` which do not check if there is relationship
 	 * between object and taxonomy.
 	 */
-	register_taxonomy( 'background_job', array(), $args );
+	register_taxonomy( BACKGROUND_JOB_TAXONOMY_SLUG, array(), $args );
 }
 add_action( 'init', 'perflab_register_background_job_taxonomy' );
 

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -19,10 +19,6 @@
  * @since n.e.x.t
  */
 function perflab_register_background_job_taxonomy() {
-	/**
-	 * Require background job class.
-	 */
-	require_once __DIR__ . '/background-process/class-perflab-background-job.php';
 
 	// Labels for the background job taxonomy.
 	$labels = array(

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -140,3 +140,25 @@ function perflab_delete_background_job( $job_id ) {
 
 	return wp_delete_term( $job_id, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 }
+
+/**
+ * Schedule a status check cron.
+ *
+ * This cron job will be responsible to stop any running jobs which
+ * may have stopped due to some failure.
+ *
+ * It will also clear the completed jobs, basically remove the terms from the
+ * taxonomy.
+ *
+ * @return void
+ */
+function perflab_statuc_check_cron() {
+	// Check if event is already scheduled.
+	$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
+
+	// Schedule the event if it does not exist already.
+	if ( empty( $scheduled ) ) {
+		wp_schedule_event( time(), 'hourly', 'perflab_background_process_status_check' );
+	}
+}
+add_action( 'init', 'perflab_statuc_check_cron' );

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -15,9 +15,7 @@
  *
  * @var Background job taxonomy slug.
  */
-if ( ! defined( 'BACKGROUND_JOB_TAXONOMY_SLUG' ) ) {
-	define( 'BACKGROUND_JOB_TAXONOMY_SLUG', 'background_job' );
-}
+define( 'PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG', 'background_job' );
 
 /**
  * Registers the background job taxonomy.
@@ -70,7 +68,7 @@ function perflab_register_background_job_taxonomy() {
 	 * `wp_set_object_terms` which do not check if there is relationship
 	 * between object and taxonomy.
 	 */
-	register_taxonomy( BACKGROUND_JOB_TAXONOMY_SLUG, array(), $args );
+	register_taxonomy( PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG, array(), $args );
 }
 add_action( 'init', 'perflab_register_background_job_taxonomy' );
 

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -33,12 +33,12 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->job = new Perflab_Background_Job();
 		$job_class = get_class( $this->job );
 
-		$this->assertTrue( defined( $job_class . '::JOB_NAME_META_KEY' ) );
-		$this->assertTrue( defined( $job_class . '::JOB_DATA_META_KEY' ) );
-		$this->assertTrue( defined( $job_class . '::JOB_ATTEMPTS_META_KEY' ) );
-		$this->assertTrue( defined( $job_class . '::JOB_LOCK_META_KEY' ) );
-		$this->assertTrue( defined( $job_class . '::JOB_ERRORS_META_KEY' ) );
-		$this->assertTrue( defined( $job_class . '::JOB_STATUS_META_KEY' ) );
+		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_NAME' ) );
+		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_DATA' ) );
+		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_ATTEMPTS' ) );
+		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_LOCK' ) );
+		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_ERRORS' ) );
+		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_STATUS' ) );
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_QUEUED' ) );
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_RUNNING' ) );
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_PARTIAL' ) );
@@ -50,12 +50,12 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->job = new Perflab_Background_Job();
 		$job_class = get_class( $this->job );
 
-		$this->assertEquals( 'perflab_job_name', constant( $job_class . '::JOB_NAME_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_data', constant( $job_class . '::JOB_DATA_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_attempts', constant( $job_class . '::JOB_ATTEMPTS_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_lock', constant( $job_class . '::JOB_LOCK_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_errors', constant( $job_class . '::JOB_ERRORS_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_status', constant( $job_class . '::JOB_STATUS_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_name', constant( $job_class . '::META_KEY_JOB_NAME' ) );
+		$this->assertEquals( 'perflab_job_data', constant( $job_class . '::META_KEY_JOB_DATA' ) );
+		$this->assertEquals( 'perflab_job_attempts', constant( $job_class . '::META_KEY_JOB_ATTEMPTS' ) );
+		$this->assertEquals( 'perflab_job_lock', constant( $job_class . '::META_KEY_JOB_LOCK' ) );
+		$this->assertEquals( 'perflab_job_errors', constant( $job_class . '::META_KEY_JOB_ERRORS' ) );
+		$this->assertEquals( 'perflab_job_status', constant( $job_class . '::META_KEY_JOB_STATUS' ) );
 		$this->assertEquals( 'perflab_job_queued', constant( $job_class . '::JOB_STATUS_QUEUED' ) );
 		$this->assertEquals( 'perflab_job_running', constant( $job_class . '::JOB_STATUS_RUNNING' ) );
 		$this->assertEquals( 'perflab_job_partial', constant( $job_class . '::JOB_STATUS_PARTIAL' ) );

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -21,6 +21,15 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 */
 	private $job;
 
+	/**
+	 * Runs before any test is executed inside class.
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php';
+	}
+
 	public function test_class_constants_exists() {
 		$this->job = new Perflab_Background_Job();
 		$job_class = get_class( $this->job );

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Tests for background-job module.
+ *
+ * @package performance-lab
+ * @group   background-process
+ */
+
+/**
+ * Class Perflab_Background_Job_Test
+ *
+ * @coversDefaultClass Perflab_Background_Job
+ * @group background-process
+ */
+class Perflab_Background_Job_Test extends WP_UnitTestCase {
+
+	/**
+	 * Job instance.
+	 *
+	 * @var Perflab_Background_Job
+	 */
+	private $job;
+
+	public function test_class_constants_exists() {
+		$this->job = new Perflab_Background_Job();
+
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_NAME_META_KEY' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_DATA_META_KEY' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_RETRY_META_KEY' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_LOCK_META_KEY' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_ERRORS_META_KEY' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_META_KEY' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_QUEUED' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_RUNNING' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_COMPLETE' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_FAILED' ) );
+	}
+
+	public function test_class_constants_values() {
+		$this->job = new Perflab_Background_Job();
+
+		$this->assertEquals( 'perflab_job_name', constant( get_class( $this->job ) . '::JOB_NAME_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_data', constant( get_class( $this->job ) . '::JOB_DATA_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_retries', constant( get_class( $this->job ) . '::JOB_RETRY_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_lock', constant( get_class( $this->job ) . '::JOB_LOCK_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_errors', constant( get_class( $this->job ) . '::JOB_ERRORS_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_status', constant( get_class( $this->job ) . '::JOB_STATUS_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_queued', constant( get_class( $this->job ) . '::JOB_STATUS_QUEUED' ) );
+		$this->assertEquals( 'perflab_job_running', constant( get_class( $this->job ) . '::JOB_STATUS_RUNNING' ) );
+		$this->assertEquals( 'perflab_job_complete', constant( get_class( $this->job ) . '::JOB_STATUS_COMPLETE' ) );
+		$this->assertEquals( 'perflab_job_failed', constant( get_class( $this->job ) . '::JOB_STATUS_FAILED' ) );
+	}
+}

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -65,7 +65,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::set_status
 	 */
 	public function test_set_status_false_for_invalid_status() {
-		$this->job = Perflab_Background_Job::create( 'test' );
+		$this->job = perflab_create_background_job( 'test' );
 
 		$result = $this->job->set_status( 'invalid_status' );
 		$this->assertFalse( $result );
@@ -75,7 +75,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::set_status
 	 */
 	public function test_set_status_false_for_valid_status() {
-		$this->job = Perflab_Background_Job::create( 'test' );
+		$this->job = perflab_create_background_job( 'test' );
 
 		$running_status  = $this->job->set_status( 'perflab_job_running' );
 		$partial_status  = $this->job->set_status( 'perflab_job_partial' );
@@ -97,7 +97,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 			'some_random_data' => 'some_random_string',
 		);
 
-		$job = Perflab_Background_Job::create( 'test_job', $job_data );
+		$job = perflab_create_background_job( 'test_job', $job_data );
 
 		$this->assertInstanceOf( Perflab_Background_Job::class, $job );
 	}
@@ -117,7 +117,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 			'some_random_data' => 'some_random_string',
 		);
 
-		$this->job = Perflab_Background_Job::create( 'tecdcdcdst', $job_data );
+		$this->job = perflab_create_background_job( 'tecdcdcdst', $job_data );
 		$this->job->set_error( $error );
 
 		$error_metadata = get_term_meta( $this->job->get_id(), 'perflab_job_errors', true );
@@ -131,7 +131,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::should_run
 	 */
 	public function test_job_should_run_for_job() {
-		$this->job = Perflab_Background_Job::create( 'test' );
+		$this->job = perflab_create_background_job( 'test' );
 
 		$run = $this->job->should_run();
 		$this->assertTrue( $run );
@@ -141,8 +141,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::should_run
 	 */
 	public function test_job_should_not_run_for_completed_job() {
-		$this->job = Perflab_Background_Job::create( 'test' );
-		$this->job->create( 'test_job' );
+		$this->job = perflab_create_background_job( 'test' );
 
 		// Mark job as complete.
 		$this->job->set_status( 'perflab_job_complete' );
@@ -156,7 +155,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::unlock
 	 */
 	public function test_lock_unlock() {
-		$this->job = Perflab_Background_Job::create( 'test' );
+		$this->job = perflab_create_background_job( 'test' );
 		$time      = time();
 		$this->job->lock( $time );
 		$lock_time = get_term_meta( $this->job->get_id(), 'perflab_job_lock', true );
@@ -170,7 +169,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::get_start_time
 	 */
 	public function test_get_start_time() {
-		$this->job = Perflab_Background_Job::create( 'test' );
+		$this->job = perflab_create_background_job( 'test' );
 		$time      = time();
 		$this->job->lock( $time );
 		$lock_time = get_term_meta( $this->job->get_id(), 'perflab_job_lock', true );

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -23,32 +23,34 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 
 	public function test_class_constants_exists() {
 		$this->job = new Perflab_Background_Job();
+		$job_class = get_class( $this->job );
 
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_NAME_META_KEY' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_DATA_META_KEY' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_ATTEMPTS_META_KEY' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_LOCK_META_KEY' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_ERRORS_META_KEY' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_META_KEY' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_QUEUED' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_RUNNING' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_COMPLETE' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_FAILED' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_NAME_META_KEY' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_DATA_META_KEY' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_ATTEMPTS_META_KEY' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_LOCK_META_KEY' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_ERRORS_META_KEY' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_STATUS_META_KEY' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_STATUS_QUEUED' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_STATUS_RUNNING' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_STATUS_COMPLETE' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_STATUS_FAILED' ) );
 	}
 
 	public function test_class_constants_values() {
 		$this->job = new Perflab_Background_Job();
+		$job_class = get_class( $this->job );
 
-		$this->assertEquals( 'perflab_job_name', constant( get_class( $this->job ) . '::JOB_NAME_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_data', constant( get_class( $this->job ) . '::JOB_DATA_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_attempts', constant( get_class( $this->job ) . '::JOB_ATTEMPTS_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_lock', constant( get_class( $this->job ) . '::JOB_LOCK_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_errors', constant( get_class( $this->job ) . '::JOB_ERRORS_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_status', constant( get_class( $this->job ) . '::JOB_STATUS_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_queued', constant( get_class( $this->job ) . '::JOB_STATUS_QUEUED' ) );
-		$this->assertEquals( 'perflab_job_running', constant( get_class( $this->job ) . '::JOB_STATUS_RUNNING' ) );
-		$this->assertEquals( 'perflab_job_complete', constant( get_class( $this->job ) . '::JOB_STATUS_COMPLETE' ) );
-		$this->assertEquals( 'perflab_job_failed', constant( get_class( $this->job ) . '::JOB_STATUS_FAILED' ) );
+		$this->assertEquals( 'perflab_job_name', constant( $job_class . '::JOB_NAME_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_data', constant( $job_class . '::JOB_DATA_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_attempts', constant( $job_class . '::JOB_ATTEMPTS_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_lock', constant( $job_class . '::JOB_LOCK_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_errors', constant( $job_class . '::JOB_ERRORS_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_status', constant( $job_class . '::JOB_STATUS_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_queued', constant( $job_class . '::JOB_STATUS_QUEUED' ) );
+		$this->assertEquals( 'perflab_job_running', constant( $job_class . '::JOB_STATUS_RUNNING' ) );
+		$this->assertEquals( 'perflab_job_complete', constant( $job_class . '::JOB_STATUS_COMPLETE' ) );
+		$this->assertEquals( 'perflab_job_failed', constant( $job_class . '::JOB_STATUS_FAILED' ) );
 	}
 
 	public function test_job_id_is_zero() {

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -13,7 +13,6 @@
  * @group background-process
  */
 class Perflab_Background_Job_Test extends WP_UnitTestCase {
-
 	/**
 	 * Job instance.
 	 *
@@ -92,53 +91,10 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * @covers ::batch
-	 *
-	 * @todo Add the check if filter ran, once 6.1 is released.
-	 * @see https://core.trac.wordpress.org/ticket/35357
-	 */
-	public function test_batch() {
-		$this->job = new Perflab_Background_Job();
-
-		$items = $this->job->batch();
-
-		$this->assertIsArray( $items );
-		$this->assertEmpty( $items );
-	}
-
-	/**
-	 * @covers ::process
-	 */
-	public function test_process() {
-		$job_data = array(
-			'post_id'          => 10,
-			'some_random_data' => 'some_random_string',
-		);
-
-		$job = Perflab_Background_Job::create( 'random', $job_data );
-
-		$test_items = array(
-			'test_item_1',
-			'test_item_2',
-			'test_item_3',
-			'test_item_4',
-			'test_item_5',
-		);
-
-		foreach ( $test_items as $item ) {
-			$job->process( $item );
-		}
-
-		$process_hook = did_action( 'perflab_process_random_job_item' );
-
-		$this->assertEquals( 5, $process_hook );
-	}
-
-	/**
-	 * @covers ::record_error
+	 * @covers ::set_error
 	 * @covers ::get_attempts
 	 */
-	public function test_record_error() {
+	public function test_set_error() {
 		$error      = new WP_Error();
 		$error_data = array(
 			'test_error_data' => 'descriptive_infomation',
@@ -151,7 +107,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		);
 
 		$this->job = Perflab_Background_Job::create( 'random', $job_data );
-		$this->job->record_error( $error );
+		$this->job->set_error( $error );
 
 		$error_metadata = get_term_meta( $this->job->job_id, 'perflab_job_errors', true );
 		$attempts       = $this->job->get_attempts();

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -26,7 +26,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_NAME_META_KEY' ) );
 		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_DATA_META_KEY' ) );
-		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_RETRY_META_KEY' ) );
+		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_ATTEMPTS_META_KEY' ) );
 		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_LOCK_META_KEY' ) );
 		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_ERRORS_META_KEY' ) );
 		$this->assertTrue( defined( get_class( $this->job ) . '::JOB_STATUS_META_KEY' ) );
@@ -41,7 +41,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'perflab_job_name', constant( get_class( $this->job ) . '::JOB_NAME_META_KEY' ) );
 		$this->assertEquals( 'perflab_job_data', constant( get_class( $this->job ) . '::JOB_DATA_META_KEY' ) );
-		$this->assertEquals( 'perflab_job_retries', constant( get_class( $this->job ) . '::JOB_RETRY_META_KEY' ) );
+		$this->assertEquals( 'perflab_job_attempts', constant( get_class( $this->job ) . '::JOB_ATTEMPTS_META_KEY' ) );
 		$this->assertEquals( 'perflab_job_lock', constant( get_class( $this->job ) . '::JOB_LOCK_META_KEY' ) );
 		$this->assertEquals( 'perflab_job_errors', constant( get_class( $this->job ) . '::JOB_ERRORS_META_KEY' ) );
 		$this->assertEquals( 'perflab_job_status', constant( get_class( $this->job ) . '::JOB_STATUS_META_KEY' ) );
@@ -49,5 +49,154 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'perflab_job_running', constant( get_class( $this->job ) . '::JOB_STATUS_RUNNING' ) );
 		$this->assertEquals( 'perflab_job_complete', constant( get_class( $this->job ) . '::JOB_STATUS_COMPLETE' ) );
 		$this->assertEquals( 'perflab_job_failed', constant( get_class( $this->job ) . '::JOB_STATUS_FAILED' ) );
+	}
+
+	public function test_job_id_is_zero() {
+		$this->job = new Perflab_Background_Job();
+
+		$this->assertSame( 0, $this->job->job_id );
+	}
+
+	public function test_set_status_false_for_invalid_status() {
+		$this->job = new Perflab_Background_Job();
+
+		$result = $this->job->set_status( 'invalid_status' );
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @covers ::create
+	 */
+	public function test_create_job() {
+		$this->job = new Perflab_Background_Job();
+
+		$job_data = array(
+			'post_id'          => 10,
+			'some_random_data' => 'some_random_string',
+		);
+
+		$job_info = $this->job->create( 'test_job', $job_data );
+
+		$this->assertIsArray( $job_info );
+		$this->assertArrayHasKey( 'term_id', $job_info );
+		$this->assertArrayHasKey( 'term_taxonomy_id', $job_info );
+
+		$job_created_hook = did_action( 'perflab_job_created' );
+
+		$this->assertEquals( 1, $job_created_hook );
+	}
+
+	/**
+	 * Returns wp error for non-zero job id.
+	 *
+	 * @covers ::create
+	 */
+	public function test_create_returns_wp_error() {
+		$this->job = new Perflab_Background_Job( 10 ); // non-zero ID.
+		$job_data  = $this->job->create( 'test_job', array() );
+
+		$this->assertInstanceOf( WP_Error::class, $job_data );
+	}
+
+	/**
+	 * @covers ::batch
+	 *
+	 * @todo Add the check if filter ran, once 6.1 is released.
+	 * @see https://core.trac.wordpress.org/ticket/35357
+	 */
+	public function test_batch() {
+		$this->job = new Perflab_Background_Job();
+
+		$items = $this->job->batch();
+
+		$this->assertIsArray( $items );
+		$this->assertEmpty( $items );
+	}
+
+	/**
+	 * @covers ::process
+	 */
+	public function test_process() {
+		$this->job = new Perflab_Background_Job();
+
+		$job_data = array(
+			'post_id'          => 10,
+			'some_random_data' => 'some_random_string',
+		);
+
+		$job_info = $this->job->create( 'random', $job_data );
+
+		$test_items = array(
+			'test_item_1',
+			'test_item_2',
+			'test_item_3',
+			'test_item_4',
+			'test_item_5',
+		);
+
+		foreach ( $test_items as $item ) {
+			$this->job->process( $item );
+		}
+
+		$process_hook = did_action( 'perflab_process_random_job_item' );
+
+		$this->assertEquals( 5, $process_hook );
+	}
+
+	/**
+	 * @covers ::record_error
+	 * @covers ::get_attempts
+	 */
+	public function test_record_error() {
+		$error      = new WP_Error();
+		$error_data = array(
+			'test_error_data' => 'descriptive_infomation',
+		);
+		$error->add_data( $error_data, 'perflab_job_failure' );
+		$this->job = new Perflab_Background_Job();
+		$job_data  = array(
+			'post_id'          => 10,
+			'some_random_data' => 'some_random_string',
+		);
+		$this->job->create( 'random', $job_data );
+		$this->job->record_error( $error );
+
+		$error_metadata = get_term_meta( $this->job->job_id, 'perflab_job_errors', true );
+		$attempts       = $this->job->get_attempts();
+
+		$this->assertSame( $error_data, $error_metadata );
+		$this->assertEquals( 1, $attempts );
+	}
+
+	public function test_job_should_not_run_non_existing_job() {
+		$this->job = new Perflab_Background_Job();
+
+		$run = $this->job->should_run();
+		$this->assertFalse( $run );
+	}
+
+	public function test_job_should_not_run_for_completed_job() {
+		$this->job = new Perflab_Background_Job();
+		$this->job->create( 'test_job' );
+
+		// Mark job as complete.
+		$this->job->set_status( 'perflab_job_complete' );
+		$run = $this->job->should_run();
+
+		$this->assertFalse( $run );
+	}
+
+	/**
+	 * @covers ::lock
+	 * @covers ::get_status
+	 */
+	public function test_lock() {
+		$this->job = new Perflab_Background_Job();
+		$this->job->create( 'test_job' );
+
+		$this->job->lock();
+		$status = $this->job->get_status();
+
+		$this->assertSame( 'perflab_job_running', $status );
 	}
 }

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -66,7 +66,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	public function test_job_id_is_zero() {
 		$this->job = new Perflab_Background_Job();
 
-		$this->assertSame( 0, $this->job->job_id );
+		$this->assertSame( 0, $this->job->get_id() );
 	}
 
 	/**
@@ -129,7 +129,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->job = Perflab_Background_Job::create( 'random', $job_data );
 		$this->job->set_error( $error );
 
-		$error_metadata = get_term_meta( $this->job->job_id, 'perflab_job_errors', true );
+		$error_metadata = get_term_meta( $this->job->get_id(), 'perflab_job_errors', true );
 		$attempts       = $this->job->get_attempts();
 
 		$this->assertSame( $error_data, $error_metadata );
@@ -168,10 +168,10 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->job = Perflab_Background_Job::create( 'test' );
 		$time      = time();
 		$this->job->lock( $time );
-		$lock_time = get_term_meta( $this->job->job_id, 'perflab_job_lock', true );
+		$lock_time = get_term_meta( $this->job->get_id(), 'perflab_job_lock', true );
 		$this->assertSame( absint( $lock_time ), $time );
 		$this->job->unlock();
-		$lock_time = get_term_meta( $this->job->job_id, 'perflab_job_lock', true );
+		$lock_time = get_term_meta( $this->job->get_id(), 'perflab_job_lock', true );
 		$this->assertEmpty( $lock_time );
 	}
 
@@ -182,8 +182,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->job = Perflab_Background_Job::create( 'test' );
 		$time      = time();
 		$this->job->lock( $time );
-		$status    = $this->job->get_status();
-		$lock_time = get_term_meta( $this->job->job_id, 'perflab_job_lock', true );
+		$lock_time = get_term_meta( $this->job->get_id(), 'perflab_job_lock', true );
 		$this->assertSame( absint( $lock_time ), $time );
 
 		$start_time = $this->job->get_start_time();

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -81,34 +81,14 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::create
 	 */
 	public function test_create_job() {
-		$this->job = new Perflab_Background_Job();
-
 		$job_data = array(
 			'post_id'          => 10,
 			'some_random_data' => 'some_random_string',
 		);
 
-		$job_info = $this->job->create( 'test_job', $job_data );
+		$job = Perflab_Background_Job::create( 'test_job', $job_data );
 
-		$this->assertIsArray( $job_info );
-		$this->assertArrayHasKey( 'term_id', $job_info );
-		$this->assertArrayHasKey( 'term_taxonomy_id', $job_info );
-
-		$job_created_hook = did_action( 'perflab_job_created' );
-
-		$this->assertEquals( 1, $job_created_hook );
-	}
-
-	/**
-	 * Returns wp error for non-zero job id.
-	 *
-	 * @covers ::create
-	 */
-	public function test_create_returns_wp_error() {
-		$this->job = new Perflab_Background_Job( 10 ); // non-zero ID.
-		$job_data  = $this->job->create( 'test_job', array() );
-
-		$this->assertInstanceOf( WP_Error::class, $job_data );
+		$this->assertInstanceOf( Perflab_Background_Job::class, $job );
 	}
 
 	/**
@@ -130,14 +110,12 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::process
 	 */
 	public function test_process() {
-		$this->job = new Perflab_Background_Job();
-
 		$job_data = array(
 			'post_id'          => 10,
 			'some_random_data' => 'some_random_string',
 		);
 
-		$job_info = $this->job->create( 'random', $job_data );
+		$job = Perflab_Background_Job::create( 'random', $job_data );
 
 		$test_items = array(
 			'test_item_1',
@@ -148,7 +126,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		);
 
 		foreach ( $test_items as $item ) {
-			$this->job->process( $item );
+			$job->process( $item );
 		}
 
 		$process_hook = did_action( 'perflab_process_random_job_item' );
@@ -171,7 +149,8 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 			'post_id'          => 10,
 			'some_random_data' => 'some_random_string',
 		);
-		$this->job->create( 'random', $job_data );
+
+		$this->job = Perflab_Background_Job::create( 'random', $job_data );
 		$this->job->record_error( $error );
 
 		$error_metadata = get_term_meta( $this->job->job_id, 'perflab_job_errors', true );
@@ -204,12 +183,10 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	 * @covers ::get_status
 	 */
 	public function test_lock() {
-		$this->job = new Perflab_Background_Job();
-		$this->job->create( 'test_job' );
+		$this->job = Perflab_Background_Job::create( 'test' );
+		$status    = $this->job->get_status();
 
-		$this->job->lock();
-		$status = $this->job->get_status();
-
-		$this->assertSame( 'perflab_job_running', $status );
+		// Job status is queued as soon as it is created.
+		$this->assertSame( 'perflab_job_queued', $status );
 	}
 }

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -30,8 +30,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	}
 
 	public function test_class_constants_exists() {
-		$this->job = new Perflab_Background_Job();
-		$job_class = get_class( $this->job );
+		$job_class = Perflab_Background_Job::class;
 
 		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_NAME' ) );
 		$this->assertTrue( defined( $job_class . '::META_KEY_JOB_DATA' ) );
@@ -47,8 +46,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	}
 
 	public function test_class_constants_values() {
-		$this->job = new Perflab_Background_Job();
-		$job_class = get_class( $this->job );
+		$job_class = Perflab_Background_Job::class;
 
 		$this->assertEquals( 'perflab_job_name', constant( $job_class . '::META_KEY_JOB_NAME' ) );
 		$this->assertEquals( 'perflab_job_data', constant( $job_class . '::META_KEY_JOB_DATA' ) );
@@ -63,17 +61,11 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'perflab_job_failed', constant( $job_class . '::JOB_STATUS_FAILED' ) );
 	}
 
-	public function test_job_id_is_zero() {
-		$this->job = new Perflab_Background_Job();
-
-		$this->assertSame( 0, $this->job->get_id() );
-	}
-
 	/**
 	 * @covers ::set_status
 	 */
 	public function test_set_status_false_for_invalid_status() {
-		$this->job = new Perflab_Background_Job();
+		$this->job = Perflab_Background_Job::create( 'test' );
 
 		$result = $this->job->set_status( 'invalid_status' );
 		$this->assertFalse( $result );
@@ -120,13 +112,12 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 			'test_error_data' => 'descriptive_infomation',
 		);
 		$error->add_data( $error_data, 'perflab_job_failure' );
-		$this->job = new Perflab_Background_Job();
-		$job_data  = array(
+		$job_data = array(
 			'post_id'          => 10,
 			'some_random_data' => 'some_random_string',
 		);
 
-		$this->job = Perflab_Background_Job::create( 'random', $job_data );
+		$this->job = Perflab_Background_Job::create( 'tecdcdcdst', $job_data );
 		$this->job->set_error( $error );
 
 		$error_metadata = get_term_meta( $this->job->get_id(), 'perflab_job_errors', true );
@@ -139,18 +130,18 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 	/**
 	 * @covers ::should_run
 	 */
-	public function test_job_should_not_run_non_existing_job() {
-		$this->job = new Perflab_Background_Job();
+	public function test_job_should_run_for_job() {
+		$this->job = Perflab_Background_Job::create( 'test' );
 
 		$run = $this->job->should_run();
-		$this->assertFalse( $run );
+		$this->assertTrue( $run );
 	}
 
 	/**
 	 * @covers ::should_run
 	 */
 	public function test_job_should_not_run_for_completed_job() {
-		$this->job = new Perflab_Background_Job();
+		$this->job = Perflab_Background_Job::create( 'test' );
 		$this->job->create( 'test_job' );
 
 		// Mark job as complete.
@@ -189,5 +180,16 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->assertEquals( $start_time, $lock_time );
 		$this->assertEquals( $start_time, $time );
 		$this->assertEquals( $time, $lock_time );
+	}
+
+	/**
+	 * Runs after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		if ( $this->job instanceof Perflab_Background_Job ) {
+			wp_delete_term( $this->job->get_id(), 'background_job' );
+		}
 	}
 }

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-job-test.php
@@ -42,6 +42,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_META_KEY' ) );
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_QUEUED' ) );
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_RUNNING' ) );
+		$this->assertTrue( defined( $job_class . '::JOB_STATUS_PARTIAL' ) );
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_COMPLETE' ) );
 		$this->assertTrue( defined( $job_class . '::JOB_STATUS_FAILED' ) );
 	}
@@ -58,6 +59,7 @@ class Perflab_Background_Job_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'perflab_job_status', constant( $job_class . '::JOB_STATUS_META_KEY' ) );
 		$this->assertEquals( 'perflab_job_queued', constant( $job_class . '::JOB_STATUS_QUEUED' ) );
 		$this->assertEquals( 'perflab_job_running', constant( $job_class . '::JOB_STATUS_RUNNING' ) );
+		$this->assertEquals( 'perflab_job_partial', constant( $job_class . '::JOB_STATUS_PARTIAL' ) );
 		$this->assertEquals( 'perflab_job_complete', constant( $job_class . '::JOB_STATUS_COMPLETE' ) );
 		$this->assertEquals( 'perflab_job_failed', constant( $job_class . '::JOB_STATUS_FAILED' ) );
 	}

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -44,7 +44,7 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$process_class = get_class( $this->process );
 		$this->assertTrue( defined( $process_class . '::BG_PROCESS_ACTION' ) );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
-		$this->assertEquals( 'background_process_handle_request', $constant_value );
+		$this->assertEquals( 'perflab_background_process_handle_request', $constant_value );
 	}
 
 	/**
@@ -88,11 +88,10 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
 		$_REQUEST['job_id'] = $job->job_id;
-
 		$this->process->handle_request();
-
 		$hook_ran = did_action( 'perflab_job_test_task' );
+		$hook_ran = 1 < $hook_ran;
 
-		$this->assertSame( 1, $hook_ran );
+		$this->assertTrue( $hook_ran );
 	}
 }

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -76,50 +76,23 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @dataProvider job_instance
 	 * @covers ::handle_request
-	 * @group abc
 	 */
-	public function test_handle_request_throws_exception( $job_id ) {
+	public function test_handle_request() {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
 		$nonce          = wp_create_nonce( $constant_value );
+		$job            = Perflab_Background_Job::create( 'test_task' );
 
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
-		$_REQUEST['job_id'] = $job_id;
+		$_REQUEST['job_id'] = $job->job_id;
 
-		// Call the method with adding and removing filters.
-		add_filter( 'perflab_job_batch_items', array( $this, 'batch_items' ) );
 		$this->process->handle_request();
-		remove_filter( 'perflab_job_batch_items', array( $this, 'batch_items' ) );
 
-		$hook_ran = did_action( 'perflab_process_test_task_job_item' );
+		$hook_ran = did_action( 'perflab_job_test_task' );
 
-		$this->assertSame( 5, $hook_ran );
-	}
-
-	public function job_instance() {
-		$job = Perflab_Background_Job::create( 'test_task', array( 'test_data' => 123 ) );
-
-		return array(
-			array( $job->job_id ),
-		);
-	}
-
-	/**
-	 * Batch items filter callback.
-	 *
-	 * @return array Filtered batch items.
-	 */
-	public function batch_items() {
-		return array(
-			1,
-			2,
-			3,
-			4,
-			5,
-		);
+		$this->assertSame( 1, $hook_ran );
 	}
 }

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -83,11 +83,11 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$process_class  = get_class( $this->process );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
 		$nonce          = wp_create_nonce( $constant_value );
-		$job            = Perflab_Background_Job::create( 'test_task' );
+		$job            = perflab_create_background_job( 'test_task' );
 
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
-		$_REQUEST['job_id'] = $job->job_id;
+		$_REQUEST['job_id'] = $job->get_id();
 		$this->process->handle_request();
 		$hook_ran = did_action( 'perflab_job_test_task' );
 		$hook_ran = 1 < $hook_ran;

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for background-process runner class.
+ *
+ * @package performance-lab
+ * @group   background-process
+ */
+
+/**
+ * Class Perflab_Background_Process_Test
+ *
+ * @coversDefaultClass Perflab_Background_Process
+ * @group background-process
+ */
+class Perflab_Background_Process_Test extends WP_UnitTestCase {
+
+	private $process;
+
+	/**
+	 * Runs before any test is executed inside class.
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php';
+		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php';
+	}
+
+	public function test_class_constants_exists() {
+		$this->process = new Perflab_Background_Process();
+		$process_class = get_class( $this->process );
+		$this->assertTrue( defined( $process_class . '::BG_PROCESS_ACTION' ) );
+		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
+		$this->assertEquals( 'background_process_handle_request', $constant_value );
+	}
+
+	public function test_handle_request_actions_added() {
+		$this->process  = new Perflab_Background_Process();
+		$process_class  = get_class( $this->process );
+		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
+
+		$authenticated_action     = has_action( 'wp_ajax_' . $constant_value, array( $this->process, 'handle_request' ) );
+		$non_authenticated_action = has_action( 'wp_ajax_nopriv_' . $constant_value, array( $this->process, 'handle_request' ) );
+
+		// Ensure has_action is not returning false.
+		$this->assertNotEquals( false, $authenticated_action );
+		$this->assertNotEquals( false, $non_authenticated_action );
+
+		// has_action will return priority, so check that as well.
+		$this->assertEquals( 10, $authenticated_action );
+		$this->assertEquals( 10, $non_authenticated_action );
+	}
+
+}

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -14,6 +14,13 @@
  */
 class Perflab_Background_Process_Test extends WP_UnitTestCase {
 
+    /**
+     * Process instance.
+     * 
+     * @since n.e.x.t
+     *
+     * @var Perflab_Background_Process
+     */
 	private $process;
 
 	/**
@@ -26,6 +33,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php';
 	}
 
+    /**
+     * Test that constant exists and its value.
+     * 
+     * @since n.e.x.t
+     *
+     * @return void
+     */
 	public function test_class_constants_exists() {
 		$this->process = new Perflab_Background_Process();
 		$process_class = get_class( $this->process );
@@ -34,6 +48,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'background_process_handle_request', $constant_value );
 	}
 
+    /**
+     * Test that ajax hooks are getting added when object is instantiated.
+     * 
+     * @since n.e.x.t
+     *
+     * @return void
+     */
 	public function test_handle_request_actions_added() {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -80,7 +80,7 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 * @covers ::handle_request
 	 * @group abc
 	 */
-	public function test_handle_request_throws_exception( $job ) {
+	public function test_handle_request_throws_exception( $job_id ) {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
@@ -88,7 +88,7 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
-		$_REQUEST['job_id'] = $job['term_id'];
+		$_REQUEST['job_id'] = $job_id;
 
 		// Call the method with adding and removing filters.
 		add_filter( 'perflab_job_batch_items', array( $this, 'batch_items' ) );
@@ -101,11 +101,10 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	}
 
 	public function job_instance() {
-		$job    = new Perflab_Background_Job();
-		$job_id = $job->create( 'test_task', array( 'test_data' => 123 ) );
+		$job = Perflab_Background_Job::create( 'test_task', array( 'test_data' => 123 ) );
 
 		return array(
-			array( $job_id ),
+			array( $job->job_id ),
 		);
 	}
 

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -13,14 +13,13 @@
  * @group background-process
  */
 class Perflab_Background_Process_Test extends WP_UnitTestCase {
-
-    /**
-     * Process instance.
-     * 
-     * @since n.e.x.t
-     *
-     * @var Perflab_Background_Process
-     */
+	/**
+	 * Process instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var Perflab_Background_Process
+	 */
 	private $process;
 
 	/**
@@ -33,13 +32,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php';
 	}
 
-    /**
-     * Test that constant exists and its value.
-     * 
-     * @since n.e.x.t
-     *
-     * @return void
-     */
+	/**
+	 * Test that constant exists and its value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @covers ::__construct
+	 */
 	public function test_class_constants_exists() {
 		$this->process = new Perflab_Background_Process();
 		$process_class = get_class( $this->process );
@@ -48,13 +47,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'background_process_handle_request', $constant_value );
 	}
 
-    /**
-     * Test that ajax hooks are getting added when object is instantiated.
-     * 
-     * @since n.e.x.t
-     *
-     * @return void
-     */
+	/**
+	 * Test that ajax hooks are getting added when object is instantiated.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @covers ::__construct
+	 */
 	public function test_handle_request_actions_added() {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );


### PR DESCRIPTION
## Summary

Status check cron for background job.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes 

## Relevant technical choices

1. Cron will be schedule if it does not exist already.
2. It will restart any job which is halted due to failure.
3. Remove old completed jobs.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
