### PR TITLE
Add dominant color styling before any existing inline style attributes

### DIFF
--- a/modules/images/dominant-color-images/hooks.php
+++ b/modules/images/dominant-color-images/hooks.php
@@ -62,7 +62,9 @@ function dominant_color_update_attachment_image_attributes( $attr, $attachment )
 		if ( empty( $attr['style'] ) ) {
 			$attr['style'] = '';
 		}
-		$attr['style'] .= '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';';
+		$style_attribute = $attr['style'];
+		$attr['style']   = '';
+		$attr['style']  .= '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';' . $style_attribute;
 	}
 
 	return $attr;

--- a/modules/images/dominant-color-images/hooks.php
+++ b/modules/images/dominant-color-images/hooks.php
@@ -59,12 +59,8 @@ function dominant_color_update_attachment_image_attributes( $attr, $attachment )
 
 	if ( ! empty( $image_meta['dominant_color'] ) ) {
 		$attr['data-dominant-color'] = esc_attr( $image_meta['dominant_color'] );
-		if ( empty( $attr['style'] ) ) {
-			$attr['style'] = '';
-		}
-		$style_attribute = $attr['style'];
-		$attr['style']   = '';
-		$attr['style']  .= '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';' . $style_attribute;
+		$style_attribute = empty( $attr['style'] ) ? '' : $attr['style'];
+		$attr['style']   = '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';' . $style_attribute;
 	}
 
 	return $attr;

--- a/modules/images/dominant-color-images/hooks.php
+++ b/modules/images/dominant-color-images/hooks.php
@@ -59,8 +59,8 @@ function dominant_color_update_attachment_image_attributes( $attr, $attachment )
 
 	if ( ! empty( $image_meta['dominant_color'] ) ) {
 		$attr['data-dominant-color'] = esc_attr( $image_meta['dominant_color'] );
-		$style_attribute = empty( $attr['style'] ) ? '' : $attr['style'];
-		$attr['style']   = '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';' . $style_attribute;
+		$style_attribute             = empty( $attr['style'] ) ? '' : $attr['style'];
+		$attr['style']               = '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';' . $style_attribute;
 	}
 
 	return $attr;

--- a/tests/modules/images/dominant-color-images/dominant-color-test.php
+++ b/tests/modules/images/dominant-color-images/dominant-color-test.php
@@ -200,6 +200,43 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	}
 
 	/**
+	 * Tests that the dominant color style always comes before other existing inline styles.
+	 *
+	 * @dataProvider data_provider_dominant_color_filter_check_inline_style
+	 *
+	 * @param string $style_attr The image style attribute.
+	 * @param string $expected   The expected style attribute and value.
+	 */
+	public function test_dominant_color_update_attachment_image_attributes( $style_attr, $expected ) {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/dominant-color-images/red.jpg' );
+		
+		$attachment_image = wp_get_attachment_image( $attachment_id, 'full', '', array( "style" => $style_attr )  );
+		$this->assertStringContainsString( $expected, $attachment_image );
+	}
+
+	/**
+	 * Data provider for test_dominant_color_update_attachment_image_attributes().
+	 *
+	 * @return array[]
+	 */
+	public function data_provider_dominant_color_filter_check_inline_style() {
+		return array(
+			'no inline styles'                   => array(
+				'style_attr' => '',
+				'expected'   => 'style="--dominant-color: #fe0000;"',
+			),
+			'inline style with end semicolon'    => array(
+				'style_attr' => 'color: #ffffff;',
+				'expected'   => 'style="--dominant-color: #fe0000;color: #ffffff;"',
+			),
+			'inline style without end semicolon' => array(
+				'style_attr' => 'color: #ffffff',
+				'expected'   => 'style="--dominant-color: #fe0000;color: #ffffff"',
+			),
+		);
+	}
+
+	/**
 	 * Tests dominant_color_set_image_editors().
 	 *
 	 * @dataProvider provider_dominant_color_set_image_editors


### PR DESCRIPTION
## Summary

To replicate the issue follow below steps:
- Go to Admin Panel then add new post
- Upload featured image for the post
- Add Cover block in which use "Use featured image" for image
- Select "FOCAL POINT PICKER"
- Check frontend.

**Before the patch:**
<img width="1345" alt="Screenshot 2023-04-20 at 2 37 17 PM" src="https://user-images.githubusercontent.com/10103365/233317502-0ea265e5-ddd5-4085-9635-ed5a3ebaf9e3.png">

**After the patch:**
<img width="1361" alt="Screenshot 2023-04-20 at 2 36 49 PM" src="https://user-images.githubusercontent.com/10103365/233317580-63e23bce-6b2c-4de1-910d-dca043486481.png">

Initially i also think about to use `str_ends_with` but it will create problem when someone add style with space i.e.`display: block; ` then it give false result.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #658

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
