### PR TITLE
Make `Server-Timing` header output more robust

### DIFF
--- a/server-timing/class-perflab-server-timing.php
+++ b/server-timing/class-perflab-server-timing.php
@@ -227,16 +227,11 @@ class Perflab_Server_Timing {
 			return $passthrough;
 		}
 
-		ob_start();
-		add_action(
-			'shutdown',
-			function() {
-				$output = ob_get_clean();
+		ob_start(
+			function( $output ) {
 				$this->send_header();
-				echo $output;
-			},
-			// phpcs:ignore PHPCompatibility.Constants.NewConstants
-			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -1000
+				return $output;
+			}
 		);
 		return $passthrough;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

I activated the plugin on my local WP core Docker environment and filtered `perflab_server_timing_use_output_buffer` to enable output buffering, yet I did not see the `Server-Timing` header.

The `shutdown` hook is too late to send the header, but using the `ob_start()` callback for this works.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
