### PR TITLE
Fix JS lint errors by formatting with Prettier

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -73,11 +73,12 @@ withOptions( program.command( 'module-translations' ), translationsOptions )
 	)
 	.action( catchException( translationsHandler ) );
 
-withOptions( program.command( 'build-standalone-plugins' ), buildPluginsOptions )
+withOptions(
+	program.command( 'build-standalone-plugins' ),
+	buildPluginsOptions
+)
 	.alias( 'build-plugins' )
-	.description(
-		'Build standalone plugins'
-	)
+	.description( 'Build standalone plugins' )
 	.action( catchException( buildPluginsHandler ) );
 
 withOptions(

--- a/bin/plugin/commands/build-plugins.js
+++ b/bin/plugin/commands/build-plugins.js
@@ -20,11 +20,7 @@ exports.handler = async () => {
 	const pluginsFile = path.join( '.', 'plugins.json' );
 	fs.readFile( pluginsFile, 'utf8', ( err, jsonString ) => {
 		if ( err ) {
-			log(
-				formats.error(
-					`Error reading file from disk: "${ err }"`
-				)
-			);
+			log( formats.error( `Error reading file from disk: "${ err }"` ) );
 		}
 
 		try {
@@ -45,12 +41,20 @@ exports.handler = async () => {
 				try {
 					// Copy module files from the folder.
 					const modulePath = path.join( '.', 'modules/' + moduleDir );
-					const buildModulePath = path.join( '.', 'build/' + pluginSlug );
+					const buildModulePath = path.join(
+						'.',
+						'build/' + pluginSlug
+					);
 					try {
 						// Clean up build module files directory.
-						fs.rmSync( buildModulePath, { force: true, recursive: true } );
+						fs.rmSync( buildModulePath, {
+							force: true,
+							recursive: true,
+						} );
 
-						fs.copySync( modulePath, buildModulePath, { overwrite: true } );
+						fs.copySync( modulePath, buildModulePath, {
+							overwrite: true,
+						} );
 					} catch ( copyError ) {
 						log(
 							formats.error(
@@ -71,7 +75,7 @@ exports.handler = async () => {
 					// Update text domain.
 					updateModuleDetails( {
 						pluginPath: buildModulePath,
-						regex: '[\']performance-lab[\']',
+						regex: "[']performance-lab[']",
 						result: `'${ pluginSlug }'`,
 					} );
 
@@ -82,18 +86,12 @@ exports.handler = async () => {
 						result: '@package ' + pluginSlug,
 					} );
 				} catch ( error ) {
-					log(
-						formats.error(
-							`${ error }`
-						)
-					);
+					log( formats.error( `${ error }` ) );
 				}
 			}
 		} catch ( jsonError ) {
 			log(
-				formats.error(
-					`Error parsing JSON string: "${ jsonError }"`
-				)
+				formats.error( `Error parsing JSON string: "${ jsonError }"` )
 			);
 		}
 	} );
@@ -120,11 +118,7 @@ async function updatePluginHeader( settings ) {
 	}
 
 	if ( buildLoadFileContent === '' ) {
-		log(
-			formats.error(
-				`Error reading the file "${ buildLoadFile }"`
-			)
-		);
+		log( formats.error( `Error reading the file "${ buildLoadFile }"` ) );
 		return false;
 	}
 	const moduleHeader = await getModuleHeader( buildLoadFileContent );
@@ -149,12 +143,13 @@ async function updatePluginHeader( settings ) {
  `;
 	try {
 		// Replace the module file header.
-		fs.writeFileSync( buildLoadFile, buildLoadFileContent.replace( moduleHeader, pluginHeader ) );
+		fs.writeFileSync(
+			buildLoadFile,
+			buildLoadFileContent.replace( moduleHeader, pluginHeader )
+		);
 	} catch ( error ) {
 		log(
-			formats.error(
-				`Error replacing module file header: "${ error }"`
-			)
+			formats.error( `Error replacing module file header: "${ error }"` )
 		);
 	}
 }
@@ -165,9 +160,7 @@ async function updatePluginHeader( settings ) {
  * @param {Object} settings Plugin settings.
  */
 async function updateModuleDetails( settings ) {
-	const patterns = [
-		path.resolve( settings.pluginPath, './**/*.php' ),
-	];
+	const patterns = [ path.resolve( settings.pluginPath, './**/*.php' ) ];
 
 	const files = await glob( patterns, {
 		ignore: [ __filename ],
@@ -188,11 +181,7 @@ async function updateModuleDetails( settings ) {
 		}
 
 		if ( content === '' ) {
-			log(
-				formats.error(
-					`Error reading the file "${ file }"`
-				)
-			);
+			log( formats.error( `Error reading the file "${ file }"` ) );
 			return false;
 		}
 

--- a/bin/plugin/commands/common.js
+++ b/bin/plugin/commands/common.js
@@ -148,7 +148,7 @@ exports.getModuleDataFromHeader = ( moduleHeader ) => {
 	// Parse experimental field into a boolean.
 	if ( typeof moduleData.experimental === 'string' ) {
 		moduleData.experimental =
-		moduleData.experimental.toLowerCase() === 'yes';
+			moduleData.experimental.toLowerCase() === 'yes';
 	}
 
 	return moduleData;
@@ -161,7 +161,7 @@ exports.getModuleDataFromHeader = ( moduleHeader ) => {
  * @return {string} Module file header.
  */
 exports.getModuleHeader = ( moduleFileContent ) => {
-	const regex = /\/\\*\\*[\s\S]+?(?=\*\/)/mi;
+	const regex = /\/\\*\\*[\s\S]+?(?=\*\/)/im;
 	const moduleHeader = moduleFileContent.match( regex )?.[ 0 ];
 	return moduleHeader;
 };


### PR DESCRIPTION
## Summary

I just noticed this locally in my code editor being flagged. We only added a GitHub action workflow for this recently in `trunk` that wasn't executed prior in the `feature/creating-standalone-plugins` branch, which is probably why we missed this before.

This PR can be approved simply based on whether the CI workflows pass.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
