### PR TITLE
Fix invalid docs and return types as highlighted by static analysis

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -27,6 +27,7 @@ function perflab_add_modules_page() {
 	// Add the following hooks only if the screen was successfully added.
 	if ( false !== $hook_suffix ) {
 		add_action( "load-{$hook_suffix}", 'perflab_load_modules_page', 10, 0 );
+		add_action( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ), 'perflab_plugin_action_links_add_settings' );
 	}
 
 	return $hook_suffix;

--- a/admin/load.php
+++ b/admin/load.php
@@ -27,7 +27,6 @@ function perflab_add_modules_page() {
 	// Add the following hooks only if the screen was successfully added.
 	if ( false !== $hook_suffix ) {
 		add_action( "load-{$hook_suffix}", 'perflab_load_modules_page', 10, 0 );
-		add_action( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ), 'perflab_plugin_action_links_add_settings' );
 	}
 
 	return $hook_suffix;

--- a/load.php
+++ b/load.php
@@ -159,7 +159,7 @@ function perflab_get_active_modules() {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param array An array of the currently active modules.
+	 * @param array $modules An array of the currently active modules.
 	 */
 	$modules = apply_filters( 'perflab_active_modules', $modules );
 

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-db.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-db.php
@@ -112,7 +112,7 @@ class Perflab_SQLite_DB extends wpdb {
 	 *
 	 * @param string $str The error to display.
 	 *
-	 * @return bool False if the showing of errors is disabled.
+	 * @return bool|void False if the showing of errors is disabled.
 	 */
 	public function print_error( $str = '' ) {
 		global $EZSQL_ERROR;
@@ -168,7 +168,6 @@ class Perflab_SQLite_DB extends wpdb {
 				'<code>' . $query . '</code>'
 			);
 		}
-		return true;
 	}
 
 	/**
@@ -197,6 +196,7 @@ class Perflab_SQLite_DB extends wpdb {
 	 * @see wpdb::db_connect()
 	 *
 	 * @param bool $allow_bail Not used.
+	 * @return void
 	 */
 	public function db_connect( $allow_bail = true ) {
 		$this->init_charset();

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-db.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-db.php
@@ -168,6 +168,7 @@ class Perflab_SQLite_DB extends wpdb {
 				'<code>' . $query . '</code>'
 			);
 		}
+		return true;
 	}
 
 	/**

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
@@ -724,7 +724,7 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 	 *
 	 * @param object $statement The PDO statement.
 	 *
-	 * @return boolean
+	 * @return boolean|void
 	 */
 	private function execute_query( $statement ) {
 		$reason  = 0;
@@ -1277,7 +1277,7 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 	 * @param string $function Indicate the function name where the error occurred.
 	 * @param string $message  The message.
 	 *
-	 * @return boolean
+	 * @return boolean|void
 	 */
 	private function set_error( $line, $function, $message ) {
 		global $wpdb;
@@ -1507,6 +1507,7 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 	 * Method to call PDO::commit().
 	 *
 	 * @see PDO::commit()
+	 * @return void
 	 */
 	public function commit() {
 		$this->pdo->commit();
@@ -1517,6 +1518,7 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 	 * Method to call PDO::rollBack().
 	 *
 	 * @see PDO::rollBack()
+	 * @return void
 	 */
 	public function rollBack() {
 		$this->pdo->rollBack();

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-user-defined-functions.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-user-defined-functions.php
@@ -443,6 +443,7 @@ class Perflab_SQLite_PDO_User_Defined_Functions {
 				list($years, $months) = explode( '-', $_parts[0] );
 				return 'P' . $years . 'Y' . $months . 'M';
 		}
+		return '';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #622

Fix issues with doc type and return that was throwing error in static test.


## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
