### PR TITLE
Feature/ #636 Module Specific Readme Files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,10 +31,4 @@
 /.gitattributes export-ignore
 /.gitignore export-ignore
 
-/modules/database/audit-autoloaded-options/readme.txt export-ignore
-modules/database/sqlite/readme.txt export-ignore
-/modules/images/dominant-color/readme.txt export-ignore
-/modules/images/fetchpriority/readme.txt export-ignore
-/modules/images/webp-support/readme.txt export-ignore
-/modules/images/webp-uploads/readme.txt export-ignore
-/modules/js-and-css/audit-enqueued-assets/readme.txt export-ignore
+/modules/**/readme.txt export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -30,3 +30,11 @@
 
 /.gitattributes export-ignore
 /.gitignore export-ignore
+
+/modules/database/audit-autoloaded-options/readme.txt export-ignore
+modules/database/sqlite/readme.txt export-ignore
+/modules/images/dominant-color/readme.txt export-ignore
+/modules/images/fetchpriority/readme.txt export-ignore
+/modules/images/webp-support/readme.txt export-ignore
+/modules/images/webp-uploads/readme.txt export-ignore
+/modules/js-and-css/audit-enqueued-assets/readme.txt export-ignore

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -1,4 +1,4 @@
-=== Performance Lab - WebP Uploads Module ===
+=== WebP Uploads ===
 
 Contributors:      wordpressdotorg
 Requires at least: 6.1
@@ -7,9 +7,9 @@ Requires PHP:      5.6
 Stable tag:        1.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, site health, measurement, webp
+Tags:              performance, images, webp
 
