### PR TITLE
Load the WP_Image_Editor_Imagick class if it doesn't exist

### DIFF
--- a/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
+++ b/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
@@ -9,6 +9,11 @@
  * @since 1.2.0
  */
 
+if ( ! class_exists( 'WP_Image_Editor_GD' ) ) {
+	require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
+	require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';
+}
+
 /**
  * WordPress Image Editor Class for Image Manipulation through GD
  * with dominant color detection.

--- a/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
+++ b/modules/images/dominant-color/class-dominant-color-image-editor-gd.php
@@ -9,11 +9,6 @@
  * @since 1.2.0
  */
 
-if ( ! class_exists( 'WP_Image_Editor_GD' ) ) {
-	require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
-	require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';
-}
-
 /**
  * WordPress Image Editor Class for Image Manipulation through GD
  * with dominant color detection.

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -68,7 +68,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		remove_all_filters( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ) );
 
 		// Rely on current user to be an administrator (with 'manage_options' capability).
-		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 		$hook_suffix = perflab_add_modules_page();
 		$this->assertSame( get_plugin_page_hookname( PERFLAB_MODULES_SCREEN, 'options-general.php' ), $hook_suffix );

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -111,19 +111,28 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'images'     => array(
-					'id'       => 'images',
-					'title'    => 'Images',
-					'callback' => null,
+					'id'             => 'images',
+					'title'          => 'Images',
+					'callback'       => null,
+					'before_section' => '',
+					'after_section'  => '',
+					'section_class'  => '',
 				),
 				'javascript' => array(
-					'id'       => 'javascript',
-					'title'    => 'JavaScript',
-					'callback' => null,
+					'id'             => 'javascript',
+					'title'          => 'JavaScript',
+					'callback'       => null,
+					'before_section' => '',
+					'after_section'  => '',
+					'section_class'  => '',
 				),
 				'other'      => array(
-					'id'       => 'other',
-					'title'    => 'Other',
-					'callback' => null,
+					'id'             => 'other',
+					'title'          => 'Other',
+					'callback'       => null,
+					'before_section' => '',
+					'after_section'  => '',
+					'section_class'  => '',
 				),
 			),
 			$wp_settings_sections[ PERFLAB_MODULES_SCREEN ]

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -68,7 +68,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		remove_all_filters( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ) );
 
 		// Rely on current user to be an administrator (with 'manage_options' capability).
-		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );
 		$hook_suffix = perflab_add_modules_page();
 		$this->assertSame( get_plugin_page_hookname( PERFLAB_MODULES_SCREEN, 'options-general.php' ), $hook_suffix );

--- a/tests/modules/images/dominant-color/dominant-color-image-editor-gd-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-image-editor-gd-test.php
@@ -30,7 +30,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -50,7 +50,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_invalid( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -68,7 +68,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_none_images( $image_path ) {
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );

--- a/tests/modules/images/dominant-color/dominant-color-image-editor-gd-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-image-editor-gd-test.php
@@ -30,7 +30,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -50,7 +50,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_invalid( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -68,7 +68,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_none_images( $image_path ) {
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );

--- a/tests/modules/images/dominant-color/dominant-color-image-editor-imageick-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-image-editor-imageick-test.php
@@ -32,7 +32,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -52,7 +52,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_invalid( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -70,7 +70,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_none_images( $image_path ) {
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );

--- a/tests/modules/images/dominant-color/dominant-color-image-editor-imageick-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-image-editor-imageick-test.php
@@ -32,7 +32,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -52,7 +52,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_invalid( $image_path, $expected_color, $expected_transparency ) {
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
@@ -70,7 +70,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 	 */
 	public function test_get_dominant_color_none_images( $image_path ) {
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -22,7 +22,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 		$this->assertEmpty( $dominant_color_metadata );
 
 		// Creating attachment.
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$dominant_color_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'dominant_color', $dominant_color_metadata );
@@ -39,7 +39,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 */
 	public function test_dominant_color_get_dominant_color( $image_path, $expected_color, $expected_transparency ) {
 		// Creating attachment.
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		$this->assertContains( dominant_color_get_dominant_color( $attachment_id ), $expected_color );
 	}
 
