### PR TITLE
Fix incorrect handling of `admin_email` and actual admin user's email when original `admin_email` user was deleted

### DIFF
--- a/modules/database/sqlite/activate.php
+++ b/modules/database/sqlite/activate.php
@@ -41,6 +41,12 @@ return function() {
 		}
 	}
 
+	// Do not automatically set up SQLite DB on a multisite as that is notably
+	// more complex. Potentially it can be added in the future.
+	if ( is_multisite() ) {
+		return;
+	}
+
 	// As an extra safety check, bail if the current user cannot update
 	// (or install) WordPress core.
 	if ( ! current_user_can( 'update_core' ) ) {


### PR DESCRIPTION
## Summary

Fixes #601

## Relevant technical choices

* This PR ensures the `admin_email` option and the admin user's email keep their original values even in case they were different (e.g. when the original admin user was deleted).
* See https://github.com/WordPress/performance/issues/601#issuecomment-1352012473 for additional context on the fix.
* The PR includes one additional (somewhat unrelated) safe guard of not running the automatic setup in a multisite. While it would be great to eventually cover that too, it is a lot more complicated; for now it's the safest option to let the user handle it for a multisite environment.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