-WebP uploads module for the [performance plugin](https://wordpress.org/plugins/performance-lab/) from the WordPress Performance Team.
+Creates WebP versions for new JPEG image uploads if supported by the server.
 
 == Description ==
 
@@ -22,34 +22,20 @@ This plugin is intended to be used alongside the [performance plugin](https://wo
 = Installation from within WordPress =
 
 1. Visit **Plugins > Add New**.
-2. Search for **Performance Lab - WebP Uploads Module**.
-3. Install and activate the **Performance Lab - WebP Uploads Module** plugin.
+2. Search for **WebP Uploads**.
+3. Install and activate the **WebP Uploads** plugin.
 
 = Manual installation =
 
-1. Upload the entire `performance-lab-webp-support-module` folder to the `/wp-content/plugins/` directory.
+1. Upload the entire `webp-uploads` folder to the `/wp-content/plugins/` directory.
 2. Visit **Plugins**.
-3. Activate the **Performance Lab - WebP Uploads Module** plugin.
-
-= After activation =
-
-1. Visit the new **Settings > Performance** menu.
-2. Enable the individual modules you would like to use, one of which should be this WebP support module.
+3. Activate the **WebP Uploads** plugin.
 
 == Frequently Asked Questions ==
 
-= What is the purpose of this plugin? =
-
-The primary purpose of the Performance Lab - WebP Support Module plugin is to add an additional module to the performance plugin that enables the ability to toggle on/off WebP support.
-
-= Can I use this plugin on my production site? =
-
-Per the primary purpose of the plugin (see above), it can be considered stable for production usage given that this particular module is not marked as experimental.
-
 = Where can I submit my plugin feedback? =
 
-Feedback is encouraged and much appreciated, especially since this plugin may contain future WordPress core features. If you have suggestions or requests for new features, you can [submit them as an issue in the Performance Lab GitHub repository](https://github.com/WordPress/performance/issues/new/choose). If you need help with troubleshooting or have a question about the plugin, please [create a new topic on our support forum](https://wordpress.org/support/plugin/performance-lab/#new-topic-0).
-
+Feedback is encouraged and much appreciated, especially since this plugin may contain future WordPress core features. If you have suggestions or requests for new features, you can [submit them as an issue in the WordPress Performance Team's GitHub repository](https://github.com/WordPress/performance/issues/new/choose). If you need help with troubleshooting or have a question about the plugin, please [create a new topic on our support forum](https://wordpress.org/support/plugin/webp-uploads/#new-topic-0).
 = How can I contribute to the plugin? =
 
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -36,9 +36,21 @@ This plugin is intended to be used alongside the [performance plugin](https://wo
 = Where can I submit my plugin feedback? =
 
 Feedback is encouraged and much appreciated, especially since this plugin may contain future WordPress core features. If you have suggestions or requests for new features, you can [submit them as an issue in the WordPress Performance Team's GitHub repository](https://github.com/WordPress/performance/issues/new/choose). If you need help with troubleshooting or have a question about the plugin, please [create a new topic on our support forum](https://wordpress.org/support/plugin/webp-uploads/#new-topic-0).
+
 = How can I contribute to the plugin? =
 
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
+
+= I've activated the WebP Uploads module, but WebP images are not always generated when I upload a JPEG image. Why? =
+
+There are two primary reasons that a WebP image may not be generated:
+
+1. The WebP Uploads plugin has identified that the WebP version of the uploaded JPEG image would have a larger file size than the original JPEG image, so it does not generate the WebP version.
+2. The JPEG image was not uploaded to the [Media Library](https://wordpress.com/support/media/). At this time, WebP versions are only generated for images to the Media Library. WebP versions are not generated for JPEG images that are added to your site in other ways, such as in a template file or the [Customizer](https://wordpress.com/support/customizer/).
+
+= With the WebP Uploads plugin activated, will the plugin generate JPEG and WebP versions of every image that I upload? =
+
+By default, the WebP Uploads plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
 
@@ -46,4 +58,4 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 **Initial Release**
 
-* Initial release of the WebP support performance plugin module as a standalone plugin. ([636](https://github.com/WordPress/performance/issues/636))
+* Initial release of the WebP Uploads plugin as a standalone plugin. ([664](https://github.com/WordPress/performance/pull/664))

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -13,9 +13,8 @@ Creates WebP versions for new JPEG image uploads if supported by the server.
 
 == Description ==
 
-This plugin adds a WebP uploads module to the [performance plugin](https://wordpress.org/plugins/performance-lab/), enabling WebP support for media uploads within the WordPress application, when this module is enabled.
+This plugin adds WebP support for media uploads within the WordPress application.
 
-This plugin is intended to be used alongside the [performance plugin](https://wordpress.org/plugins/performance-lab/), and will not function as a standalone plugin. The performance plugin may be obtained [here](https://wordpress.org/plugins/performance-lab/).
 
 == Installation ==
 

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -13,7 +13,7 @@ Creates WebP versions for new JPEG image uploads if supported by the server.
 
 == Description ==
 
-This plugin adds WebP support for media uploads within the WordPress application. WebP images will be generated only for new uploads, preexisting imagery will not be converted to WebP format. By default, WebP images will only be generated for JPEG uploads, only the original uploaded file will still exist as a JPEG image. ALl generated image sizes will exist as WebP only. If you wish to change this behaviour, there is a checkbox in `Settings > Media` that - when checked - will alter the behaviour of this plugin to generate both JPEG and WebP images for every sub-size (noting again that this will only affect newly uploaded images, i.e. after making said change).
+This plugin adds WebP support for media uploads within the WordPress application. WebP images will be generated only for new uploads, pre-existing imagery will not be converted to WebP format. By default, WebP images will only be generated for JPEG uploads, only the original uploaded file will still exist as a JPEG image. All generated image sizes will exist as WebP only. If you wish to change this behaviour, there is a checkbox in `Settings > Media` that - when checked - will alter the behaviour of this plugin to generate both JPEG and WebP images for every sub-size (noting again that this will only affect newly uploaded images, i.e. after making said change).
 
 == Installation ==
 

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -13,7 +13,7 @@ Creates WebP versions for new JPEG image uploads if supported by the server.
 
 == Description ==
 
-This plugin adds WebP support for media uploads within the WordPress application.
+This plugin adds WebP support for media uploads within the WordPress application. WebP images will be generated only for new uploads, preexisting imagery will not be converted to WebP format. By default, WebP images will only be generated for JPEG uploads, only the original uploaded file will still exist as a JPEG image. ALl generated image sizes will exist as WebP only. If you wish to change this behaviour, there is a checkbox in `Settings > Media` that - when checked - will alter the behaviour of this plugin to generate both JPEG and WebP images for every sub-size (noting again that this will only affect newly uploaded images, i.e. after making said change).
 
 == Installation ==
 

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -54,6 +54,4 @@ By default, the WebP Uploads plugin will only generate WebP versions of the imag
 
 = 1.0.0 =
 
-**Initial Release**
-
 * Initial release of the WebP Uploads plugin as a standalone plugin. ([664](https://github.com/WordPress/performance/pull/664))

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.1
 Tested up to:      6.1
 Requires PHP:      5.6
-Stable tag:        2.0.0
+Stable tag:        1.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, site health, measurement, webp

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -15,7 +15,6 @@ Creates WebP versions for new JPEG image uploads if supported by the server.
 
 This plugin adds WebP support for media uploads within the WordPress application.
 
-
 == Installation ==
 
 = Installation from within WordPress =

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -1,0 +1,63 @@
+=== Performance Lab - WebP Uploads Module ===
+
+Contributors:      wordpressdotorg
+Requires at least: 6.1
+Tested up to:      6.1
+Requires PHP:      5.6
+Stable tag:        2.0.0
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              performance, images, site health, measurement, webp
+
+WebP uploads module for the [performance plugin](https://wordpress.org/plugins/performance-lab/) from the WordPress Performance Team.
+
+== Description ==
+
+This plugin adds a WebP uploads module to the [performance plugin](https://wordpress.org/plugins/performance-lab/), enabling WebP support for media uploads within the WordPress application, when this module is enabled.
+
+This plugin is intended to be used alongside the [performance plugin](https://wordpress.org/plugins/performance-lab/), and will not function as a standalone plugin. The performance plugin may be obtained [here](https://wordpress.org/plugins/performance-lab/).
+
+== Installation ==
+
+= Installation from within WordPress =
+
+1. Visit **Plugins > Add New**.
+2. Search for **Performance Lab - WebP Uploads Module**.
+3. Install and activate the **Performance Lab - WebP Uploads Module** plugin.
+
+= Manual installation =
+
+1. Upload the entire `performance-lab-webp-support-module` folder to the `/wp-content/plugins/` directory.
+2. Visit **Plugins**.
+3. Activate the **Performance Lab - WebP Uploads Module** plugin.
+
+= After activation =
+
+1. Visit the new **Settings > Performance** menu.
+2. Enable the individual modules you would like to use, one of which should be this WebP support module.
+
+== Frequently Asked Questions ==
+
+= What is the purpose of this plugin? =
+
+The primary purpose of the Performance Lab - WebP Support Module plugin is to add an additional module to the performance plugin that enables the ability to toggle on/off WebP support.
+
+= Can I use this plugin on my production site? =
+
+Per the primary purpose of the plugin (see above), it can be considered stable for production usage given that this particular module is not marked as experimental.
+
+= Where can I submit my plugin feedback? =
+
+Feedback is encouraged and much appreciated, especially since this plugin may contain future WordPress core features. If you have suggestions or requests for new features, you can [submit them as an issue in the Performance Lab GitHub repository](https://github.com/WordPress/performance/issues/new/choose). If you need help with troubleshooting or have a question about the plugin, please [create a new topic on our support forum](https://wordpress.org/support/plugin/performance-lab/#new-topic-0).
+
+= How can I contribute to the plugin? =
+
+Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
+
+== Changelog ==
+
+= 1.0.0 =
+
+**Initial Release**
+
+* Initial release of the WebP support performance plugin module as a standalone plugin. ([636](https://github.com/WordPress/performance/issues/636))


### PR DESCRIPTION
## Summary

Addresses #636 

## Relevant technical choices

- Adds a draft v1 `readme.txt` file to the `webp-uploads` module folder for copying over to the relevant build directory as per the work carried out in #662 .
- Flags all `readme.txt` files in all performance plugin module folders for `export-ignore` via `.gitattributes` glob pattern match.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
