### PR TITLE
Fix whitespace not matching in `since` command.

### DIFF
--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -47,13 +47,14 @@ exports.handler = async ( opt ) => {
 		ignore: [ __filename, '**/node_modules', '**/vendor' ],
 	} );
 
-	const regexp = new RegExp( '@since n.e.x.t', 'g' );
+	const regexp = new RegExp( '@since(\\s+)n.e.x.t', 'g' );
+
 	files.forEach( ( file ) => {
 		const content = fs.readFileSync( file, 'utf-8' );
 		if ( regexp.test( content ) ) {
 			fs.writeFileSync(
 				file,
-				content.replace( regexp, `@since ${ opt.release }` )
+				content.replace( regexp, `@since$1${ opt.release }` )
 			);
 		}
 	} );


### PR DESCRIPTION
## Summary

This fixes an issue where the since command was failing to replace instances of `n.e.x.t` when more than once space occurred between the `@since` and the placeholder version number, e.g., for docblock alignment purposes.

## Relevant technical choices

While prepping for the 2.5.0 release, I noticed that running `npm run since -- -r 2.5.0` missed one case in [modules/images/fetchpriority/can-load.php](https://github.com/WordPress/performance/blob/release/2.5.0/modules/images/fetchpriority/can-load.php#L5) that was added during this release. It looks like this is due to the alignment spacing in the docblock, which is causing the regex pattern to not match. Updating the regex pattern to look for multiple spaces and apply the same number of spaces in the replacement fixes the issue.


## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
