### PR TITLE
Add an indicator in the adminbar to show when using SQLite

### DIFF
--- a/modules/database/sqlite/load.php
+++ b/modules/database/sqlite/load.php
@@ -58,3 +58,21 @@ function perflab_sqlite_plugin_admin_notice() {
 	);
 }
 add_action( 'admin_notices', 'perflab_sqlite_plugin_admin_notice' ); // Add the admin notices.
+
+/**
+ * Add a link to the admin bar.
+ *
+ * @param WP_Admin_Bar $admin_bar The admin bar object.
+ */
+function perflab_sqlite_plugin_adminbar_item( $admin_bar ) {
+	$args = array(
+		'id'     => 'performance-lab-sqlite',
+		'parent' => 'top-secondary',
+		/* translators: %s: SQLite icon. */
+		'title'  => '<span style="color:#46B450;">' . __( 'SQLite activated', 'performance-lab' ) . '</span>',
+		'href'   => esc_url( admin_url( 'options-general.php?page=' . PERFLAB_MODULES_SCREEN ) ),
+		'meta'   => false,
+	);
+	$admin_bar->add_node( $args );
+}
+add_action( 'admin_bar_menu', 'perflab_sqlite_plugin_adminbar_item', 999 );

--- a/modules/database/sqlite/load.php
+++ b/modules/database/sqlite/load.php
@@ -65,6 +65,9 @@ add_action( 'admin_notices', 'perflab_sqlite_plugin_admin_notice' ); // Add the 
  * @param WP_Admin_Bar $admin_bar The admin bar object.
  */
 function perflab_sqlite_plugin_adminbar_item( $admin_bar ) {
+	if ( ! defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) ) {
+		return;
+	}
 	$args = array(
 		'id'     => 'performance-lab-sqlite',
 		'parent' => 'top-secondary',

--- a/modules/database/sqlite/load.php
+++ b/modules/database/sqlite/load.php
@@ -65,14 +65,13 @@ add_action( 'admin_notices', 'perflab_sqlite_plugin_admin_notice' ); // Add the 
  * @param WP_Admin_Bar $admin_bar The admin bar object.
  */
 function perflab_sqlite_plugin_adminbar_item( $admin_bar ) {
-	if ( ! defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) ) {
-		return;
-	}
 	$args = array(
 		'id'     => 'performance-lab-sqlite',
 		'parent' => 'top-secondary',
 		/* translators: %s: SQLite icon. */
-		'title'  => '<span style="color:#46B450;">' . __( 'SQLite activated', 'performance-lab' ) . '</span>',
+		'title'  => defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) && defined( 'DATABASE_TYPE' ) && 'sqlite' === DATABASE_TYPE
+			? '<span style="color:#46B450;">' . __( 'Database: SQLite', 'performance-lab' ) . '</span>'
+			: '<span style="color:#DC3232;">' . __( 'Database: MySQL', 'performance-lab' ) . '</span>',
 		'href'   => esc_url( admin_url( 'options-general.php?page=' . PERFLAB_MODULES_SCREEN ) ),
 		'meta'   => false,
 	);

--- a/modules/database/sqlite/load.php
+++ b/modules/database/sqlite/load.php
@@ -73,13 +73,10 @@ function perflab_sqlite_plugin_adminbar_item( $admin_bar ) {
 
 	if ( defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) && defined( 'DATABASE_TYPE' ) && 'sqlite' === DATABASE_TYPE ) {
 		$title = '<span style="color:#46B450;">' . __( 'Database: SQLite', 'performance-lab' ) . '</span>';
+	} elseif ( stripos( $wpdb->db_server_info(), 'maria' ) !== false ) {
+		$title = '<span style="color:#DC3232;">' . __( 'Database: MariaDB', 'performance-lab' ) . '</span>';
 	} else {
-		$db_info = $wpdb->db_server_info();
-		if ( stripos( $db_info, 'maria' ) !== false ) {
-			$title = '<span style="color:#DC3232;">' . __( 'Database: MariaDB', 'performance-lab' ) . '</span>';
-		} else {
-			$title = '<span style="color:#DC3232;">' . __( 'Database: MySQL', 'performance-lab' ) . '</span>';
-		}
+		$title = '<span style="color:#DC3232;">' . __( 'Database: MySQL', 'performance-lab' ) . '</span>';
 	}
 
 	$args = array(

--- a/modules/database/sqlite/load.php
+++ b/modules/database/sqlite/load.php
@@ -14,7 +14,7 @@
 require_once __DIR__ . '/site-health.php';
 
 /**
- * Add admin notices.
+ * Adds admin notices.
  *
  * When the plugin gets merged in wp-core, this is not to be ported.
  *
@@ -60,18 +60,32 @@ function perflab_sqlite_plugin_admin_notice() {
 add_action( 'admin_notices', 'perflab_sqlite_plugin_admin_notice' ); // Add the admin notices.
 
 /**
- * Add a link to the admin bar.
+ * Adds a link to the admin bar.
+ *
+ * @since n.e.x.t
+ *
+ * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @param WP_Admin_Bar $admin_bar The admin bar object.
  */
 function perflab_sqlite_plugin_adminbar_item( $admin_bar ) {
+	global $wpdb;
+
+	if ( defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) && defined( 'DATABASE_TYPE' ) && 'sqlite' === DATABASE_TYPE ) {
+		$title = '<span style="color:#46B450;">' . __( 'Database: SQLite', 'performance-lab' ) . '</span>';
+	} else {
+		$db_info = $wpdb->db_server_info();
+		if ( stripos( $db_info, 'maria' ) !== false ) {
+			$title = '<span style="color:#DC3232;">' . __( 'Database: MariaDB', 'performance-lab' ) . '</span>';
+		} else {
+			$title = '<span style="color:#DC3232;">' . __( 'Database: MySQL', 'performance-lab' ) . '</span>';
+		}
+	}
+
 	$args = array(
 		'id'     => 'performance-lab-sqlite',
 		'parent' => 'top-secondary',
-		/* translators: %s: SQLite icon. */
-		'title'  => defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) && defined( 'DATABASE_TYPE' ) && 'sqlite' === DATABASE_TYPE
-			? '<span style="color:#46B450;">' . __( 'Database: SQLite', 'performance-lab' ) . '</span>'
-			: '<span style="color:#DC3232;">' . __( 'Database: MySQL', 'performance-lab' ) . '</span>',
+		'title'  => $title,
 		'href'   => esc_url( admin_url( 'options-general.php?page=' . PERFLAB_MODULES_SCREEN ) ),
 		'meta'   => false,
 	);


### PR DESCRIPTION
## Summary

Adds an indicator in the adminbar to show when using SQLite:

<img width="871" alt="Screenshot 2022-12-15 at 2 54 54 PM" src="https://user-images.githubusercontent.com/588688/207864568-42a8ec4b-2548-4b8f-887f-e2d55e56c6a0.png">

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
