### PR TITLE
Add missing 2.3.0 changelog entry

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -92,6 +92,7 @@ By default, the WebP Uploads module will only generate WebP versions of the imag
 **Bug Fixes**
 
 * Images: Add dominant color styling before any existing inline style attributes. ([716](https://github.com/WordPress/performance/pull/716))
+* Infrastructure: Resolve low-severity security advisory [GHSA-66qq-69rw-6x63](https://github.com/WordPress/performance/security/advisories/GHSA-66qq-69rw-6x63).
 
 = 2.2.0 =
 


### PR DESCRIPTION
## Summary

## Relevant technical choices

* Adds missing changelog entry for 2.3.0 release about resolved security advisory.
* The advisory URL https://github.com/WordPress/performance/security/advisories/GHSA-66qq-69rw-6x63 is intentionally not public yet, and will be published in a few days from now to give time for sites to update first.
    * Due to this being a low severity issue, this is strictly speaking not that critical, but still a best practice worth following.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