@@ -55,7 +55,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 		$transparency_metadata = dominant_color_metadata( array(), 1 );
 		$this->assertEmpty( $transparency_metadata );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$transparency_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'has_transparency', $transparency_metadata );
@@ -71,7 +71,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 */
 	public function test_dominant_color_has_transparency( $image_path, $expected_color, $expected_transparency ) {
 		// Creating attachment.
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		$this->assertSame( $expected_transparency, dominant_color_has_transparency( $attachment_id ) );
 	}
 
@@ -83,7 +83,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 * @covers ::dominant_color_img_tag_add_dominant_color
 	 */
 	public function test_tag_add_adjust_to_image_attributes( $image_path, $expected_color, $expected_transparency ) {
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -22,7 +22,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 		$this->assertEmpty( $dominant_color_metadata );
 
 		// Creating attachment.
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$dominant_color_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'dominant_color', $dominant_color_metadata );
@@ -39,7 +39,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 */
 	public function test_dominant_color_get_dominant_color( $image_path, $expected_color, $expected_transparency ) {
 		// Creating attachment.
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		$this->assertContains( dominant_color_get_dominant_color( $attachment_id ), $expected_color );
 	}
 
@@ -55,7 +55,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 		$transparency_metadata = dominant_color_metadata( array(), 1 );
 		$this->assertEmpty( $transparency_metadata );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$transparency_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'has_transparency', $transparency_metadata );
@@ -71,7 +71,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 */
 	public function test_dominant_color_has_transparency( $image_path, $expected_color, $expected_transparency ) {
 		// Creating attachment.
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		$this->assertSame( $expected_transparency, dominant_color_has_transparency( $attachment_id ) );
 	}
 
