### PR TITLE
Rename `Dominant Color` module to `Dominant Color images`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -49,7 +49,7 @@
 /tests/modules/js-and-css/audit-enqueued-assets                             @manuelRod
 /tests/testdata/modules/js-and-css/audit-enqueued-assets                    @manuelRod
 
-# Module: Dominant Color
+# Module: Dominant Color Images
 /modules/images/dominant-color                                              @pbearne @spacedmonkey
 /tests/modules/images/dominant-color                                        @pbearne @spacedmonkey
 /tests/testdata/modules/images/dominant-color                               @pbearne @spacedmonkey

--- a/modules/images/dominant-color/helper.php
+++ b/modules/images/dominant-color/helper.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Helper functions used for Dominant Color.
+ * Helper functions used for Dominant Color Images.
  *
  * @package performance-lab
  * @since 2.1.0

--- a/modules/images/dominant-color/hooks.php
+++ b/modules/images/dominant-color/hooks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Hook callbacks used for Dominant Color.
+ * Hook callbacks used for Dominant Color Images.
  *
  * @package performance-lab
  * @since 2.1.0

--- a/modules/images/dominant-color/load.php
+++ b/modules/images/dominant-color/load.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Dominant Color
+ * Module Name: Dominant Color Images
  * Description: Adds support to store dominant color for an image and create a placeholder background with that color.
  * Experimental: No
  *


### PR DESCRIPTION
## Summary

Related to #640, however can be merged independently.

## Relevant technical choices

* Per https://github.com/WordPress/performance/issues/638#issuecomment-1480343450, the `Dominant Color` module should be renamed to `Dominant Color Images`, since the `dominant-color` slug is already taken by another plugin in the WordPress plugin repository. It was decided to go with that name in the linked discussion.
* While we are only going to publish the standalone plugin later, we can already rename the module independently of that.
* I opened this separate PR to do just that, also to make it more visible, as this way it'll independently appear as an entry in the PL plugin's changelog.
* Note that the name is not yet translated in the `readme.txt` and the `module-i18n.php` files, which is not necessary as that will automatically happen as part of the release preparation scripts (see https://make.wordpress.org/performance/handbook/performance-lab/releasing-the-plugin/#preparing-the-release).

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
