### PR TITLE
Remove warning about multi-server environment from the SQLite module description

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -194,7 +194,7 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 			<?php else : ?>
 				<?php // Don't use the WP notice classes here, as that makes them move to the top of the page. ?>
 				<p class="notice notice-warning" style="padding:1em;max-width:50em;">
-					<?php esc_html_e( 'Enabling this module will switch to a separate database and install WordPress in it. You will need to reconfigure your site, and start with a fresh site. Disabling the module you will get back to your previous MySQL database, with all your previous data intact. Warning: Do not activate if your site is implemented in a multi-server environment.', 'performance-lab' ); ?>
+					<?php esc_html_e( 'Enabling this module will switch to a separate database and install WordPress in it. You will need to reconfigure your site, and start with a fresh site. Disabling the module you will get back to your previous MySQL database, with all your previous data intact.', 'performance-lab' ); ?>
 				</p>
 			<?php endif; ?>
 		<?php endif; ?>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #609

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
