### PR TITLE
Create Queue Admin Screen

### DIFF
--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -22,9 +22,10 @@ function perflab_add_queue_screen_hooks() {
 	 * @since n.e.x.t
 	 * @param bool $enable Flag to enable admin queue screen. Default false.
 	 */
-	if ( apply_filters( 'perflab_enable_background_process_queue_screen', false ) ) {
+	if ( apply_filters( 'perflab_enable_background_process_queue_screen', true ) ) {
 		add_action( 'admin_menu', 'perflab_management_page' );
-		add_action( 'parent_file', 'perflab_backgroun_job_parent_file' );
+		add_action( 'parent_file', 'perflab_background_job_parent_file' );
+		add_action( 'manage_edit-background_job_columns', 'perflab_job_taxonomy_columns' );
 	}
 }
 add_action( 'init', 'perflab_add_queue_screen_hooks', 100 );
@@ -55,11 +56,34 @@ function perflab_management_page() {
  * @param  string $parent_file Parent file.
  * @return string
  */
-function perflab_backgroun_job_parent_file( $parent_file ) {
+function perflab_background_job_parent_file( $parent_file ) {
 	$screen = get_current_screen();
 	if ( $screen instanceof WP_Screen && isset( $screen->taxonomy ) && 'background_job' === $screen->taxonomy ) {
 		return 'tools.php';
 	}
 
 	return $parent_file;
+}
+
+/**
+ * Add custom columns to the job taxonomy list table.
+ *
+ * @since n.e.x.t
+ *
+ * @param array $columns Columns for job taxonomy list table.
+ *
+ * @return array Filtered list of columns.
+ */
+function perflab_job_taxonomy_columns( array $columns ) {
+	$new_columns = array(
+		'job_id'     => __( 'Job ID', 'performance-lab' ),
+		'job_name'   => __( 'Job Name', 'performance-lab' ),
+		'job_status' => __( 'Job Status', 'performance-lab' ),
+	);
+
+	if ( isset( $columns['cb'] ) ) {
+		$new_columns['cb'] = $columns['cb'];
+	}
+
+	return $new_columns;
 }

--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -22,8 +22,6 @@ function perflab_management_page() {
 		'',
 		100
 	);
-
-	remove_submenu_page( 'edit.php', 'edit-tags.php?taxonomy=background_job' );
 }
 add_action( 'admin_menu', 'perflab_management_page' );
 

--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Admin functions used by the background process API.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * Add management page which will be added in Tools menu.
+ *
+ * @since n.e.x.t
+ *
+ * @return void
+ */
+function perflab_management_page() {
+	add_management_page(
+		__( 'Background Jobs', 'performance-lab' ),
+		__( 'Background Jobs', 'performance-lab' ),
+		'edit_jobs',
+		'edit-tags.php?taxonomy=background_job',
+		'',
+		100
+	);
+
+	remove_submenu_page( 'edit.php', 'edit-tags.php?taxonomy=background_job' );
+}
+add_action( 'admin_menu', 'perflab_management_page' );
+
+/**
+ * Changes the parent file for background_job screen.
+ *
+ * @since n.e.x.t
+ *
+ * @param  string $parent_file Parent file.
+ * @return string
+ */
+function perflab_backgroun_job_parent_file( $parent_file ) {
+	$screen = get_current_screen();
+	if ( $screen instanceof WP_Screen && isset( $screen->taxonomy ) && 'background_job' === $screen->taxonomy ) {
+		return 'tools.php';
+	}
+
+	return $parent_file;
+}
+add_action( 'parent_file', 'perflab_backgroun_job_parent_file' );

--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -77,7 +77,7 @@ function perflab_background_job_parent_file( $parent_file ) {
 		return $parent_file;
 	}
 
-	if ( isset( $screen->taxonomy ) && 'background_job' === $screen->taxonomy ) {
+	if ( isset( $screen->taxonomy ) && PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG === $screen->taxonomy ) {
 		return 'tools.php';
 	}
 
@@ -189,7 +189,7 @@ function perflab_admin_job_details() {
 	}
 
 	$job_id = absint( $_REQUEST['job_id'] );
-	$job    = get_term( $job_id, 'background_job' );
+	$job    = get_term( $job_id, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 
 	if ( ! $job instanceof WP_Term ) {
 		wp_die( __( 'You attempted to edit an item that does not exist. Perhaps it was deleted?', 'performance-lab' ) );

--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -21,6 +21,7 @@ function perflab_add_queue_screen_hooks() {
 	 *
 	 * @since n.e.x.t
 	 * @param bool $enable Flag to enable admin queue screen. Default false.
+	 * @todo Change default value to false before merge.
 	 */
 	if ( apply_filters( 'perflab_enable_background_process_queue_screen', true ) ) {
 		add_action( 'admin_menu', 'perflab_management_page' );
@@ -75,15 +76,15 @@ function perflab_background_job_parent_file( $parent_file ) {
  * @return array Filtered list of columns.
  */
 function perflab_job_taxonomy_columns( array $columns ) {
-	$new_columns = array(
-		'job_id'     => __( 'Job ID', 'performance-lab' ),
-		'job_name'   => __( 'Job Name', 'performance-lab' ),
-		'job_status' => __( 'Job Status', 'performance-lab' ),
-	);
+	$new_columns = array();
 
 	if ( isset( $columns['cb'] ) ) {
 		$new_columns['cb'] = $columns['cb'];
 	}
+
+	$new_columns['job_id']     = __( 'Job ID', 'performance-lab' );
+	$new_columns['job_name']   = __( 'Job Name', 'performance-lab' );
+	$new_columns['job_status'] = __( 'Job Status', 'performance-lab' );
 
 	return $new_columns;
 }

--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -181,5 +181,36 @@ function perflab_job_column_data( $column, $column_name, $term_id ) {
  * @since n.e.x.t
  */
 function perflab_admin_job_details() {
-	load_template( __DIR__ . '/job-details.php' );
+	/**
+	 * If job ID is not present, redirect back to term listing page.
+	 */
+	if ( empty( $_REQUEST['job_id'] ) ) {
+		wp_die( __( 'No job ID specified.', 'performance-lab' ) );
+	}
+
+	$job_id = absint( $_REQUEST['job_id'] );
+	$job    = get_term( $job_id, 'background_job' );
+
+	if ( ! $job instanceof WP_Term ) {
+		wp_die( __( 'You attempted to edit an item that does not exist. Perhaps it was deleted?', 'performance-lab' ) );
+	}
+
+	if ( ! current_user_can( 'manage_jobs' ) ) {
+		wp_die( __( 'You do not have permission to access this page. Please contact administrator for more information.', 'performance-lab' ) );
+	}
+
+	$tax        = get_taxonomy( $job->taxonomy );
+	$job_data   = get_term_meta( $job_id, 'perflab_job_data', true );
+	$job_errors = get_term_meta( $job_id, 'perflab_job_errors', true );
+
+	$template_args = array(
+		'taxonomy'   => $tax,
+		'job'        => $job,
+		'job_data'   => $job_data,
+		'job_status' => 'Queued',
+		'job_errors' => $job_errors,
+	);
+
+	// Pass all the data as arguments to the template.
+	load_template( __DIR__ . '/job-details.php', true, $template_args );
 }

--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -206,6 +206,7 @@ function perflab_admin_job_details() {
 	$template_args = array(
 		'taxonomy'   => $tax,
 		'job'        => $job,
+		'job_id'     => $job_id,
 		'job_data'   => $job_data,
 		'job_status' => 'Queued',
 		'job_errors' => $job_errors,

--- a/modules/images/regenerate-existing-images/admin.php
+++ b/modules/images/regenerate-existing-images/admin.php
@@ -7,6 +7,29 @@
  */
 
 /**
+ * Adds necessary hooks to enable job queue admin screen.
+ *
+ * This will add a submenu page under Tools menu.
+ *
+ * @since n.e.x.t
+ *
+ * @return void
+ */
+function perflab_add_queue_screen_hooks() {
+	/**
+	 * By default admin screen will be disabled.
+	 *
+	 * @since n.e.x.t
+	 * @param bool $enable Flag to enable admin queue screen. Default false.
+	 */
+	if ( apply_filters( 'perflab_enable_background_process_queue_screen', false ) ) {
+		add_action( 'admin_menu', 'perflab_management_page' );
+		add_action( 'parent_file', 'perflab_backgroun_job_parent_file' );
+	}
+}
+add_action( 'init', 'perflab_add_queue_screen_hooks', 100 );
+
+/**
  * Add management page which will be added in Tools menu.
  *
  * @since n.e.x.t
@@ -23,7 +46,6 @@ function perflab_management_page() {
 		100
 	);
 }
-add_action( 'admin_menu', 'perflab_management_page' );
 
 /**
  * Changes the parent file for background_job screen.
@@ -41,4 +63,3 @@ function perflab_backgroun_job_parent_file( $parent_file ) {
 
 	return $parent_file;
 }
-add_action( 'parent_file', 'perflab_backgroun_job_parent_file' );

--- a/modules/images/regenerate-existing-images/job-details.php
+++ b/modules/images/regenerate-existing-images/job-details.php
@@ -1,50 +1,45 @@
 <?php
 /**
- * Term details.
+ * Job details.
+ *
+ * Displays the job details on custom admin page.
  *
  * @package performance-lab
  * @since n.e.x.t
+ * @param array $args {
+ *      $taxonomy   WP_Taxonomy Taxonomy object for background_job taxonomy.
+ *      $job_status string      Current job status.
+ *      $job        WP_Term     Job term object.
+ *      $job_errors array       List of errors while job was executed.
+ *      $job_data   array       Job data.
+ * } These arguments will be passed to the template.
  */
 
-/**
- * If job ID is not present, redirect back to term listing page.
- */
-if ( empty( $_REQUEST['job_id'] ) ) {
-	wp_die( __( 'No job ID specified.', 'performance-lab' ) );
-}
-
-$job_id = absint( $_REQUEST['job_id'] );
-$job    = get_term( $job_id, 'background_job' );
-
-if ( ! $job instanceof WP_Term ) {
-	wp_die( __( 'You attempted to edit an item that does not exist. Perhaps it was deleted?', 'performance-lab' ) );
-}
-
-if ( ! current_user_can( 'manage_jobs' ) ) {
-	wp_die( __( 'You do not have permission to access this page. Please contact administrator for more information.', 'performance-lab' ) );
-}
-
-$tax = get_taxonomy( $job->taxonomy );
-
-$job_data = get_term_meta( $job_id, 'perflab_job_data', true );
 ?>
-
 <div class="wrap">
-	<h1><?php echo $tax->labels->view_item; ?></h1>
-	<h3><?php _e( 'Job Name', 'performance-lab' ); ?></h3>
+	<h1><?php echo $args['taxonomy']->labels->view_item; ?></h1>	
+	<!-- Job name -->
+	<h3><?php esc_html_e( 'Job Name', 'performance-lab' ); ?></h3>
+	<span><?php echo esc_html( $args['job']->name ); ?></span>
+
+	<!-- Job status -->
+	<h3><?php esc_html_e( 'Job Status', 'performance-lab' ); ?></h3>
+	<span><?php echo esc_html( $args['job_status'] ); ?></span>
+
+	<!-- Job data -->
 	<h3><?php _e( 'Job Data', 'performance-lab' ); ?></h3>
 	<textarea rows="10" cols="50" readonly>
 <?php
-			$data = array(
-				'test'             => 123456,
-				'post_ids'         => array(
-					10,
-					20,
-					30,
-				),
-				'something_random' => 'stuff',
-			);
-			echo wp_json_encode( $data, JSON_PRETTY_PRINT );
-			?>
+	$job_data = array(
+		'test'             => 123456,
+		'post_ids'         => array(
+			10,
+			20,
+			30,
+		),
+		'something_random' => 'stuff',
+	);
+			echo wp_json_encode( $job_data, JSON_PRETTY_PRINT );
+	?>
 	</textarea>
 </div>

--- a/modules/images/regenerate-existing-images/job-details.php
+++ b/modules/images/regenerate-existing-images/job-details.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Term details.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * If job ID is not present, redirect back to term listing page.
+ */
+if ( empty( $_REQUEST['job_id'] ) ) {
+	wp_die( __( 'No job ID specified.', 'performance-lab' ) );
+}
+
+$job_id = absint( $_REQUEST['job_id'] );
+$job    = get_term( $job_id, 'background_job' );
+
+if ( ! $job instanceof WP_Term ) {
+	wp_die( __( 'You attempted to edit an item that does not exist. Perhaps it was deleted?', 'performance-lab' ) );
+}
+
+if ( ! current_user_can( 'manage_jobs' ) ) {
+	wp_die( __( 'You do not have permission to access this page. Please contact administrator for more information.', 'performance-lab' ) );
+}
+
+$tax = get_taxonomy( $job->taxonomy );
+
+$job_data = get_term_meta( $job_id, 'perflab_job_data', true );
+?>
+
+<div class="wrap">
+	<h1><?php echo $tax->labels->view_item; ?></h1>
+
+	<h3><?php _e( 'Job Name', 'performance-lab' ); ?></h3>
+
+	<h3><?php _e( 'Job Data', 'performance-lab' ); ?></h3>
+	<textarea readonly rows="5" cols="50">
+		<?php
+			$data = array(
+				'test'             => 123456,
+				'post_ids'         => array(
+					10,
+					20,
+					30,
+				),
+				'something_random' => 'stuff',
+			);
+
+			echo esc_html( maybe_serialize( $data ) );
+			?>
+	</textarea>
+</div>

--- a/modules/images/regenerate-existing-images/job-details.php
+++ b/modules/images/regenerate-existing-images/job-details.php
@@ -15,31 +15,57 @@
  * } These arguments will be passed to the template.
  */
 
+$job_data = array(
+	'test'             => 123456,
+	'post_ids'         => array(
+		10,
+		20,
+		30,
+	),
+	'something_random' => 'stuff',
+);
+
+$job_errors = array(
+	array(
+		'datetime' => gmdate( 'Y-m-d H:I:s' ),
+		'message'  => 'An error occured.',
+		'data'     => array( 'post' => 10 ),
+	),
+);
+
 ?>
 <div class="wrap">
-	<h1><?php echo $args['taxonomy']->labels->view_item; ?></h1>	
-	<!-- Job name -->
-	<h3><?php esc_html_e( 'Job Name', 'performance-lab' ); ?></h3>
-	<span><?php echo esc_html( $args['job']->name ); ?></span>
 
-	<!-- Job status -->
-	<h3><?php esc_html_e( 'Job Status', 'performance-lab' ); ?></h3>
-	<span><?php echo esc_html( $args['job_status'] ); ?></span>
+	<h1><?php echo $args['taxonomy']->labels->view_item; ?></h1>
 
-	<!-- Job data -->
-	<h3><?php _e( 'Job Data', 'performance-lab' ); ?></h3>
-	<textarea rows="10" cols="50" readonly>
-<?php
-	$job_data = array(
-		'test'             => 123456,
-		'post_ids'         => array(
-			10,
-			20,
-			30,
-		),
-		'something_random' => 'stuff',
-	);
-			echo wp_json_encode( $job_data, JSON_PRETTY_PRINT );
-	?>
-	</textarea>
+	<table class="form-table" role="presentation">
+		<tr>
+			<th><?php esc_html_e( 'Job ID', 'performance-lab' ); ?></th>
+			<td><?php echo esc_html( $args['job_id'] ); ?></td>
+		</tr>
+		<tr>
+			<th><?php esc_html_e( 'Job Name', 'performance-lab' ); ?></th>
+			<td><?php echo esc_html( $args['job']->name ); ?></td>
+		</tr>
+		<tr>
+			<th><?php esc_html_e( 'Job Status', 'performance-lab' ); ?></th>
+			<td><?php echo esc_html( $args['job_status'] ); ?></td>
+		</tr>
+		<tr>
+			<th><?php _e( 'Job Data', 'performance-lab' ); ?></th>
+			<td>
+				<code style="display: block"><pre><?php echo wp_json_encode( $job_data, JSON_PRETTY_PRINT ); ?></pre></code>
+			</td>
+		</tr>
+		<tr>
+			<th><?php esc_html_e( 'Job Errors', 'performance-lab' ); ?></th>
+			<td>
+				<ol style="list-style: none; margin: 0;">
+				<?php foreach ( $job_errors as $job_error ) : ?>
+					<li>[<?php echo $job_error['datetime']; ?>] <?php echo $job_error['message']; ?> <?php echo wp_json_encode( $job_error['data'] ); ?></li>
+				<?php endforeach; ?>
+				</ol>
+			</td>
+		</tr>
+	</table>
 </div>

--- a/modules/images/regenerate-existing-images/job-details.php
+++ b/modules/images/regenerate-existing-images/job-details.php
@@ -31,12 +31,10 @@ $job_data = get_term_meta( $job_id, 'perflab_job_data', true );
 
 <div class="wrap">
 	<h1><?php echo $tax->labels->view_item; ?></h1>
-
 	<h3><?php _e( 'Job Name', 'performance-lab' ); ?></h3>
-
 	<h3><?php _e( 'Job Data', 'performance-lab' ); ?></h3>
-	<textarea readonly rows="5" cols="50">
-		<?php
+	<textarea rows="10" cols="50" readonly>
+<?php
 			$data = array(
 				'test'             => 123456,
 				'post_ids'         => array(
@@ -46,8 +44,7 @@ $job_data = get_term_meta( $job_id, 'perflab_job_data', true );
 				),
 				'something_random' => 'stuff',
 			);
-
-			echo esc_html( maybe_serialize( $data ) );
+			echo wp_json_encode( $data, JSON_PRETTY_PRINT );
 			?>
 	</textarea>
 </div>

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -9,6 +9,11 @@
  */
 
 /**
+ * Inlcude admin related functions.
+ */
+require __DIR__ . '/admin.php';
+
+/**
  * Registers the background job taxonomy.
  *
  * Intentionally on lower priority, so that other post types can be


### PR DESCRIPTION
## Summary

Create an admin screen for managing the jobs in the queue. This is technically managing the terms in `background_job` taxonomy.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #491 

## Relevant technical choices

1. Add custom menu under `tools.php`
2. Customise WP_List_Table to add custom items.

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.