@@ -83,7 +83,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 * @covers ::dominant_color_img_tag_add_dominant_color
 	 */
 	public function test_tag_add_adjust_to_image_attributes( $image_path, $expected_color, $expected_transparency ) {
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -31,7 +31,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		add_filter( 'wp_image_editors', '__return_empty_array' );
 		yield 'when no editor is present' => array(
-			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(),
 			'image/avif',
@@ -39,21 +39,21 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		remove_filter( 'wp_image_editors', '__return_empty_array' );
 		yield 'when using a mime that is not supported' => array(
-			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(),
 			'image/avif',
 		);
 
 		yield 'when no dimension is provided' => array(
-			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(),
 			'image/webp',
 		);
 
 		yield 'when both dimensions are negative numbers' => array(
-			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(
 				'width'  => -10,
@@ -63,7 +63,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		);
 
 		yield 'when both dimensions are zero' => array(
-			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(
 				'width'  => 0,
@@ -82,7 +82,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		// Create JPEG and WebP so that both versions are generated.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 		$size_data     = array(
 			'width'  => 300,
 			'height' => 300,
@@ -107,7 +107,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_create_a_file_in_the_specified_location_with_the_specified_name() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 		$size_data     = array(
 			'width'  => 300,
 			'height' => 300,
@@ -131,7 +131,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_processing_an_image_with_corrupted_metadata( callable $callback, $size ) {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp'
 		);
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -175,7 +175,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_to_create_an_image_size_when_attached_file_does_not_exists() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 		$file          = get_attached_file( $attachment_id );
@@ -199,7 +199,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_to_create_a_subsize_if_the_image_editor_does_not_exists() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -216,7 +216,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_to_upload_a_mime_that_is_not_supported_by_wordpress() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 		$result        = webp_uploads_generate_image_size( $attachment_id, 'medium', 'image/avif' );
@@ -231,7 +231,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 */
 	public function it_should_prevent_to_process_an_image_when_the_editor_does_not_support_the_format() {
 		// Make sure no editor is available.
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -255,7 +255,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_create_an_image_with_filter_webp_uploads_pre_generate_additional_image_source() {
 		remove_all_filters( 'webp_uploads_pre_generate_additional_image_source' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
@@ -289,7 +289,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_use_filesize_when_filter_webp_uploads_pre_generate_additional_image_source_returns_filesize() {
 		remove_all_filters( 'webp_uploads_pre_generate_additional_image_source' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
@@ -324,7 +324,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_return_an_error_when_filter_webp_uploads_pre_generate_additional_image_source_returns_wp_error() {
 		remove_all_filters( 'webp_uploads_pre_generate_additional_image_source' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
@@ -547,8 +547,8 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_add_original_image_extension_to_the_webp_file_name_to_ensure_it_is_unique( $jpeg_image, $jpg_image ) {
-		$jpeg_image_attachment_id = self::factory()->attachment->create_upload_object( $jpeg_image );
-		$jpg_image_attachment_id  = self::factory()->attachment->create_upload_object( $jpg_image );
+		$jpeg_image_attachment_id = $this->factory->attachment->create_upload_object( $jpeg_image );
+		$jpg_image_attachment_id  = $this->factory->attachment->create_upload_object( $jpg_image );
 
 		$size_data = array(
 			'width'  => 300,

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -31,7 +31,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		add_filter( 'wp_image_editors', '__return_empty_array' );
 		yield 'when no editor is present' => array(
-			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(),
 			'image/avif',
@@ -39,21 +39,21 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		remove_filter( 'wp_image_editors', '__return_empty_array' );
 		yield 'when using a mime that is not supported' => array(
-			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(),
 			'image/avif',
 		);
 
 		yield 'when no dimension is provided' => array(
-			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(),
 			'image/webp',
 		);
 
 		yield 'when both dimensions are negative numbers' => array(
-			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(
 				'width'  => -10,
@@ -63,7 +63,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		);
 
 		yield 'when both dimensions are zero' => array(
-			$this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
+			self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' ),
 			'medium',
 			array(
 				'width'  => 0,
@@ -82,7 +82,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		// Create JPEG and WebP so that both versions are generated.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 		$size_data     = array(
 			'width'  => 300,
 			'height' => 300,
@@ -107,7 +107,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_create_a_file_in_the_specified_location_with_the_specified_name() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 		$size_data     = array(
 			'width'  => 300,
 			'height' => 300,
@@ -131,7 +131,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_processing_an_image_with_corrupted_metadata( callable $callback, $size ) {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp'
 		);
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -175,7 +175,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_to_create_an_image_size_when_attached_file_does_not_exists() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 		$file          = get_attached_file( $attachment_id );
@@ -199,7 +199,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_to_create_a_subsize_if_the_image_editor_does_not_exists() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -216,7 +216,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_to_upload_a_mime_that_is_not_supported_by_wordpress() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 		$result        = webp_uploads_generate_image_size( $attachment_id, 'medium', 'image/avif' );
@@ -231,7 +231,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 */
 	public function it_should_prevent_to_process_an_image_when_the_editor_does_not_support_the_format() {
 		// Make sure no editor is available.
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -255,7 +255,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_create_an_image_with_filter_webp_uploads_pre_generate_additional_image_source() {
 		remove_all_filters( 'webp_uploads_pre_generate_additional_image_source' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
@@ -289,7 +289,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_use_filesize_when_filter_webp_uploads_pre_generate_additional_image_source_returns_filesize() {
 		remove_all_filters( 'webp_uploads_pre_generate_additional_image_source' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
@@ -324,7 +324,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_return_an_error_when_filter_webp_uploads_pre_generate_additional_image_source_returns_wp_error() {
 		remove_all_filters( 'webp_uploads_pre_generate_additional_image_source' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
@@ -547,8 +547,8 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_add_original_image_extension_to_the_webp_file_name_to_ensure_it_is_unique( $jpeg_image, $jpg_image ) {
-		$jpeg_image_attachment_id = $this->factory->attachment->create_upload_object( $jpeg_image );
-		$jpg_image_attachment_id  = $this->factory->attachment->create_upload_object( $jpg_image );
+		$jpeg_image_attachment_id = self::factory()->attachment->create_upload_object( $jpeg_image );
+		$jpg_image_attachment_id  = self::factory()->attachment->create_upload_object( $jpg_image );
 
 		$size_data = array(
 			'width'  => 300,

--- a/tests/modules/images/webp-uploads/image-edit-tests.php
+++ b/tests/modules/images/webp-uploads/image-edit-tests.php
@@ -22,7 +22,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_backup_the_sources_structure_alongside_the_full_size() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertEmpty( get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true ) );
@@ -64,7 +64,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_restore_the_sources_array_from_the_backup_when_an_image_is_edited() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$editor = new WP_Image_Edit( $attachment_id );
@@ -118,7 +118,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Disable the generation of the sources attributes.
 		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$this->assertArrayNotHasKey( 'sources', $metadata );
@@ -147,7 +147,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 		$this->assertArrayHasKey( 'sources', $metadata );
 
@@ -195,7 +195,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_backup_the_image_when_all_images_except_the_thumbnail_are_updated() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$editor = new WP_Image_Edit( $attachment_id );
@@ -245,7 +245,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -290,7 +290,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_validate_source_attribute_update_when_webp_edited() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$editor = new WP_Image_Edit( $attachment_id );
 		$editor->crop( 1000, 200, 0, 0 )->save();
@@ -319,7 +319,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_not_return_a_target_if_no_backup_image_exists() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$this->assertNull( webp_uploads_get_next_full_size_key_from_backup( $attachment_id ) );
 	}
 
@@ -332,7 +332,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Remove the filter to prevent the usage of the next target.
 		remove_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_metadata' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -346,7 +346,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_return_null_when_looking_for_a_target_that_is_already_used() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -363,7 +363,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -385,7 +385,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Remove the filter to prevent the usage of the next target.
 		remove_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_metadata' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 		$this->assertTrue( $editor->success() );
@@ -405,7 +405,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$editor = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
@@ -437,7 +437,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Remove the filter to prevent the usage of the next target.
 		remove_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_metadata' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -453,7 +453,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_store_the_next_image_hash_on_the_backup_sources() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		// Edit the image.
 		$editor->rotate_right()->save();
@@ -482,7 +482,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$editor = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();

--- a/tests/modules/images/webp-uploads/image-edit-tests.php
+++ b/tests/modules/images/webp-uploads/image-edit-tests.php
@@ -22,7 +22,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_backup_the_sources_structure_alongside_the_full_size() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertEmpty( get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true ) );
@@ -64,7 +64,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_restore_the_sources_array_from_the_backup_when_an_image_is_edited() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$editor = new WP_Image_Edit( $attachment_id );
@@ -118,7 +118,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Disable the generation of the sources attributes.
 		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$this->assertArrayNotHasKey( 'sources', $metadata );
@@ -147,7 +147,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 		$this->assertArrayHasKey( 'sources', $metadata );
 
@@ -195,7 +195,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_backup_the_image_when_all_images_except_the_thumbnail_are_updated() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$editor = new WP_Image_Edit( $attachment_id );
@@ -245,7 +245,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -290,7 +290,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_validate_source_attribute_update_when_webp_edited() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$editor = new WP_Image_Edit( $attachment_id );
 		$editor->crop( 1000, 200, 0, 0 )->save();
@@ -319,7 +319,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_not_return_a_target_if_no_backup_image_exists() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$this->assertNull( webp_uploads_get_next_full_size_key_from_backup( $attachment_id ) );
 	}
 
@@ -332,7 +332,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Remove the filter to prevent the usage of the next target.
 		remove_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_metadata' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -346,7 +346,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_return_null_when_looking_for_a_target_that_is_already_used() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -363,7 +363,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -385,7 +385,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Remove the filter to prevent the usage of the next target.
 		remove_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_metadata' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 		$this->assertTrue( $editor->success() );
@@ -405,7 +405,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$editor = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
@@ -437,7 +437,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Remove the filter to prevent the usage of the next target.
 		remove_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_metadata' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();
 
@@ -453,7 +453,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_store_the_next_image_hash_on_the_backup_sources() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$editor        = new WP_Image_Edit( $attachment_id );
 		// Edit the image.
 		$editor->rotate_right()->save();
@@ -482,7 +482,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$editor = new WP_Image_Edit( $attachment_id );
 		$editor->rotate_right()->save();

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -22,7 +22,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_not_create_the_original_mime_type_for_jpeg_images() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		// There should be a WebP source, but no JPEG source for the full image.
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
@@ -54,7 +54,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_create_the_original_mime_type_as_well_with_all_the_available_sources_for_the_specified_mime() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
 
 		// There should be a WebP source, but no JPEG source for the full image.
 		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
@@ -85,7 +85,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_create_jpeg_and_webp_for_jpeg_images_if_opted_in() {
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		// There should be JPEG and WebP sources for the full image.
 		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
@@ -116,7 +116,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_create_jpeg_and_webp_for_jpeg_images_if_generate_webp_and_jpeg_set() {
 		update_option( 'perflab_generate_webp_and_jpeg', true );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		// There should be JPEG and WebP sources for the full image.
 		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
@@ -147,7 +147,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_not_create_the_sources_property_if_no_transform_is_provided() {
 		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -173,7 +173,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -200,7 +200,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp'
 		);
 
@@ -219,7 +219,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_create_a_webp_version_with_all_the_required_properties() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -250,7 +250,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );
 		add_filter( 'fallback_intermediate_image_sizes', '__return_empty_array' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertEmpty( $metadata['sizes'] );
@@ -276,7 +276,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -292,7 +292,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_remove_the_generated_webp_images_when_the_attachment_is_deleted() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -327,7 +327,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_remove_the_attached_webp_version_if_the_attachment_is_force_deleted() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -357,7 +357,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );
 		add_filter( 'fallback_intermediate_image_sizes', '__return_empty_array' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$file    = get_attached_file( $attachment_id, true );
 		$dirname = pathinfo( $file, PATHINFO_DIRNAME );
@@ -379,7 +379,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_remove_the_backup_sizes_and_sources_if_the_attachment_is_deleted_after_edit() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -449,7 +449,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP to check that WebP does not get replaced with JPEG.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp'
 		);
 
@@ -473,7 +473,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_replacing_a_jpg_image_if_the_image_does_not_have_the_target_class_name() {
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -497,7 +497,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP to check replacement of JPEG => WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 
 		$tag          = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$expected_tag = $tag;
@@ -532,7 +532,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 		$tag           = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
@@ -552,7 +552,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP to check replacement of JPEG => WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -578,7 +578,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_prevent_replacing_an_image_with_no_available_sources() {
 		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
@@ -593,7 +593,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_update_not_supported_images_with_no_available_sources( $image_path ) {
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
 
 		$this->assertIsNumeric( $attachment_id );
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
@@ -620,7 +620,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		foreach ( $metadata['sizes'] as $size ) {
@@ -647,7 +647,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
@@ -676,7 +676,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		$this->assertTrue( wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$this->assertArrayHasKey( 'sources', $metadata );
@@ -695,8 +695,8 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_replace_the_featured_image_to_webp_when_requesting_the_featured_image() {
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
-		$post_id       = self::factory()->post->create();
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
+		$post_id       = $this->factory()->post->create();
 		set_post_thumbnail( $post_id, $attachment_id );
 
 		$featured_image = get_the_post_thumbnail( $post_id );
@@ -720,7 +720,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		$tag = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$this->assertNotSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
@@ -738,7 +738,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 		$tag           = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$expected_tag  = $tag;
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -777,7 +777,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains only full size mime type images.
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$tag           = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 		$file          = get_attached_file( $attachment_id, true );
@@ -803,7 +803,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
 		$tag           = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$expected_tag  = $tag;
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -834,7 +834,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		remove_all_actions( 'wp_footer' );
 
-		$attachment_id = self::factory()->attachment->create_upload_object(
+		$attachment_id = $this->factory->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -888,7 +888,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_image_size( 'allowed_size_400x300', 400, 300, true );
 		add_image_size( 'not_allowed_size_200x150', 200, 150, true );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		remove_image_size( 'allowed_size_400x300' );
 		remove_image_size( 'not_allowed_size_200x150' );
@@ -909,7 +909,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// TODO: This property should later be set via a new parameter on add_image_size().
 		$GLOBALS['_wp_additional_image_sizes']['allowed_size_400x300']['provide_additional_mime_types'] = true;
 
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		remove_image_size( 'allowed_size_400x300' );
 		remove_image_size( 'not_allowed_size_200x150' );

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -22,7 +22,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_not_create_the_original_mime_type_for_jpeg_images() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		// There should be a WebP source, but no JPEG source for the full image.
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
@@ -54,7 +54,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_create_the_original_mime_type_as_well_with_all_the_available_sources_for_the_specified_mime() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
 
 		// There should be a WebP source, but no JPEG source for the full image.
 		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
@@ -85,7 +85,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_create_jpeg_and_webp_for_jpeg_images_if_opted_in() {
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		// There should be JPEG and WebP sources for the full image.
 		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
@@ -116,7 +116,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_create_jpeg_and_webp_for_jpeg_images_if_generate_webp_and_jpeg_set() {
 		update_option( 'perflab_generate_webp_and_jpeg', true );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		// There should be JPEG and WebP sources for the full image.
 		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
@@ -147,7 +147,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_not_create_the_sources_property_if_no_transform_is_provided() {
 		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -173,7 +173,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -200,7 +200,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp'
 		);
 
@@ -219,7 +219,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_create_a_webp_version_with_all_the_required_properties() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -250,7 +250,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );
 		add_filter( 'fallback_intermediate_image_sizes', '__return_empty_array' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertEmpty( $metadata['sizes'] );
@@ -276,7 +276,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -292,7 +292,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_remove_the_generated_webp_images_when_the_attachment_is_deleted() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -327,7 +327,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_remove_the_attached_webp_version_if_the_attachment_is_force_deleted() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -357,7 +357,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'intermediate_image_sizes', '__return_empty_array' );
 		add_filter( 'fallback_intermediate_image_sizes', '__return_empty_array' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 
 		$file    = get_attached_file( $attachment_id, true );
 		$dirname = pathinfo( $file, PATHINFO_DIRNAME );
@@ -379,7 +379,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_remove_the_backup_sizes_and_sources_if_the_attachment_is_deleted_after_edit() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -449,7 +449,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP to check that WebP does not get replaced with JPEG.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp'
 		);
 
@@ -473,7 +473,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_replacing_a_jpg_image_if_the_image_does_not_have_the_target_class_name() {
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -497,7 +497,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP to check replacement of JPEG => WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 
 		$tag          = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$expected_tag = $tag;
@@ -532,7 +532,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		$tag           = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
@@ -552,7 +552,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP to check replacement of JPEG => WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -578,7 +578,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_prevent_replacing_an_image_with_no_available_sources() {
 		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_empty_array' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
@@ -593,7 +593,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_prevent_update_not_supported_images_with_no_available_sources( $image_path ) {
-		$attachment_id = $this->factory->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 
 		$this->assertIsNumeric( $attachment_id );
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
@@ -620,7 +620,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		foreach ( $metadata['sizes'] as $size ) {
@@ -647,7 +647,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Create JPEG and WebP.
 		$this->opt_in_to_jpeg_and_webp();
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
@@ -676,7 +676,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		$this->assertTrue( wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$this->assertArrayHasKey( 'sources', $metadata );
@@ -695,8 +695,8 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_replace_the_featured_image_to_webp_when_requesting_the_featured_image() {
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
-		$post_id       = $this->factory()->post->create();
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/paint.jpeg' );
+		$post_id       = self::factory()->post->create();
 		set_post_thumbnail( $post_id, $attachment_id );
 
 		$featured_image = get_the_post_thumbnail( $post_id );
@@ -720,7 +720,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 		);
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		$tag = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$this->assertNotSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
@@ -738,7 +738,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 		$tag           = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$expected_tag  = $tag;
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -777,7 +777,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains only full size mime type images.
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg' );
 		$tag           = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 		$file          = get_attached_file( $attachment_id, true );
@@ -803,7 +803,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_filter( 'webp_uploads_discard_larger_generated_images', '__return_true' );
 
 		// Look for an image that contains all of the additional mime type images.
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/balloons.webp' );
 		$tag           = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$expected_tag  = $tag;
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
@@ -834,7 +834,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		remove_all_actions( 'wp_footer' );
 
-		$attachment_id = $this->factory->attachment->create_upload_object(
+		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg'
 		);
 
@@ -888,7 +888,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		add_image_size( 'allowed_size_400x300', 400, 300, true );
 		add_image_size( 'not_allowed_size_200x150', 200, 150, true );
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		remove_image_size( 'allowed_size_400x300' );
 		remove_image_size( 'not_allowed_size_200x150' );
@@ -909,7 +909,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// TODO: This property should later be set via a new parameter on add_image_size().
 		$GLOBALS['_wp_additional_image_sizes']['allowed_size_400x300']['provide_additional_mime_types'] = true;
 
-		$attachment_id = $this->factory->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/car.jpeg' );
 
 		remove_image_size( 'allowed_size_400x300' );
 		remove_image_size( 'not_allowed_size_200x150' );

--- a/tests/modules/images/webp-uploads/rest-api-tests.php
+++ b/tests/modules/images/webp-uploads/rest-api-tests.php
@@ -31,7 +31,7 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 		);
 
 		$file_location = TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg';
-		$attachment_id = self::factory()->attachment->create_upload_object( $file_location );
+		$attachment_id = $this->factory->attachment->create_upload_object( $file_location );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$request       = new WP_REST_Request();
@@ -78,7 +78,7 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 	 */
 	public function it_should_check_media_details_in_rest_response() {
 		$file_location = TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg';
-		$attachment_id = self::factory()->attachment->create_upload_object( $file_location );
+		$attachment_id = $this->factory->attachment->create_upload_object( $file_location );
 
 		$request       = new WP_REST_Request();
 		$request['id'] = $attachment_id;

--- a/tests/modules/images/webp-uploads/rest-api-tests.php
+++ b/tests/modules/images/webp-uploads/rest-api-tests.php
@@ -31,7 +31,7 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 		);
 
 		$file_location = TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg';
-		$attachment_id = $this->factory->attachment->create_upload_object( $file_location );
+		$attachment_id = self::factory()->attachment->create_upload_object( $file_location );
 		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
 		$request       = new WP_REST_Request();
@@ -78,7 +78,7 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 	 */
 	public function it_should_check_media_details_in_rest_response() {
 		$file_location = TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leafs.jpg';
-		$attachment_id = $this->factory->attachment->create_upload_object( $file_location );
+		$attachment_id = self::factory()->attachment->create_upload_object( $file_location );
 
 		$request       = new WP_REST_Request();
 		$request['id'] = $attachment_id;

--- a/tests/testdata/modules/images/webp-uploads/class-wp-image-doesnt-support-webp.php
+++ b/tests/testdata/modules/images/webp-uploads/class-wp-image-doesnt-support-webp.php
@@ -6,6 +6,11 @@
  * @since 1.0.0
  */
 
+if ( ! class_exists( 'WP_Image_Editor_Imagick' ) ) {
+	require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
+	require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
+}
+
 /**
  * Class WP_Image_Doesnt_Support_WebP mocks a WP_Image_Editor that doesn't support WebP.
  *


### PR DESCRIPTION
## Summary

Recently I noticed that some tests are failing. I'm _assuming_ (though not sure) that it's because of the WP 6.1 release, at least the timing lines-up. 
Example: https://github.com/WordPress/performance/actions/runs/3374928930/jobs/5601071400
The problem seems to be the fact that the `WP_Image_Editor_Imagick` class is not loaded.

## Relevant technical choices

Added a `class_exists` check before the class in tests, and I'm just require_once the missing files.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
