### PR TITLE
Add pointer for where to report security bugs to `readme.txt`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.1
-Tested up to:      6.1
+Tested up to:      6.2
 Requires PHP:      5.6
 Stable tag:        2.0.0
 License:           GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,12 @@ Per the primary purpose of the plugin (see above), it can mostly be considered a
 
 Feedback is encouraged and much appreciated, especially since this plugin is a collection of future WordPress core features. If you have suggestions or requests for new features, you can [submit them as an issue in the Performance Lab GitHub repository](https://github.com/WordPress/performance/issues/new/choose). If you need help with troubleshooting or have a question about the plugin, please [create a new topic on our support forum](https://wordpress.org/support/plugin/performance-lab/#new-topic-0).
 
+= Where can I report security bugs? =
+
+The Performance team and WordPress community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please visit the [WordPress HackerOne](https://hackerone.com/wordpress) program.
+
 = How can I contribute to the plugin? =
 
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).


### PR DESCRIPTION
## Summary

This is being added per request from the WordPress security team.

## Relevant technical choices

* Uses the same copy we already have in our `SECURITY.md` file.
* Also sets Tested up to version to WP 6.2, since the plugin works as expected with it and it'll be out in less than 2 weeks.
* Both of those are worth including in Monday's release since the changes are just documentation related, and particularly the latter is time-sensitive.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
