### PR TITLE
Fix incorrect function prefixes in Dominant Color Images

### DIFF
--- a/modules/images/dominant-color-images/helper.php
+++ b/modules/images/dominant-color-images/helper.php
@@ -41,17 +41,18 @@ function dominant_color_set_image_editors( $editors ) {
  * Computes the dominant color of the given attachment image and whether it has transparency.
  *
  * @since 1.2.0
+ * @since n.e.x.t Function renamed to remove the `_` prefix.
  * @access private
  *
  * @param int $attachment_id The attachment ID.
  * @return array|WP_Error Array with the dominant color and has transparency values or WP_Error on error.
  */
-function _dominant_color_get_dominant_color_data( $attachment_id ) {
+function dominant_color_get_dominant_color_data( $attachment_id ) {
 	$mime_type = get_post_mime_type( $attachment_id );
 	if ( 'application/pdf' === $mime_type ) {
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'performance-lab' ) );
 	}
-	$file = wp_get_attachment_file_path( $attachment_id );
+	$file = dominant_color_get_attachment_file_path( $attachment_id );
 	if ( ! $file ) {
 		$file = get_attached_file( $attachment_id );
 	}
@@ -90,12 +91,13 @@ function _dominant_color_get_dominant_color_data( $attachment_id ) {
  * Gets file path of image based on size.
  *
  * @since 1.2.0
+ * @since n.e.x.t Function renamed to change `wp_` prefix to `dominant_color_`.
  *
  * @param int    $attachment_id Attachment ID for image.
  * @param string $size          Optional. Image size. Default 'medium'.
  * @return false|string Path to an image or false if not found.
  */
-function wp_get_attachment_file_path( $attachment_id, $size = 'medium' ) {
+function dominant_color_get_attachment_file_path( $attachment_id, $size = 'medium' ) {
 	$imagedata = wp_get_attachment_metadata( $attachment_id );
 	if ( ! is_array( $imagedata ) ) {
 		return false;

--- a/modules/images/dominant-color-images/hooks.php
+++ b/modules/images/dominant-color-images/hooks.php
@@ -16,7 +16,7 @@
  * @return array $metadata The attachment metadata.
  */
 function dominant_color_metadata( $metadata, $attachment_id ) {
-	$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
+	$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 	if ( ! is_wp_error( $dominant_color_data ) ) {
 		if ( isset( $dominant_color_data['dominant_color'] ) ) {
 			$metadata['dominant_color'] = $dominant_color_data['dominant_color'];

--- a/tests/modules/images/dominant-color-images/dominant-color-image-editor-gd-test.php
+++ b/tests/modules/images/dominant-color-images/dominant-color-image-editor-gd-test.php
@@ -33,7 +33,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
-		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
+		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertContains( $dominant_color_data['dominant_color'], $expected_color );
 		$this->assertSame( $dominant_color_data['has_transparency'], $expected_transparency );
@@ -53,7 +53,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
-		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
+		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
 		$this->assertStringContainsString( 'image_no_editor', $dominant_color_data->get_error_code() );
@@ -71,7 +71,7 @@ class Dominant_Color_Image_Editor_GD_Test extends DominantColorTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
-		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
+		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
 	}

--- a/tests/modules/images/dominant-color-images/dominant-color-image-editor-imageick-test.php
+++ b/tests/modules/images/dominant-color-images/dominant-color-image-editor-imageick-test.php
@@ -35,7 +35,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
-		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
+		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertContains( $dominant_color_data['dominant_color'], $expected_color );
 		$this->assertSame( $dominant_color_data['has_transparency'], $expected_transparency );
@@ -55,7 +55,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
-		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
+		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertContains( $dominant_color_data['dominant_color'], $expected_color );
 		$this->assertSame( $dominant_color_data['has_transparency'], $expected_transparency );
@@ -73,7 +73,7 @@ class Dominant_Color_Image_Editor_Imageick_Test extends DominantColorTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
 		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
-		$dominant_color_data = _dominant_color_get_dominant_color_data( $attachment_id );
+		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
 	}


### PR DESCRIPTION
## Summary

This was flagged during plugin review of the "Dominant Color Images" submission. Of course this is intended to be a feature plugin, but we should still properly prefix functions. Specifically, using `_` or `wp_` as prefix is not allowed in plugins.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
