### PR TITLE
Temporarily remove Dominant Color Images from standalone `plugins.json` definition

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,8 +1,4 @@
 {
-  "images/dominant-color-images": {
-    "slug": "dominant-color-images",
-    "version": "1.0.0"
-  },
   "images/fetchpriority": {
     "slug": "fetchpriority",
     "version": "1.0.0"


### PR DESCRIPTION
## Summary

This is a temporary change just to remove the standalone plugin entry for `dominant-color-images` from `plugins.json`, since the plugin was just submitted for review, and the review process will at least take 25 days.

Since we have at least one more Performance Lab release before, we need to remove it to avoid workflow failures when that release happens.

Any other references to the standalone plugin in the code can remain, just this one needs to be temporarily removed for the above reason.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
