### PR TITLE
Use correct number of arguments in filter callback

### DIFF
--- a/modules/images/webp-uploads/image-edit.php
+++ b/modules/images/webp-uploads/image-edit.php
@@ -221,7 +221,7 @@ function webp_uploads_update_image_onchange( $override, $file_path, $editor, $mi
 
 	return $override;
 }
-add_filter( 'wp_save_image_editor_file', 'webp_uploads_update_image_onchange', 10, 7 );
+add_filter( 'wp_save_image_editor_file', 'webp_uploads_update_image_onchange', 10, 5 );
 
 /**
  * Inspect if the current call to `wp_update_attachment_metadata()` was done from within the context


### PR DESCRIPTION
The `webp_uploads_update_image_onchange` function takes 5 arguments. 

See #622

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
