### PR TITLE
Update the module constant

### DIFF
--- a/bin/plugin/commands/build-plugins.js
+++ b/bin/plugin/commands/build-plugins.js
@@ -81,6 +81,13 @@ exports.handler = async () => {
 						regex: '@package\\s{1,}performance-lab',
 						result: '@package ' + pluginSlug,
 					} );
+
+					// Update version constant.
+					updateModuleDetails( {
+						pluginPath: buildModulePath,
+						regex: '[\']Performance Lab [\'] . PERFLAB_VERSION',
+						result: `'${ pluginVersion }'`,
+					} );
 				} catch ( error ) {
 					log(
 						formats.error(


### PR DESCRIPTION
## Summary
This PR is followup work in which the `build-plugins` command updates the constant value defined in #666.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
