### PR TITLE
Feature: Allow updating with git-updater

### DIFF
--- a/load.php
+++ b/load.php
@@ -11,6 +11,7 @@
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Text Domain: performance-lab
+ * GitHub Plugin URI: WordPress/performance
  *
  * @package performance-lab
  */


### PR DESCRIPTION
See: https://github.com/afragen/git-updater

## Summary
Adds GitHub Plugin URI to plugin header to allow for optionally tracking with the development of the plugin on GitHub and updating directly from the WordPress backend.

## Relevant technical choices
This uses the required header URI syntax as specified by [The Git Updater Plugin](https://github.com/afragen/git-updater)

