### PR TITLE
Use PHP 7.4 for unit tests

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -12,6 +12,7 @@ on:
       - '**.json'
       - '.eslint*'
       - '.nvmrc'
+      - '.wp-env.json'
       - '**/package.json'
       - 'package-lock.json'
   pull_request:
@@ -26,6 +27,7 @@ on:
       - '**.json'
       - '.eslint*'
       - '.nvmrc'
+      - '.wp-env.json'
       - '**/package.json'
       - 'package-lock.json'
     types:

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
+      - name: Composer update
+        run: composer update
       - name: npm install
         run: npm ci
       - name: Install WordPress

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - name: Composer update
-        run: composer update
       - name: npm install
         run: npm ci
       - name: Install WordPress

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - '.github/workflows/php-test.yml'
       - '**.php'
+      - '.wp-env.json'
+      - '**/package.json'
+      - 'package-lock.json'
       - 'phpunit.xml.dist'
       - 'tests/multisite.xml'
       - 'composer.json'
@@ -22,6 +25,9 @@ on:
     paths:
       - '.github/workflows/php-test.yml'
       - '**.php'
+      - '.wp-env.json'
+      - '**/package.json'
+      - 'package-lock.json'
       - 'phpunit.xml.dist'
       - 'tests/multisite.xml'
       - 'composer.json'

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
+      - name: Composer update
+        run: composer update
       - name: npm install
         run: npm ci
       - name: Install WordPress

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,4 +1,9 @@
 {
 	"core": null,
-	"plugins": [ "." ]
+	"plugins": [ "." ],
+	"env": {
+		"tests": {
+			"phpVersion": "7.4"
+		}
+	}
 }


### PR DESCRIPTION
## Summary
Resolve unit test failures that occurred after the release of PHP 8.2. 

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
