### PR TITLE
Bump tested up to version to 6.3

### DIFF
--- a/modules/images/dominant-color-images/readme.txt
+++ b/modules/images/dominant-color-images/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.1
-Tested up to:      6.2
+Tested up to:      6.3
 Requires PHP:      5.6
 Stable tag:        1.0.0
 License:           GPLv2 or later

--- a/modules/images/webp-uploads/readme.txt
+++ b/modules/images/webp-uploads/readme.txt
@@ -2,9 +2,9 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.1
-Tested up to:      6.2
+Tested up to:      6.3
 Requires PHP:      5.6
-Stable tag:        1.0.0
+Stable tag:        1.0.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, webp
@@ -57,6 +57,10 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the WebP Uploads plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 1.0.1 =
+
+* Bump tested up to version to 6.3. ([772](https://github.com/WordPress/performance/pull/772))
 
 = 1.0.0 =
 

--- a/plugins.json
+++ b/plugins.json
@@ -5,6 +5,6 @@
   },
   "images/webp-uploads": {
     "slug": "webp-uploads",
-    "version": "1.0.0"
+    "version": "1.0.1"
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.1
-Tested up to:      6.2
+Tested up to:      6.3
 Requires PHP:      5.6
 Stable tag:        2.4.0
 License:           GPLv2 or later


### PR DESCRIPTION
## Summary

* Bump main plugin tested up to version to 6.3.
* Bump remaining standalone plugin tested up to versions to 6.3.
* Bump WebP Uploads version so that the change will be deployed when the next PL release goes out. (This wasn't necessary for the other standalone plugins since Fetchpriority has already seen its version bump and Dominant Color Images is not released yet.)

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
