### PR TITLE
Add `wp-total` metric to default Server-Timing metrics

### DIFF
--- a/server-timing/defaults.php
+++ b/server-timing/defaults.php
@@ -152,6 +152,23 @@ function perflab_register_default_server_timing_template_metrics() {
 		PHP_INT_MAX
 	);
 
+	add_action(
+		'perflab_server_timing_send_header',
+		function() {
+			// WordPress total load time.
+			perflab_server_timing_register_metric(
+				'total',
+				array(
+					'measure_callback' => function( $metric ) {
+						// The 'timestart' global is set right at the beginning of WordPress execution.
+						$metric->set_value( ( microtime( true ) - $GLOBALS['timestart'] ) * 1000.0 );
+					},
+					'access_cap'       => 'exist',
+				)
+			);
+		}
+	);
+
 	// SQL query time is only measured if the SAVEQUERIES constant is set to true.
 	if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
 		add_action(


### PR DESCRIPTION
## Summary

Fixes #668

* Note that in order to see the metric, you need to enable output buffering via the Server Timing API filter. See [this Gist](https://gist.github.com/felixarntz/9c3d7150c74082e69bb426393b68b12e).
* [This data](https://docs.google.com/spreadsheets/d/1Oe-6ZO_Jqt6qSp2yF-ohb05McEB2y22aqU0S7gXuyGs/edit#gid=1501750953) (also see [WordPress Trac ticket](https://core.trac.wordpress.org/ticket/57814)) is an example where the code from this PR was already used.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
