### PR TITLE
Job status check cron

### DIFF
--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -81,7 +81,7 @@ class Perflab_Background_Process {
 			/**
 			 * Check if the key in request matches that of in the options.
 			 */
-			$request_key = isset( $_REQUEST['key'] ) ? urldecode_deep( sanitize_text_field( $_REQUEST['key'] ) ) : '';
+			$request_key = isset( $_REQUEST['key'] ) ? urldecode_deep( $_REQUEST['key'] ) : '';
 			$stored_key  = get_option( 'background_process_key_' . $job_id );
 
 			// Check if key is present in request.

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -118,9 +118,6 @@ class Perflab_Background_Process {
 			 */
 			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
 		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! $this->job->is_completed() );
-
-		// Once job ran successfully, change its status to queued.
-		$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );
 	}
 
 	/**
@@ -141,7 +138,7 @@ class Perflab_Background_Process {
 		}
 
 		$nonce  = wp_create_nonce( self::BG_PROCESS_ACTION );
-		$job_id = $this->job->job_id;
+		$job_id = $this->job->get_id();
 
 		$url    = admin_url( 'admin-ajax.php' );
 		$params = array(

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -192,9 +192,11 @@ class Perflab_Background_Process {
 			/**
 			 * Consumer code will hook to this action to perform necessary tasks.
 			 *
+			 * @since n.e.x.t
+			 *
 			 * @param array $data Job data.
 			 */
