### PR TITLE
Use `assertStringContainsString` instead of `assertContains` to fix PHPUnit deprecation warnings

### DIFF
--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -163,8 +163,8 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		ob_start();
 		perflab_render_modules_page();
 		$output = ob_get_clean();
-		$this->assertContains( '<div class="wrap">', $output );
-		$this->assertContains( "<input type='hidden' name='option_page' value='" . PERFLAB_MODULES_SCREEN . "' />", $output );
+		$this->assertStringContainsString( '<div class="wrap">', $output );
+		$this->assertStringContainsString( "<input type='hidden' name='option_page' value='" . PERFLAB_MODULES_SCREEN . "' />", $output );
 	}
 
 	public function test_perflab_render_modules_page_field() {
@@ -176,10 +176,10 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		ob_start();
 		perflab_render_modules_page_field( $module_slug, $module_data, $module_settings );
 		$output = ob_get_clean();
-		$this->assertContains( ' id="module_' . $module_slug . '_enabled"', $output );
-		$this->assertContains( ' name="' . PERFLAB_MODULES_SETTING . '[' . $module_slug . '][enabled]"', $output );
-		$this->assertContains( 'Enable ' . $module_data['name'], $output );
-		$this->assertNotContains( ' checked', $output );
+		$this->assertStringContainsString( ' id="module_' . $module_slug . '_enabled"', $output );
+		$this->assertStringContainsString( ' name="' . PERFLAB_MODULES_SETTING . '[' . $module_slug . '][enabled]"', $output );
+		$this->assertStringContainsString( 'Enable ' . $module_data['name'], $output );
+		$this->assertStringNotContainsString( ' checked', $output );
 
 		// Assert correct 'id' and 'name' attributes, experimental label, and checked checkbox.
 		$module_data['experimental'] = true;
@@ -187,10 +187,10 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		ob_start();
 		perflab_render_modules_page_field( $module_slug, $module_data, $module_settings );
 		$output = ob_get_clean();
-		$this->assertContains( ' id="module_' . $module_slug . '_enabled"', $output );
-		$this->assertContains( ' name="' . PERFLAB_MODULES_SETTING . '[' . $module_slug . '][enabled]"', $output );
-		$this->assertContains( 'Enable ' . $module_data['name'] . ' <strong>(experimental)</strong>', $output );
-		$this->assertContains( " checked='checked'", $output );
+		$this->assertStringContainsString( ' id="module_' . $module_slug . '_enabled"', $output );
+		$this->assertStringContainsString( ' name="' . PERFLAB_MODULES_SETTING . '[' . $module_slug . '][enabled]"', $output );
+		$this->assertStringContainsString( 'Enable ' . $module_data['name'] . ' <strong>(experimental)</strong>', $output );
+		$this->assertStringContainsString( " checked='checked'", $output );
 	}
 
 	public function test_perflab_get_focus_areas() {

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -179,7 +179,7 @@ class Load_Tests extends WP_UnitTestCase {
 		ob_start();
 		do_action( 'wp_head' );
 		$output = ob_get_clean();
-		$this->assertContains( $expected, $output );
+		$this->assertStringContainsString( $expected, $output );
 	}
 
 	/**

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -582,8 +582,8 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		);
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertSame( $expected, wp_check_filetype( get_attached_file( $attachment_id ) ) );
-		$this->assertNotContains( wp_basename( get_attached_file( $attachment_id ) ), webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
-		$this->assertContains( $metadata['sources']['image/webp']['file'], webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->assertStringNotContainsString( wp_basename( get_attached_file( $attachment_id ) ), webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->assertStringContainsString( $metadata['sources']['image/webp']['file'], webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The PR fixes PHPUnit deprecation warnings and uses `assertStringContainsString` instead of `assertContains` and `assertStringNotContainsString` instead of `assertNotContains`.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #594

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
