### PR TITLE
Enhance object-cache.php drop-in interoperability with other plugins

### DIFF
--- a/load.php
+++ b/load.php
@@ -300,11 +300,14 @@ function perflab_maybe_set_object_cache_dropin() {
 	}
 
 	if ( $wp_filesystem || WP_Filesystem() ) {
+		$dropin_path        = WP_CONTENT_DIR . '/object-cache.php';
+		$dropin_backup_path = WP_CONTENT_DIR . '/object-cache-plst-orig.php';
+
 		// If there is an actual object-cache.php file, rename it to effectively
 		// back it up.
 		// The Performance Lab object-cache.php will still load it, so the
 		// behavior does not change.
-		if ( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
+		if ( $wp_filesystem->exists( $dropin_path ) ) {
 			// If even the backup file already exists, we should not do anything,
 			// except for the case where that file is the same as the main
 			// object-cache.php file. This can happen if another plugin is
@@ -314,17 +317,17 @@ function perflab_maybe_set_object_cache_dropin() {
 			// https://github.com/WordPress/performance/issues/612).
 			// In that case we can simply delete the main file since it is
 			// already backed up.
-			if ( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) ) {
-				$oc_content      = $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' );
-				$oc_orig_content = $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php' );
+			if ( $wp_filesystem->exists( $dropin_backup_path ) ) {
+				$oc_content      = $wp_filesystem->get_contents( $dropin_path );
+				$oc_orig_content = $wp_filesystem->get_contents( $dropin_backup_path );
 				if ( ! $oc_content || $oc_content !== $oc_orig_content ) {
 					// Set timeout of 1 hour before retrying again (only in case of failure).
 					set_transient( 'perflab_set_object_cache_dropin', true, HOUR_IN_SECONDS );
 					return;
 				}
-				$wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
+				$wp_filesystem->delete( $dropin_path );
 			} else {
-				$wp_filesystem->move( WP_CONTENT_DIR . '/object-cache.php', WP_CONTENT_DIR . '/object-cache-plst-orig.php' );
+				$wp_filesystem->move( $dropin_path, $dropin_backup_path );
 			}
 		}
 
@@ -364,13 +367,16 @@ function perflab_maybe_remove_object_cache_dropin() {
 	}
 
 	if ( $wp_filesystem || WP_Filesystem() ) {
+		$dropin_path        = WP_CONTENT_DIR . '/object-cache.php';
+		$dropin_backup_path = WP_CONTENT_DIR . '/object-cache-plst-orig.php';
+
 		// If there is an actual object-cache.php file, restore it
 		// and override the Performance Lab file.
 		// Otherwise just delete the Performance Lab file.
-		if ( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) ) {
-			$wp_filesystem->move( WP_CONTENT_DIR . '/object-cache-plst-orig.php', WP_CONTENT_DIR . '/object-cache.php', true );
+		if ( $wp_filesystem->exists( $dropin_backup_path ) ) {
+			$wp_filesystem->move( $dropin_backup_path, $dropin_path, true );
 		} else {
-			$wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
+			$wp_filesystem->delete( $dropin_path );
 		}
 	}
 

--- a/load.php
+++ b/load.php
@@ -300,11 +300,32 @@ function perflab_maybe_set_object_cache_dropin() {
 	}
 
 	if ( $wp_filesystem || WP_Filesystem() ) {
-		// If there is an actual object-cache.php file, rename it.
+		// If there is an actual object-cache.php file, rename it to effectively
+		// back it up.
 		// The Performance Lab object-cache.php will still load it, so the
 		// behavior does not change.
 		if ( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
-			$wp_filesystem->move( WP_CONTENT_DIR . '/object-cache.php', WP_CONTENT_DIR . '/object-cache-plst-orig.php' );
+			// If even the backup file already exists, we should not do anything,
+			// except for the case where that file is the same as the main
+			// object-cache.php file. This can happen if another plugin is
+			// aggressively trying to re-add its own object-cache.php file,
+			// ignoring that the Performance Lab object-cache.php file still
+			// loads that other file. This is also outlined in the bug
+			// https://github.com/WordPress/performance/issues/612).
+			// In that case we can simply delete the main file since it is
+			// already backed up.
+			if ( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) ) {
+				$oc_content      = $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' );
+				$oc_orig_content = $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php' );
+				if ( ! $oc_content || $oc_content !== $oc_orig_content ) {
+					// Set timeout of 1 hour before retrying again (only in case of failure).
+					set_transient( 'perflab_set_object_cache_dropin', true, HOUR_IN_SECONDS );
+					return;
+				}
+				$wp_filesystem->delete( WP_CONTENT_DIR . '/object-cache.php' );
+			} else {
+				$wp_filesystem->move( WP_CONTENT_DIR . '/object-cache.php', WP_CONTENT_DIR . '/object-cache-plst-orig.php' );
+			}
 		}
 
 		$wp_filesystem->copy( PERFLAB_PLUGIN_DIR_PATH . 'server-timing/object-cache.copy.php', WP_CONTENT_DIR . '/object-cache.php' );

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
 	<testsuites>
 		<testsuite name="default">
 			<directory suffix=".php">./tests</directory>
+    		<exclude>./tests/utils</exclude>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/tests/multisite.xml
+++ b/tests/multisite.xml
@@ -9,6 +9,7 @@
 	<testsuites>
 		<testsuite name="default">
 			<directory suffix=".php">./</directory>
+    		<exclude>./utils</exclude>
 		</testsuite>
 	</testsuites>
 	<groups>

--- a/tests/utils/Filesystem/WP_Filesystem_MockFilesystem.php
+++ b/tests/utils/Filesystem/WP_Filesystem_MockFilesystem.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * This file needs to be in the global namespace due to how WordPress requires loading it.
+ *
+ * @package performance-lab
+ */
+
+/**
+ * Simple mock filesystem, limited to working with concrete file paths.
+ * No support for hierarchy or parent directories etc.
+ *
+ * Could be expanded in the future if needed.
+ */
+class WP_Filesystem_MockFilesystem extends WP_Filesystem_Base {
+
+	private $file_contents = array();
+
+	public function get_contents( $file ) {
+		if ( isset( $this->file_contents[ $file ] ) ) {
+			return $this->file_contents[ $file ];
+		}
+		return false;
+	}
+
+	public function get_contents_array( $file ) {
+		if ( isset( $this->file_contents[ $file ] ) ) {
+			return array( $this->file_contents[ $file ] );
+		}
+		return false;
+	}
+
+	public function put_contents( $file, $contents, $mode = false ) {
+		$this->file_contents[ $file ] = $contents;
+		return true;
+	}
+
+	public function cwd() {
+		return false;
+	}
+
+	public function chdir( $dir ) {
+		return false;
+	}
+
+	public function chgrp( $file, $group, $recursive = false ) {
+		return false;
+	}
+
+	public function chmod( $file, $mode = false, $recursive = false ) {
+		return false;
+	}
+
+	public function owner( $file ) {
+		return false;
+	}
+
+	public function group( $file ) {
+		return false;
+	}
+
+	public function copy( $source, $destination, $overwrite = false, $mode = false ) {
+		if ( ! isset( $this->file_contents[ $source ] ) ) {
+			return false;
+		}
+		if ( ! $overwrite && isset( $this->file_contents[ $destination ] ) ) {
+			return false;
+		}
+		$this->file_contents[ $destination ] = $this->file_contents[ $source ];
+		return true;
+	}
+
+	public function move( $source, $destination, $overwrite = false ) {
+		if ( $this->copy( $source, $destination, $overwrite, false ) ) {
+			return $this->delete( $source );
+		}
+		return false;
+	}
+
+	public function delete( $file, $recursive = false, $type = false ) {
+		if ( isset( $this->file_contents[ $file ] ) ) {
+			unset( $this->file_contents[ $file ] );
+		}
+		return true;
+	}
+
+	public function exists( $path ) {
+		return isset( $this->file_contents[ $path ] );
+	}
+
+	public function is_file( $file ) {
+		return isset( $this->file_contents[ $file ] );
+	}
+
+	public function is_dir( $path ) {
+		return false;
+	}
+
+	public function is_readable( $file ) {
+		return isset( $this->file_contents[ $file ] );
+	}
+
+	public function is_writable( $path ) {
+		return true;
+	}
+
+	public function atime( $file ) {
+		return false;
+	}
+
+	public function mtime( $file ) {
+		return false;
+	}
+
+	public function size( $file ) {
+		if ( isset( $this->file_contents[ $file ] ) ) {
+			return strlen( $this->file_contents[ $file ] );
+		}
+		return false;
+	}
+
+	public function touch( $file, $time = 0, $atime = 0 ) {
+		if ( ! isset( $this->file_contents[ $file ] ) ) {
+			$this->file_contents[ $file ] = '';
+		}
+		return true;
+	}
+
+	public function mkdir( $path, $chmod = false, $chown = false, $chgrp = false ) {
+		return false;
+	}
+
+	public function rmdir( $path, $recursive = false ) {
+		return false;
+	}
+
+	public function dirlist( $path, $include_hidden = true, $recursive = false ) {
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #612

## Relevant technical choices

* Fixes the one PL-side bug outlined in https://github.com/WordPress/performance/issues/612#issuecomment-1363417637.
* Adds comprehensive test coverage for the change and original logic in `perflab_maybe_set_object_cache_dropin()`, which previously was basically untested. It does so via a new (for now very basic) mock filesystem class.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
