### PR TITLE
Correct a typo in Getting-started.md

### DIFF
--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -40,7 +40,7 @@ We use GitHub Projects as well as a few different sets of labels to ensure that 
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). For complete documentation about Performance Lab plugin modules specifications, read this [documentation](./Writing-a-module.md).
 
 ### WordPress and PHP compatibility
-All code in the Performance Lab plugin must follow theses requirements:
+All code in the Performance Lab plugin must follow these requirements:
 - **WordPress**: the latest release is the minimum required version. Right now, the plugin is compatible with WordPress 5.8.
 - **PHP**: always match the latest WordPress version. The minimum required version right now is 5.6.
 


### PR DESCRIPTION
## Summary
While I was working on #549, I found this document bug.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
