### PR TITLE
Merge 2.3.0 release back to `trunk`

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -508,7 +508,7 @@ function perflab_plugin_action_links_add_settings( $links ) {
  * This function adds a nonce check before dismissing perflab-admin-pointer
  * It runs before the dismiss-wp-pointer AJAX action is performed.
  *
- * @since n.e.x.t
+ * @since 2.3.0
  * @see perflab_render_modules_pointer()
  */
 function perflab_dismiss_wp_pointer_wrapper() {

--- a/admin/load.php
+++ b/admin/load.php
@@ -508,7 +508,7 @@ function perflab_plugin_action_links_add_settings( $links ) {
  * This function adds a nonce check before dismissing perflab-admin-pointer
  * It runs before the dismiss-wp-pointer AJAX action is performed.
  *
- * @since 2.2.1
+ * @since n.e.x.t
  * @see perflab_render_modules_pointer()
  */
 function perflab_dismiss_wp_pointer_wrapper() {

--- a/admin/load.php
+++ b/admin/load.php
@@ -467,6 +467,7 @@ function perflab_render_pointer() {
 						{
 							pointer: 'perflab-admin-pointer',
 							action:  'dismiss-wp-pointer',
+							_wpnonce: <?php echo wp_json_encode( wp_create_nonce( 'dismiss_pointer' ) ); ?>,
 						}
 					);
 				}
@@ -500,3 +501,21 @@ function perflab_plugin_action_links_add_settings( $links ) {
 
 	return $links;
 }
+
+/**
+ * Dismisses notification pointer after verfying nonce.
+ *
+ * This function adds a nonce check before dismissing perflab-admin-pointer
+ * It runs before the dismiss-wp-pointer AJAX action is performed.
+ *
+ * @since 2.2.1
+ * @see perflab_render_modules_pointer()
+ */
+function perflab_dismiss_wp_pointer_wrapper() {
+	if ( isset( $_POST['pointer'] ) && 'perflab-admin-pointer' !== $_POST['pointer'] ) {
+		// Another plugin's pointer, do nothing.
+		return;
+	}
+	check_ajax_referer( 'dismiss_pointer' );
+}
+add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 0 );

--- a/load.php
+++ b/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance modules.
  * Requires at least: 6.1
  * Requires PHP: 5.6
- * Version: 2.2.0
+ * Version: 2.3.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later

--- a/modules/images/dominant-color-images/hooks.php
+++ b/modules/images/dominant-color-images/hooks.php
@@ -248,7 +248,7 @@ add_filter( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
  *
  * See {@see 'wp_head'}.
  *
- * @since n.e.x.t
+ * @since 2.3.0
  */
 function dominant_color_render_generator() {
 	if (

--- a/modules/images/fetchpriority/hooks.php
+++ b/modules/images/fetchpriority/hooks.php
@@ -56,7 +56,7 @@ add_filter( 'post_thumbnail_html', 'fetchpriority_filter_post_thumbnail_html' );
  *
  * See {@see 'wp_head'}.
  *
- * @since n.e.x.t
+ * @since 2.3.0
  */
 function fetchpriority_render_generator() {
 	if (

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.1
 Tested up to:      6.2
 Requires PHP:      5.6
-Stable tag:        2.2.0
+Stable tag:        2.3.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, javascript, site health, measurement, object caching

--- a/readme.txt
+++ b/readme.txt
@@ -81,6 +81,18 @@ By default, the WebP Uploads module will only generate WebP versions of the imag
 
 == Changelog ==
 
+= 2.3.0 =
+
+**Enhancements**
+
+* Images: Configure `Dominant Color` and `Fetchpriority` modules for their standalone plugins. ([704](https://github.com/WordPress/performance/pull/704))
+* Infrastructure: Temporarily remove Dominant Color Images from standalone `plugins.json` definition. ([719](https://github.com/WordPress/performance/pull/719))
+* Infrastructure: Use dynamic version from `plugins.json` for manual workflow. ([710](https://github.com/WordPress/performance/pull/710))
+
+**Bug Fixes**
+
+* Images: Add dominant color styling before any existing inline style attributes. ([716](https://github.com/WordPress/performance/pull/716))
+
 = 2.2.0 =
 
 **Enhancements**


### PR DESCRIPTION
## Summary

Fixes #720 

## Relevant technical choices

This just merges the 2.3.0 release branch to trunk. All code has already been approved, so this is just a formality.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
