### PR TITLE
Merge Release/2.5.0 back to trunk

### DIFF
--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -47,13 +47,14 @@ exports.handler = async ( opt ) => {
 		ignore: [ __filename, '**/node_modules', '**/vendor' ],
 	} );
 
-	const regexp = new RegExp( '@since n.e.x.t', 'g' );
+	const regexp = new RegExp( '@since(\\s+)n.e.x.t', 'g' );
+
 	files.forEach( ( file ) => {
 		const content = fs.readFileSync( file, 'utf-8' );
 		if ( regexp.test( content ) ) {
 			fs.writeFileSync(
 				file,
-				content.replace( regexp, `@since ${ opt.release }` )
+				content.replace( regexp, `@since$1${ opt.release }` )
 			);
 		}
 	} );

--- a/load.php
+++ b/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance modules.
  * Requires at least: 6.1
  * Requires PHP: 5.6
- * Version: 2.4.0
+ * Version: 2.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -15,7 +15,7 @@
  * @package performance-lab
  */
 
-define( 'PERFLAB_VERSION', '2.4.0' );
+define( 'PERFLAB_VERSION', '2.5.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );

--- a/module-i18n.php
+++ b/module-i18n.php
@@ -13,7 +13,5 @@ $generated_i18n_strings = array(
 	_x( 'Adds a CSS and JS resource check in Site Health status.', 'module description', 'performance-lab' ),
 	_x( 'Autoloaded Options Health Check', 'module name', 'performance-lab' ),
 	_x( 'Adds a check for autoloaded options in Site Health status.', 'module description', 'performance-lab' ),
-	_x( 'SQLite Integration', 'module name', 'performance-lab' ),
-	_x( 'Use an SQLite database instead of MySQL.', 'module description', 'performance-lab' ),
 );
 /* THIS IS THE END OF THE GENERATED FILE */

--- a/modules/images/fetchpriority/can-load.php
+++ b/modules/images/fetchpriority/can-load.php
@@ -2,7 +2,7 @@
 /**
  * Can load function to determine if the Fetchpriority feature is already available in WordPress core.
  *
- * @since   n.e.x.t
+ * @since   2.5.0
  * @package performance-lab
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,6 @@ Currently the plugin includes the following performance modules:
 * **WebP Uploads:** Creates WebP versions for new JPEG image uploads if supported by the server.
 * **Enqueued Assets Health Check:** Adds a CSS and JS resource check in Site Health status.
 * **Autoloaded Options Health Check:** Adds a check for autoloaded options in Site Health status.
-* **SQLite Integration:** Use an SQLite database instead of MySQL.
 
 == Installation ==
 
@@ -80,6 +79,14 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the WebP Uploads module will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.5.0 =
+
+**Enhancements**
+
+* Images: Check for fetchpriority feature being available in WordPress core before loading the module. ([769](https://github.com/WordPress/performance/pull/769))
+* Database Optimization: Remove SQLite module. ([764](https://github.com/WordPress/performance/pull/764))
+* Infrastructure: Bump tested up to version to 6.3. ([772](https://github.com/WordPress/performance/pull/772))
 
 = 2.4.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.1
 Tested up to:      6.3
 Requires PHP:      5.6
-Stable tag:        2.4.0
+Stable tag:        2.5.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, javascript, site health, measurement, object caching


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
This merges the 2.5.0 release branch back to trunk following the release.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
