### PR TITLE
Fix SQLite module deactivation routine to make standalone plugin migration work correctly

### DIFF
--- a/load.php
+++ b/load.php
@@ -287,6 +287,7 @@ function perflab_get_standalone_plugins_constants() {
 		'images/dominant-color-images' => 'DOMINANT_COLOR_IMAGES_VERSION',
 		'images/fetchpriority'         => 'FETCHPRIORITY_VERSION',
 		'images/webp-uploads'          => 'WEBP_UPLOADS_VERSION',
+		'database/sqlite'              => 'SQLITE_MAIN_FILE',
 	);
 }
 

--- a/modules/database/sqlite/deactivate.php
+++ b/modules/database/sqlite/deactivate.php
@@ -12,17 +12,21 @@
  * @since 1.8.0
  */
 return static function() {
-	if ( ! defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) || ! file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
+	// If neither of these constants are defined, the site is not operating in SQLite database.
+	if ( ! defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) && ! defined( 'SQLITE_DB_DROPIN_VERSION' ) ) {
 		return;
 	}
 
 	global $wp_filesystem;
 
-	require_once ABSPATH . '/wp-admin/includes/file.php';
+	// If the PL's own drop-in file is used, it should be removed.
+	if ( defined( 'PERFLAB_SQLITE_DB_DROPIN_VERSION' ) && file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
+		require_once ABSPATH . '/wp-admin/includes/file.php';
 
-	// Init the filesystem if needed, then delete custom drop-in.
-	if ( $wp_filesystem || WP_Filesystem() ) {
-		$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
+		// Init the filesystem if needed, then delete custom drop-in.
+		if ( $wp_filesystem || WP_Filesystem() ) {
+			$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
+		}
 	}
 
 	// Run an action on `shutdown`, to deactivate the option in the MySQL database.


### PR DESCRIPTION
## Summary

Follow up to #739: When testing the migration flow from the SQLite module to the standalone plugin, @10upsimon noticed that the module is still active technically in case that the SQLite _plugin_ gets deactivated after the migration. That is because the logic to deactivate the module was only applying on the SQLite database, but not the MySQL/MariaDB database.

This PR fixes that problem.

## Relevant technical choices

* The issue was that the standalone plugin's routine to migrate from the PL module to it triggers the option change in a specific way that made the PL module's deactivation routine not run: At the point of the routine being called, no `db.php` drop-in file is present, since the SQLite plugin removes the PL drop-in before and only adds its own drop-in after.
* This PR therefore removes the file check from the main entry condition to the deactivation routine.
* Additionally, it also ensures the deactivation routine is run in case the SQLite plugin's constant is defined: Basically as long as either the PL module constant or SQLite plugin constant is defined, the WP site is using an SQLite database, so in that case the logic to modify the module settings in the other DB needs to run.

## Testing steps
1. Activate the SQLite module.
2. Go to the PL settings page and spot the admin notice to migrate.
3. Install and activate the SQLite plugin. It should redirect you to its migration screen.
4. Click the primary CTA to migrate.
5. At this point you'll see a red notice that the drop-in is missing, even though the PL module is already deactivated in the SQLite database. This is odd, but unless we can find an easy fix, it's not critical: As soon as you refresh the page, it'll be gone.
6. Now the migration is complete. So go ahead and deactivate the SQLite plugin.
7. After a potential relogin to WordPress, you should notice that the PL module is _still_ inactive, even though we're back to using the MySQL/MariaDB database.

The 7th point is the one that this PR fixes. Previously, the PL module would have been active at that point.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
