### PR TITLE
Fix fatal error in REST API response when an image has no attachment metadata.

### DIFF
--- a/modules/images/webp-uploads/rest-api.php
+++ b/modules/images/webp-uploads/rest-api.php
@@ -18,7 +18,7 @@
  */
 function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ) {
 	$data = $response->get_data();
-	if ( ! isset( $data['media_details']['sizes'] ) || ! is_array( $data['media_details']['sizes'] ) ) {
+	if ( ! isset( $data['media_details'] ) || ! is_array( $data['media_details'] ) || ! isset( $data['media_details']['sizes'] ) || ! is_array( $data['media_details']['sizes'] ) ) {
 		return $response;
 	}
 

--- a/tests/modules/images/webp-uploads/rest-api-tests.php
+++ b/tests/modules/images/webp-uploads/rest-api-tests.php
@@ -71,4 +71,39 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'sources', $data['media_details'] );
 	}
 
+	/**
+	 * Checks whether the media details information is added to the REST response object.
+	 *
+	 * @test
+	 */
+	public function it_should_check_media_details_in_rest_response() {
+		$file_location = TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg';
+		$attachment_id = $this->factory->attachment->create_upload_object( $file_location );
+
+		$request       = new WP_REST_Request();
+		$request['id'] = $attachment_id;
+
+		$controller = new WP_REST_Attachments_Controller( 'attachment' );
+		$response   = $controller->get_item( $request );
+
+		$this->assertNotWPError( $response );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'media_details', $data );
+		$this->assertIsArray( $data['media_details'] );
+
+		// Delete attachment metadata to set media_details as object in response.
+		delete_post_meta( $attachment_id, '_wp_attachment_metadata' );
+
+		$response = $controller->get_item( $request );
+
+		$this->assertNotWPError( $response );
+
+		$data = $response->get_data();
+
+		$this->assertArrayHasKey( 'media_details', $data );
+		$this->assertIsNotArray( $data['media_details'] );
+		$this->assertIsObject( $data['media_details'] );
+	}
 }


### PR DESCRIPTION
## Summary
This bug is very unlikely to happen as it depends on attachment metadata. It is assumed that metadata should always be present for the attachment but when metadata is deleted from DB, we should ensure proper error handling by checking the data from REST.

Fixes #567 

## Relevant technical choices

Added more checks for `media_details` in response of REST API for attachments

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
