### PR TITLE
Merge 1.5.0 back into `trunk`

### DIFF
--- a/load.php
+++ b/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance modules.
  * Requires at least: 5.8
  * Requires PHP: 5.6
- * Version: 1.4.0
+ * Version: 1.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -15,7 +15,7 @@
  * @package performance-lab
  */
 
-define( 'PERFLAB_VERSION', '1.4.0' );
+define( 'PERFLAB_VERSION', '1.5.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );

--- a/modules/site-health/audit-autoloaded-options/load.php
+++ b/modules/site-health/audit-autoloaded-options/load.php
@@ -120,7 +120,7 @@ function perflab_aao_autoloaded_options_size() {
 /**
  * Fetches autoload top list.
  *
- * @since n.e.x.t
+ * @since 1.5.0
  *
  * @return array Autoloaded data as option names and their sizes.
  */
@@ -134,7 +134,7 @@ function perflab_aao_query_autoloaded_options() {
 	 * options exceed the threshold for being considered large. This filters the value
 	 * for what is considered a large option.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.5.0
 	 *
 	 * @param int $option_threshold Threshold for an option's value to be considered
 	 *                              large, in bytes. Default 100.
@@ -147,7 +147,7 @@ function perflab_aao_query_autoloaded_options() {
 /**
  * Gets formatted autoload options table.
  *
- * @since n.e.x.t
+ * @since 1.5.0
  *
  * @return string HTML formatted table.
  */

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,12 @@ Contributions welcome! There are several ways to contribute:
 
 == Changelog ==
 
+= 1.5.0 =
+
+**Enhancements**
+
+* Site Health: Improve autoloaded options check by highlighting largest autoloaded options. ([353](https://github.com/WordPress/performance/pull/353))
+
 = 1.4.0 =
 
 **Enhancements**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 5.8
 Tested up to:      6.0
 Requires PHP:      5.6
-Stable tag:        1.4.0
+Stable tag:        1.5.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, javascript, site health, measurement, object caching


### PR DESCRIPTION
## Summary

Fixes #466

## Relevant technical choices

* This has already been reviewed, approving is purely a formality.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
