### PR TITLE
Add `perflab_disable_object_cache_dropin` filter

### DIFF
--- a/load.php
+++ b/load.php
@@ -294,7 +294,7 @@ function perflab_maybe_set_object_cache_dropin() {
 	/**
 	 * Filters whether the Perflab server timing drop-in should be set.
 	 *
-	 * @since x.x.x
+	 * @since n.e.x.t
 	 *
 	 * @param bool Whether the server timing drop-in should be set.
 	 */

--- a/load.php
+++ b/load.php
@@ -290,6 +290,17 @@ function perflab_maybe_set_object_cache_dropin() {
 	if ( PERFLAB_OBJECT_CACHE_DROPIN_VERSION ) {
 		return;
 	}
+	
+	/**
+	 * Filters whether the Perflab server timing drop-in should be set.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param bool Whether the server timing drop-in should be set.
+	 */
+	if ( apply_filters( 'perflab_object_cache_dropin', '__return_false' ) ) {
+		return;
+	}
 
 	// Bail if already attempted before timeout has been completed.
 	// This is present in case placing the file fails for some reason, to avoid

--- a/load.php
+++ b/load.php
@@ -290,7 +290,7 @@ function perflab_maybe_set_object_cache_dropin() {
 	if ( PERFLAB_OBJECT_CACHE_DROPIN_VERSION ) {
 		return;
 	}
-	
+
 	/**
 	 * Filters whether the Perflab server timing drop-in should be set.
 	 *

--- a/load.php
+++ b/load.php
@@ -298,7 +298,7 @@ function perflab_maybe_set_object_cache_dropin() {
 	 *
 	 * @param bool Whether the server timing drop-in should be set.
 	 */
-	if ( apply_filters( 'perflab_object_cache_dropin', '__return_false' ) ) {
+	if ( apply_filters( 'perflab_disable_object_cache_dropin', false ) ) {
 		return;
 	}
 

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -343,6 +343,23 @@ class Load_Tests extends WP_UnitTestCase {
 		$this->assertSame( $dummy_file_content2, $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
 	}
 
+	public function test_perflab_object_cache_dropin_may_be_disabled_via_filter() {
+		global $wp_filesystem;
+
+		$this->set_up_mock_filesystem();
+
+		// Ensure PL object-cache.php drop-in is not present and constant is not set.
+		$this->assertFalse( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
+		$this->assertFalse( PERFLAB_OBJECT_CACHE_DROPIN_VERSION );
+
+		// Add filter to disable drop-in.
+		add_filter( 'perflab_disable_object_cache_dropin', '__return_true' );
+
+		// Run function to place drop-in and ensure it still doesn't exist afterwards.
+		perflab_maybe_set_object_cache_dropin();
+		$this->assertFalse( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
+	}
+
 	private function set_up_mock_filesystem() {
 		global $wp_filesystem;
 

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -41,23 +41,6 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 		$this->assertTrue( perflab_server_timing_use_output_buffer() );
 	}
 
-	public function test_perflab_object_cache_dropin_may_be_disabled_via_filter() {
-		global $wp_filesystem;
-
-		$this->set_up_mock_filesystem();
-
-		// Ensure PL object-cache.php drop-in is not present and constant is not set.
-		$this->assertFalse( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertFalse( PERFLAB_OBJECT_CACHE_DROPIN_VERSION );
-
-		// Add filter to disable drop-in.
-		add_filter( 'perflab_disable_object_cache_dropin', '__return_true' );
-
-		// Run function to place drop-in and ensure it still doesn't exist afterwards.
-		perflab_maybe_set_object_cache_dropin();
-		$this->assertFalse( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
-	}
-
 	public function test_perflab_wrap_server_timing() {
 		$cb = function() {
 			return 123;

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -40,6 +40,23 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 		add_filter( 'perflab_server_timing_use_output_buffer', '__return_true' );
 		$this->assertTrue( perflab_server_timing_use_output_buffer() );
 	}
+	
+	public function test_perflab_object_cache_dropin_may_be_disabled_via_filter() {
+		global $wp_filesystem;
+
+		$this->set_up_mock_filesystem();
+
+		// Ensure PL object-cache.php drop-in is not present and constant is not set.
+		$this->assertFalse( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
+		$this->assertFalse( PERFLAB_OBJECT_CACHE_DROPIN_VERSION );
+
+		// Add filter to disable drop-in.
+		add_filter( 'perflab_disable_object_cache_dropin', '__return_true' );
+
+		// Run function to place drop-in and ensure it still doesn't exist afterwards.
+		perflab_maybe_set_object_cache_dropin();
+		$this->assertFalse( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
+	}
 
 	public function test_perflab_wrap_server_timing() {
 		$cb = function() {

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -40,7 +40,7 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 		add_filter( 'perflab_server_timing_use_output_buffer', '__return_true' );
 		$this->assertTrue( perflab_server_timing_use_output_buffer() );
 	}
-	
+
 	public function test_perflab_object_cache_dropin_may_be_disabled_via_filter() {
 		global $wp_filesystem;
 


### PR DESCRIPTION
## Summary

Fixes #628 and #629.

## Relevant technical choices

Using a filter is easy for other plugin to use, while the existing constant would need to be set in the `wp-config.php` which isn't easily controlled by a plugin.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
