### PR TITLE
Fix SQLite notices related to undefined properties

### DIFF
--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-db.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-db.php
@@ -81,7 +81,7 @@ class Perflab_SQLite_DB extends wpdb {
 	 * @return string escaped
 	 */
 	function _real_escape( $str ) {
-		return SQLite3::escapeString( $str );
+		return addslashes( $str );
 	}
 
 	/**

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
@@ -1335,12 +1335,22 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 			echo $this->get_error_message();
 		} else {
 			foreach ( $this->_results as $row ) {
-				$_columns['Field']   = $row->name;
-				$_columns['Type']    = $row->type;
-				$_columns['Null']    = $row->notnull ? 'NO' : 'YES';
-				$_columns['Key']     = $row->pk ? 'PRI' : '';
-				$_columns['Default'] = $row->dflt_value;
-				$_results[]          = new Perflab_SQLite_Object_Array( $_columns );
+				if ( property_exists( $row, 'name' ) ) {
+					$_columns['Field'] = $row->name;
+				}
+				if ( property_exists( $row, 'type' ) ) {
+					$_columns['Type'] = $row->type;
+				}
+				if ( property_exists( $row, 'notnull' ) ) {
+					$_columns['Null'] = $row->notnull ? 'NO' : 'YES';
+				}
+				if ( property_exists( $row, 'pk' ) ) {
+					$_columns['Key'] = $row->pk ? 'PRI' : '';
+				}
+				if ( property_exists( $row, 'dflt_value' ) ) {
+					$_columns['Default'] = $row->dflt_value;
+				}
+				$_results[] = new Perflab_SQLite_Object_Array( $_columns );
 			}
 		}
 		$this->results = $_results;

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
@@ -1335,6 +1335,9 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 			echo $this->get_error_message();
 		} else {
 			foreach ( $this->_results as $row ) {
+				if ( ! is_object( $row ) ) {
+					continue;
+				}
 				if ( property_exists( $row, 'name' ) ) {
 					$_columns['Field'] = $row->name;
 				}


### PR DESCRIPTION
## Summary

Fixes #599 

In addition to the above fix, I encountered some other notices when testing various plugins:
```
PHP Notice:  Undefined property: stdClass::$name in class-perflab-sqlite-pdo-engine.php on line 1338
PHP Notice:  Undefined property: stdClass::$type in class-perflab-sqlite-pdo-engine.php on line 1339
PHP Notice:  Undefined property: stdClass::$notnull in class-perflab-sqlite-pdo-engine.php on line 1340
PHP Notice:  Undefined property: stdClass::$pk in class-perflab-sqlite-pdo-engine.php on line 1341
PHP Notice:  Undefined property: stdClass::$dflt_value in class-perflab-sqlite-pdo-engine.php on line 1342
```

This PR adds some additional checks to ensure that `$row` is an object, and the properties exist before using them.

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
