### PR TITLE
Fix opt-in checkbox for generating WebP and JPEG to also show on Multisite

### DIFF
--- a/modules/images/webp-uploads/settings.php
+++ b/modules/images/webp-uploads/settings.php
@@ -33,10 +33,10 @@ function webp_uploads_add_media_settings_field() {
 	// Add settings field.
 	add_settings_field(
 		'perflab_generate_webp_and_jpeg',
-		__( 'Generate WebP and JPEG', 'performance-lab' ),
+		__( 'WebP and JPEG', 'performance-lab' ),
 		'webp_uploads_generate_webp_jpeg_setting_callback',
 		'media',
-		'uploads',
+		! is_multisite() ? 'uploads' : 'default',
 		array( 'class' => 'perflab-generate-webp-and-jpeg' )
 	);
 }
@@ -50,7 +50,7 @@ add_action( 'admin_init', 'webp_uploads_add_media_settings_field' );
 function webp_uploads_generate_webp_jpeg_setting_callback() {
 	?>
 	</td>
-	<td class="td-full">
+	<td <?php echo ! is_multisite() ? esc_html( 'class="td-full"' ) : ''; ?>>
 		<label for="perflab_generate_webp_and_jpeg">
 			<input name="perflab_generate_webp_and_jpeg" type="checkbox" id="perflab_generate_webp_and_jpeg" aria-describedby="perflab_generate_webp_and_jpeg_description" value="1"<?php checked( '1', get_option( 'perflab_generate_webp_and_jpeg' ) ); ?> />
 			<?php esc_html_e( 'Generate JPEG files in addition to WebP', 'performance-lab' ); ?>
@@ -67,10 +67,19 @@ function webp_uploads_generate_webp_jpeg_setting_callback() {
 function webp_uploads_media_setting_style() {
 	?>
 	<style>
-	.form-table .perflab-generate-webp-and-jpeg th,
-	.form-table .perflab-generate-webp-and-jpeg td:not(.td-full) {
-		display: none;
-	}
+		<?php if ( ! is_multisite() ) : ?>
+		.form-table .perflab-generate-webp-and-jpeg th,
+		.form-table .perflab-generate-webp-and-jpeg td:not(.td-full) {
+			display: none;
+		}
+		<?php else : ?>
+		.form-table .perflab-generate-webp-and-jpeg > th {
+			font-size: 16px;
+		}
+		.form-table .perflab-generate-webp-and-jpeg > td:nth-child(2) {
+			display: none;
+		}
+		<?php endif; ?>
 	</style>
 	<?php
 }

--- a/modules/images/webp-uploads/settings.php
+++ b/modules/images/webp-uploads/settings.php
@@ -50,7 +50,7 @@ add_action( 'admin_init', 'webp_uploads_add_media_settings_field' );
 function webp_uploads_generate_webp_jpeg_setting_callback() {
 	?>
 	</td>
-	<td <?php echo ! is_multisite() ? esc_html( 'class="td-full"' ) : ''; ?>>
+	<td class="<?php echo ! is_multisite() ? esc_attr( 'td-full' ) : ''; ?>">
 		<label for="perflab_generate_webp_and_jpeg">
 			<input name="perflab_generate_webp_and_jpeg" type="checkbox" id="perflab_generate_webp_and_jpeg" aria-describedby="perflab_generate_webp_and_jpeg_description" value="1"<?php checked( '1', get_option( 'perflab_generate_webp_and_jpeg' ) ); ?> />
 			<?php esc_html_e( 'Generate JPEG files in addition to WebP', 'performance-lab' ); ?>

--- a/modules/images/webp-uploads/settings.php
+++ b/modules/images/webp-uploads/settings.php
@@ -48,9 +48,13 @@ add_action( 'admin_init', 'webp_uploads_add_media_settings_field' );
  * @since 1.6.0
  */
 function webp_uploads_generate_webp_jpeg_setting_callback() {
+	if ( ! is_multisite() ) {
+		?>
+			</td>
+			<td class="td-full">
+		<?php
+	}
 	?>
-	</td>
-	<td class="<?php echo ! is_multisite() ? esc_attr( 'td-full' ) : ''; ?>">
 		<label for="perflab_generate_webp_and_jpeg">
 			<input name="perflab_generate_webp_and_jpeg" type="checkbox" id="perflab_generate_webp_and_jpeg" aria-describedby="perflab_generate_webp_and_jpeg_description" value="1"<?php checked( '1', get_option( 'perflab_generate_webp_and_jpeg' ) ); ?> />
 			<?php esc_html_e( 'Generate JPEG files in addition to WebP', 'performance-lab' ); ?>
@@ -68,17 +72,10 @@ function webp_uploads_media_setting_style() {
 	?>
 	<style>
 		<?php if ( ! is_multisite() ) : ?>
-		.form-table .perflab-generate-webp-and-jpeg th,
-		.form-table .perflab-generate-webp-and-jpeg td:not(.td-full) {
-			display: none;
-		}
-		<?php else : ?>
-		.form-table .perflab-generate-webp-and-jpeg > th {
-			font-size: 16px;
-		}
-		.form-table .perflab-generate-webp-and-jpeg > td:nth-child(2) {
-			display: none;
-		}
+			.form-table .perflab-generate-webp-and-jpeg th,
+			.form-table .perflab-generate-webp-and-jpeg td:not(.td-full) {
+				display: none;
+			}
 		<?php endif; ?>
 	</style>
 	<?php

--- a/modules/images/webp-uploads/settings.php
+++ b/modules/images/webp-uploads/settings.php
@@ -69,14 +69,15 @@ function webp_uploads_generate_webp_jpeg_setting_callback() {
  * @since 1.6.0
  */
 function webp_uploads_media_setting_style() {
+	if ( is_multisite() ) {
+		return;
+	}
 	?>
 	<style>
-		<?php if ( ! is_multisite() ) : ?>
-			.form-table .perflab-generate-webp-and-jpeg th,
-			.form-table .perflab-generate-webp-and-jpeg td:not(.td-full) {
-				display: none;
-			}
-		<?php endif; ?>
+		.form-table .perflab-generate-webp-and-jpeg th,
+		.form-table .perflab-generate-webp-and-jpeg td:not(.td-full) {
+			display: none;
+		}
 	</style>
 	<?php
 }

--- a/modules/images/webp-uploads/settings.php
+++ b/modules/images/webp-uploads/settings.php
@@ -36,7 +36,7 @@ function webp_uploads_add_media_settings_field() {
 		__( 'WebP and JPEG', 'performance-lab' ),
 		'webp_uploads_generate_webp_jpeg_setting_callback',
 		'media',
-		! is_multisite() ? 'uploads' : 'default',
+		is_multisite() ? 'default' : 'uploads',
 		array( 'class' => 'perflab-generate-webp-and-jpeg' )
 	);
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #560 

## Relevant technical choices

PR adds checkbox setting for WebP and JPEG in Settings > Media in the default section in the multisite for each site.

<img width="1071" alt="Screenshot 2022-10-20 at 6 58 21 PM" src="https://user-images.githubusercontent.com/4090336/196962079-73c22cf9-20db-4678-bade-914b32251278.png">


## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
