### PR TITLE
Implement logic to measure specific hook execution time with Server-Timing controlled by a WP Admin screen

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -111,7 +111,7 @@ function perflab_render_modules_page() {
 			<?php esc_html_e( 'Performance Modules', 'performance-lab' ); ?>
 		</h1>
 
-		<form action="options.php" method="post" novalidate="novalidate">
+		<form action="options.php" method="post" novalidate>
 			<?php settings_fields( PERFLAB_MODULES_SCREEN ); ?>
 			<?php do_settings_sections( PERFLAB_MODULES_SCREEN ); ?>
 			<?php submit_button(); ?>

--- a/admin/load.php
+++ b/admin/load.php
@@ -111,7 +111,7 @@ function perflab_render_modules_page() {
 			<?php esc_html_e( 'Performance Modules', 'performance-lab' ); ?>
 		</h1>
 
-		<form action="options.php" method="post" novalidate>
+		<form action="options.php" method="post">
 			<?php settings_fields( PERFLAB_MODULES_SCREEN ); ?>
 			<?php do_settings_sections( PERFLAB_MODULES_SCREEN ); ?>
 			<?php submit_button(); ?>

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -5,6 +5,10 @@
  * @package performance-lab
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Adds the Server-Timing page to the Tools menu.
  *

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Server-Timing API admin integration file.
+ *
+ * @package performance-lab
+ */
+
+/**
+ * Adds the Server-Timing page to the Tools menu.
+ *
+ * @since n.e.x.t
+ */
+function perflab_add_server_timing_page() {
+	$hook_suffix = add_management_page(
+		__( 'Server-Timing', 'performance-lab' ),
+		__( 'Server-Timing', 'performance-lab' ),
+		'manage_options',
+		PERFLAB_SERVER_TIMING_SCREEN,
+		'perflab_render_server_timing_page'
+	);
+
+	// Add the following hooks only if the screen was successfully added.
+	if ( false !== $hook_suffix ) {
+		add_action( "load-{$hook_suffix}", 'perflab_load_server_timing_page' );
+	}
+
+	return $hook_suffix;
+}
+add_action( 'admin_menu', 'perflab_add_server_timing_page' );
+
+/**
+ * Initializes settings sections and fields for the Server-Timing page.
+ *
+ * @since n.e.x.t
+ */
+function perflab_load_server_timing_page() {
+	add_settings_section(
+		'benchmarking',
+		__( 'Benchmarking', 'performance-lab' ),
+		static function() {
+			?>
+			<p>
+				<?php esc_html_e( 'In this section, you can provide hook names to include measurements for them in the Server-Timing header.', 'performance-lab' ); ?>
+			</p>
+			<?php
+		},
+		PERFLAB_SERVER_TIMING_SCREEN
+	);
+
+	/*
+	 * For all settings fields, the field slug, option sub key, and label
+	 * suffix have to match for the rendering in the callback to be
+	 * semantically correct.
+	 */
+	add_settings_field(
+		'benchmarking_actions',
+		__( 'Actions', 'performance-lab' ),
+		static function() {
+			perflab_render_server_timing_page_field( 'benchmarking_actions' );
+		},
+		PERFLAB_SERVER_TIMING_SCREEN,
+		'benchmarking',
+		array( 'label_for' => 'server_timing_benchmarking_actions' )
+	);
+	add_settings_field(
+		'benchmarking_filters',
+		__( 'Filters', 'performance-lab' ),
+		static function() {
+			perflab_render_server_timing_page_field( 'benchmarking_filters' );
+		},
+		PERFLAB_SERVER_TIMING_SCREEN,
+		'benchmarking',
+		array( 'label_for' => 'server_timing_benchmarking_filters' )
+	);
+}
+
+/**
+ * Renders the Server-Timing page.
+ *
+ * @since n.e.x.t
+ */
+function perflab_render_server_timing_page() {
+	?>
+	<div class="wrap">
+		<?php settings_errors(); ?>
+		<h1>
+			<?php esc_html_e( 'Server-Timing', 'performance-lab' ); ?>
+		</h1>
+
+		<form action="options.php" method="post" novalidate="novalidate">
+			<?php settings_fields( PERFLAB_SERVER_TIMING_SCREEN ); ?>
+			<?php do_settings_sections( PERFLAB_SERVER_TIMING_SCREEN ); ?>
+			<?php submit_button(); ?>
+		</form>
+	</div>
+	<?php
+}
+
+/**
+ * Renders a field for the given Server-Timing option.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $slug Slug of the field and sub-key in the Server-Timing option.
+ */
+function perflab_render_server_timing_page_field( $slug ) {
+	$options = (array) get_option( PERFLAB_SERVER_TIMING_SETTING, array() );
+
+	// Value for the sub-key is an array of hook names.
+	$value = '';
+	if ( isset( $options[ $slug ] ) ) {
+		$value = implode( "\n", $options[ $slug ] );
+	}
+
+	$field_id       = "server_timing_{$slug}";
+	$field_name     = PERFLAB_SERVER_TIMING_SETTING . '[' . $slug . ']';
+	$description_id = "{$field_id}_description";
+
+	?>
+	<textarea
+		id="<?php echo esc_attr( $field_id ); ?>"
+		name="<?php echo esc_attr( $field_name ); ?>"
+		aria-describedby="<?php echo esc_attr( $description_id ); ?>"
+		class="large-text code"
+		rows="8"
+	><?php echo esc_textarea( $value ); ?></textarea>
+	<p id="<?php echo esc_attr( $description_id ); ?>" class="description">
+		<?php esc_html_e( 'Enter a single hook name per line.', 'performance-lab' ); ?>
+	</p>
+	<?php
+}

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -94,7 +94,7 @@ function perflab_render_server_timing_page() {
 			<?php esc_html_e( 'Server-Timing', 'performance-lab' ); ?>
 		</h1>
 
-		<form action="options.php" method="post" novalidate>
+		<form action="options.php" method="post">
 			<?php settings_fields( PERFLAB_SERVER_TIMING_SCREEN ); ?>
 			<?php do_settings_sections( PERFLAB_SERVER_TIMING_SCREEN ); ?>
 			<?php submit_button(); ?>

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -47,6 +47,15 @@ function perflab_load_server_timing_page() {
 					__( 'For any hook name provided, the <strong>cumulative duration between all callbacks</strong> attached to the hook is measured, in milliseconds.', 'performance-lab' ),
 					array( 'strong' => array() )
 				);
+				if ( ! perflab_server_timing_use_output_buffer() ) {
+					?>
+					<br>
+					<?php
+					echo wp_kses(
+						__( 'Since the Server-Timing header is sent before the template is loaded, only hooks before the <code>template_include</code> filter can be measured.', 'performance-lab' ),
+						array( 'code' => array() )
+					);
+				}
 				?>
 			</p>
 			<?php

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -40,7 +40,16 @@ function perflab_load_server_timing_page() {
 		static function() {
 			?>
 			<p>
-				<?php esc_html_e( 'In this section, you can provide hook names to include measurements for them in the Server-Timing header.', 'performance-lab' ); ?>
+				<?php
+				echo wp_kses(
+					sprintf(
+						/* translators: %s: Server-Timing */
+						__( 'In this section, you can provide hook names to include measurements for them in the %s header.', 'performance-lab' ),
+						'<code>Server-Timing</code>'
+					),
+					array( 'code' => array() )
+				);
+				?>
 				<br>
 				<?php
 				echo wp_kses(
@@ -52,7 +61,12 @@ function perflab_load_server_timing_page() {
 					<br>
 					<?php
 					echo wp_kses(
-						__( 'Since the Server-Timing header is sent before the template is loaded, only hooks before the <code>template_include</code> filter can be measured.', 'performance-lab' ),
+						sprintf(
+							/* translators: 1: Server-Timing, 2: template_include */
+							__( 'Since the %1$s header is sent before the template is loaded, only hooks before the %2$s filter can be measured.', 'performance-lab' ),
+							'<code>Server-Timing</code>',
+							'<code>template_include</code>'
+						),
 						array( 'code' => array() )
 					);
 				}

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -41,6 +41,13 @@ function perflab_load_server_timing_page() {
 			?>
 			<p>
 				<?php esc_html_e( 'In this section, you can provide hook names to include measurements for them in the Server-Timing header.', 'performance-lab' ); ?>
+				<br>
+				<?php
+				echo wp_kses(
+					__( 'For any hook name provided, the <strong>cumulative duration between all callbacks</strong> attached to the hook is measured, in milliseconds.', 'performance-lab' ),
+					array( 'strong' => array() )
+				);
+				?>
 			</p>
 			<?php
 		},

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -94,7 +94,7 @@ function perflab_render_server_timing_page() {
 			<?php esc_html_e( 'Server-Timing', 'performance-lab' ); ?>
 		</h1>
 
-		<form action="options.php" method="post" novalidate="novalidate">
+		<form action="options.php" method="post" novalidate>
 			<?php settings_fields( PERFLAB_SERVER_TIMING_SCREEN ); ?>
 			<?php do_settings_sections( PERFLAB_SERVER_TIMING_SCREEN ); ?>
 			<?php submit_button(); ?>

--- a/load.php
+++ b/load.php
@@ -431,6 +431,7 @@ register_deactivation_hook( __FILE__, 'perflab_maybe_remove_object_cache_dropin'
 // Only load admin integration when in admin.
 if ( is_admin() ) {
 	require_once PERFLAB_PLUGIN_DIR_PATH . 'admin/load.php';
+	require_once PERFLAB_PLUGIN_DIR_PATH . 'admin/server-timing.php';
 }
 
 /**

--- a/server-timing/defaults.php
+++ b/server-timing/defaults.php
@@ -223,63 +223,62 @@ add_action( 'wp_loaded', 'perflab_register_default_server_timing_template_metric
 function perflab_register_additional_server_timing_metrics_from_setting() {
 	$options = (array) get_option( PERFLAB_SERVER_TIMING_SETTING, array() );
 
+	/*
+	 * This closure measures performance of a hook (action or filter), as follows:
+	 *
+	 * 1. Add a hook callback at the minimum (i.e. earliest) priority possible.
+	 * 2. In that callback, register the metric for the hook, with a prefix of either "action" or "filter".
+	 * 3. Provide a measuring callback which captures the time span between beginning to end of the hook:
+	 *     1. Capture the current time immediately, i.e. at the earliest hook priority.
+	 *     2. Add another hook callback at the maximum (i.e. latest) priority possible.
+	 *     3. In that callback, capture the current time, leading the Server-Timing API to calculate the difference.
+	 *
+	 * Parameters to this closure are the hook name, what type of hook it is (either "action" or "filter", used as a
+	 * prefix for the registered metric), and the callback function to add the hook (either "add_action" or
+	 * "add_filter").
+	 */
+	$measure_hook = static function( $hook_name, $hook_type, $add_hook_func ) {
+		$metric_slug      = "{$hook_type}-{$hook_name}";
+		$measure_callback = static function( $metric ) use ( $hook_name, $add_hook_func ) {
+			$metric->measure_before();
+			call_user_func(
+				$add_hook_func,
+				$hook_name,
+				static function( $passthrough = null ) use ( $metric ) {
+					$metric->measure_after();
+					return $passthrough;
+				},
+				PHP_INT_MAX
+			);
+		};
+
+		call_user_func(
+			$add_hook_func,
+			$hook_name,
+			static function( $passthrough = null ) use ( $metric_slug, $measure_callback ) {
+				perflab_server_timing_register_metric(
+					$metric_slug,
+					array(
+						'measure_callback' => $measure_callback,
+						'access_cap'       => 'exist',
+					)
+				);
+				return $passthrough;
+			},
+			// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
+			defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX
+		);
+	};
+
 	if ( isset( $options['benchmarking_actions'] ) ) {
 		foreach ( $options['benchmarking_actions'] as $action ) {
-			$metric_slug = 'action-' . $action;
-
-			$measure_callback = static function( $metric ) use ( $action ) {
-				$metric->measure_before();
-				add_action( $action, array( $metric, 'measure_after' ), PHP_INT_MAX, 0 );
-			};
-
-			add_action(
-				$action,
-				static function() use ( $metric_slug, $measure_callback ) {
-					perflab_server_timing_register_metric(
-						$metric_slug,
-						array(
-							'measure_callback' => $measure_callback,
-							'access_cap'       => 'exist',
-						)
-					);
-				},
-				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX
-			);
+			$measure_hook( $action, 'action', 'add_action' );
 		}
 	}
 
 	if ( isset( $options['benchmarking_filters'] ) ) {
 		foreach ( $options['benchmarking_filters'] as $filter ) {
-			$metric_slug = 'filter-' . $filter;
-
-			$measure_callback = static function( $metric ) use ( $filter ) {
-				$metric->measure_before();
-				add_filter(
-					$filter,
-					static function( $passthrough ) use ( $metric ) {
-						$metric->measure_after();
-						return $passthrough;
-					},
-					PHP_INT_MAX
-				);
-			};
-
-			add_filter(
-				$filter,
-				static function( $passthrough ) use ( $metric_slug, $measure_callback ) {
-					perflab_server_timing_register_metric(
-						$metric_slug,
-						array(
-							'measure_callback' => $measure_callback,
-							'access_cap'       => 'exist',
-						)
-					);
-					return $passthrough;
-				},
-				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX
-			);
+			$measure_hook( $filter, 'filter', 'add_filter' );
 		}
 	}
 }

--- a/server-timing/defaults.php
+++ b/server-timing/defaults.php
@@ -240,7 +240,7 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 					);
 				},
 				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -9999
+				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX
 			);
 		}
 	}
@@ -274,7 +274,7 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 					return $passthrough;
 				},
 				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
-				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -9999
+				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : ~PHP_INT_MAX
 			);
 		}
 	}

