### PR TITLE
Fix GitHub action deprecation warning during plugin deployment

### DIFF
--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: WordPress plugin deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -19,7 +19,7 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SLUG: performance-lab
       - name: Upload release assets
-        uses: softprops/action-gh-release@v0.1.14
+        uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: ${{github.workspace}}/${{ github.event.repository.name }}.zip

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "name=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -34,8 +34,6 @@ jobs:
     name: PHP
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    outputs:
-      composer-cache-dir: ${{ steps.composer-cache.outputs.dir }}
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
       - uses: actions/checkout@v3
@@ -45,10 +43,10 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "name=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
-          path: ${{ needs.php-lint.outputs.composer-cache-dir }}
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -34,6 +34,8 @@ jobs:
     name: PHP
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    outputs:
+      composer-cache-dir: ${{ steps.composer-cache.outputs.dir }}
     steps:
       - uses: styfle/cancel-workflow-action@0.9.1
       - uses: actions/checkout@v3
@@ -46,7 +48,7 @@ jobs:
           echo "name=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
+          path: ${{ needs.php-lint.outputs.composer-cache-dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: styfle/cancel-workflow-action@0.8.0
-      - uses: actions/checkout@v2
+      - uses: styfle/cancel-workflow-action@0.9.1
+      - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '7.4'
@@ -44,7 +44,7 @@ jobs:
         id: composer-cache
         run: |
           echo "name=dir::$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: styfle/cancel-workflow-action@0.8.0
+      - uses: styfle/cancel-workflow-action@0.9.1
       - uses: actions/checkout@v3
       - name: Setup Node.js (.nvmrc)
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #561 

## Relevant technical choices

`actions/checkout@v3`
`softprops/action-gh-release@v1`
`set-output` command updated as per [GH changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
`styfle/cancel-workflow-action@0.9.1`
`actions/cache@v3`

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
