### PR TITLE
Implement migration prompt to migrate from SQLite module to standalone plugin due to removal in the following release

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -647,14 +647,16 @@ add_action(
 		$step3_before      = $todo_before;
 		$step3_after       = $todo_after;
 		$step3_placeholder = 'SQLite';
-		if ( 'index.php' === $hook_suffix ) { // Link to Performance Lab settings.
+		if ( 'index.php' === $hook_suffix && defined( 'SQLITE_MAIN_FILE' ) ) {
+			// Link to Performance Lab settings.
 			$screen_url = add_query_arg(
 				'page',
 				PERFLAB_MODULES_SCREEN,
 				admin_url( 'options-general.php' )
 			);
 
-			$step3_placeholder = '<a href="' . esc_url( $screen_url ) . '">' . $step3_placeholder . '</a>';
+			$step3_before .= '<a href="' . esc_url( $screen_url ) . '">';
+			$step3_after   = '</a>' . $step3_after;
 		}
 
 		/*

--- a/admin/load.php
+++ b/admin/load.php
@@ -201,7 +201,10 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 			<?php else : ?>
 				<?php // Don't use the WP notice classes here, as that makes them move to the top of the page. ?>
 				<p class="notice notice-warning" style="padding:1em;max-width:50em;">
-					<?php esc_html_e( 'Enabling this module will switch to a separate database and install WordPress in it. You will need to reconfigure your site, and start with a fresh site. Disabling the module you will get back to your previous MySQL database, with all your previous data intact.', 'performance-lab' ); ?>
+					<?php esc_html_e( 'It is not advised to activate this module since it will be removed in the upcoming Performance Lab release.', 'performance-lab' ); ?>
+					<a href="https://wordpress.org/plugins/sqlite-database-integration">
+						<?php esc_html_e( 'Please use the standalone plugin instead.', 'performance-lab' ); ?>
+					</a>
 				</p>
 			<?php endif; ?>
 		<?php endif; ?>
@@ -417,6 +420,47 @@ function perflab_admin_pointer( $hook_suffix ) {
 	$current_user = get_current_user_id();
 	$dismissed    = explode( ',', (string) get_user_meta( $current_user, 'dismissed_wp_pointers', true ) );
 
+	/*
+	 * Temporary: Show an admin pointer if SQLite module is active to prompt
+	 * for an action to use the standalone plugin instead.
+	 *
+	 * This code will be removed again when the SQLite module is removed from
+	 * the codebase.
+	 */
+	if (
+		defined( 'SQLITE_VERSION' )
+		&& str_starts_with( SQLITE_VERSION, 'Performance Lab ' )
+		&& ! in_array( 'perflab-sqlite-module-removal-pointer', $dismissed, true )
+		&& current_user_can( 'activate_plugins' )
+	) {
+		/*
+		 * Enqueue the pointer logic and return early. A closure is used to
+		 * avoid introducing a new function as it should be removed again in
+		 * the following release.
+		 */
+		wp_enqueue_style( 'wp-pointer' );
+		wp_enqueue_script( 'wp-pointer' );
+		add_action(
+			'admin_print_footer_scripts',
+			function() {
+				$content  = __( 'The SQLite module will be removed in the upcoming Performance Lab release in favor of a standalone plugin.', 'performance-lab' );
+				$content .= ' ' . sprintf(
+					/* translators: %s: settings page link */
+					__( 'Open %s to learn more about next steps to keep the functionality available.', 'performance-lab' ),
+					'<a href="' . esc_url( add_query_arg( 'page', PERFLAB_MODULES_SCREEN, admin_url( 'options-general.php' ) ) ) . '">' . __( 'Settings > Performance', 'performance-lab' ) . '</a>'
+				);
+				perflab_render_pointer(
+					'perflab-sqlite-module-removal-pointer',
+					array(
+						'heading' => __( 'Action required', 'performance-lab' ),
+						'content' => $content,
+					)
+				);
+			}
+		);
+		return;
+	}
+
 	if ( in_array( 'perflab-admin-pointer', $dismissed, true ) ) {
 		return;
 	}
@@ -424,7 +468,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 	// Enqueue pointer CSS and JS.
 	wp_enqueue_style( 'wp-pointer' );
 	wp_enqueue_script( 'wp-pointer' );
-	add_action( 'admin_print_footer_scripts', 'perflab_render_pointer' );
+	add_action( 'admin_print_footer_scripts', 'perflab_render_pointer', 10, 0 );
 }
 add_action( 'admin_enqueue_scripts', 'perflab_admin_pointer' );
 
@@ -434,27 +478,36 @@ add_action( 'admin_enqueue_scripts', 'perflab_admin_pointer' );
  * Handles the rendering of the admin pointer.
  *
  * @since 1.0.0
+ * @since n.e.x.t Optional arguments were added to make the function reusable for different pointers.
+ *
+ * @param string $pointer_id Optional. ID of the pointer. Default 'perflab-admin-pointer'.
+ * @param array  $args       Optional. Pointer arguments. Supports 'heading' and 'content' entries.
+ *                           Defaults are the heading and content for the 'perflab-admin-pointer'.
  */
-function perflab_render_pointer() {
-	$heading         = __( 'Performance Lab', 'performance-lab' );
+function perflab_render_pointer( $pointer_id = 'perflab-admin-pointer', $args = array() ) {
+	if ( ! isset( $args['heading'] ) ) {
+		$args['heading'] = __( 'Performance Lab', 'performance-lab' );
+	}
+	if ( ! isset( $args['content'] ) ) {
+		$args['content'] = sprintf(
+			/* translators: %s: settings page link */
+			__( 'You can now test upcoming WordPress performance features. Open %s to individually toggle the performance features included in the plugin.', 'performance-lab' ),
+			'<a href="' . esc_url( add_query_arg( 'page', PERFLAB_MODULES_SCREEN, admin_url( 'options-general.php' ) ) ) . '">' . __( 'Settings > Performance', 'performance-lab' ) . '</a>'
+		);
+	}
+
 	$wp_kses_options = array(
 		'a' => array(
 			'href' => array(),
 		),
 	);
 
-	$content = sprintf(
-		/* translators: %s: settings page link */
-		__( 'You can now test upcoming WordPress performance features. Open %s to individually toggle the performance features included in the plugin.', 'performance-lab' ),
-		'<a href="' . esc_url( add_query_arg( 'page', PERFLAB_MODULES_SCREEN, admin_url( 'options-general.php' ) ) ) . '">' . __( 'Settings > Performance', 'performance-lab' ) . '</a>'
-	);
-
 	?>
-	<script id="perflab-admin-pointer" type="text/javascript">
+	<script id="<?php echo esc_attr( $pointer_id ); ?>" type="text/javascript">
 		jQuery( function() {
 			// Pointer Options.
 			var options = {
-				content: '<h3><?php echo esc_js( $heading ); ?></h3><p><?php echo wp_kses( $content, $wp_kses_options ); ?></p>',
+				content: '<h3><?php echo esc_js( $args['heading'] ); ?></h3><p><?php echo wp_kses( $args['content'], $wp_kses_options ); ?></p>',
 				position: {
 					edge:  'left',
 					align: 'right',
@@ -465,7 +518,7 @@ function perflab_render_pointer() {
 					jQuery.post(
 						window.ajaxurl,
 						{
-							pointer: 'perflab-admin-pointer',
+							pointer: '<?php echo esc_js( $pointer_id ); ?>',
 							action:  'dismiss-wp-pointer',
 							_wpnonce: <?php echo wp_json_encode( wp_create_nonce( 'dismiss_pointer' ) ); ?>,
 						}
@@ -512,10 +565,153 @@ function perflab_plugin_action_links_add_settings( $links ) {
  * @see perflab_render_modules_pointer()
  */
 function perflab_dismiss_wp_pointer_wrapper() {
-	if ( isset( $_POST['pointer'] ) && 'perflab-admin-pointer' !== $_POST['pointer'] ) {
+	if ( isset( $_POST['pointer'] ) && 'perflab-admin-pointer' !== $_POST['pointer'] && 'perflab-sqlite-module-removal-pointer' !== $_POST['pointer'] ) {
 		// Another plugin's pointer, do nothing.
 		return;
 	}
 	check_ajax_referer( 'dismiss_pointer' );
 }
 add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 0 );
+
+/*
+ * Temporary code to inform about SQLite module removal. Since it will be
+ * removed again when the module is removed from the plugin, it uses a closure
+ * instead of a regular function.
+ */
+add_action(
+	'admin_notices',
+	function() {
+		global $hook_suffix;
+
+		// Only show in the WordPress dashboard and Performance Lab admin screen.
+		if ( ! in_array( $hook_suffix, array( 'index.php', 'settings_page_' . PERFLAB_MODULES_SCREEN ), true ) ) {
+			return;
+		}
+
+		// Only show if the SQLite module is active.
+		if ( ! defined( 'SQLITE_VERSION' ) || ! str_starts_with( SQLITE_VERSION, 'Performance Lab ' ) ) {
+			return;
+		}
+
+		// Only show if the user can manage plugins.
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		$wp_kses_options = array(
+			'span'   => array(
+				'style' => array(),
+			),
+			'strong' => array(),
+			'a'      => array(
+				'href' => array(),
+			),
+		);
+
+		$todo_before = '<span>';
+		$todo_after  = '</span>';
+		$done_before = '<span style="text-decoration: line-through;">';
+		$done_after  = '</span> ✅';
+
+		if ( file_exists( WP_PLUGIN_DIR . '/sqlite-database-integration/load.php' ) ) {
+			$step1_before      = $done_before;
+			$step1_after       = $done_after;
+			$step1_placeholder = 'SQLite Database Integration';
+		} else {
+			$step1_before      = $todo_before;
+			$step1_after       = $todo_after;
+			$step1_placeholder = '<a href="https://wordpress.org/plugins/sqlite-database-integration/">SQLite Database Integration</a></strong>';
+		}
+		if ( defined( 'SQLITE_MAIN_FILE' ) ) {
+			$step2_before = $done_before;
+			$step2_after  = $done_after;
+		} else {
+			$step2_before = $todo_before;
+			$step2_after  = $todo_after;
+			if ( file_exists( WP_PLUGIN_DIR . '/sqlite-database-integration/load.php' ) ) {
+				$activate_url = wp_nonce_url(
+					add_query_arg(
+						array(
+							'action' => 'activate',
+							'plugin' => 'sqlite-database-integration/load.php',
+						),
+						admin_url( 'plugins.php' )
+					),
+					'activate-plugin_sqlite-database-integration/load.php'
+				);
+
+				$step2_before .= '<a href="' . esc_url( $activate_url ) . '">';
+				$step2_after   = '</a>' . $step2_after;
+			}
+		}
+		$step3_before      = $todo_before;
+		$step3_after       = $todo_after;
+		$step3_placeholder = 'SQLite';
+		if ( 'index.php' === $hook_suffix ) { // Link to Performance Lab settings.
+			$screen_url = add_query_arg(
+				'page',
+				PERFLAB_MODULES_SCREEN,
+				admin_url( 'options-general.php' )
+			);
+
+			$step3_placeholder = '<a href="' . esc_url( $screen_url ) . '">' . $step3_placeholder . '</a>';
+		}
+
+		/*
+		 * The first two translation strings below are reused in the SQLite
+		 * module admin pointer to keep new temporary translation strings at a
+		 * small number.
+		 */
+		?>
+		<div class="notice notice-warning">
+			<h2><?php esc_html_e( 'Action required', 'performance-lab' ); ?></h2>
+			<p>
+				<?php esc_html_e( 'The SQLite module will be removed in the upcoming Performance Lab release in favor of a standalone plugin.', 'performance-lab' ); ?>
+				<?php esc_html_e( 'In order to keep the functionality available, please go through the following steps:', 'performance-lab' ); ?>
+			</p>
+			<ol>
+				<li>
+					<?php
+					echo wp_kses(
+						sprintf(
+							/* translators: %s: plugin name */
+							'%s' . __( 'Install the %s plugin', 'performance-lab' ) . '%s',
+							$step1_before,
+							$step1_placeholder,
+							$step1_after
+						),
+						$wp_kses_options
+					);
+					?>
+				</li>
+				<li>
+					<?php
+					echo wp_kses(
+						sprintf(
+							'%s' . __( 'Activate the plugin', 'performance-lab' ) . '%s',
+							$step2_before,
+							$step2_after
+						),
+						$wp_kses_options
+					);
+					?>
+				</li>
+				<li>
+					<?php
+					echo wp_kses(
+						sprintf(
+							/* translators: %s: module name */
+							'%s' . __( 'Deactivate the %s module', 'performance-lab' ) . '%s',
+							$step3_before,
+							$step3_placeholder,
+							$step3_after
+						),
+						$wp_kses_options
+					);
+					?>
+				</li>
+			</ol>
+		</div>
+		<?php
+	}
+);

--- a/modules/database/sqlite/admin.php
+++ b/modules/database/sqlite/admin.php
@@ -19,6 +19,11 @@ function perflab_sqlite_plugin_admin_notice() {
 		return;
 	}
 
+	// Bail early if the standalone plugin's equivalent constant is defined.
+	if ( defined( 'SQLITE_DB_DROPIN_VERSION' ) ) {
+		return;
+	}
+
 	/*
 	 * If the PERFLAB_SQLITE_DB_DROPIN_VERSION constant is not defined
 	 * but there's a db.php file in the wp-content directory, then the module can't be activated.

--- a/modules/database/sqlite/can-load.php
+++ b/modules/database/sqlite/can-load.php
@@ -19,7 +19,8 @@ return function() {
 	}
 
 	// If a db.php file already exists in the wp-content directory, then the module cannot be activated.
-	if ( file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
+	// Except if it is the standalone plugin's drop-in.
+	if ( file_exists( WP_CONTENT_DIR . '/db.php' ) && ! defined( 'SQLITE_DB_DROPIN_VERSION' ) ) {
 		return false;
 	}
 

--- a/modules/database/sqlite/load.php
+++ b/modules/database/sqlite/load.php
@@ -8,6 +8,13 @@
  * @since 1.8.0
  */
 
+// Define the version constant.
+if ( defined( 'SQLITE_VERSION' ) ) {
+	return;
+}
+
+define( 'SQLITE_VERSION', 'Performance Lab ' . PERFLAB_VERSION );
+
 // Do not load the code if it is already loaded through another means.
 if ( function_exists( 'perflab_sqlite_plugin_admin_notice' ) ) {
 	return;


### PR DESCRIPTION
## Summary

Fixes #737

## Relevant technical choices

* An admin notice is added with 3 steps to migrate, each of which is conditionally marked already completed depending where the site owner is at in the process.
* An admin pointer is added as an additional way to make site owners aware that they need to take an action, since admin notices can easily be overlooked across _other_ admin notices.
* A few minor interoperability fixes we added (in the `modules/database/sqlite` files).
* No new functions are being introduced since they would need to be removed again in the following release. Therefore the new **temporary** code relies heavily on closures.
* Also see the requirements on the issue.

## Screenshots
**Admin notice awaiting step 1**
![Screenshot 2023-05-31 at 3 57 35 PM](https://github.com/WordPress/performance/assets/3531426/d96ead24-2c52-4d8c-8d1c-e6711f647fc1)

**Admin notice awaiting step 2**
![Screenshot 2023-05-31 at 3 59 29 PM](https://github.com/WordPress/performance/assets/3531426/3c1c2357-7b2c-4df2-b230-888f779faa19)

**Admin notice awaiting step 3**
![Screenshot 2023-05-31 at 4 05 01 PM](https://github.com/WordPress/performance/assets/3531426/8369615e-6098-41fc-9166-cb4e1eacf5d4)

**Admin pointer**
![Screenshot 2023-05-31 at 3 06 46 PM](https://github.com/WordPress/performance/assets/3531426/6a3bfee3-cfe0-4767-a4e1-cd9a1a0bd99b)

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