--- a/server-timing/defaults.php
+++ b/server-timing/defaults.php
@@ -223,7 +223,7 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 		foreach ( $options['benchmarking_actions'] as $action ) {
 			$metric_slug = 'action-' . $action;
 
-			$measure_callback = function( $metric ) use ( $action ) {
+			$measure_callback = static function( $metric ) use ( $action ) {
 				$metric->measure_before();
 				add_action( $action, array( $metric, 'measure_after' ), PHP_INT_MAX, 0 );
 			};
@@ -239,6 +239,7 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 						)
 					);
 				},
+				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -9999
 			);
 		}
@@ -248,7 +249,7 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 		foreach ( $options['benchmarking_filters'] as $filter ) {
 			$metric_slug = 'filter-' . $filter;
 
-			$measure_callback = function( $metric ) use ( $filter ) {
+			$measure_callback = static function( $metric ) use ( $filter ) {
 				$metric->measure_before();
 				add_filter(
 					$filter,
@@ -272,6 +273,7 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 					);
 					return $passthrough;
 				},
+				// phpcs:ignore PHPCompatibility.Constants.NewConstants.php_int_minFound
 				defined( 'PHP_INT_MIN' ) ? PHP_INT_MIN : -9999
 			);
 		}

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -161,7 +161,16 @@ function perflab_sanitize_server_timing_setting( $value ) {
 				return array_values(
 					array_unique(
 						array_filter(
-							array_map( 'sanitize_key', $hooks )
+							array_map(
+								static function( $hookname ) {
+									return preg_replace(
+										'/[^A-Za-z0-9_\-\/\.]/',
+										'',
+										strtolower( $hookname )
+									);
+								},
+								$hooks
+							)
 						)
 					)
 				);

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -44,14 +44,17 @@ function perflab_sanitize_server_timing_setting( $value ) {
 		return array();
 	}
 
-	// Ensure that every element is an indexed array of hook names.
+	/*
+	 * Ensure that every element is an indexed array of hook names.
+	 * Any duplicates across a group of hooks are removed.
+	 */
 	return array_filter(
 		array_map(
 			static function( $hooks ) {
 				if ( ! is_array( $hooks ) ) {
 					$hooks = explode( "\n", $hooks );
 				}
-				return array_filter( array_map( 'sanitize_key', $hooks ) );
+				return array_unique( array_filter( array_map( 'sanitize_key', $hooks ) ) );
 			},
 			$value
 		)

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -144,44 +144,48 @@ add_action( 'init', 'perflab_register_server_timing_setting' );
  * @return array Sanitized Server-Timing setting value.
  */
 function perflab_sanitize_server_timing_setting( $value ) {
+	static $allowed_keys = array(
+		'benchmarking_actions' => true,
+		'benchmarking_filters' => true,
+	);
+
 	if ( ! is_array( $value ) ) {
 		return array();
 	}
+
+	$value = array_intersect_key( $value, $allowed_keys );
 
 	/*
 	 * Ensure that every element is an indexed array of hook names.
 	 * Any duplicates across a group of hooks are removed.
 	 */
-	return array_filter(
-		array_map(
-			static function( $hooks ) {
-				if ( ! is_array( $hooks ) ) {
-					$hooks = explode( "\n", $hooks );
-				}
-				return array_values(
-					array_unique(
-						array_filter(
-							array_map(
-								static function( $hookname ) {
-									/*
-									 * Allow any characters except whitespace.
-									 * While most hooks use a limited set of characters, hook names in plugins are not
-									 * restricted to them, therefore the sanitization does not limit the characters
-									 * used.
-									 */
-									return preg_replace(
-										'/\s/',
-										'',
-										sanitize_text_field( $hookname )
-									);
-								},
-								$hooks
-							)
-						)
+	foreach ( $value as $key => $hooks ) {
+		if ( ! is_array( $hooks ) ) {
+			$hooks = explode( "\n", $hooks );
+		}
+		$value[ $key ] = array_values(
+			array_unique(
+				array_filter(
+					array_map(
+						static function( $hookname ) {
+							/*
+							 * Allow any characters except whitespace.
+							 * While most hooks use a limited set of characters, hook names in plugins are not
+							 * restricted to them, therefore the sanitization does not limit the characters
+							 * used.
+							 */
+							return preg_replace(
+								'/\s/',
+								'',
+								sanitize_text_field( $hookname )
+							);
+						},
+						$hooks
 					)
-				);
-			},
-			$value
-		)
-	);
+				)
+			)
+		);
+	}
+
+	return $value;
 }

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -163,10 +163,16 @@ function perflab_sanitize_server_timing_setting( $value ) {
 						array_filter(
 							array_map(
 								static function( $hookname ) {
+									/*
+									 * Allow any characters except whitespace.
+									 * While most hooks use a limited set of characters, hook names in plugins are not
+									 * restricted to them, therefore the sanitization does not limit the characters
+									 * used.
+									 */
 									return preg_replace(
-										'/[^A-Za-z0-9_\-\/\.]/',
+										'/\s/',
 										'',
-										strtolower( $hookname )
+										sanitize_text_field( $hookname )
 									);
 								},
 								$hooks

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -6,6 +6,54 @@
  * @since 1.8.0
  */
 
+define( 'PERFLAB_SERVER_TIMING_SETTING', 'perflab_server_timing_settings' );
+define( 'PERFLAB_SERVER_TIMING_SCREEN', 'perflab-server-timing' );
+
+/**
+ * Registers the Server-Timing setting.
+ *
+ * @since n.e.x.t
+ */
+function perflab_register_server_timing_setting() {
+	register_setting(
+		PERFLAB_SERVER_TIMING_SCREEN,
+		PERFLAB_SERVER_TIMING_SETTING,
+		array(
+			'type'              => 'object',
+			'sanitize_callback' => 'perflab_sanitize_server_timing_setting',
+			'default'           => array(),
+		)
+	);
+}
+add_action( 'init', 'perflab_register_server_timing_setting' );
+
+/**
+ * Sanitizes the Server-Timing setting.
+ *
+ * @since n.e.x.t
+ *
+ * @param mixed $value Server-Timing setting value.
+ * @return array Sanitized Server-Timing setting value.
+ */
+function perflab_sanitize_server_timing_setting( $value ) {
+	if ( ! is_array( $value ) ) {
+		return array();
+	}
+
+	// Ensure that every element is an indexed array of hook names.
+	return array_filter(
+		array_map(
+			static function( $hooks ) {
+				if ( ! is_array( $hooks ) ) {
+					$hooks = explode( "\n", $hooks );
+				}
+				return array_filter( array_map( 'sanitize_key', $hooks ) );
+			},
+			$value
+		)
+	);
+}
+
 /**
  * Provides access the Server-Timing API.
  *

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -14,54 +14,6 @@ define( 'PERFLAB_SERVER_TIMING_SETTING', 'perflab_server_timing_settings' );
 define( 'PERFLAB_SERVER_TIMING_SCREEN', 'perflab-server-timing' );
 
 /**
- * Registers the Server-Timing setting.
- *
- * @since n.e.x.t
- */
-function perflab_register_server_timing_setting() {
-	register_setting(
-		PERFLAB_SERVER_TIMING_SCREEN,
-		PERFLAB_SERVER_TIMING_SETTING,
-		array(
-			'type'              => 'object',
-			'sanitize_callback' => 'perflab_sanitize_server_timing_setting',
-			'default'           => array(),
-		)
-	);
-}
-add_action( 'init', 'perflab_register_server_timing_setting' );
-
-/**
- * Sanitizes the Server-Timing setting.
- *
- * @since n.e.x.t
- *
- * @param mixed $value Server-Timing setting value.
- * @return array Sanitized Server-Timing setting value.
- */
-function perflab_sanitize_server_timing_setting( $value ) {
-	if ( ! is_array( $value ) ) {
-		return array();
-	}
-
-	/*
-	 * Ensure that every element is an indexed array of hook names.
-	 * Any duplicates across a group of hooks are removed.
-	 */
-	return array_filter(
-		array_map(
-			static function( $hooks ) {
-				if ( ! is_array( $hooks ) ) {
-					$hooks = explode( "\n", $hooks );
-				}
-				return array_unique( array_filter( array_map( 'sanitize_key', $hooks ) ) );
-			},
-			$value
-		)
-	);
-}
-
-/**
  * Provides access the Server-Timing API.
  *
  * When called for the first time, this also initializes the API to schedule the header for output.
@@ -163,4 +115,58 @@ function perflab_wrap_server_timing( $callback, $metric_slug, $access_cap ) {
 		// Return result (e.g. in case this is a filter callback).
 		return $result;
 	};
+}
+
+/**
+ * Registers the Server-Timing setting.
+ *
+ * @since n.e.x.t
+ */
+function perflab_register_server_timing_setting() {
+	register_setting(
+		PERFLAB_SERVER_TIMING_SCREEN,
+		PERFLAB_SERVER_TIMING_SETTING,
+		array(
+			'type'              => 'object',
+			'sanitize_callback' => 'perflab_sanitize_server_timing_setting',
+			'default'           => array(),
+		)
+	);
+}
+add_action( 'init', 'perflab_register_server_timing_setting' );
+
+/**
+ * Sanitizes the Server-Timing setting.
+ *
+ * @since n.e.x.t
+ *
+ * @param mixed $value Server-Timing setting value.
+ * @return array Sanitized Server-Timing setting value.
+ */
+function perflab_sanitize_server_timing_setting( $value ) {
+	if ( ! is_array( $value ) ) {
+		return array();
+	}
+
+	/*
+	 * Ensure that every element is an indexed array of hook names.
+	 * Any duplicates across a group of hooks are removed.
+	 */
+	return array_filter(
+		array_map(
+			static function( $hooks ) {
+				if ( ! is_array( $hooks ) ) {
+					$hooks = explode( "\n", $hooks );
+				}
+				return array_values(
+					array_unique(
+						array_filter(
+							array_map( 'sanitize_key', $hooks )
+						)
+					)
+				);
+			},
+			$value
+		)
+	);
 }

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -5,6 +5,9 @@
  * @package performance-lab
  */
 
+/**
+ * @group admin
+ */
 class Admin_Load_Tests extends WP_UnitTestCase {
 
 	private static $demo_modules = array(

--- a/tests/admin/server-timing-tests.php
+++ b/tests/admin/server-timing-tests.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Tests for admin/server-timing.php
+ *
+ * @package performance-lab
+ */
+
+/**
+ * @group admin
+ * @group server-timing
+ */
+class Admin_Server_Timing_Tests extends WP_UnitTestCase {
+
+	public function test_perflab_add_server_timing_page() {
+		global $_wp_submenu_nopriv;
+
+		// Reset relevant globals and filters.
+		$_wp_submenu_nopriv = array();
+		remove_all_filters( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ) );
+
+		// Rely on current user to be an administrator (with 'manage_options' capability).
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$hook_suffix = perflab_add_server_timing_page();
+		$this->assertSame( get_plugin_page_hookname( PERFLAB_SERVER_TIMING_SCREEN, 'tools.php' ), $hook_suffix );
+		$this->assertFalse( isset( $_wp_submenu_nopriv['tools.php'][ PERFLAB_SERVER_TIMING_SCREEN ] ) );
+	}
+
+	public function test_perflab_add_server_timing_page_missing_caps() {
+		global $_wp_submenu_nopriv;
+
+		// Reset relevant globals and filters.
+		$_wp_submenu_nopriv = array();
+		remove_all_filters( 'plugin_action_links_' . plugin_basename( PERFLAB_MAIN_FILE ) );
+
+		// The default user does not have the 'manage_options' capability.
+		$hook_suffix = perflab_add_server_timing_page();
+		$this->assertFalse( $hook_suffix );
+		$this->assertTrue( isset( $_wp_submenu_nopriv['tools.php'][ PERFLAB_SERVER_TIMING_SCREEN ] ) );
+	}
+
+	public function test_perflab_load_server_timing_page() {
+		global $wp_settings_sections, $wp_settings_fields;
+
+		// Reset relevant globals.
+		$wp_settings_sections = array();
+		$wp_settings_fields   = array();
+
+		perflab_load_server_timing_page();
+		$this->assertArrayHasKey( PERFLAB_SERVER_TIMING_SCREEN, $wp_settings_sections );
+		$this->assertEqualSets(
+			array( 'benchmarking' ),
+			array_keys( $wp_settings_sections[ PERFLAB_SERVER_TIMING_SCREEN ] )
+		);
+		$this->assertEqualSets(
+			array( 'benchmarking' ),
+			array_keys( $wp_settings_fields[ PERFLAB_SERVER_TIMING_SCREEN ] )
+		);
+		$this->assertEqualSets(
+			array( 'benchmarking_actions', 'benchmarking_filters' ),
+			array_keys( $wp_settings_fields[ PERFLAB_SERVER_TIMING_SCREEN ]['benchmarking'] )
+		);
+	}
+
+	public function test_perflab_render_server_timing_page() {
+		ob_start();
+		perflab_render_server_timing_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<div class="wrap">', $output );
+		$this->assertStringContainsString( "<input type='hidden' name='option_page' value='" . PERFLAB_SERVER_TIMING_SCREEN . "' />", $output );
+	}
+
+	public function test_perflab_render_server_timing_page_field() {
+		$slug = 'benchmarking_actions';
+
+		ob_start();
+		perflab_render_server_timing_page_field( $slug );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '<textarea', $output );
+		$this->assertStringContainsString( 'id="server_timing_' . $slug . '"', $output );
+		$this->assertStringContainsString( 'name="' . PERFLAB_SERVER_TIMING_SETTING . '[' . $slug . ']"', $output );
+	}
+
+	public function test_perflab_render_server_timing_page_field_empty_option() {
+		delete_option( PERFLAB_SERVER_TIMING_SETTING );
+
+		ob_start();
+		perflab_render_server_timing_page_field( 'benchmarking_actions' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( '></textarea>', $output );
+	}
+
+	public function test_perflab_render_server_timing_page_field_populated_option() {
+		update_option(
+			PERFLAB_SERVER_TIMING_SETTING,
+			array( 'benchmarking_actions' => array( 'init', 'wp_loaded' ) )
+		);
+
+		ob_start();
+		perflab_render_server_timing_page_field( 'benchmarking_actions' );
+		$output = ob_get_clean();
+
+		// Array is formatted/imploded as strings, one per line.
+		$this->assertStringContainsString( ">init\nwp_loaded</textarea>", $output );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,6 +43,7 @@ tests_add_filter(
 	'plugins_loaded',
 	static function() {
 		require_once TESTS_PLUGIN_DIR . '/admin/load.php';
+		require_once TESTS_PLUGIN_DIR . '/admin/server-timing.php';
 		$module_files = glob( TESTS_PLUGIN_DIR . '/modules/*/*/load.php' );
 		if ( $module_files ) {
 			foreach ( $module_files as $module_file ) {

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -97,41 +97,45 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 
 	public function data_perflab_sanitize_server_timing_setting() {
 		return array(
-			'invalid type'                          => array(
+			'invalid type'                                => array(
 				'invalid',
 				array(),
 			),
-			'empty list, array'                     => array(
+			'empty list, array'                           => array(
 				array( 'benchmarking_actions' => array() ),
 				array(),
 			),
-			'empty list, string'                    => array(
+			'empty list, string'                          => array(
 				array( 'benchmarking_actions' => '' ),
 				array(),
 			),
-			'empty list, string with whitespace'    => array(
+			'empty list, string with whitespace'          => array(
 				array( 'benchmarking_actions' => ' ' ),
 				array(),
 			),
-			'regular list, array'                   => array(
+			'regular list, array'                         => array(
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 			),
-			'regular list, string'                  => array(
+			'regular list, string'                        => array(
 				array( 'benchmarking_actions' => "after_setup_theme\ninit\nwp_loaded" ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 			),
-			'regular list, string with whitespace'  => array(
+			'regular list, string with whitespace'        => array(
 				array( 'benchmarking_actions' => "after_setup_theme \ninit \n\nwp_loaded\n" ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 			),
-			'regular list, string with unformatted' => array(
+			'regular list, string with unformatted'       => array(
 				array( 'benchmarking_actions' => "After_Setup_Theme\ninit?\nWP_Loaded" ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 			),
-			'regular list, array with duplicates'   => array(
+			'regular list, array with duplicates'         => array(
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded', 'init' ) ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+			),
+			'regular list, array with special hook chars' => array(
+				array( 'benchmarking_actions' => array( 'namespace/hookname', 'namespace.hookname' ) ),
+				array( 'benchmarking_actions' => array( 'namespace/hookname', 'namespace.hookname' ) ),
 			),
 		);
 	}

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -103,15 +103,15 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 			),
 			'empty list, array'                           => array(
 				array( 'benchmarking_actions' => array() ),
-				array(),
+				array( 'benchmarking_actions' => array() ),
 			),
 			'empty list, string'                          => array(
 				array( 'benchmarking_actions' => '' ),
-				array(),
+				array( 'benchmarking_actions' => array() ),
 			),
 			'empty list, string with whitespace'          => array(
 				array( 'benchmarking_actions' => ' ' ),
-				array(),
+				array( 'benchmarking_actions' => array() ),
 			),
 			'regular list, array'                         => array(
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -122,7 +122,7 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 			),
 			'regular list, string with whitespace'        => array(
-				array( 'benchmarking_actions' => "after_setup_theme \ninit \n\nwp_loaded\n" ),
+				array( 'benchmarking_actions' => "after_setup_  theme \ninit \n\nwp_loaded\n" ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 			),
 			'regular list, array with duplicates'         => array(

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -125,10 +125,6 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 				array( 'benchmarking_actions' => "after_setup_theme \ninit \n\nwp_loaded\n" ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
 			),
-			'regular list, string with unformatted'       => array(
-				array( 'benchmarking_actions' => "After_Setup_Theme\ninit?\nWP_Loaded" ),
-				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
-			),
 			'regular list, array with duplicates'         => array(
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded', 'init' ) ),
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -58,4 +58,81 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 
 		$this->assertSame( 123, $wrapped(), 'Calling wrapped callback multiple times should not result in warning' );
 	}
+
+	public function test_perflab_register_server_timing_setting() {
+		global $new_allowed_options, $wp_registered_settings;
+
+		// Reset relevant globals.
+		$wp_registered_settings = array();
+		$new_allowed_options = array();
+
+		perflab_register_server_timing_setting();
+
+		// Assert that the setting is correctly registered.
+		$settings = get_registered_settings();
+		$this->assertTrue( isset( $settings[ PERFLAB_SERVER_TIMING_SETTING ] ) );
+
+		// Assert that the setting is allowlisted for the relevant screen.
+		$this->assertTrue( isset( $new_allowed_options[ PERFLAB_SERVER_TIMING_SCREEN ] ) );
+		$this->assertSame( array( PERFLAB_SERVER_TIMING_SETTING ), $new_allowed_options[ PERFLAB_SERVER_TIMING_SCREEN ] );
+
+		// Assert that registered default works correctly.
+		$this->assertSame( array(), get_option( PERFLAB_SERVER_TIMING_SETTING ) );
+
+		// Assert that most basic sanitization works correctly (an array is required).
+		update_option( PERFLAB_SERVER_TIMING_SETTING, 'invalid' );
+		$this->assertSame( array(), get_option( PERFLAB_SERVER_TIMING_SETTING ) );
+	}
+
+	/**
+	 * @dataProvider data_perflab_sanitize_server_timing_setting
+	 *
+	 * @param mixed $unsanitized Unsanitized input.
+	 * @param array $expected    Expected sanitized output.
+	 */
+	public function test_perflab_sanitize_server_timing_setting( $unsanitized, $expected ) {
+		$sanitized = perflab_sanitize_server_timing_setting( $unsanitized );
+		$this->assertSame( $expected, $sanitized );
+	}
+
+	public function data_perflab_sanitize_server_timing_setting() {
+		return array(
+			'invalid type'                          => array(
+				'invalid',
+				array(),
+			),
+			'empty list, array'                     => array(
+				array( 'benchmarking_actions' => array() ),
+				array(),
+			),
+			'empty list, string'                    => array(
+				array( 'benchmarking_actions' => '' ),
+				array(),
+			),
+			'empty list, string with whitespace'    => array(
+				array( 'benchmarking_actions' => ' ' ),
+				array(),
+			),
+			'regular list, array'                   => array(
+				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+			),
+			'regular list, string'                  => array(
+				array( 'benchmarking_actions' => "after_setup_theme\ninit\nwp_loaded" ),
+				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+			),
+			'regular list, string with whitespace'  => array(
+				array( 'benchmarking_actions' => "after_setup_theme \ninit \n\nwp_loaded\n" ),
+				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+			),
+			'regular list, string with unformatted' => array(
+				array( 'benchmarking_actions' => "After_Setup_Theme\ninit?\nWP_Loaded" ),
+				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+			),
+			'regular list, array with duplicates'   => array(
+				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded', 'init' ) ),
+				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+			),
+		);
+	}
 }

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -133,6 +133,10 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 				array( 'benchmarking_actions' => array( 'namespace/hookname', 'namespace.hookname' ) ),
 				array( 'benchmarking_actions' => array( 'namespace/hookname', 'namespace.hookname' ) ),
 			),
+			'regular list, disallowed key'                => array(
+				array( 'not_allowed' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
+				array(),
+			),
 		);
 	}
 }


### PR DESCRIPTION
## Summary

This PR implements a WP Admin screen _Tools > Server-Timing_ which allows providing action and filter names. Any hook names provided will be measured and exposed in the `Server-Timing` header in the frontend.

While the Server-Timing API from #553 has been a powerful foundation, it can sometimes be cumbersome to measure specific hooks performance, since it always requires writing custom code. [Gists like this one](https://gist.github.com/felixarntz/63c05392dbf7d51cc7f8f4a424b1ff39) can be used for that, but even with such thing it may be easier to just add the action or filter to a UI instead of having to modify a plugin's code. This PR makes it really easy and gives site owners control about specific hooks to measure.

<img width="1186" alt="Admin screen to manage hooks to measure with Server-Timing" src="https://github.com/WordPress/performance/assets/3531426/2d897138-894b-4a35-b02e-e2a6bb3bec54">

_The new admin screen with example input_

## Relevant technical choices

* Adds a new WordPress option/setting to store Server-Timing configuration.
* Adds a new WP Admin screen with textareas to provide action and filter names.
* Uses the data from the new option/setting to measure the duration of those hooks, using similar logic as previously implemented in [the aforementioned Gist](https://gist.github.com/felixarntz/63c05392dbf7d51cc7f8f4a424b1ff39).

## Testing
1. Go to _Tools > Server-Timing_.
2. Add some hook names (actions and/or filters), one per line. For example those from the screenshot above.
3. Save and verify the hook names are still shown in the textareas, in a sanitized way.
    * For example, try to add spaces or (other) invalid characters and check that they're stripped after submitting.
4. Load the frontend.
5. Type `console.table( performance.getEntries()[0].serverTiming )` in the browser's dev tools console.
6. Verify that you see measurements for the actions/filters you provided, via `wp-action-{$action}` / `wp-filter-{$filter}` metrics.
    * Note that metrics will only show up if the respective action/filter was actually run during the request.
    * If you provide hook names that are only run after the template is being parsed (e.g. `wp_enqueue_scripts` action), they won't show up by default. You'll need to activate output buffering (e.g. via [this Gist plugin](https://gist.github.com/felixarntz/9c3d7150c74082e69bb426393b68b12e)) so that those can be exposed as well.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
