### PR TITLE
Strip new PL milestone prefix from milestone title to only have version in changelog

### DIFF
--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -162,7 +162,7 @@ function getIssueFocus( issue ) {
  * @return {string} The formatted changelog string.
  */
 function formatChangelog( milestone, pullRequests ) {
-	let changelog = '= ' + milestone + ' =\n\n';
+	let changelog = '= ' + milestone.replace( 'PL Plugin ', '' ) + ' =\n\n';
 
 	// Group PRs by type.
 	const typeGroups = groupBy( pullRequests, getIssueType );


### PR DESCRIPTION
## Summary

Now that the PL milestone title format has been changed from just containing the version to "PL Plugin {version}", we need to update the readme script to ensure that it strips that new prefix when generating the changelog.

To test the PR, run `npm run readme -- -m "PL Plugin 2.5.0"`, and verify that the changelog in the readme only contains "2.5.0", not "PL Plugin 2.5.0".

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
