### PR TITLE
Use static closures for minor performance improvement whenever instance access is not needed

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -79,7 +79,7 @@ function perflab_load_modules_page( $modules = null, $focus_areas = null ) {
 		add_settings_field(
 			$module_slug,
 			$module_data['name'],
-			function() use ( $module_slug, $module_data, $module_settings ) {
+			static function() use ( $module_slug, $module_data, $module_settings ) {
 				perflab_render_modules_page_field( $module_slug, $module_data, $module_settings );
 			},
 			PERFLAB_MODULES_SCREEN,
@@ -329,7 +329,7 @@ function perflab_get_modules( $modules_root = null ) {
 
 	uasort(
 		$modules,
-		function( $a, $b ) {
+		static function( $a, $b ) {
 			return strnatcasecmp( $a['name'], $b['name'] );
 		}
 	);

--- a/admin/load.php
+++ b/admin/load.php
@@ -442,7 +442,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 		wp_enqueue_script( 'wp-pointer' );
 		add_action(
 			'admin_print_footer_scripts',
-			function() {
+			static function() {
 				$content  = __( 'The SQLite module will be removed in the upcoming Performance Lab release in favor of a standalone plugin.', 'performance-lab' );
 				$content .= ' ' . sprintf(
 					/* translators: %s: settings page link */
@@ -580,7 +580,7 @@ add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 
  */
 add_action(
 	'admin_notices',
-	function() {
+	static function() {
 		global $hook_suffix;
 
 		// Only show in the WordPress dashboard and Performance Lab admin screen.

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
     "phpcompatibility/php-compatibility": "^9.3",
     "phpunit/phpunit": "^4|^5|^6|^7|^8|^9",
+    "slevomat/coding-standard": "^8.0",
     "squizlabs/php_codesniffer": "^3.5",
     "wp-coding-standards/wpcs": "^2.2",
     "wp-phpunit/wp-phpunit": "^5.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "800fb1ee62ef74aa3e6c6cd409939cff",
+    "content-hash": "74407702964db355128ee84aec3248df",
     "packages": [
         {
             "name": "composer/installers",
@@ -591,6 +591,51 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
             "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.20.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "reference": "7d568c87a9df9c5f7e8b5f075fc469aa8cb0a4cd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.4"
+            },
+            "time": "2023-05-02T09:19:37+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1977,6 +2022,71 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "slevomat/coding-standard",
+            "version": "8.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "cc04334ed0ce5a251389112fbd2dbe1dbc931ae8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/cc04334ed0ce5a251389112fbd2dbe1dbc931ae8",
+                "reference": "cc04334ed0ce5a251389112fbd2dbe1dbc931ae8",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": ">=1.20.0 <1.21.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.15",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.3.11",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.8|10.1.3"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-05-14T20:06:01+00:00"
+        },
+        {
             "name": "squizlabs/php_codesniffer",
             "version": "3.7.1",
             "source": {
@@ -2252,5 +2362,5 @@
         "php": ">=5.6|^7|^8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "74407702964db355128ee84aec3248df",
+    "content-hash": "32fa41f51359ae28fd9313097e1bfee6",
     "packages": [
         {
             "name": "composer/installers",
@@ -236,30 +236,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^0.16 || ^1",
                 "phpstan/phpstan": "^1.4",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -286,7 +286,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -302,20 +302,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614"
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/14daed4296fae74d9e3201d2c4925d1acb7aa614",
-                "reference": "14daed4296fae74d9e3201d2c4925d1acb7aa614",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
                 "shasum": ""
             },
             "require": {
@@ -353,7 +353,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
             },
             "funding": [
                 {
@@ -361,20 +361,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T13:19:32+00:00"
+            "time": "2023-03-08T13:26:56+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.2",
+            "version": "v4.15.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc"
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
-                "reference": "f59bbe44bf7d96f24f3e2b4ddc21cd52c1d2adbc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
                 "shasum": ""
             },
             "require": {
@@ -415,9 +415,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
             },
-            "time": "2022-11-12T15:38:23+00:00"
+            "time": "2023-03-05T19:49:14+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -639,23 +639,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.19",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c77b56b63e3d2031bd8997fcec43c1925ae46559",
-                "reference": "c77b56b63e3d2031bd8997fcec43c1925ae46559",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.14",
+                "nikic/php-parser": "^4.15",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -670,8 +670,8 @@
                 "phpunit/phpunit": "^9.3"
             },
             "suggest": {
-                "ext-pcov": "*",
-                "ext-xdebug": "*"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
@@ -704,7 +704,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.19"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -712,7 +712,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-11-18T07:47:47+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -957,20 +957,20 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.27",
+            "version": "9.6.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38"
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a2bc7ffdca99f92d959b3f2270529334030bba38",
-                "reference": "a2bc7ffdca99f92d959b3f2270529334030bba38",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/17d621b3aff84d0c8b62539e269e87d8d5baa76e",
+                "reference": "17d621b3aff84d0c8b62539e269e87d8d5baa76e",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.3.1",
+                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -999,8 +999,8 @@
                 "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "*",
-                "ext-xdebug": "*"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -1008,7 +1008,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.5-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -1039,7 +1039,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.27"
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.8"
             },
             "funding": [
                 {
@@ -1055,7 +1056,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-09T07:31:23+00:00"
+            "time": "2023-05-11T05:14:45+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1357,16 +1358,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
-                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
                 "shasum": ""
             },
             "require": {
@@ -1411,7 +1412,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
             },
             "funding": [
                 {
@@ -1419,20 +1420,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:10:38+00:00"
+            "time": "2023-05-07T05:35:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/1b5dff7bb151a4db11d49d90e5408e4e938270f7",
-                "reference": "1b5dff7bb151a4db11d49d90e5408e4e938270f7",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
@@ -1474,7 +1475,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -1482,7 +1483,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-04-03T09:37:03+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1796,16 +1797,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.4",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/cd9d8cf3c5804de4341c283ed787f099f5506172",
-                "reference": "cd9d8cf3c5804de4341c283ed787f099f5506172",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
@@ -1844,10 +1845,10 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -1855,7 +1856,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:17:30+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -1914,16 +1915,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "3.2.0",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e"
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
-                "reference": "fb3fe09c5f0bae6bc27ef3ce933a1e0ed9464b6e",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
                 "shasum": ""
             },
             "require": {
@@ -1958,7 +1959,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -1966,7 +1967,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-12T14:47:03+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2088,16 +2089,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
-                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
@@ -2133,14 +2134,15 @@
             "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2022-06-18T07:21:10+00:00"
+            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2293,16 +2295,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c"
+                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
-                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
+                "reference": "3b59adeef77fb1c03ff5381dbb9d68b0aaff3171",
                 "shasum": ""
             },
             "require": {
@@ -2310,13 +2312,12 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.1"
+                "yoast/yoastcs": "^2.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.x-dev",
-                    "dev-develop": "1.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -2350,7 +2351,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2022-11-16T09:07:52+00:00"
+            "time": "2023-03-30T23:39:05+00:00"
         }
     ],
     "aliases": [],

--- a/load.php
+++ b/load.php
@@ -66,7 +66,7 @@ function perflab_get_modules_setting_default() {
 		$default_enabled_modules = require PERFLAB_PLUGIN_DIR_PATH . 'default-enabled-modules.php';
 		$default_option          = array_reduce(
 			$default_enabled_modules,
-			function( $module_settings, $module_dir ) {
+			static function( $module_settings, $module_dir ) {
 				$module_settings[ $module_dir ] = array( 'enabled' => true );
 				return $module_settings;
 			},
@@ -93,7 +93,7 @@ function perflab_sanitize_modules_setting( $value ) {
 	// Ensure that every element is an array with an 'enabled' key.
 	return array_filter(
 		array_map(
-			function( $module_settings ) {
+			static function( $module_settings ) {
 				if ( ! is_array( $module_settings ) ) {
 					return array();
 				}
@@ -148,7 +148,7 @@ function perflab_get_active_modules() {
 	$modules = array_keys(
 		array_filter(
 			perflab_get_module_settings(),
-			function( $module_settings ) {
+			static function( $module_settings ) {
 				return isset( $module_settings['enabled'] ) && $module_settings['enabled'];
 			}
 		)
@@ -520,7 +520,7 @@ add_action(
 	 * @param string $option Name of the option to add.
 	 * @param mixed  $value  Value of the option.
 	 */
-	function( $option, $value ) {
+	static function( $option, $value ) {
 		perflab_run_module_activation_deactivation( perflab_get_modules_setting_default(), $value );
 	},
 	10,

--- a/modules/database/sqlite/activate.php
+++ b/modules/database/sqlite/activate.php
@@ -11,7 +11,7 @@
  *
  * @since 1.8.0
  */
-return function() {
+return static function() {
 	// Bail early if the SQLite3 class does not exist.
 	if ( ! class_exists( 'SQLite3' ) ) {
 		return;
@@ -58,7 +58,7 @@ return function() {
 	// but rather remains in the Performance Lab modules screen.
 	add_filter(
 		'wp_redirect',
-		function( $redirect_location ) {
+		static function( $redirect_location ) {
 			if ( ! defined( 'DATABASE_TYPE' ) ) {
 				define( 'DATABASE_TYPE', 'sqlite' );
 			}
@@ -118,7 +118,7 @@ return function() {
 			// Since $admin_user->user_pass is already hashed, add a filter to
 			// ensure it is inserted into the database like that, instead of
 			// being re-hashed.
-			$unhash_user_pass = function( $data, $update, $user_id, $userdata ) use ( $admin_user, $current_user ) {
+			$unhash_user_pass = static function( $data, $update, $user_id, $userdata ) use ( $admin_user, $current_user ) {
 				// Double check this is actually the already hashed password,
 				// to prevent any chance of accidentally putting another
 				// password into the database which would then be plain text.

--- a/modules/database/sqlite/can-load.php
+++ b/modules/database/sqlite/can-load.php
@@ -11,7 +11,7 @@
  *
  * @since 1.8.0
  */
-return function() {
+return static function() {
 
 	// If the PERFLAB_SQLITE_DB_DROPIN_VERSION constant is defined, then the module is already active.
 	if ( defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) ) {

--- a/modules/database/sqlite/deactivate.php
+++ b/modules/database/sqlite/deactivate.php
@@ -11,7 +11,7 @@
  *
  * @since 1.8.0
  */
-return function() {
+return static function() {
 	if ( ! defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) || ! file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
 		return;
 	}
@@ -28,7 +28,7 @@ return function() {
 	// Run an action on `shutdown`, to deactivate the option in the MySQL database.
 	add_action(
 		'shutdown',
-		function() {
+		static function() {
 			global $table_prefix;
 
 			// Get credentials for the MySQL database.

--- a/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-driver.php
+++ b/modules/database/sqlite/wp-includes/sqlite/class-perflab-sqlite-pdo-driver.php
@@ -737,7 +737,7 @@ class Perflab_SQLite_PDO_Driver {
 				$_wpdb   = null;
 				usort(
 					$results,
-					function ( $a, $b ) use ( $flipped ) {
+					static function ( $a, $b ) use ( $flipped ) {
 						return $flipped[ $a->ID ] - $flipped[ $b->ID ];
 					}
 				);

--- a/modules/images/webp-uploads/can-load.php
+++ b/modules/images/webp-uploads/can-load.php
@@ -6,6 +6,6 @@
  * @package performance-lab
  */
 
-return function() {
+return static function() {
 	return ! function_exists( 'wp_image_use_alternate_mime_types' );
 };

--- a/modules/images/webp-uploads/image-edit.php
+++ b/modules/images/webp-uploads/image-edit.php
@@ -103,7 +103,7 @@ function webp_uploads_update_image_onchange( $override, $file_path, $editor, $mi
 	$callback_executed = false;
 	add_filter(
 		'wp_update_attachment_metadata',
-		function ( $metadata, $post_meta_id ) use ( $post_id, $file_path, $mime_type, $editor, $mime_transforms, &$callback_executed ) {
+		static function ( $metadata, $post_meta_id ) use ( $post_id, $file_path, $mime_type, $editor, $mime_transforms, &$callback_executed ) {
 			if ( $post_meta_id !== $post_id ) {
 				return $metadata;
 			}
@@ -297,7 +297,7 @@ function webp_uploads_backup_sources( $attachment_id, $data ) {
 	// Prevent execution of the callbacks more than once if the callback was already executed.
 	$has_been_processed = false;
 
-	$hook = function ( $meta_id, $post_id, $meta_name ) use ( $attachment_id, $sources, &$has_been_processed ) {
+	$hook = static function ( $meta_id, $post_id, $meta_name ) use ( $attachment_id, $sources, &$has_been_processed ) {
 		// Make sure this hook is only executed in the same context for the provided $attachment_id.
 		if ( $post_id !== $attachment_id ) {
 			return;

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -24,7 +24,7 @@ if ( function_exists( 'webp_uploads_create_sources_property' ) ) {
 if ( ! require __DIR__ . '/can-load.php' ) {
 	add_action(
 		'admin_notices',
-		function() {
+		static function() {
 			printf(
 				'<div class="notice notice-error"><p>%s</p></div>',
 				esc_html__( 'The WebP Uploads feature cannot be loaded from within the plugin since it is already merged into WordPress core.', 'performance-lab' )

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -72,6 +72,11 @@
 	<rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.boolFound">
 		<exclude-pattern>tests/utils/*</exclude-pattern>
 	</rule>
+
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
 	<!--
 	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
 	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -73,9 +73,7 @@
 		<exclude-pattern>tests/utils/*</exclude-pattern>
 	</rule>
 
-	<rule ref="SlevomatCodingStandard.Functions.StaticClosure">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
 
 	<!--
 	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -81,7 +81,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		remove_all_filters( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ) );
 
 		// Does not register the page if the perflab_active_modules filter is used.
-		add_filter( 'perflab_active_modules', function() {} );
+		add_filter( 'perflab_active_modules', static function() {} );
 		$hook_suffix = perflab_add_modules_page();
 		$this->assertFalse( $hook_suffix );
 		$this->assertFalse( isset( $_wp_submenu_nopriv['options-general.php'][ PERFLAB_MODULES_SCREEN ] ) );

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -81,7 +81,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 		remove_all_filters( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ) );
 
 		// Does not register the page if the perflab_active_modules filter is used.
-		add_filter( 'perflab_active_modules', static function() {} );
+		add_filter( 'perflab_active_modules', '__return_null' );
 		$hook_suffix = perflab_add_modules_page();
 		$this->assertFalse( $hook_suffix );
 		$this->assertFalse( isset( $_wp_submenu_nopriv['options-general.php'][ PERFLAB_MODULES_SCREEN ] ) );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,7 +41,7 @@ $GLOBALS['wp_tests_options'] = array(
 require_once $_test_root . '/includes/functions.php';
 tests_add_filter(
 	'plugins_loaded',
-	function() {
+	static function() {
 		require_once TESTS_PLUGIN_DIR . '/admin/load.php';
 		$module_files = glob( TESTS_PLUGIN_DIR . '/modules/*/*/load.php' );
 		if ( $module_files ) {

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -78,7 +78,7 @@ class Load_Tests extends WP_UnitTestCase {
 		$has_passed_default = false;
 		add_filter(
 			'default_option_' . PERFLAB_MODULES_SETTING,
-			function( $default, $option, $passed_default ) use ( &$has_passed_default ) {
+			static function( $default, $option, $passed_default ) use ( &$has_passed_default ) {
 				// This callback just records whether there is a default value being passed.
 				$has_passed_default = $passed_default;
 				return $default;
@@ -134,7 +134,7 @@ class Load_Tests extends WP_UnitTestCase {
 		$expected_active_modules = array_keys(
 			array_filter(
 				perflab_get_modules_setting_default(),
-				function( $module_settings ) {
+				static function( $module_settings ) {
 					return $module_settings['enabled'];
 				}
 			)
@@ -158,7 +158,7 @@ class Load_Tests extends WP_UnitTestCase {
 		array_pop( $active_modules );
 		add_filter(
 			'perflab_active_modules',
-			function() use ( $active_modules ) {
+			static function() use ( $active_modules ) {
 				return $active_modules;
 			}
 		);
@@ -229,7 +229,7 @@ class Load_Tests extends WP_UnitTestCase {
 		$default_enabled_modules = require PERFLAB_PLUGIN_DIR_PATH . 'default-enabled-modules.php';
 		return array_reduce(
 			$default_enabled_modules,
-			function( $module_settings, $module_dir ) {
+			static function( $module_settings, $module_dir ) {
 				$module_settings[ $module_dir ] = array( 'enabled' => true );
 				return $module_settings;
 			},
@@ -312,13 +312,13 @@ class Load_Tests extends WP_UnitTestCase {
 
 		add_filter(
 			'filesystem_method_file',
-			function() {
+			static function() {
 				return __DIR__ . '/utils/Filesystem/WP_Filesystem_MockFilesystem.php';
 			}
 		);
 		add_filter(
 			'filesystem_method',
-			function() {
+			static function() {
 				return 'MockFilesystem';
 			}
 		);

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -144,14 +144,14 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 	public function provider_with_modified_metadata() {
 		yield 'using a size that does not exists' => array(
-			function ( $metadata ) {
+			static function ( $metadata ) {
 				return $metadata;
 			},
 			'not-existing-size',
 		);
 
 		yield 'removing an existing metadata simulating that the image size still does not exists' => array(
-			function ( $metadata ) {
+			static function ( $metadata ) {
 				unset( $metadata['sizes']['medium'] );
 
 				return $metadata;
@@ -160,7 +160,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		);
 
 		yield 'when the specified size is not a valid array' => array(
-			function ( $metadata ) {
+			static function ( $metadata ) {
 				$metadata['sizes']['medium'] = null;
 
 				return $metadata;
@@ -237,7 +237,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		add_filter(
 			'wp_image_editors',
-			function () {
+			static function () {
 				return array( 'WP_Image_Doesnt_Support_WebP' );
 			}
 		);
@@ -259,7 +259,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
-			function () {
+			static function () {
 				return array(
 					'file' => 'image.webp',
 					'path' => '/tmp/image.webp',
@@ -293,7 +293,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
-			function () {
+			static function () {
 				return array(
 					'file'     => 'image.webp',
 					'filesize' => 777,
@@ -328,7 +328,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 		add_filter(
 			'webp_uploads_pre_generate_additional_image_source',
-			function () {
+			static function () {
 				return new WP_Error( 'image_additional_generated_error', __( 'Additional image was not generated.', 'performance-lab' ) );
 			}
 		);
@@ -366,7 +366,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_return_default_transforms_when_filter_returns_non_array_type() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			function () {
+			static function () {
 				return;
 			}
 		);
@@ -390,7 +390,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_return_fallback_transforms_when_overwritten_invalid_transforms() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			function () {
+			static function () {
 				return array( 'image/jpeg' => array() );
 			}
 		);
@@ -409,7 +409,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	public function it_should_return_custom_transforms_when_overwritten_by_filter() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			function () {
+			static function () {
 				return array( 'image/jpeg' => array( 'image/jpeg', 'image/webp' ) );
 			}
 		);
@@ -525,7 +525,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		$result = null;
 		add_action(
 			'wp_head',
-			function() use ( &$result ) {
+			static function() use ( &$result ) {
 				$result = webp_uploads_in_frontend_body();
 			}
 		);

--- a/tests/modules/images/webp-uploads/image-edit-tests.php
+++ b/tests/modules/images/webp-uploads/image-edit-tests.php
@@ -239,7 +239,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		// The leafs image is 1080 pixels wide with this filter we ensure a -scaled version is created for this test.
 		add_filter(
 			'big_image_size_threshold',
-			function () {
+			static function () {
 				// Due to the largest image size is 1024 and the image is 1080x720, 1050 is a good spot to create a scaled size for all images sizes.
 				return 1050;
 			}

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -26,7 +26,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function tear_down() {
 		$this->to_unlink = array_filter(
 			$this->to_unlink,
-			function ( $filename ) {
+			static function ( $filename ) {
 				return unlink( $filename );
 			}
 		);
@@ -186,7 +186,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_create_the_sources_property_when_no_transform_is_available() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			function () {
+			static function () {
 				return array( 'image/jpeg' => array() );
 			}
 		);
@@ -213,7 +213,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_not_create_the_sources_property_if_the_mime_is_not_specified_on_the_transforms_images() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			function () {
+			static function () {
 				return array( 'image/jpeg' => array() );
 			}
 		);
@@ -289,7 +289,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// The leafs image is 1080 pixels wide with this filter we ensure a -scaled version is created.
 		add_filter(
 			'big_image_size_threshold',
-			function () {
+			static function () {
 				return 850;
 			}
 		);
@@ -544,7 +544,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		add_filter(
 			'webp_uploads_content_image_mimes',
-			function( $mime_types ) {
+			static function( $mime_types ) {
 				unset( $mime_types[ array_search( 'image/webp', $mime_types, true ) ] );
 				return $mime_types;
 			}
@@ -633,7 +633,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 		// Use a 1500 threshold.
 		add_filter(
 			'big_image_size_threshold',
-			function () {
+			static function () {
 				return 1500;
 			}
 		);
@@ -685,7 +685,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_allow_the_upload_of_a_webp_image_if_at_least_one_editor_supports_the_format() {
 		add_filter(
 			'wp_image_editors',
-			function () {
+			static function () {
 				// WP core does not choose the WP_Image_Editor instance based on MIME type support,
 				// therefore the one that does support WebP needs to be first in this list.
 				return array( 'WP_Image_Editor_GD', 'WP_Image_Doesnt_Support_WebP' );
@@ -733,7 +733,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		add_filter(
 			'webp_uploads_pre_replace_additional_image_source',
-			function() {
+			static function() {
 				return '<img src="https://ia600200.us.archive.org/16/items/SPD-SLRSY-1867/hubblesite_2001_06.jpg">';
 			}
 		);
@@ -899,7 +899,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_create_mime_types_for_allowed_sizes_only_via_filter() {
 		add_filter(
 			'webp_uploads_image_sizes_with_additional_mime_type_support',
-			function( $sizes ) {
+			static function( $sizes ) {
 				$sizes['allowed_size_400x300'] = true;
 				return $sizes;
 			}

--- a/tests/modules/images/webp-uploads/rest-api-tests.php
+++ b/tests/modules/images/webp-uploads/rest-api-tests.php
@@ -24,7 +24,7 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			function( $transforms ) {
+			static function( $transforms ) {
 				$transforms['image/jpeg'] = array( 'image/jpeg', 'image/webp' );
 				return $transforms;
 			}

--- a/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -101,7 +101,7 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 		$expected_path = WP_CONTENT_DIR . '/themes/test-theme/style.css';
 		add_filter(
 			'content_url',
-			function( $url ) {
+			static function( $url ) {
 				return site_url() . '/content';
 			}
 		);

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -25,7 +25,7 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 		perflab_server_timing_register_metric(
 			'test-metric',
 			array(
-				'measure_callback' => function( $metric ) {
+				'measure_callback' => static function( $metric ) {
 					$metric->set_value( 100 );
 				},
 				'access_cap'       => 'exist',
@@ -42,7 +42,7 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_perflab_wrap_server_timing() {
-		$cb = function() {
+		$cb = static function() {
 			return 123;
 		};
 

--- a/tests/server-timing/perflab-server-timing-tests.php
+++ b/tests/server-timing/perflab-server-timing-tests.php
@@ -17,7 +17,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$dummy_args = array(
-			'measure_callback' => function() {},
+			'measure_callback' => static function() {},
 			'access_cap'       => 'exist',
 		);
 
@@ -38,7 +38,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 		$this->server_timing->register_metric(
 			'test-metric',
 			array(
-				'measure_callback' => function() use ( &$called ) {
+				'measure_callback' => static function() use ( &$called ) {
 					$called = true;
 				},
 				'access_cap'       => 'exist',
@@ -52,7 +52,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 	public function test_register_metric_runs_measure_callback_based_on_access_cap() {
 		$called = false;
 		$args   = array(
-			'measure_callback' => function() use ( &$called ) {
+			'measure_callback' => static function() use ( &$called ) {
 				$called = true;
 			},
 			'access_cap'       => 'manage_options', // Admin capability.
@@ -106,7 +106,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-access-cap',
-			array( 'measure_callback' => function() {} )
+			array( 'measure_callback' => static function() {} )
 		);
 
 		$this->assertFalse( $this->server_timing->has_registered_metric( 'metric-without-access-cap' ) );
@@ -130,13 +130,13 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 	}
 
 	public function data_get_header() {
-		$measure_42         = function( $metric ) {
+		$measure_42         = static function( $metric ) {
 			$metric->set_value( 42 );
 		};
-		$measure_300        = function( $metric ) {
+		$measure_300        = static function( $metric ) {
 			$metric->set_value( 300 );
 		};
-		$measure_12point345 = function( $metric ) {
+		$measure_12point345 = static function( $metric ) {
 			$metric->set_value( 12.345 );
 		};
 

--- a/tests/server-timing/perflab-server-timing-tests.php
+++ b/tests/server-timing/perflab-server-timing-tests.php
@@ -17,7 +17,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
 		self::$dummy_args = array(
-			'measure_callback' => static function() {},
+			'measure_callback' => '__return_null',
 			'access_cap'       => 'exist',
 		);
 
@@ -106,7 +106,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-access-cap',
-			array( 'measure_callback' => static function() {} )
+			array( 'measure_callback' => '__return_null' )
 		);
 
 		$this->assertFalse( $this->server_timing->has_registered_metric( 'metric-without-access-cap' ) );

--- a/tests/testdata/demo-modules/something/demo-module-2/activate.php
+++ b/tests/testdata/demo-modules/something/demo-module-2/activate.php
@@ -6,6 +6,6 @@
  * @package performance-lab
  */
 
-return function() {
+return static function() {
 	update_option( 'test_demo_module_activation_status', 'activated' );
 };

--- a/tests/testdata/demo-modules/something/demo-module-2/deactivate.php
+++ b/tests/testdata/demo-modules/something/demo-module-2/deactivate.php
@@ -6,6 +6,6 @@
  * @package performance-lab
  */
 
-return function() {
+return static function() {
 	update_option( 'test_demo_module_activation_status', 'deactivated' );
 };

--- a/tests/utils/TestCase/ImagesTestCase.php
+++ b/tests/utils/TestCase/ImagesTestCase.php
@@ -116,7 +116,7 @@ abstract class ImagesTestCase extends WP_UnitTestCase {
 	public function opt_in_to_jpeg_and_webp() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			function( $transforms ) {
+			static function( $transforms ) {
 				$transforms['image/jpeg'] = array( 'image/jpeg', 'image/webp' );
 				$transforms['image/webp'] = array( 'image/webp', 'image/jpeg' );
 				return $transforms;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #728

## Relevant technical choices

* Added the `SlevomatCodingStandard.Functions.StaticClosure` sniff to the PHPCS ruleset.
* Ran PHPCBF to add `static` where relevant.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
