### PR TITLE
Generator meta tag for WebP Uploads standalone plugin

### DIFF
--- a/modules/images/webp-uploads/hooks.php
+++ b/modules/images/webp-uploads/hooks.php
@@ -773,7 +773,7 @@ add_filter( 'wp_editor_set_quality', 'webp_uploads_modify_webp_quality', 10, 2 )
 function webp_uploads_render_generator() {
 	if (
 		defined( 'WEBP_UPLOADS_VERSION' ) &&
-		! str_starts_with( constant( 'WEBP_UPLOADS_VERSION' ), 'Performance Lab ' )
+		! str_starts_with( WEBP_UPLOADS_VERSION, 'Performance Lab ' )
 	) {
 		echo '<meta name="generator" content="WebP Uploads ' . esc_attr( WEBP_UPLOADS_VERSION ) . '">' . "\n";
 	}

--- a/modules/images/webp-uploads/hooks.php
+++ b/modules/images/webp-uploads/hooks.php
@@ -775,7 +775,7 @@ function webp_uploads_render_generator() {
 		defined( 'WEBP_UPLOADS_VERSION' ) &&
 		! str_starts_with( constant( 'WEBP_UPLOADS_VERSION' ), 'Performance Lab ' )
 	) {
-		echo '<meta name="generator" content="Performance Lab plugin: webp-uploads:' . WEBP_UPLOADS_VERSION . '" />' . "\n";
+		echo '<meta name="generator" content="WebP Uploads ' . esc_attr( WEBP_UPLOADS_VERSION ) . '">' . "\n";
 	}
 }
 add_action( 'wp_head', 'webp_uploads_render_generator' );

--- a/modules/images/webp-uploads/hooks.php
+++ b/modules/images/webp-uploads/hooks.php
@@ -762,3 +762,20 @@ function webp_uploads_modify_webp_quality( $quality, $mime_type ) {
 	return $quality;
 }
 add_filter( 'wp_editor_set_quality', 'webp_uploads_modify_webp_quality', 10, 2 );
+
+/**
+ * Displays the HTML generator tag for the WebP Uploads plugin.
+ *
+ * See {@see 'wp_head'}.
+ *
+ * @since n.e.x.t
+ */
+function webp_uploads_render_generator() {
+	if (
+		defined( 'WEBP_UPLOADS_VERSION' ) &&
+		! str_starts_with( constant( 'WEBP_UPLOADS_VERSION' ), 'Performance Lab ' )
+	) {
+		echo '<meta name="generator" content="Performance Lab plugin: webp-uploads:' . WEBP_UPLOADS_VERSION . '" />' . "\n";
+	}
+}
+add_action( 'wp_head', 'webp_uploads_render_generator' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #692 

This PR adds a generator meta tag for the WebP Uploads module. We can use the same function for other modules once the WebP Uploads plugin is released.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
