### PR TITLE
Include `WordPress-Extra` rules in PHPCS configuration and fix resulting problems

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -138,18 +138,13 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 			<?php if ( perflab_can_load_module( $module_slug ) ) { ?>
 				<input type="checkbox" id="<?php echo esc_attr( "{$base_id}_enabled" ); ?>" name="<?php echo esc_attr( "{$base_name}[enabled]" ); ?>" aria-describedby="<?php echo esc_attr( "{$base_id}_description" ); ?>" value="1"<?php checked( $enabled ); ?>>
 				<?php
+					printf(
+						/* translators: %s: module name */
+						esc_html__( 'Enable %s', 'performance-lab' ),
+						esc_html( $module_data['name'] )
+					);
 				if ( $module_data['experimental'] ) {
-					printf(
-						/* translators: %s: module name */
-						__( 'Enable %s <strong>(experimental)</strong>', 'performance-lab' ),
-						esc_html( $module_data['name'] )
-					);
-				} else {
-					printf(
-						/* translators: %s: module name */
-						__( 'Enable %s', 'performance-lab' ),
-						esc_html( $module_data['name'] )
-					);
+					echo '<strong>' . esc_html__( '(experimental)', 'performance-lab' ) . '</strong>';
 				}
 				?>
 			<?php } else { ?>
@@ -173,7 +168,7 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 				} else {
 					printf(
 						/* translators: %s: module name */
-						__( '%s is already part of your WordPress version and therefore cannot be loaded as part of the plugin.', 'performance-lab' ),
+						esc_html__( '%s is already part of your WordPress version and therefore cannot be loaded as part of the plugin.', 'performance-lab' ),
 						esc_html( $module_data['name'] )
 					);
 				}
