### PR TITLE
Fix broken command for readme changelog

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const { groupBy } = require( 'lodash' );
-const Octokit = require( '@octokit/rest' );
+const { Octokit } = require( '@octokit/rest' );
 
 /**
  * Internal dependencies

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -17,7 +17,7 @@
  * @return {Promise<OktokitIssuesListMilestonesForRepoResponseItem|void>} Promise resolving to milestone, if exists.
  */
 async function getMilestoneByTitle( octokit, owner, repo, title ) {
-	const options = octokit.issues.listMilestonesForRepo.endpoint.merge( {
+	const options = octokit.issues.listMilestones.endpoint.merge( {
 		owner,
 		repo,
 	} );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #539

## Relevant technical choices

If we revert the `@octokit/rest` version to `16.26.0` then we don't need this changes.

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
