### PR TITLE
Make WP filesystem setup more robust to prevent potential errors

### DIFF
--- a/modules/database/sqlite/activate.php
+++ b/modules/database/sqlite/activate.php
@@ -24,13 +24,11 @@ return function() {
 	if ( ! defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) && ! file_exists( $destination ) ) {
 		// Init the filesystem to allow copying the file.
 		global $wp_filesystem;
-		if ( ! $wp_filesystem ) {
-			require_once ABSPATH . '/wp-admin/includes/file.php';
-			WP_Filesystem();
-		}
 
-		// Copy the file, replacing contents as needed.
-		if ( $wp_filesystem->touch( $destination ) ) {
+		require_once ABSPATH . '/wp-admin/includes/file.php';
+
+		// Init the filesystem if needed, then copy the file, replacing contents as needed.
+		if ( ( $wp_filesystem || WP_Filesystem() ) && $wp_filesystem->touch( $destination ) ) {
 
 			// Get the db.copy.php file contents, replace placeholders and write it to the destination.
 			$file_contents = str_replace(

--- a/modules/database/sqlite/deactivate.php
+++ b/modules/database/sqlite/deactivate.php
@@ -17,11 +17,13 @@ return function() {
 	}
 
 	global $wp_filesystem;
-	if ( ! $wp_filesystem ) {
-		require_once ABSPATH . '/wp-admin/includes/file.php';
-		WP_Filesystem();
+
+	require_once ABSPATH . '/wp-admin/includes/file.php';
+
+	// Init the filesystem if needed, then delete custom drop-in.
+	if ( $wp_filesystem || WP_Filesystem() ) {
+		$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
 	}
-	$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
 
 	// Run an action on `shutdown`, to deactivate the option in the MySQL database.
 	add_action(


### PR DESCRIPTION
## Summary

Follow up to #547: The `WP_Filesystem()` function is not guaranteed to succeed. If it fails in an environment, we need to account for that, as otherwise methods called on the global will at best "just not work", at worst result in a fatal error.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
