### PR TITLE
Check for fetchpriority feature being available in WordPress core before loading the module

### DIFF
--- a/modules/images/fetchpriority/can-load.php
+++ b/modules/images/fetchpriority/can-load.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Can load function to determine if the Fetchpriority feature is already available in WordPress core.
+ *
+ * @since   n.e.x.t
+ * @package performance-lab
+ */
+
+return static function() {
+	return ! function_exists( 'wp_get_loading_optimization_attributes' );
+};

--- a/modules/images/fetchpriority/hooks.php
+++ b/modules/images/fetchpriority/hooks.php
@@ -67,3 +67,19 @@ function fetchpriority_render_generator() {
 	}
 }
 add_action( 'wp_head', 'fetchpriority_render_generator' );
+
+// Show an admin notice if fetchpriority is already available in WordPress core (only relevant for the standalone plugin).
+if ( function_exists( 'wp_get_loading_optimization_attributes' ) && ! str_starts_with( FETCHPRIORITY_VERSION, 'Performance Lab ' ) ) {
+	add_action(
+		'admin_notices',
+		static function() {
+			?>
+			<div class="notice notice-warning">
+				<p>
+					<?php esc_html_e( 'Fetchpriority is already part of your WordPress version. Please deactivate the Fetchpriority plugin.', 'performance-lab' ); ?>
+				</p>
+			</div>
+			<?php
+		}
+	);
+}

--- a/modules/images/fetchpriority/readme.txt
+++ b/modules/images/fetchpriority/readme.txt
@@ -2,9 +2,9 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.1
-Tested up to:      6.2
+Tested up to:      6.3
 Requires PHP:      5.6
-Stable tag:        1.0.0
+Stable tag:        1.1.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, fetchpriority
@@ -46,6 +46,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.1.0 =
+
+* Display admin notice to deactivate the plugin if feature already available in WordPress core. ([769](https://github.com/WordPress/performance/pull/769))
 
 = 1.0.0 =
 

--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,7 @@
 {
   "images/fetchpriority": {
     "slug": "fetchpriority",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   "images/webp-uploads": {
     "slug": "webp-uploads",


### PR DESCRIPTION
## Summary

This PR checks for existence of the fetchpriority feature in WordPress core, which was merged earlier this week and will become widely available with the WordPress 6.3 launch in August (see https://core.trac.wordpress.org/ticket/58235). We should therefore ensure _before_ that release that Performance Lab caters for that situation.

## Relevant technical choices

* For the module, a `can-load.php` file is added, the default mechanism to check whether a module can be loaded, with the closure returning `false` when the WP core version on the site already provides the feature.
* For the standalone plugin version of the module, the `can-load.php` file is irrelevant, therefore the PR adds an admin notice closure which is only shown for the standalone plugin (based on the specific constant check).
* The standalone plugin's `readme.txt` has been updated and the standalone plugin version is bumped to 1.1.0. This will automatically be published together with the next Performance Lab plugin release on July 17.

## Screenshots

**Performance Lab module checkbox when feature already in core**
![Screenshot 2023-06-28 at 10 54 13 AM](https://github.com/WordPress/performance/assets/3531426/c5ece953-1bc0-47eb-8281-15948af07328)

**Admin notice for standalone plugin when feature already in core**
![Screenshot 2023-06-28 at 11 03 17 AM](https://github.com/WordPress/performance/assets/3531426/495f99a4-e44d-4e68-bc0e-143e4e276a02)

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