-			do_action( 'perflab_job_' . $this->job->get_identifier(), $this->job->get_data() );
+			do_action( 'perflab_job_' . $this->job->get_action(), $this->job->get_data() );
 		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded( $this->job->get_id() ) && ! $this->job->is_completed() );
 	}
 

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -86,7 +86,7 @@ class Perflab_Background_Process {
 		} catch ( Exception $e ) {
 			if ( $this->job instanceof Perflab_Background_Job ) {
 				$error = new WP_Error( 'perflab_job_failure', $e->getMessage() );
-				$this->job->record_error( $error );
+				$this->job->set_error( $error );
 			}
 		} finally {
 			if ( $this->job instanceof Perflab_Background_Job ) {
@@ -109,23 +109,14 @@ class Perflab_Background_Process {
 	 * @return void
 	 */
 	private function run() {
-		$iterator    = 0;
-		$batch_items = array_values( $this->job->batch() ); // Ensure array is numerically indexed.
-
-		if ( ! empty( $batch_items ) ) {
-			do {
-				$this->job->process( $batch_items[ $iterator ] );
-
-				unset( $batch_items[ $iterator ] );
-				// Increment the count.
-				$iterator += 1;
-			} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! empty( $batch_items ) );
-
-			return;
-		}
-
-		// If we are here, means there are no batch items to process, so mark job as complete.
-		$this->job->set_status( 'complete' );
+		do {
+			/**
+			 * Consumer code will hook to this action to perform necessary tasks.
+			 *
+			 * @param array $data Job data.
+			 */
+			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
+		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! empty( $batch_items ) );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -138,20 +138,7 @@ class Perflab_Background_Process {
 			return;
 		}
 
-		$nonce  = wp_create_nonce( self::BG_PROCESS_ACTION );
-		$url    = admin_url( 'admin-ajax.php' );
-		$params = array(
-			'blocking'  => false,
-			'body'      => array(
-				'action' => self::BG_PROCESS_ACTION,
-				'job_id' => $job_id,
-				'nonce'  => $nonce,
-			),
-			'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
-			'timeout'   => 0.1,
-		);
-
-		wp_remote_post( $url, $params );
+		perflab_dispatch_background_process_request( $job_id );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * Background process runner class.
+ *
+ * @since n.e.x.t
+ * @package performance-lab
+ */
+
+/**
+ * Class Perflab_Background_Process.
+ *
+ * Runs the heavy lifting tasks in background in separate process.
+ */
+class Perflab_Background_Process {
+	/**
+	 * Name of the action which will trigger background
+	 * process to run the job.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var string Background process action name.
+	 */
+	const BG_PROCESS_ACTION = 'background_process_handle_request';
+
+	/**
+	 * Job instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var Perflab_Background_Job Background job instance.
+	 */
+	private $job;
+
+	/**
+	 * Perflab_Background_Process constructor.
+	 *
+	 * Adds the necessary hooks to trigger process handling.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return void
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
+		add_action( 'wp_ajax_nopriv' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
+	}
+
+	/**
+	 * Handle incoming request to run the batch of job.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @throws Exception Invalid request for background process.
+	 *
+	 * @return void
+	 */
+	public function handle_request() {
+		try {
+
+			// Exit if nonce varification fails.
+			check_ajax_referer( Perflab_Background_Process::BG_PROCESS_ACTION, 'nonce' );
+
+			$job_id = isset( $_POST['job_id'] ) ? absint( sanitize_text_field( $_POST['job_id'] ) ) : 0;
+
+			// Job ID is mandatory to be specified.
+			if ( empty( $job_id ) ) {
+				throw new Exception( 'empty_background_job_id', __( 'No job specified to execute.', 'performance-lab' ) );
+			}
+
+			$this->job = new Perflab_Background_Job( $job_id );
+
+			// Silently exit if the job is not ready to run.
+			if ( $this->job->should_run() ) {
+				return;
+			}
+
+			$this->job->lock(); // Lock the process for this job before running.
+			$this->run(); // Run the job.
+
+		} catch ( Exception $e ) {
+
+			$error = new WP_Error( 'perflab_job_failure', $e->getMessage() );
+			$this->job->record_error( $error );
+
+		} finally {
+			// Unlock the process once everything is done.
+			$this->job->unlock();
+		}
+	}
+
+	/**
+	 * Runs the process over a batch of job.
+	 *
+	 * As of now, it won't fetch the next batch if memory or time
+	 * is not exceeded, but this can be introduced later.
+	 *
+	 * Consumer code can fine-tune the batch size according to requirement.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return void
+	 */
+	private function run() {
+		$iterator    = 0;
+		$batch_items = array_values( $this->job->batch() ); // Ensure array is numerically indexed.
+
+		if ( ! empty( $batch_items ) ) {
+			do {
+				$this->job->process( $batch_items[ $iterator ] );
+
+				unset( $batch_items[ $iterator ] );
+				// Increment the count.
+				$iterator += 1;
+			} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! empty( $batch_items ) );
+
+			return;
+		}
+
+		// If we are here, means there are no batch items to process, so mark job as complete.
+		$this->job->set_status( 'complete' );
+	}
+
+	/**
+	 * Checks whether the memory is exceeded for the current process.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool
+	 */
+	private function memory_exceeded() {
+		return false;
+	}
+
+	/**
+	 * Checks if current execution time is exceeded for the process.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool
+	 */
+	private function time_exceeded() {
+		$current_time       = time();
+		$run_start_time     = $this->job->get_start_time();
+		$min_execution_time = 20; // Default to 20 seconds. Almost, all servers will have this much of time.
+
+		if ( function_exists( 'ini_get' ) ) {
+			$time               = ini_get( 'max_execution_time' );
+			$max_execution_time = ( ! empty( $time ) && ( $time > $min_execution_time ) ) ? $time - 10 : $min_execution_time;
+		}
+
+		return ( $current_time >= ( $run_start_time + $max_execution_time ) );
+	}
+}

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -81,7 +81,7 @@ class Perflab_Background_Process {
 			$this->run(); // Run the job.
 
 			// Once job ran successfully, change its status to queued.
-			$this->job->set_status( Perflab_Background_Job::JOB_STATUS_QUEUED );
+			$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );
 
 		} catch ( Exception $e ) {
 			if ( $this->job instanceof Perflab_Background_Job ) {

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -69,7 +69,7 @@ class Perflab_Background_Process {
 				throw new Exception( __( 'No job specified to execute.', 'performance-lab' ) );
 			}
 
-			$this->job = new Perflab_Background_Job( $job_id );
+			$this->job = perflab_get_background_job( $job_id );
 
 			// Silently exit if the job is not ready to run.
 			if ( ! $this->job->should_run() ) {
@@ -204,7 +204,7 @@ class Perflab_Background_Process {
 	 * @return bool Whether the time has been exceeded for currently running script.
 	 */
 	private function time_exceeded( $job_id ) {
-		$job                = new Perflab_Background_Job( $job_id );
+		$job                = perflab_get_background_job( $job_id );
 		$current_time       = time();
 		$run_start_time     = $job->get_start_time();
 		$max_execution_time = $this->get_max_execution_time();

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -131,6 +131,9 @@ class Perflab_Background_Process {
 	/**
 	 * Checks whether the memory is exceeded for the current process.
 	 *
+	 * Keep memory limit to 90% of the values assigned to PHP config,
+	 * it will prevent the error and help run the memory exhaustion check.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @return bool
@@ -158,6 +161,9 @@ class Perflab_Background_Process {
 	/**
 	 * Get the memory limit allotted for PHP.
 	 *
+	 * Keep the default memory limit of 128M which
+	 * is there on most of the hosts.
+	 *
 	 * @return int
 	 */
 	private function get_memory_limit() {
@@ -177,6 +183,11 @@ class Perflab_Background_Process {
 
 	/**
 	 * Checks if current execution time is exceeded for the process.
+	 *
+	 * A sensible default of 20 seconds has been taken in case ini_get does not
+	 * work. Keep max_execution_time to 10 seconds less than whatever is set in PHP
+	 * configuration, so that those 10 seconds can be used to cleanup everything and
+	 * call the next batch of job.
 	 *
 	 * @since n.e.x.t
 	 *

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -85,10 +85,7 @@ class Perflab_Background_Process {
 			$this->run(); // Run the job.
 
 		} catch ( Exception $e ) {
-			if ( $this->job instanceof Perflab_Background_Job ) {
-				$error = new WP_Error( 'perflab_job_failure', $e->getMessage() );
-				$this->job->set_error( $error );
-			}
+			// @todo Add the error handling
 		} finally {
 			if ( $this->job instanceof Perflab_Background_Job ) {
 				// Unlock the process once everything is done.
@@ -203,7 +200,7 @@ class Perflab_Background_Process {
 			 *
 			 * @param array $data Job data.
 			 */
-			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
+			do_action( 'perflab_job_' . $this->job->get_identifier(), $this->job->get_data() );
 		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded( $this->job->get_id() ) && ! $this->job->is_completed() );
 	}
 

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -42,7 +42,7 @@ class Perflab_Background_Process {
 	 */
 	public function __construct() {
 		add_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
-		add_action( 'wp_ajax_nopriv' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
+		add_action( 'wp_ajax_nopriv_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this, 'handle_request' ) );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -117,7 +117,7 @@ class Perflab_Background_Process {
 			 * @param array $data Job data.
 			 */
 			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
-		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() );
+		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && $this->job->is_completed() );
 
 		// Once job ran successfully, change its status to queued.
 		$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -10,6 +10,8 @@
  * Class Perflab_Background_Process.
  *
  * Runs the heavy lifting tasks in background in separate process.
+ *
+ * @since n.e.x.t
  */
 class Perflab_Background_Process {
 	/**
@@ -18,7 +20,7 @@ class Perflab_Background_Process {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @var string Background process action name.
+	 * @var string
 	 */
 	const BG_PROCESS_ACTION = 'perflab_background_process_handle_request';
 
@@ -27,7 +29,7 @@ class Perflab_Background_Process {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @var Perflab_Background_Job Background job instance.
+	 * @var Perflab_Background_Job|null
 	 */
 	private $job;
 
@@ -37,8 +39,6 @@ class Perflab_Background_Process {
 	 * Adds the necessary hooks to trigger process handling.
 	 *
 	 * @since n.e.x.t
-	 *
-	 * @return void
 	 */
 	public function __construct() {
 		// Handle job execution request.
@@ -55,8 +55,6 @@ class Perflab_Background_Process {
 	 * @since n.e.x.t
 	 *
 	 * @throws Exception Invalid request for background process.
-	 *
-	 * @return void
 	 */
 	public function handle_request() {
 		try {
@@ -98,26 +96,25 @@ class Perflab_Background_Process {
 	/**
 	 * Status check cron handler.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * 1. Cron will be schedule if it does not exist already.
 	 * 2. It will restart any job which is halted due to failure.
 	 * 3. Remove old completed jobs.
-	 *
-	 * @return void
 	 */
 	public function status_check() {
 		$this->status_check_running_jobs();
-		$this->status_check_completed_jobs();
+		$this->delete_completed_jobs();
 	}
 
 	/**
 	 * Check the running jobs.
 	 *
 	 * If they are still running, bail it.
-	 *
 	 * If the execution has been stopped by exceeding maximum execution
 	 * time, restart the job.
 	 *
-	 * @return void
+	 * @since n.e.x.t
 	 */
 	private function status_check_running_jobs() {
 		$jobs_args = array(
@@ -149,9 +146,9 @@ class Perflab_Background_Process {
 	 * If the job has been marked as completed and completed
 	 * time has been over 7 days, remove that job from job queue (history).
 	 *
-	 * @return void
+	 * @since n.e.x.t
 	 */
-	private function status_check_completed_jobs() {
+	private function delete_completed_jobs() {
 		$jobs_args = array(
 			'taxonomy'   => PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG,
 			'meta_key'   => Perflab_Background_Job::META_KEY_JOB_STATUS,
@@ -183,12 +180,9 @@ class Perflab_Background_Process {
 	 *
 	 * As of now, it won't fetch the next batch if memory or time
 	 * is not exceeded, but this can be introduced later.
-	 *
 	 * Consumer code can fine-tune the batch size according to requirement.
 	 *
 	 * @since n.e.x.t
-	 *
-	 * @return void
 	 */
 	private function run() {
 		// Lock the process for this job before running.
@@ -209,6 +203,8 @@ class Perflab_Background_Process {
 	 *
 	 * This will send a POST request to admin-ajax.php with background
 	 * process specific action to continue executing the job in a new process.
+	 *
+	 * @since n.e.x.t
 	 *
 	 * @param int $job_id Job ID. This is the term id from `background_job` taxonomy.
 	 * @return void
@@ -233,7 +229,7 @@ class Perflab_Background_Process {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return bool
+	 * @return bool Whether the memory has been exceeded for currently running script.
 	 */
 	private function memory_exceeded() {
 		$memory_limit     = $this->get_memory_limit() * 0.9; // Use 90% of memory limit.
@@ -261,7 +257,9 @@ class Perflab_Background_Process {
 	 * Keep the default memory limit of 128M which
 	 * is there on most of the hosts.
 	 *
-	 * @return int
+	 * @since n.e.x.t
+	 *
+	 * @return int Memory limit allotted for script execution.
 	 */
 	private function get_memory_limit() {
 		$default_memory_limit = '128M';
@@ -289,7 +287,7 @@ class Perflab_Background_Process {
 	 * @since n.e.x.t
 	 *
 	 * @param int $job_id Job ID. Term ID for `background_job` taxonomy.
-	 * @return bool
+	 * @return bool Whether the time has been exceeded for currently running script.
 	 */
 	private function time_exceeded( $job_id ) {
 		$job                = new Perflab_Background_Job( $job_id );
@@ -313,12 +311,13 @@ class Perflab_Background_Process {
 	 * Get the maximum execution time for php script.
 	 *
 	 * By default this will be 20 seconds.
-	 *
 	 * If init_get returns the time, max execution time will be 10 seconds less than
 	 * what has been returned. These 10 seconds will be utilised to perform cleanup actions
 	 * like unlocking the job and making new request for background process.
 	 *
-	 * @return int
+	 * @since n.e.x.t
+	 *
+	 * @return int Time (in seconds ) for execution of the currently running script.
 	 */
 	private function get_max_execution_time() {
 		$min_execution_time = 20; // Default to 20 seconds. Almost, all servers will have this much of time.

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -80,6 +80,9 @@ class Perflab_Background_Process {
 			$this->job->lock(); // Lock the process for this job before running.
 			$this->run(); // Run the job.
 
+			// Once job ran successfully, change its status to queued.
+			$this->job->set_status( Perflab_Background_Job::JOB_STATUS_QUEUED );
+
 		} catch ( Exception $e ) {
 			if ( $this->job instanceof Perflab_Background_Job ) {
 				$error = new WP_Error( 'perflab_job_failure', $e->getMessage() );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -128,7 +128,43 @@ class Perflab_Background_Process {
 	 * @return bool
 	 */
 	private function memory_exceeded() {
-		return false;
+		$memory_limit     = $this->get_memory_limit() * 0.9; // Use 90% of memory limit.
+		$memmory_usage    = memory_get_usage( true ); // Memory allotted to php.
+		$memory_exhausted = false;
+
+		// Check if memory usage has reached the memory limit (90%).
+		if ( $memmory_usage >= $memory_limit ) {
+			$memory_exhausted = true;
+		}
+
+		/**
+		 * Filters the memory exceeded flag.
+		 *
+		 * @since n.e.x.t
+		 *
+		 * @param bool $memory_exhausted Whether the memory limit has been reached.
+		 */
+		return apply_filters( 'perflab_background_process_memory_exceeded', $memory_exhausted );
+	}
+
+	/**
+	 * Get the memory limit allotted for PHP.
+	 *
+	 * @return int
+	 */
+	private function get_memory_limit() {
+		$default_memory_limit = '128M';
+
+		if ( function_exists( 'memory_limit' ) ) {
+			$memory_limit = ini_get( 'memory_limit' );
+		}
+
+		if ( empty( $memory_limit ) || -1 === $memory_limit ) {
+			$memory_limit = $default_memory_limit;
+		}
+
+		// Convert memory to bytes in integer format.
+		return wp_convert_hr_to_bytes( $memory_limit );
 	}
 
 	/**

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -50,7 +50,7 @@ class Perflab_Background_Process {
 	}
 
 	/**
-	 * Handle incoming request to run the batch of job.
+	 * Handles incoming request to run the batch of job.
 	 *
 	 * @since n.e.x.t
 	 *
@@ -98,9 +98,8 @@ class Perflab_Background_Process {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * 1. Cron will be schedule if it does not exist already.
-	 * 2. It will restart any job which is halted due to failure.
-	 * 3. Remove old completed jobs.
+	 * 1. Restarts any job which is halted due to failure.
+	 * 2. Removes old completed jobs.
 	 */
 	public function status_check() {
 		$this->status_check_running_jobs();
@@ -141,7 +140,7 @@ class Perflab_Background_Process {
 	}
 
 	/**
-	 * Check the completed jobs.
+	 * Checks the completed jobs and removes them from job queue.
 	 *
 	 * If the job has been marked as completed and completed
 	 * time has been over 7 days, remove that job from job queue (history).
@@ -159,7 +158,15 @@ class Perflab_Background_Process {
 		$completed_jobs = get_terms( $jobs_args );
 
 		if ( ! empty( $completed_jobs ) && ! is_wp_error( $completed_jobs ) ) {
-			$expiry_days  = 7 * DAY_IN_SECONDS;
+			/**
+			 * Number of days a job should reside in queue before removal.
+			 *
+			 * @since n.e.x.t
+			 *
+			 * @param int $expiry_days Number of days a job will be in queue before it gets removed. default 7 days.
+			 */
+			$expiry_days  = (int) apply_filters( 'perflab_job_cleanup_days', 7 );
+			$expiry_days  = $expiry_days * DAY_IN_SECONDS;
 			$current_time = time();
 
 			foreach ( $completed_jobs as $completed_job ) {
@@ -201,7 +208,7 @@ class Perflab_Background_Process {
 	}
 
 	/**
-	 * Call the next batch of the job if it is not completed already.
+	 * Calls the next batch of the job if it is not completed already.
 	 *
 	 * This will send a POST request to admin-ajax.php with background
 	 * process specific action to continue executing the job in a new process.
@@ -254,7 +261,7 @@ class Perflab_Background_Process {
 	}
 
 	/**
-	 * Get the memory limit allotted for PHP.
+	 * Gets the memory limit allotted for PHP.
 	 *
 	 * Keep the default memory limit of 128M which
 	 * is there on most of the hosts.
@@ -310,16 +317,16 @@ class Perflab_Background_Process {
 	}
 
 	/**
-	 * Get the maximum execution time for php script.
+	 * Gets the maximum execution time for php script.
 	 *
 	 * By default this will be 20 seconds.
-	 * If init_get returns the time, max execution time will be 10 seconds less than
+	 * If ini_get returns the time, max execution time will be 10 seconds less than
 	 * what has been returned. These 10 seconds will be utilised to perform cleanup actions
 	 * like unlocking the job and making new request for background process.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @return int Time (in seconds ) for execution of the currently running script.
+	 * @return int Time (in seconds) for executing current script.
 	 */
 	private function get_max_execution_time() {
 		$min_execution_time = 20; // Default to 20 seconds. Almost, all servers will have this much of time.

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -117,7 +117,7 @@ class Perflab_Background_Process {
 			 * @param array $data Job data.
 			 */
 			do_action( 'perflab_job_' . $this->job->get_name(), $this->job->get_data() );
-		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && $this->job->is_completed() );
+		} while ( ! $this->memory_exceeded() && ! $this->time_exceeded() && ! $this->job->is_completed() );
 
 		// Once job ran successfully, change its status to queued.
 		$this->job->set_status( Perflab_Background_Job::JOB_STATUS_PARTIAL );

--- a/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
+++ b/modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php
@@ -89,7 +89,7 @@ class Perflab_Background_Process {
 			if ( $this->job instanceof Perflab_Background_Job ) {
 				// Unlock the process once everything is done.
 				$this->job->unlock();
-				$this->next_batch();
+				$this->next_batch( $this->job->get_id() );
 			}
 		}
 	}
@@ -126,9 +126,10 @@ class Perflab_Background_Process {
 	 * This will send a POST request to admin-ajax.php with background
 	 * process specific action to continue executing the job in a new process.
 	 *
+	 * @param int $job_id Job ID. This is the term id from `background_job` taxonomy.
 	 * @return void
 	 */
-	private function next_batch() {
+	private function next_batch( $job_id ) {
 		/**
 		 * Do not call the background process from within the script if the
 		 * real cron has been setup to do so.
@@ -138,8 +139,6 @@ class Perflab_Background_Process {
 		}
 
 		$nonce  = wp_create_nonce( self::BG_PROCESS_ACTION );
-		$job_id = $this->job->get_id();
-
 		$url    = admin_url( 'admin-ajax.php' );
 		$params = array(
 			'blocking'  => false,

--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -158,7 +158,7 @@ function perflab_start_background_job( $job_id, $request_body = array() ) {
 function perflab_background_process_next_batch( $job_id ) {
 	// Create a secret key for validating next batch request.
 	$key         = wp_generate_password( 20, true, true );
-	$encoded_key = urlencode_deep( $key );
+	$encoded_key = rawurlencode_deep( $key );
 
 	update_option( 'background_process_key_' . absint( $job_id ), $key, false );
 

--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -73,6 +73,39 @@ function perflab_delete_background_job( $job_id ) {
 }
 
 /**
+ * Retrives the background job instance based on job ID.
+ *
+ * @since n.e.x.t
+ *
+ * @param  int $job_id Background job ID. Technically the term_id for `background_job` taxonomy.
+ * @return Perflab_Background_Job|false Job instance. False if job doesn't exist.
+ */
+function perflab_get_background_job( $job_id ) {
+	$job_id      = absint( $job_id );
+	$found       = null;
+	$cache_key   = 'perflab_job_' . $job_id;
+	$cache_group = 'perflab_job_pool';
+
+	$cached_job = wp_cache_get( $cache_key, $cache_group, $found );
+
+	if ( null !== $found ) {
+		$cached_job;
+	}
+
+	// Create the instance.
+	$job = new Perflab_Background_Job( $job_id );
+
+	if ( ! $job->exists() ) {
+		$job = false;
+	}
+
+	// Save the result in object cache.
+	wp_cache_set( $cache_key, $job, $cache_group );
+
+	return $job;
+}
+
+/**
  * Dispatches the request to trigger the background job.
  *
  * @since n.e.x.t

--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -112,7 +112,7 @@ function perflab_get_background_job( $job_id ) {
  *
  * @param int $job_id Job ID.
  */
-function perflab_dispatch_background_process_request( $job_id ) {
+function perflab_start_background_job( $job_id ) {
 	// Do not call the background process from within the script if the real cron has been setup to do so.
 	if ( defined( 'ENABLE_BG_PROCESS_CRON' ) ) {
 		return;

--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -58,3 +58,35 @@ function perflab_delete_background_job( $job_id ) {
 
 	return wp_delete_term( $job_id, PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG );
 }
+
+/**
+ * Dispatch the request to trigger the background process job.
+ *
+ * @param int $job_id Job ID.
+ * @return void
+ */
+function perflab_dispatch_background_process_request( $job_id ) {
+	/**
+	 * Do not call the background process from within the script if the
+	 * real cron has been setup to do so.
+	 */
+	if ( defined( 'ENABLE_BG_PROCESS_CRON' ) ) {
+		return;
+	}
+
+	$nonce  = wp_create_nonce( Perflab_Background_Process::BG_PROCESS_ACTION );
+	$url    = admin_url( 'admin-ajax.php' );
+	$params = array(
+		'blocking'  => false,
+		'body'      => array(
+			'action' => Perflab_Background_Process::BG_PROCESS_ACTION,
+			'job_id' => $job_id,
+			'nonce'  => $nonce,
+		),
+		'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+		'timeout'   => 0.1,
+	);
+
+	// We won't collect the response as it is trigger and forget!
+	wp_remote_post( $url, $params );
+}

--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -67,8 +67,9 @@ function perflab_delete_background_job( $job_id ) {
 /**
  * Dispatch the request to trigger the background process job.
  *
+ * @since n.e.x.t
+ *
  * @param int $job_id Job ID.
- * @return void
  */
 function perflab_dispatch_background_process_request( $job_id ) {
 	/**

--- a/modules/images/regenerate-existing-images/helper.php
+++ b/modules/images/regenerate-existing-images/helper.php
@@ -73,17 +73,14 @@ function perflab_delete_background_job( $job_id ) {
 }
 
 /**
- * Dispatch the request to trigger the background process job.
+ * Dispatches the request to trigger the background job.
  *
  * @since n.e.x.t
  *
  * @param int $job_id Job ID.
  */
 function perflab_dispatch_background_process_request( $job_id ) {
-	/**
-	 * Do not call the background process from within the script if the
-	 * real cron has been setup to do so.
-	 */
+	// Do not call the background process from within the script if the real cron has been setup to do so.
 	if ( defined( 'ENABLE_BG_PROCESS_CRON' ) ) {
 		return;
 	}

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -142,6 +142,28 @@ function perflab_delete_background_job( $job_id ) {
 }
 
 /**
+ * Schedule a status check cron.
+ *
+ * This cron job will be responsible to stop any running jobs which
+ * may have stopped due to some failure.
+ *
+ * It will also clear the completed jobs, basically remove the terms from the
+ * taxonomy.
+ *
+ * @return void
+ */
+function perflab_statuc_check_cron() {
+	// Check if event is already scheduled.
+	$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
+
+	// Schedule the event if it does not exist already.
+	if ( empty( $scheduled ) ) {
+		wp_schedule_event( time(), 'hourly', 'perflab_background_process_status_check' );
+	}
+}
+add_action( 'init', 'perflab_statuc_check_cron' );
+
+/**
  * Dispatch the request to trigger the background process job.
  *
  * @param int $job_id Job ID.

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -102,3 +102,25 @@ function perflab_get_background_job_capabilities() {
 		'assign_terms' => 'assign_jobs', // To assign background_job terms to posts.
 	);
 }
+
+/**
+ * Schedule a status check cron.
+ *
+ * This cron job will be responsible to stop any running jobs which
+ * may have stopped due to some failure.
+ *
+ * It will also clear the completed jobs, basically remove the terms from the
+ * taxonomy.
+ *
+ * @return void
+ */
+function perflab_status_check_cron() {
+	// Check if event is already scheduled.
+	$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
+
+	// Schedule the event if it does not exist already.
+	if ( empty( $scheduled ) ) {
+		wp_schedule_event( time(), 'hourly', 'perflab_background_process_status_check' );
+	}
+}
+add_action( 'init', 'perflab_status_check_cron' );

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -112,34 +112,3 @@ function perflab_status_check_cron() {
 	}
 }
 add_action( 'init', 'perflab_status_check_cron' );
-
-/**
- * Dispatch the request to trigger the background process job.
- *
- * @param int $job_id Job ID.
- * @return void
- */
-function perflab_dispatch_background_process_request( $job_id ) {
-	/**
-	 * Do not call the background process from within the script if the
-	 * real cron has been setup to do so.
-	 */
-	if ( defined( 'ENABLE_BG_PROCESS_CRON' ) ) {
-		return;
-	}
-
-	$nonce  = wp_create_nonce( Perflab_Background_Process::BG_PROCESS_ACTION );
-	$url    = admin_url( 'admin-ajax.php' );
-	$params = array(
-		'blocking'  => false,
-		'body'      => array(
-			'action' => Perflab_Background_Process::BG_PROCESS_ACTION,
-			'job_id' => $job_id,
-			'nonce'  => $nonce,
-		),
-		'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
-		'timeout'   => 0.1,
-	);
-
-	wp_remote_post( $url, $params );
-}

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -23,6 +23,11 @@ define( 'PERFLAB_BACKGROUND_JOB_TAXONOMY_SLUG', 'background_job' );
 require_once __DIR__ . '/background-process/class-perflab-background-job.php';
 
 /**
+ * Require the background process runner class.
+ */
+require_once __DIR__ . '/background-process/class-perflab-background-process.php';
+
+/**
  * Require helper functions and specific integrations.
  */
 require_once __DIR__ . '/helper.php';
@@ -97,25 +102,3 @@ function perflab_get_background_job_capabilities() {
 		'assign_terms' => 'assign_jobs', // To assign background_job terms to posts.
 	);
 }
-
-/**
- * Schedule a status check cron.
- *
- * This cron job will be responsible to stop any running jobs which
- * may have stopped due to some failure.
- *
- * It will also clear the completed jobs, basically remove the terms from the
- * taxonomy.
- *
- * @return void
- */
-function perflab_status_check_cron() {
-	// Check if event is already scheduled.
-	$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
-
-	// Schedule the event if it does not exist already.
-	if ( empty( $scheduled ) ) {
-		wp_schedule_event( time(), 'hourly', 'perflab_background_process_status_check' );
-	}
-}
-add_action( 'init', 'perflab_status_check_cron' );

--- a/modules/images/regenerate-existing-images/load.php
+++ b/modules/images/regenerate-existing-images/load.php
@@ -102,7 +102,7 @@ function perflab_get_background_job_capabilities() {
  *
  * @return void
  */
-function perflab_statuc_check_cron() {
+function perflab_status_check_cron() {
 	// Check if event is already scheduled.
 	$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
 
@@ -111,7 +111,7 @@ function perflab_statuc_check_cron() {
 		wp_schedule_event( time(), 'hourly', 'perflab_background_process_status_check' );
 	}
 }
-add_action( 'init', 'perflab_statuc_check_cron' );
+add_action( 'init', 'perflab_status_check_cron' );
 
 /**
  * Dispatch the request to trigger the background process job.

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -44,7 +44,7 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$process_class = get_class( $this->process );
 		$this->assertTrue( defined( $process_class . '::BG_PROCESS_ACTION' ) );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
-		$this->assertEquals( 'background_process_handle_request', $constant_value );
+		$this->assertEquals( 'perflab_background_process_handle_request', $constant_value );
 	}
 
 	/**
@@ -88,11 +88,10 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
 		$_REQUEST['job_id'] = $job->job_id;
-
 		$this->process->handle_request();
-
 		$hook_ran = did_action( 'perflab_job_test_task' );
+		$hook_ran = 1 < $hook_ran;
 
-		$this->assertSame( 1, $hook_ran );
+		$this->assertTrue( $hook_ran );
 	}
 }

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -23,13 +23,10 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	private $process;
 
 	/**
-	 * Runs before any test is executed inside class.
-	 *
-	 * @return void
+	 * Runs before each test in class.
 	 */
-	public static function set_up_before_class() {
-		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php';
-		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php';
+	public function set_up() {
+		$this->process = new Perflab_Background_Process();
 	}
 
 	/**
@@ -39,12 +36,8 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 *
 	 * @covers ::__construct
 	 */
-	public function test_class_constants_exists() {
-		$this->process = new Perflab_Background_Process();
-		$process_class = get_class( $this->process );
-		$this->assertTrue( defined( $process_class . '::BG_PROCESS_ACTION' ) );
-		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
-		$this->assertEquals( 'perflab_background_process_handle_request', $constant_value );
+	public function test_ajax_action_constant() {
+		$this->assertEquals( 'perflab_background_process_handle_request', Perflab_Background_Process::BG_PROCESS_ACTION );
 	}
 
 	/**
@@ -55,12 +48,8 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 * @covers ::__construct
 	 */
 	public function test_handle_request_actions_added() {
-		$this->process  = new Perflab_Background_Process();
-		$process_class  = get_class( $this->process );
-		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
-
-		$authenticated_action     = has_action( 'wp_ajax_' . $constant_value, array( $this->process, 'handle_request' ) );
-		$non_authenticated_action = has_action( 'wp_ajax_nopriv_' . $constant_value, array( $this->process, 'handle_request' ) );
+		$authenticated_action     = has_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this->process, 'handle_request' ) );
+		$non_authenticated_action = has_action( 'wp_ajax_nopriv_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this->process, 'handle_request' ) );
 
 		// Ensure has_action is not returning false.
 		$this->assertNotEquals( false, $authenticated_action );
@@ -79,11 +68,8 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 * @covers ::handle_request
 	 */
 	public function test_handle_request() {
-		$this->process  = new Perflab_Background_Process();
-		$process_class  = get_class( $this->process );
-		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
-		$nonce          = wp_create_nonce( $constant_value );
-		$job            = perflab_create_background_job( 'test_task' );
+		$nonce = wp_create_nonce( Perflab_Background_Process::BG_PROCESS_ACTION );
+		$job   = perflab_create_background_job( 'test_task' );
 
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -76,50 +76,23 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @dataProvider job_instance
 	 * @covers ::handle_request
-	 * @group abc
 	 */
-	public function test_handle_request_throws_exception( $job_id ) {
+	public function test_handle_request() {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
 		$nonce          = wp_create_nonce( $constant_value );
+		$job            = Perflab_Background_Job::create( 'test_task' );
 
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
-		$_REQUEST['job_id'] = $job_id;
+		$_REQUEST['job_id'] = $job->job_id;
 
-		// Call the method with adding and removing filters.
-		add_filter( 'perflab_job_batch_items', array( $this, 'batch_items' ) );
 		$this->process->handle_request();
-		remove_filter( 'perflab_job_batch_items', array( $this, 'batch_items' ) );
 
-		$hook_ran = did_action( 'perflab_process_test_task_job_item' );
+		$hook_ran = did_action( 'perflab_job_test_task' );
 
-		$this->assertSame( 5, $hook_ran );
-	}
-
-	public function job_instance() {
-		$job = Perflab_Background_Job::create( 'test_task', array( 'test_data' => 123 ) );
-
-		return array(
-			array( $job->job_id ),
-		);
-	}
-
-	/**
-	 * Batch items filter callback.
-	 *
-	 * @return array Filtered batch items.
-	 */
-	public function batch_items() {
-		return array(
-			1,
-			2,
-			3,
-			4,
-			5,
-		);
+		$this->assertSame( 1, $hook_ran );
 	}
 }

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -83,11 +83,11 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$process_class  = get_class( $this->process );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
 		$nonce          = wp_create_nonce( $constant_value );
-		$job            = Perflab_Background_Job::create( 'test_task' );
+		$job            = perflab_create_background_job( 'test_task' );
 
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
-		$_REQUEST['job_id'] = $job->job_id;
+		$_REQUEST['job_id'] = $job->get_id();
 		$this->process->handle_request();
 		$hook_ran = did_action( 'perflab_job_test_task' );
 		$hook_ran = 1 < $hook_ran;

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -3,14 +3,14 @@
  * Tests for background-process runner class.
  *
  * @package performance-lab
- * @group   background-process
+ * @group   regenerate-existing-images
  */
 
 /**
  * Class Perflab_Background_Process_Test
  *
  * @coversDefaultClass Perflab_Background_Process
- * @group background-process
+ * @group regenerate-existing-images
  */
 class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	/**

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -88,6 +88,7 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
 		$_REQUEST['job_id'] = $job->get_id();
+
 		$this->process->handle_request();
 		$hook_ran = did_action( 'perflab_job_test_task' );
 		$hook_ran = 1 < $hook_ran;

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for background-process runner class.
+ *
+ * @package performance-lab
+ * @group   background-process
+ */
+
+/**
+ * Class Perflab_Background_Process_Test
+ *
+ * @coversDefaultClass Perflab_Background_Process
+ * @group background-process
+ */
+class Perflab_Background_Process_Test extends WP_UnitTestCase {
+
+	private $process;
+
+	/**
+	 * Runs before any test is executed inside class.
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-job.php';
+		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php';
+	}
+
+	public function test_class_constants_exists() {
+		$this->process = new Perflab_Background_Process();
+		$process_class = get_class( $this->process );
+		$this->assertTrue( defined( $process_class . '::BG_PROCESS_ACTION' ) );
+		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
+		$this->assertEquals( 'background_process_handle_request', $constant_value );
+	}
+
+	public function test_handle_request_actions_added() {
+		$this->process  = new Perflab_Background_Process();
+		$process_class  = get_class( $this->process );
+		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
+
+		$authenticated_action     = has_action( 'wp_ajax_' . $constant_value, array( $this->process, 'handle_request' ) );
+		$non_authenticated_action = has_action( 'wp_ajax_nopriv_' . $constant_value, array( $this->process, 'handle_request' ) );
+
+		// Ensure has_action is not returning false.
+		$this->assertNotEquals( false, $authenticated_action );
+		$this->assertNotEquals( false, $non_authenticated_action );
+
+		// has_action will return priority, so check that as well.
+		$this->assertEquals( 10, $authenticated_action );
+		$this->assertEquals( 10, $non_authenticated_action );
+	}
+
+}

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -48,16 +48,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 * @covers ::__construct
 	 */
 	public function test_handle_request_actions_added() {
-		$authenticated_action     = has_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this->process, 'handle_request' ) );
-		$non_authenticated_action = has_action( 'wp_ajax_nopriv_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this->process, 'handle_request' ) );
+		$authenticated_action = has_action( 'wp_ajax_' . Perflab_Background_Process::BG_PROCESS_ACTION, array( $this->process, 'handle_request' ) );
 
 		// Ensure has_action is not returning false.
 		$this->assertNotEquals( false, $authenticated_action );
-		$this->assertNotEquals( false, $non_authenticated_action );
 
 		// has_action will return priority, so check that as well.
 		$this->assertEquals( 10, $authenticated_action );
-		$this->assertEquals( 10, $non_authenticated_action );
 	}
 
 	/**

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -14,6 +14,13 @@
  */
 class Perflab_Background_Process_Test extends WP_UnitTestCase {
 
+    /**
+     * Process instance.
+     * 
+     * @since n.e.x.t
+     *
+     * @var Perflab_Background_Process
+     */
 	private $process;
 
 	/**
@@ -26,6 +33,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php';
 	}
 
+    /**
+     * Test that constant exists and its value.
+     * 
+     * @since n.e.x.t
+     *
+     * @return void
+     */
 	public function test_class_constants_exists() {
 		$this->process = new Perflab_Background_Process();
 		$process_class = get_class( $this->process );
@@ -34,6 +48,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'background_process_handle_request', $constant_value );
 	}
 
+    /**
+     * Test that ajax hooks are getting added when object is instantiated.
+     * 
+     * @since n.e.x.t
+     *
+     * @return void
+     */
 	public function test_handle_request_actions_added() {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -80,7 +80,7 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	 * @covers ::handle_request
 	 * @group abc
 	 */
-	public function test_handle_request_throws_exception( $job ) {
+	public function test_handle_request_throws_exception( $job_id ) {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );
 		$constant_value = constant( $process_class . '::BG_PROCESS_ACTION' );
@@ -88,7 +88,7 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 
 		// Prepare request params.
 		$_REQUEST['nonce']  = $nonce;
-		$_REQUEST['job_id'] = $job['term_id'];
+		$_REQUEST['job_id'] = $job_id;
 
 		// Call the method with adding and removing filters.
 		add_filter( 'perflab_job_batch_items', array( $this, 'batch_items' ) );
@@ -101,11 +101,10 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 	}
 
 	public function job_instance() {
-		$job    = new Perflab_Background_Job();
-		$job_id = $job->create( 'test_task', array( 'test_data' => 123 ) );
+		$job = Perflab_Background_Job::create( 'test_task', array( 'test_data' => 123 ) );
 
 		return array(
-			array( $job_id ),
+			array( $job->job_id ),
 		);
 	}
 

--- a/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
+++ b/tests/modules/images/regenerate-existing-images/background-process/perflab-background-process-test.php
@@ -13,14 +13,13 @@
  * @group background-process
  */
 class Perflab_Background_Process_Test extends WP_UnitTestCase {
-
-    /**
-     * Process instance.
-     * 
-     * @since n.e.x.t
-     *
-     * @var Perflab_Background_Process
-     */
+	/**
+	 * Process instance.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @var Perflab_Background_Process
+	 */
 	private $process;
 
 	/**
@@ -33,13 +32,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		require_once PERFLAB_PLUGIN_DIR_PATH . 'modules/images/regenerate-existing-images/background-process/class-perflab-background-process.php';
 	}
 
-    /**
-     * Test that constant exists and its value.
-     * 
-     * @since n.e.x.t
-     *
-     * @return void
-     */
+	/**
+	 * Test that constant exists and its value.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @covers ::__construct
+	 */
 	public function test_class_constants_exists() {
 		$this->process = new Perflab_Background_Process();
 		$process_class = get_class( $this->process );
@@ -48,13 +47,13 @@ class Perflab_Background_Process_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'background_process_handle_request', $constant_value );
 	}
 
-    /**
-     * Test that ajax hooks are getting added when object is instantiated.
-     * 
-     * @since n.e.x.t
-     *
-     * @return void
-     */
+	/**
+	 * Test that ajax hooks are getting added when object is instantiated.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @covers ::__construct
+	 */
 	public function test_handle_request_actions_added() {
 		$this->process  = new Perflab_Background_Process();
 		$process_class  = get_class( $this->process );

--- a/tests/modules/images/regenerate-existing-images/helper-tests.php
+++ b/tests/modules/images/regenerate-existing-images/helper-tests.php
@@ -44,10 +44,23 @@ class Regenerate_Existing_Images_Helper_Test extends WP_UnitTestCase {
 	/**
 	 * @covers ::perflab_get_background_job
 	 */
-	public function test_perflab_get_background_job() {
+	public function test_perflab_get_background_job_instance() {
 		$created_job = perflab_create_background_job( 'test_job' );
 		$job         = perflab_get_background_job( $created_job->get_id() );
 
 		$this->assertInstanceOf( Perflab_Background_Job::class, $job );
 	}
+
+	/**
+	 * @covers ::perflab_get_background_job
+	 */
+	public function test_perflab_get_background_job_instance_caches() {
+		$created_job  = perflab_create_background_job( 'test_job' );
+		$job          = perflab_get_background_job( $created_job->get_id() );
+		$cache_result = wp_cache_get( 'perflab_job_' . $created_job->get_id(), 'perflab_job_pool' );
+
+		$this->assertNotEmpty( $cache_result );
+		$this->assertInstanceOf( Perflab_Background_Job::class, $job );
+	}
+
 }

--- a/tests/modules/images/regenerate-existing-images/helper-tests.php
+++ b/tests/modules/images/regenerate-existing-images/helper-tests.php
@@ -40,4 +40,14 @@ class Regenerate_Existing_Images_Helper_Test extends WP_UnitTestCase {
 		// Ensure dashes have been replaced with underscore.
 		$this->assertSame( 'action_with_dash_and_special_chars', $job_term->name );
 	}
+
+	/**
+	 * @covers ::perflab_get_background_job
+	 */
+	public function test_perflab_get_background_job() {
+		$created_job = perflab_create_background_job( 'test_job' );
+		$job         = perflab_get_background_job( $created_job->get_id() );
+
+		$this->assertInstanceOf( Perflab_Background_Job::class, $job );
+	}
 }

--- a/tests/modules/images/regenerate-existing-images/helper-tests.php
+++ b/tests/modules/images/regenerate-existing-images/helper-tests.php
@@ -63,4 +63,25 @@ class Regenerate_Existing_Images_Helper_Test extends WP_UnitTestCase {
 		$this->assertInstanceOf( Perflab_Background_Job::class, $job );
 	}
 
+	/**
+	 * @covers ::perflab_start_background_job
+	 */
+	public function test_perflab_start_background_job() {
+		$job      = perflab_create_background_job( 'test' );
+		$response = perflab_start_background_job( $job->get_id() );
+
+		$this->assertTrue( $response );
+	}
+
+	/**
+	 * @covers ::perflab_background_process_next_batch
+	 */
+	public function test_perflab_background_process_next_batch() {
+		$job      = perflab_create_background_job( 'test' );
+		$response = perflab_background_process_next_batch( $job->get_id() );
+		$key      = get_option( 'background_process_key_' . $job->get_id() );
+
+		$this->assertNotEmpty( $key );
+	}
+
 }

--- a/tests/modules/images/regenerate-existing-images/load-tests.php
+++ b/tests/modules/images/regenerate-existing-images/load-tests.php
@@ -40,10 +40,4 @@ class Regenerate_Existing_Images_Load_Test extends WP_UnitTestCase {
 		$this->assertTrue( $job_tax->show_in_menu );
 		$this->assertTrue( $job_tax->show_ui );
 	}
-
-	public function test_perflab_status_check_cron() {
-		$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
-
-		$this->assertIsInt( $scheduled );
-	}
 }

--- a/tests/modules/images/regenerate-existing-images/load-tests.php
+++ b/tests/modules/images/regenerate-existing-images/load-tests.php
@@ -40,4 +40,10 @@ class Regenerate_Existing_Images_Load_Test extends WP_UnitTestCase {
 		$this->assertTrue( $job_tax->show_in_menu );
 		$this->assertTrue( $job_tax->show_ui );
 	}
+
+	public function test_perflab_status_check_cron() {
+		$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
+
+		$this->assertIsInt( $scheduled );
+	}
 }

--- a/tests/modules/images/regenerate-existing-images/load-tests.php
+++ b/tests/modules/images/regenerate-existing-images/load-tests.php
@@ -7,7 +7,6 @@
  */
 
 class Regenerate_Existing_Images_Load_Test extends WP_UnitTestCase {
-
 	/**
 	 * Test that background_job taxonomy is present in system.
 	 *
@@ -39,5 +38,14 @@ class Regenerate_Existing_Images_Load_Test extends WP_UnitTestCase {
 		// show_in_menu and show_ui should be true.
 		$this->assertTrue( $job_tax->show_in_menu );
 		$this->assertTrue( $job_tax->show_ui );
+	}
+
+	/**
+	 * @covers ::perflab_status_check_cron
+	 */
+	public function test_perflab_status_check_cron() {
+		$scheduled = wp_next_scheduled( 'perflab_background_process_status_check' );
+
+		$this->assertIsInt( $scheduled );
 	}
 }


### PR DESCRIPTION
## Summary

Create a cron which will do the following

1. Runs hourly.
2. Resume any halted/incomplete jobs.
3. Remove old completed jobs from the queue (`background_job` taxonomy).

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #484 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
