### PR TITLE
Fix image focal point bug when dominant color is enabled by not overriding `style` attribute

### DIFF
--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -117,7 +117,7 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, $context, $
 	if ( ! empty( $image_meta['dominant_color'] ) ) {
 		$data .= sprintf( 'data-dominant-color="%s" ', esc_attr( $image_meta['dominant_color'] ) );
 		if ( str_contains( $filtered_image, ' style="' ) ) {
-			$filtered_image = str_replace( ' style="', ' style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';', $filtered_image );
+			$filtered_image = str_replace( ' style="', ' style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . '; ', $filtered_image );
 		} else {
 			$filtered_image = str_replace( '<img ', '<img style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';" ', $filtered_image );
 		}

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -112,12 +112,15 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, $context, $
 	}
 
 	$data        = '';
-	$style       = '';
 	$extra_class = '';
 
 	if ( ! empty( $image_meta['dominant_color'] ) ) {
 		$data .= sprintf( 'data-dominant-color="%s" ', esc_attr( $image_meta['dominant_color'] ) );
-		$style = 'style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';" ';
+		if ( str_contains( $filtered_image, ' style="' ) ) {
+			$filtered_image = str_replace( ' style="', ' style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';', $filtered_image );
+		} else {
+			$filtered_image = str_replace( '<img ', '<img style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';" ', $filtered_image );
+		}
 	}
 
 	if ( isset( $image_meta['has_transparency'] ) ) {
@@ -126,9 +129,10 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, $context, $
 		$extra_class  = $image_meta['has_transparency'] ? 'has-transparency' : 'not-transparent';
 	}
 
-	if ( ! empty( $data ) || ! empty( $style ) ) {
-		$filtered_image = str_replace( '<img ', '<img ' . $data . $style, $filtered_image );
+	if ( ! empty( $data ) ) {
+		$filtered_image = str_replace( '<img ', '<img ' . $data, $filtered_image );
 	}
+
 	if ( ! empty( $extra_class ) ) {
 		$filtered_image = str_replace( ' class="', ' class="' . $extra_class . ' ', $filtered_image );
 	}

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -114,6 +114,10 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 * @dataProvider data_provider_dominant_color_check_inline_style
 	 *
 	 * @covers ::dominant_color_img_tag_add_dominant_color
+	 *
+	 * @param string $filtered_image The filtered image markup.
+	 *                               Must include `src="%s" width="%d" height="%d"`.
+	 * @param string $expected       The expected style attribute and value.
 	 */
 	public function test_dominant_color_img_tag_add_dominant_color_should_add_dominant_color_inline_style( $filtered_image, $expected ) {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/dominant-color/red.jpg' );

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -113,7 +113,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	 *
 	 * @covers ::dominant_color_img_tag_add_dominant_color
 	 */
-	public function test_dominant_color_do_not_override_the_style_attribute_in_img_tag() {
+	public function test_dominant_color_should_not_replace_existing_inline_styles() {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/dominant-color/red.jpg' );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -109,7 +109,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	}
 
 	/**
-	 * Tests dominant_color_img_tag_add_dominant_color() do not override the style attribute.
+	 * Tests that dominant_color_img_tag_add_dominant_color() does not replace existing inline styles.
 	 *
 	 * @covers ::dominant_color_img_tag_add_dominant_color
 	 */

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -111,21 +111,40 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	/**
 	 * Tests that dominant_color_img_tag_add_dominant_color() does not replace existing inline styles.
 	 *
+	 * @dataProvider data_provider_dominant_color_check_inline_style
+	 *
 	 * @covers ::dominant_color_img_tag_add_dominant_color
 	 */
-	public function test_dominant_color_should_not_replace_existing_inline_styles() {
+	public function test_dominant_color_img_tag_add_dominant_color_should_add_dominant_color_inline_style( $filtered_image, $expected ) {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/dominant-color/red.jpg' );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );
 
-		$filtered_image = sprintf( '<img src="%s" width="%d" height="%d" />', $src, $width, $height );
+		$filtered_image = sprintf( $filtered_image, $src, $width, $height );
 
-		$this->assertStringContainsString( 'style="--dominant-color: #fe0000;"', dominant_color_img_tag_add_dominant_color( $filtered_image, 'the_content', $attachment_id ) );
+		$this->assertStringContainsString(
+			$expected,
+			dominant_color_img_tag_add_dominant_color( $filtered_image, 'the_content', $attachment_id )
+		);
+	}
 
-		$filtered_image_with_style_tag = sprintf( '<img style="color: #ffffff;" src="%s" width="%d" height="%d" />', $src, $width, $height );
-
-		$this->assertStringContainsString( 'style="--dominant-color: #fe0000; color: #ffffff;"', dominant_color_img_tag_add_dominant_color( $filtered_image_with_style_tag, 'the_content', $attachment_id ) );
+	/**
+	 * Data provider for test_dominant_color_img_tag_add_dominant_color_should_add_dominant_color_inline_style().
+	 *
+	 * @return array[]
+	 */
+	public function data_provider_dominant_color_check_inline_style() {
+		return array(
+			'no existing inline styles' => array(
+				'filtered_image' => '<img src="%s" width="%d" height="%d" />',
+				'expected'       => 'style="--dominant-color: #fe0000;"',
+			),
+			'existing inline styles'    => array(
+				'filtered_image' => '<img style="color: #ffffff;" src="%s" width="%d" height="%d" />',
+				'expected'       => 'style="--dominant-color: #fe0000; color: #ffffff;"',
+			),
+		);
 	}
 
 	/**

--- a/tests/modules/images/dominant-color/dominant-color-test.php
+++ b/tests/modules/images/dominant-color/dominant-color-test.php
@@ -108,6 +108,25 @@ class Dominant_Color_Test extends DominantColorTestCase {
 		$this->assertEquals( $filtered_image_mock_lazy_load, $filtered_image_tags_not_added );
 	}
 
+	/**
+	 * Tests dominant_color_img_tag_add_dominant_color() do not override the style attribute.
+	 *
+	 * @covers ::dominant_color_img_tag_add_dominant_color
+	 */
+	public function test_dominant_color_do_not_override_the_style_attribute_in_img_tag() {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/dominant-color/red.jpg' );
+		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
+
+		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );
+
+		$filtered_image = sprintf( '<img src="%s" width="%d" height="%d" />', $src, $width, $height );
+
+		$this->assertStringContainsString( 'style="--dominant-color: #fe0000;"', dominant_color_img_tag_add_dominant_color( $filtered_image, 'the_content', $attachment_id ) );
+
+		$filtered_image_with_style_tag = sprintf( '<img style="color: #ffffff;" src="%s" width="%d" height="%d" />', $src, $width, $height );
+
+		$this->assertStringContainsString( 'style="--dominant-color: #fe0000; color: #ffffff;"', dominant_color_img_tag_add_dominant_color( $filtered_image_with_style_tag, 'the_content', $attachment_id ) );
+	}
 
 	/**
 	 * Tests dominant_color_set_image_editors().


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #562

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
