### PR TITLE
Fix problems with placing `object-cache.php` drop-in

### DIFF
--- a/load.php
+++ b/load.php
@@ -274,6 +274,7 @@ perflab_load_active_and_valid_modules();
  * 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is set as true.
  *
  * @since 1.8.0
+ * @since n.e.x.t No longer attempts to use two of the drop-ins together.
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  */
@@ -310,41 +311,27 @@ function perflab_maybe_set_object_cache_dropin() {
 	}
 
 	if ( $wp_filesystem || WP_Filesystem() ) {
-		$dropin_path        = WP_CONTENT_DIR . '/object-cache.php';
-		$dropin_backup_path = WP_CONTENT_DIR . '/object-cache-plst-orig.php';
+		$dropin_path = WP_CONTENT_DIR . '/object-cache.php';
 
-		// If there is an actual object-cache.php file, rename it to effectively
-		// back it up.
-		// The Performance Lab object-cache.php will still load it, so the
-		// behavior does not change.
+		/**
+		 * If there is an actual object-cache.php file, do not replace it.
+		 * Previous versions of the Performance Lab plugin were renaming the
+		 * original object-cache.php file and then loading both. However, due
+		 * to other plugins eagerly checking file headers, this caused too many
+		 * problems across sites so it was decided to remove this layer.
+		 * Only placing the drop-in file if no other one exists yet is the
+		 * safest solution.
+		 */
 		if ( $wp_filesystem->exists( $dropin_path ) ) {
-			// If even the backup file already exists, we should not do anything,
-			// except for the case where that file is the same as the main
-			// object-cache.php file. This can happen if another plugin is
-			// aggressively trying to re-add its own object-cache.php file,
-			// ignoring that the Performance Lab object-cache.php file still
-			// loads that other file. This is also outlined in the bug
-			// https://github.com/WordPress/performance/issues/612).
-			// In that case we can simply delete the main file since it is
-			// already backed up.
-			if ( $wp_filesystem->exists( $dropin_backup_path ) ) {
-				$oc_content      = $wp_filesystem->get_contents( $dropin_path );
-				$oc_orig_content = $wp_filesystem->get_contents( $dropin_backup_path );
-				if ( ! $oc_content || $oc_content !== $oc_orig_content ) {
-					// Set timeout of 1 hour before retrying again (only in case of failure).
-					set_transient( 'perflab_set_object_cache_dropin', true, HOUR_IN_SECONDS );
-					return;
-				}
-				$wp_filesystem->delete( $dropin_path );
-			} else {
-				$wp_filesystem->move( $dropin_path, $dropin_backup_path );
-			}
+			// Set timeout of 1 day before retrying again (only in case the file already exists).
+			set_transient( 'perflab_set_object_cache_dropin', true, DAY_IN_SECONDS );
+			return;
 		}
 
-		$wp_filesystem->copy( PERFLAB_PLUGIN_DIR_PATH . 'server-timing/object-cache.copy.php', WP_CONTENT_DIR . '/object-cache.php' );
+		$wp_filesystem->copy( PERFLAB_PLUGIN_DIR_PATH . 'server-timing/object-cache.copy.php', $dropin_path );
 	}
 
-	// Set timeout of 1 hour before retrying again (only in case of failure).
+	// Set timeout of 1 hour before retrying again (only relevant in case the above failed).
 	set_transient( 'perflab_set_object_cache_dropin', true, HOUR_IN_SECONDS );
 }
 add_action( 'admin_init', 'perflab_maybe_set_object_cache_dropin' );