@@ -250,7 +245,7 @@ function perflab_get_modules( $modules_root = null ) {
 
 	$modules      = array();
 	$module_files = array();
-	$modules_dir  = @opendir( $modules_root );
+	$modules_dir  = @opendir( $modules_root ); // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
 
 	// Modules are organized as {focus}/{module-slug} in the modules folder.
 	if ( $modules_dir ) {
@@ -265,7 +260,7 @@ function perflab_get_modules( $modules_root = null ) {
 				continue;
 			}
 
-			$focus_dir = @opendir( $modules_root . '/' . $focus );
+			$focus_dir = @opendir( $modules_root . '/' . $focus ); // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
 			if ( $focus_dir ) {
 				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				while ( ( $file = readdir( $focus_dir ) ) !== false ) {
@@ -274,7 +269,7 @@ function perflab_get_modules( $modules_root = null ) {
 						continue;
 					}
 
-					$module_dir = @opendir( $modules_root . '/' . $focus . '/' . $file );
+					$module_dir = @opendir( $modules_root . '/' . $focus . '/' . $file ); // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
 					if ( $module_dir ) {
 						// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 						while ( ( $subfile = readdir( $module_dir ) ) !== false ) {

--- a/admin/load.php
+++ b/admin/load.php
@@ -144,7 +144,7 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 						esc_html( $module_data['name'] )
 					);
 				if ( $module_data['experimental'] ) {
-					echo '<strong>' . esc_html__( '(experimental)', 'performance-lab' ) . '</strong>';
+					echo ' <strong>' . esc_html__( '(experimental)', 'performance-lab' ) . '</strong>';
 				}
 				?>
 			<?php } else { ?>

--- a/admin/load.php
+++ b/admin/load.php
@@ -254,7 +254,8 @@ function perflab_get_modules( $modules_root = null ) {
 	$modules      = array();
 	$module_files = array();
 	// PHPCS ignore reason: A modules directory is always present.
-	$modules_dir = @opendir( $modules_root ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+	// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+	$modules_dir = @opendir( $modules_root );
 
 	// Modules are organized as {focus}/{module-slug} in the modules folder.
 	if ( $modules_dir ) {
@@ -270,7 +271,8 @@ function perflab_get_modules( $modules_root = null ) {
 			}
 
 			// PHPCS ignore reason: Only the focus area directory is allowed.
-			$focus_dir = @opendir( $modules_root . '/' . $focus ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+			$focus_dir = @opendir( $modules_root . '/' . $focus );
 			if ( $focus_dir ) {
 				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				while ( ( $file = readdir( $focus_dir ) ) !== false ) {
@@ -280,7 +282,8 @@ function perflab_get_modules( $modules_root = null ) {
 					}
 
 					// PHPCS ignore reason: Only the module directory is allowed.
-					$module_dir = @opendir( $modules_root . '/' . $focus . '/' . $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					$module_dir = @opendir( $modules_root . '/' . $focus . '/' . $file );
 					if ( $module_dir ) {
 						// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 						while ( ( $subfile = readdir( $module_dir ) ) !== false ) {

--- a/admin/load.php
+++ b/admin/load.php
@@ -138,13 +138,21 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 			<?php if ( perflab_can_load_module( $module_slug ) ) { ?>
 				<input type="checkbox" id="<?php echo esc_attr( "{$base_id}_enabled" ); ?>" name="<?php echo esc_attr( "{$base_name}[enabled]" ); ?>" aria-describedby="<?php echo esc_attr( "{$base_id}_description" ); ?>" value="1"<?php checked( $enabled ); ?>>
 				<?php
+				if ( $module_data['experimental'] ) {
+					printf(
+						wp_kses(
+							/* translators: %s: module name */
+							__( 'Enable %s <strong>(experimental)</strong>', 'performance-lab' ),
+							array( 'strong' => array() )
+						),
+						esc_html( $module_data['name'] )
+					);
+				} else {
 					printf(
 						/* translators: %s: module name */
 						esc_html__( 'Enable %s', 'performance-lab' ),
 						esc_html( $module_data['name'] )
 					);
-				if ( $module_data['experimental'] ) {
-					echo ' <strong>' . esc_html__( '(experimental)', 'performance-lab' ) . '</strong>';
 				}
 				?>
 			<?php } else { ?>
@@ -245,7 +253,8 @@ function perflab_get_modules( $modules_root = null ) {
 
 	$modules      = array();
 	$module_files = array();
-	$modules_dir  = @opendir( $modules_root ); // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+	// PHPCS ignore reason: A modules directory is always present.
+	$modules_dir = @opendir( $modules_root ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 
 	// Modules are organized as {focus}/{module-slug} in the modules folder.
 	if ( $modules_dir ) {
@@ -260,7 +269,8 @@ function perflab_get_modules( $modules_root = null ) {
 				continue;
 			}
 
-			$focus_dir = @opendir( $modules_root . '/' . $focus ); // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+			// PHPCS ignore reason: Only the focus area directory is allowed.
+			$focus_dir = @opendir( $modules_root . '/' . $focus ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			if ( $focus_dir ) {
 				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				while ( ( $file = readdir( $focus_dir ) ) !== false ) {
@@ -269,7 +279,8 @@ function perflab_get_modules( $modules_root = null ) {
 						continue;
 					}
 
-					$module_dir = @opendir( $modules_root . '/' . $focus . '/' . $file ); // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+					// PHPCS ignore reason: Only the module directory is allowed.
+					$module_dir = @opendir( $modules_root . '/' . $focus . '/' . $file ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 					if ( $module_dir ) {
 						// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 						while ( ( $subfile = readdir( $module_dir ) ) !== false ) {

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
@@ -326,7 +326,7 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 		global $wpdb;
 		$u = umask( 0000 );
 		if ( ! is_dir( FQDBDIR ) ) {
-			if ( ! @mkdir( FQDBDIR, 0704, true ) ) {
+			if ( ! @mkdir( FQDBDIR, 0704, true ) ) { // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
 				umask( $u );
 				$message = __( 'Unable to create the required directory! Please check your server settings.', 'performance-lab' );
 				wp_die( $message, 'Error!' );

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-engine.php
@@ -326,7 +326,7 @@ class Perflab_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 		global $wpdb;
 		$u = umask( 0000 );
 		if ( ! is_dir( FQDBDIR ) ) {
-			if ( ! @mkdir( FQDBDIR, 0704, true ) ) { // phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+			if ( ! @mkdir( FQDBDIR, 0704, true ) ) {
 				umask( $u );
 				$message = __( 'Unable to create the required directory! Please check your server settings.', 'performance-lab' );
 				wp_die( $message, 'Error!' );

--- a/modules/images/dominant-color/hooks.php
+++ b/modules/images/dominant-color/hooks.php
@@ -236,6 +236,8 @@ if ( version_compare( '6', $GLOBALS['wp_version'], '>=' ) ) {
  */
 function dominant_color_add_inline_style() {
 	$handle = 'dominant-color-styles';
+	// PHPCS ignore reason: Dominant color add single line inline style that does not change frequently,
+	// so we need to avoid specifying a version at all.
 	wp_register_style( $handle, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_style( $handle );
 	$custom_css = 'img[data-dominant-color]:not(.has-transparency) { background-color: var(--dominant-color); }';

--- a/modules/images/dominant-color/hooks.php
+++ b/modules/images/dominant-color/hooks.php
@@ -236,7 +236,7 @@ if ( version_compare( '6', $GLOBALS['wp_version'], '>=' ) ) {
  */
 function dominant_color_add_inline_style() {
 	$handle = 'dominant-color-styles';
-	wp_register_style( $handle, false );
+	wp_register_style( $handle, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_style( $handle );
 	$custom_css = 'img[data-dominant-color]:not(.has-transparency) { background-color: var(--dominant-color); }';
 	wp_add_inline_style( $handle, $custom_css );

--- a/modules/images/dominant-color/hooks.php
+++ b/modules/images/dominant-color/hooks.php
@@ -236,9 +236,9 @@ if ( version_compare( '6', $GLOBALS['wp_version'], '>=' ) ) {
  */
 function dominant_color_add_inline_style() {
 	$handle = 'dominant-color-styles';
-	// PHPCS ignore reason: Dominant color add single line inline style that does not change frequently,
-	// so the version number is not used.
-	wp_register_style( $handle, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	// PHPCS ignore reason: Version not used since this handle is only registered for adding an inline style.
+	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	wp_register_style( $handle, false );
 	wp_enqueue_style( $handle );
 	$custom_css = 'img[data-dominant-color]:not(.has-transparency) { background-color: var(--dominant-color); }';
 	wp_add_inline_style( $handle, $custom_css );

--- a/modules/images/dominant-color/hooks.php
+++ b/modules/images/dominant-color/hooks.php
@@ -237,7 +237,7 @@ if ( version_compare( '6', $GLOBALS['wp_version'], '>=' ) ) {
 function dominant_color_add_inline_style() {
 	$handle = 'dominant-color-styles';
 	// PHPCS ignore reason: Dominant color add single line inline style that does not change frequently,
-	// so we need to avoid specifying a version at all.
+	// so the version number is not used.
 	wp_register_style( $handle, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_style( $handle );
 	$custom_css = 'img[data-dominant-color]:not(.has-transparency) { background-color: var(--dominant-color); }';

--- a/modules/images/webp-uploads/hooks.php
+++ b/modules/images/webp-uploads/hooks.php
@@ -242,7 +242,7 @@ function webp_uploads_wp_get_missing_image_subsizes( $missing_sizes, $image_meta
 	 * @see wp_update_image_subsizes()
 	 * @see wp_get_missing_image_subsizes()
 	 */
-	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 );
+	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 
 	foreach ( $trace as $element ) {
 		if ( isset( $element['function'] ) && 'wp_update_image_subsizes' === $element['function'] ) {

--- a/modules/images/webp-uploads/hooks.php
+++ b/modules/images/webp-uploads/hooks.php
@@ -242,7 +242,9 @@ function webp_uploads_wp_get_missing_image_subsizes( $missing_sizes, $image_meta
 	 * @see wp_update_image_subsizes()
 	 * @see wp_get_missing_image_subsizes()
 	 */
-	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+	// PHPCS ignore reason: Only the way to generate missing image subsize if all core sub-sizes have been generated.
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 );
 
 	foreach ( $trace as $element ) {
 		if ( isset( $element['function'] ) && 'wp_update_image_subsizes' === $element['function'] ) {

--- a/modules/images/webp-uploads/image-edit.php
+++ b/modules/images/webp-uploads/image-edit.php
@@ -120,7 +120,7 @@ function webp_uploads_update_image_onchange( $override, $file_path, $editor, $mi
 
 			$old_metadata = wp_get_attachment_metadata( $post_id );
 			$resize_sizes = array();
-			$target       = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all';
+			$target       = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			foreach ( $old_metadata['sizes'] as $size_name => $size_details ) {
 				// If the target is 'nothumb', skip generating the 'thumbnail' size.
@@ -237,7 +237,7 @@ add_filter( 'wp_save_image_editor_file', 'webp_uploads_update_image_onchange', 1
  * @return array The updated metadata for the attachment to be stored in the meta table.
  */
 function webp_uploads_update_attachment_metadata( $data, $attachment_id ) {
-	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 );
+	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
 
 	foreach ( $trace as $element ) {
 		if ( ! isset( $element['function'] ) ) {
@@ -272,7 +272,7 @@ add_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_met
  * @return array The updated metadata for the attachment.
  */
 function webp_uploads_backup_sources( $attachment_id, $data ) {
-	$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all';
+	$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 	// When an edit to an image is only applied to a thumbnail there's nothing we need to back up.
 	if ( 'thumbnail' === $target ) {

--- a/modules/images/webp-uploads/image-edit.php
+++ b/modules/images/webp-uploads/image-edit.php
@@ -120,7 +120,8 @@ function webp_uploads_update_image_onchange( $override, $file_path, $editor, $mi
 
 			$old_metadata = wp_get_attachment_metadata( $post_id );
 			$resize_sizes = array();
-			$target       = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// PHPCS ignore reason: A nonce check is not necessary here as this logic directly ties in with WordPress core logic which already has one.
+			$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 			foreach ( $old_metadata['sizes'] as $size_name => $size_details ) {
 				// If the target is 'nothumb', skip generating the 'thumbnail' size.

--- a/modules/images/webp-uploads/image-edit.php
+++ b/modules/images/webp-uploads/image-edit.php
@@ -120,8 +120,10 @@ function webp_uploads_update_image_onchange( $override, $file_path, $editor, $mi
 
 			$old_metadata = wp_get_attachment_metadata( $post_id );
 			$resize_sizes = array();
-			// PHPCS ignore reason: A nonce check is not necessary here as this logic directly ties in with WordPress core logic which already has one.
-			$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// PHPCS ignore reason: A nonce check is not necessary here as this logic directly ties in with WordPress core
+			// function `wp_ajax_image_editor()` which already has one.
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all';
 
 			foreach ( $old_metadata['sizes'] as $size_name => $size_details ) {
 				// If the target is 'nothumb', skip generating the 'thumbnail' size.
@@ -238,7 +240,9 @@ add_filter( 'wp_save_image_editor_file', 'webp_uploads_update_image_onchange', 1
  * @return array The updated metadata for the attachment to be stored in the meta table.
  */
 function webp_uploads_update_attachment_metadata( $data, $attachment_id ) {
-	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+	// PHPCS ignore reason: Update the attachment's metadata by either restoring or editing it.
+	// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_debug_backtrace
+	$trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 10 );
 
 	foreach ( $trace as $element ) {
 		if ( ! isset( $element['function'] ) ) {
@@ -273,7 +277,10 @@ add_filter( 'wp_update_attachment_metadata', 'webp_uploads_update_attachment_met
  * @return array The updated metadata for the attachment.
  */
 function webp_uploads_backup_sources( $attachment_id, $data ) {
-	$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	// PHPCS ignore reason: A nonce check is not necessary here as this logic directly ties in with WordPress core
+	// function `wp_ajax_image_editor()` which already has one.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all';
 
 	// When an edit to an image is only applied to a thumbnail there's nothing we need to back up.
 	if ( 'thumbnail' === $target ) {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -8,6 +8,7 @@
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress-Extra">
 		<exclude-pattern>tests/*</exclude-pattern>
+		<!-- TODO The SQLite module generates a lot of notices and errors, so it will be covered later. -->
 		<exclude-pattern>modules/database/sqlite/*</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.WP.I18n"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,8 +5,11 @@
 	<rule ref="PHPCompatibility"/>
 	<config name="testVersion" value="5.6-"/>
 
-	<rule ref="WordPress-Core"/>
 	<rule ref="WordPress-Docs"/>
+	<rule ref="WordPress-Extra">
+		<exclude-pattern>tests/*</exclude-pattern>
+		<exclude-pattern>modules/database/sqlite/*</exclude-pattern>
+	</rule>
 	<rule ref="WordPress.WP.I18n"/>
 	<config name="text_domain" value="performance-lab,default"/>
 
@@ -68,4 +71,9 @@
 	<rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.boolFound">
 		<exclude-pattern>tests/utils/*</exclude-pattern>
 	</rule>
+	<!--
+	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
+	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
+	-->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 </ruleset>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #691 

The PR add Include `WordPress-Extra` rules in PHPCS configuration and fix resulting problems.

For now i have exclude `sqlite` module files as it shows many files to change. 

## Checklist

- [ ] PR has either `[Focus]` or `Infrastructure` label.
- [ ] PR has a `[Type]` label.
- [ ] PR has a milestone or the `no milestone` label.
