### PR TITLE
Merge 1.9.0 release back into `trunk`

### DIFF
--- a/load.php
+++ b/load.php
@@ -15,7 +15,7 @@
  * @package performance-lab
  */
 
-define( 'PERFLAB_VERSION', '1.8.0' );
+define( 'PERFLAB_VERSION', '1.9.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );

--- a/load.php
+++ b/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance modules.
  * Requires at least: 6.0
  * Requires PHP: 5.6
- * Version: 1.8.0
+ * Version: 1.9.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -77,6 +77,16 @@ By default, the WebP Uploads module will only generate WebP versions of the imag
 
 == Changelog ==
 
+= 1.9.0 =
+
+**Enhancements**
+
+* Database: Remove warning about multi-server environment from the SQLite module description. ([619](https://github.com/WordPress/performance/pull/619))
+
+**Bug Fixes**
+
+* Infrastructure: Enhance object-cache.php drop-in interoperability with other plugins. ([616](https://github.com/WordPress/performance/pull/616))
+
 = 1.8.0 =
 
 **Features**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.0
 Tested up to:      6.1
 Requires PHP:      5.6
-Stable tag:        1.8.0
+Stable tag:        1.9.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, javascript, site health, measurement, object caching


### PR DESCRIPTION
## Summary

Fixes #621 

## Relevant technical choices

- Everything here has already been approved elsewhere, so this approval is just a formality.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