@@ -352,9 +339,9 @@ add_action( 'admin_init', 'perflab_maybe_set_object_cache_dropin' );
 /**
  * Removes the Performance Lab's object cache drop-in from the drop-ins folder.
  *
- * This function should be run on plugin deactivation. If there was another original
- * object-cache.php drop-in file (renamed in `perflab_maybe_set_object_cache_dropin()`
- * to object-cache-plst-orig.php), it will be restored.
+ * This function should be run on plugin deactivation. For backward compatibility with
+ * an earlier implementation of `perflab_maybe_set_object_cache_dropin()`, this function
+ * checks whether there is an object-cache-plst-orig.php file, and if so restores it.
  *
  * This function will short-circuit if the constant
  * 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is set as true.
@@ -380,9 +367,13 @@ function perflab_maybe_remove_object_cache_dropin() {
 		$dropin_path        = WP_CONTENT_DIR . '/object-cache.php';
 		$dropin_backup_path = WP_CONTENT_DIR . '/object-cache-plst-orig.php';
 
-		// If there is an actual object-cache.php file, restore it
-		// and override the Performance Lab file.
-		// Otherwise just delete the Performance Lab file.
+		/**
+		 * If there is an object-cache-plst-orig.php file, restore it and
+		 * override the Performance Lab file. This is only relevant for
+		 * backward-compatibility with previous Performance Lab versions
+		 * which were backing up the file and then loading both.
+		 * Otherwise just delete the Performance Lab file.
+		 */
 		if ( $wp_filesystem->exists( $dropin_backup_path ) ) {
 			$wp_filesystem->move( $dropin_backup_path, $dropin_path, true );
 		} else {

--- a/server-timing/object-cache.copy.php
+++ b/server-timing/object-cache.copy.php
@@ -29,7 +29,9 @@
  */
 
 // Set constant to be able to later check for whether this file was loaded.
-define( 'PERFLAB_OBJECT_CACHE_DROPIN_VERSION', 2 );
+if ( ! defined( 'PERFLAB_OBJECT_CACHE_DROPIN_VERSION' ) ) {
+	define( 'PERFLAB_OBJECT_CACHE_DROPIN_VERSION', 2 );
+}
 
 if ( ! function_exists( 'perflab_load_server_timing_api_from_dropin' ) ) {
 	/**

--- a/server-timing/object-cache.copy.php
+++ b/server-timing/object-cache.copy.php
@@ -3,7 +3,7 @@
  * Plugin Name: Performance Lab Server Timing Object Cache Drop-In
  * Plugin URI: https://github.com/WordPress/performance
  * Description: Performance Lab drop-in to register Server-Timing metrics early. This is not a real object cache drop-in and will not override other actual object cache drop-ins.
- * Version: 1
+ * Version: 2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later

--- a/server-timing/object-cache.copy.php
+++ b/server-timing/object-cache.copy.php
@@ -62,7 +62,14 @@ if ( ! function_exists( 'perflab_load_server_timing_api_from_dropin' ) ) {
 }
 perflab_load_server_timing_api_from_dropin();
 
-// Load the original object cache drop-in if present.
+/**
+ * Load the original object cache drop-in if present.
+ * This is only here for backward compatibility, as new Performance Lab
+ * versions no longer use the approach of backing up the original
+ * object-cache.php file and loading both.
+ * It is critical however to maintain this line here to not break existing
+ * sites where this approach has been working as expected.
+ */
 if ( file_exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) ) {
 	require_once WP_CONTENT_DIR . '/object-cache-plst-orig.php';
 }

--- a/server-timing/object-cache.copy.php
+++ b/server-timing/object-cache.copy.php
@@ -29,34 +29,36 @@
  */
 
 // Set constant to be able to later check for whether this file was loaded.
-define( 'PERFLAB_OBJECT_CACHE_DROPIN_VERSION', 1 );
+define( 'PERFLAB_OBJECT_CACHE_DROPIN_VERSION', 2 );
 
-/**
- * Loads the Performance Lab Server-Timing API if available.
- *
- * This function will short-circuit if the constant
- * 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is set as true.
- *
- * @since 1.8.0
- */
-function perflab_load_server_timing_api_from_dropin() {
-	if ( defined( 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' ) && PERFLAB_DISABLE_OBJECT_CACHE_DROPIN ) {
-		return;
-	}
-
-	$plugins_dir = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins';
-	$plugin_dir  = $plugins_dir . '/performance-lab/';
-	if ( ! file_exists( $plugin_dir . 'server-timing/load.php' ) ) {
-		$plugin_dir = $plugins_dir . '/performance/';
-		if ( ! file_exists( $plugin_dir . 'server-timing/load.php' ) ) {
+if ( ! function_exists( 'perflab_load_server_timing_api_from_dropin' ) ) {
+	/**
+	 * Loads the Performance Lab Server-Timing API if available.
+	 *
+	 * This function will short-circuit if the constant
+	 * 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is set as true.
+	 *
+	 * @since 1.8.0
+	 */
+	function perflab_load_server_timing_api_from_dropin() {
+		if ( defined( 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' ) && PERFLAB_DISABLE_OBJECT_CACHE_DROPIN ) {
 			return;
 		}
-	}
 
-	require_once $plugin_dir . 'server-timing/class-perflab-server-timing-metric.php';
-	require_once $plugin_dir . 'server-timing/class-perflab-server-timing.php';
-	require_once $plugin_dir . 'server-timing/load.php';
-	require_once $plugin_dir . 'server-timing/defaults.php';
+		$plugins_dir = defined( 'WP_PLUGIN_DIR' ) ? WP_PLUGIN_DIR : WP_CONTENT_DIR . '/plugins';
+		$plugin_dir  = $plugins_dir . '/performance-lab/';
+		if ( ! file_exists( $plugin_dir . 'server-timing/load.php' ) ) {
+			$plugin_dir = $plugins_dir . '/performance/';
+			if ( ! file_exists( $plugin_dir . 'server-timing/load.php' ) ) {
+				return;
+			}
+		}
+
+		require_once $plugin_dir . 'server-timing/class-perflab-server-timing-metric.php';
+		require_once $plugin_dir . 'server-timing/class-perflab-server-timing.php';
+		require_once $plugin_dir . 'server-timing/load.php';
+		require_once $plugin_dir . 'server-timing/defaults.php';
+	}
 }
 perflab_load_server_timing_api_from_dropin();
 

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -283,63 +283,10 @@ class Load_Tests extends WP_UnitTestCase {
 		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
 		$this->assertFalse( PERFLAB_OBJECT_CACHE_DROPIN_VERSION );
 
-		// Run function to place drop-in and ensure it exists afterwards, and
-		// the dummy one is backed up to object-cache-plst-orig.php.
+		// Run function to place drop-in and ensure it does not override the existing drop-in.
 		perflab_maybe_set_object_cache_dropin();
 		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertSame( file_get_contents( PERFLAB_PLUGIN_DIR_PATH . 'server-timing/object-cache.copy.php' ), $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
-		$this->assertSame( $dummy_file_content, $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
-	}
-
-	public function test_perflab_maybe_set_object_cache_dropin_with_conflict_and_orig_same_files() {
-		global $wp_filesystem;
-
-		$this->set_up_mock_filesystem();
-
-		$dummy_file_content = '<?php /* Empty object-cache.php drop-in file. */';
-		$wp_filesystem->put_contents( WP_CONTENT_DIR . '/object-cache.php', $dummy_file_content );
-		$wp_filesystem->put_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php', $dummy_file_content );
-
-		// Ensure two dummy object-cache.php drop-ins are present and PL constant is not set.
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
-		$this->assertFalse( PERFLAB_OBJECT_CACHE_DROPIN_VERSION );
-
-		// Run function to place drop-in and ensure it exists afterwards, and
-		// the dummy one remains backed up to object-cache-plst-orig.php. Since
-		// both files were the same, the original one could just be replaced.
-		perflab_maybe_set_object_cache_dropin();
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertSame( file_get_contents( PERFLAB_PLUGIN_DIR_PATH . 'server-timing/object-cache.copy.php' ), $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
-		$this->assertSame( $dummy_file_content, $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
-	}
-
-	public function test_perflab_maybe_set_object_cache_dropin_with_conflict_and_orig_different_files() {
-		global $wp_filesystem;
-
-		$this->set_up_mock_filesystem();
-
-		$dummy_file_content1 = '<?php /* Empty object-cache.php drop-in file 1. */';
-		$dummy_file_content2 = '<?php /* Empty object-cache.php drop-in file 2. */';
-		$wp_filesystem->put_contents( WP_CONTENT_DIR . '/object-cache.php', $dummy_file_content1 );
-		$wp_filesystem->put_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php', $dummy_file_content2 );
-
-		// Ensure two dummy object-cache.php drop-ins are present and PL constant is not set.
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
-		$this->assertFalse( PERFLAB_OBJECT_CACHE_DROPIN_VERSION );
-
-		// Run function to place drop-in, but in this case it should not modify
-		// anything. There are already two different object-cache.php drop-ins,
-		// one main one, and another backup one, so it is better not to touch
-		// them, in order to avoid any risk of breakage.
-		perflab_maybe_set_object_cache_dropin();
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertSame( $dummy_file_content1, $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' ) );
-		$this->assertTrue( $wp_filesystem->exists( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
-		$this->assertSame( $dummy_file_content2, $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache-plst-orig.php' ) );
+		$this->assertSame( $dummy_file_content, $wp_filesystem->get_contents( WP_CONTENT_DIR . '/object-cache.php' ) );
 	}
 
 	public function test_perflab_object_cache_dropin_may_be_disabled_via_filter() {


### PR DESCRIPTION
## Summary

Fixes #630

## Relevant technical choices

* So far, if there was an existing `object-cache.php` drop-in, the plugin would attempt to rename it to `object-cache-plst-orig.php`, then place its own `object-cache.php` file which would then also `require_once` the renamed original drop-in. This worked correctly in principle, however several popular plugins regularly check the file contents of the `object-cache.php` file to check whether their drop-in is present rather than checking for e.g. a constant that the file sets. Due to that behavior, in practice the approach the Performance Lab plugin has taken led to several incompatibilities. This PR fixes that problem going forward by removing that approach. Now the Performance Lab drop-in will only be placed if no conflicting drop-in is present.
* Some code around the `object-cache-plst-orig.php` file is maintained for backward compatibility: For example, for sites for which that approach has been working as expected, it will need to be ensured that the deactivation routine not only deletes the Performance Lab `object-cache.php` drop-in, but also restores the original drop-in (i.e. renames `object-cache-plst-orig.php` back to `object-cache.php`).
* Several comments have been added to explain the changes so that the context is clear for any future reference when looking at the code.
* The PR also adds a `function_exists()` check around the one function that the Performance Lab drop-in defines to prevent any fatal error e.g. in case another drop-in like `advanced-cache.php` loads the `object-cache.php` drop-in extra early.

## Testing instructions

### Without existing drop-in
1. Make sure there is no `wp-content/object-cache.php` file in your setup.
2. Activate PL plugin in WP Admin.
3. Validate that the `wp-content/object-cache.php` file now exists and has the same content as the `server-timing/object-cache.copy.php` file within the plugin.
4. Deactivate the PL plugin.
5. Validate that the `wp-content/object-cache.php` file no longer exists.

### With drop-in already present
1. Manually copy the plugin's `server-timing/object-cache.copy.php` file to `wp-content/object-cache.php`.
2. Activate PL plugin in WP Admin.
3. Validate that the `wp-content/object-cache.php` file still exists and has the same content as the `server-timing/object-cache.copy.php` file within the plugin.
4. Deactivate the PL plugin.
5. Validate that the `wp-content/object-cache.php` file no longer exists.

### With conflicting drop-in present
1. Place a custom PHP file (e.g. with just a comment, or you could use an actual `object-cache.php` drop-in from a plugin like e.g. W3 Total Cache) in `wp-content/object-cache.php`.
2. Activate PL plugin in WP Admin.
3. Validate that the `wp-content/object-cache.php` file still exists and has the same content as before. The plugin's own file should _not_ replace it.
4. Deactivate the PL plugin.
5. Validate that the `wp-content/object-cache.php` file _still_ exists (as it is not our own, so we shouldn't remove it).

### With old code (our drop-in plus renamed other drop-in)
1. Manually copy the plugin's `server-timing/object-cache.copy.php` file to `wp-content/object-cache.php`.
2. Place a custom PHP file (e.g. with just a comment, or you could use an actual `object-cache.php` drop-in from a plugin like e.g. W3 Total Cache) in `wp-content/object-cache-plst-orig.php`.
3. Activate PL plugin in WP Admin.
4. Validate that the `wp-content/object-cache.php` and `wp-content/object-cache-plst-orig.php` files still exist and have the same content as before.
5. Deactivate the PL plugin.
6. Validate that the `wp-content/object-cache.php` file now has the content that previously was in the `wp-content/object-cache-plst-orig.php` file, and that the `wp-content/object-cache-plst-orig.php` file is now removed (as in that case we need to restore the other drop-in in its original location, which was something the plugin used to do, so this is critical for backward compatibility with older PL plugin versions).

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
