### PR TITLE
Update @since inline doc

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -508,7 +508,7 @@ function perflab_plugin_action_links_add_settings( $links ) {
  * This function adds a nonce check before dismissing perflab-admin-pointer
  * It runs before the dismiss-wp-pointer AJAX action is performed.
  *
- * @since n.e.x.t
+ * @since 2.3.0
  * @see perflab_render_modules_pointer()
  */
 function perflab_dismiss_wp_pointer_wrapper() {


### PR DESCRIPTION
## Summary

Updates an inline `@since` doc that was missed during the release process.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
