### PR TITLE
Update / PHP Stan Memory Limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "php": ">=5.6|^7|^8"
   },
   "scripts": {
-    "phpstan": "phpstan analyze --ansi",
+    "phpstan": "phpstan analyze --ansi --memory-limit=2048M",
     "format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
     "lint": "phpcs --standard=phpcs.xml.dist",
     "test": "phpunit -c phpunit.xml.dist --verbose",


### PR DESCRIPTION
## Summary
- Increases the memory limit to 2G (2048M) for the `phpstan` composer command.

## Relevant technical choices
- Appended the `--memory-limit=2048M` to the existing `phpstan` composer command to ensure that phpstan runs with enough memory resources due to internal cases of failures when using 512M and even 1024M at times.
- Referenced other projects (as pointed out by @spacedmonkey ) where this is a common default value, such as that used in `Google for Creators - Web Stories` ([see here](https://github.com/GoogleForCreators/web-stories-wp/blob/dfd6742797f12efd83d156fa43e20dd1a6f89fc0/composer.json#L101)).

## Props
@mukeshpanchal27 @spacedmonkey 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
