### PR TITLE
Add early exit clauses to files with procedural code

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -5,6 +5,10 @@
  * @package performance-lab
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Adds the modules page to the Settings menu.
  *

--- a/load.php
+++ b/load.php
@@ -15,6 +15,10 @@
  * @package performance-lab
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 define( 'PERFLAB_VERSION', '2.5.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );

--- a/modules/database/audit-autoloaded-options/helper.php
+++ b/modules/database/audit-autoloaded-options/helper.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Callback for autoloaded_options test.
  *

--- a/modules/database/audit-autoloaded-options/hooks.php
+++ b/modules/database/audit-autoloaded-options/hooks.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Adds test to site health.
  *

--- a/modules/images/dominant-color-images/helper.php
+++ b/modules/images/dominant-color-images/helper.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Overloads wp_image_editors() to load the extended classes.
  *

--- a/modules/images/dominant-color-images/hooks.php
+++ b/modules/images/dominant-color-images/hooks.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Add the dominant color metadata to the attachment.
  *

--- a/modules/images/fetchpriority/can-load.php
+++ b/modules/images/fetchpriority/can-load.php
@@ -6,6 +6,10 @@
  * @package performance-lab
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 return static function() {
 	return ! function_exists( 'wp_get_loading_optimization_attributes' );
 };

--- a/modules/images/fetchpriority/hooks.php
+++ b/modules/images/fetchpriority/hooks.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Filters an image tag in content to add the fetchpriority attribute if it is not lazy-loaded.
  *

--- a/modules/images/webp-support/helper.php
+++ b/modules/images/webp-support/helper.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Callback for webp_enabled test.
  *

--- a/modules/images/webp-support/hooks.php
+++ b/modules/images/webp-support/hooks.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Adds tests to site health.
  *

--- a/modules/images/webp-uploads/can-load.php
+++ b/modules/images/webp-uploads/can-load.php
@@ -6,6 +6,10 @@
  * @package performance-lab
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 return static function() {
 	return ! function_exists( 'wp_image_use_alternate_mime_types' );
 };

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -6,6 +6,10 @@
  * @since 1.0.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Returns an array with the list of valid mime types that a specific mime type can be converted into it,
  * for example an image/jpeg can be converted into an image/webp.

--- a/modules/images/webp-uploads/hooks.php
+++ b/modules/images/webp-uploads/hooks.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Hook called by `wp_generate_attachment_metadata` to create the `sources` property for every image
  * size, the sources' property would create a new image size with all the mime types specified in

--- a/modules/images/webp-uploads/image-edit.php
+++ b/modules/images/webp-uploads/image-edit.php
@@ -6,6 +6,10 @@
  * @since 1.0.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Adds sources to metadata for an attachment.
  *

--- a/modules/images/webp-uploads/rest-api.php
+++ b/modules/images/webp-uploads/rest-api.php
@@ -6,6 +6,10 @@
  * @since 1.0.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Updates the response for an attachment to include sources for additional mime types available the image.
  *

--- a/modules/images/webp-uploads/settings.php
+++ b/modules/images/webp-uploads/settings.php
@@ -6,6 +6,10 @@
  * @since 1.6.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Registers setting for generating both JPEG and WebP versions for image uploads.
  *

--- a/modules/js-and-css/audit-enqueued-assets/helper.php
+++ b/modules/js-and-css/audit-enqueued-assets/helper.php
@@ -6,6 +6,10 @@
  * @since 1.0.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Callback for enqueued_js_assets test.
  *

--- a/modules/js-and-css/audit-enqueued-assets/hooks.php
+++ b/modules/js-and-css/audit-enqueued-assets/hooks.php
@@ -6,6 +6,10 @@
  * @since 2.1.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Audit enqueued and printed scripts in is_front_page(). Ignore /wp-includes scripts.
  *

--- a/server-timing/defaults.php
+++ b/server-timing/defaults.php
@@ -6,6 +6,10 @@
  * @since 1.8.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Registers the default Server-Timing metrics for before rendering the template.
  *

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -6,6 +6,10 @@
  * @since 1.8.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 /**
  * Provides access the Server-Timing API.
  *

--- a/server-timing/object-cache.copy.php
+++ b/server-timing/object-cache.copy.php
@@ -28,6 +28,10 @@
  * @since 1.8.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
 // Set constant to be able to later check for whether this file was loaded.
 if ( ! defined( 'PERFLAB_OBJECT_CACHE_DROPIN_VERSION' ) ) {
 	define( 'PERFLAB_OBJECT_CACHE_DROPIN_VERSION', 2 );


### PR DESCRIPTION
## Summary

This was flagged during plugin review of the "Dominant Color Images" submission. Any files with procedural code should have an early exit condition. Most typically the one based on whether `! defined( 'ABSPATH' )`, but another relevant constant can used as well. For example, in the files where we already check for a Performance Lab specific constant on top of the file, we don't have to add to or update those files.

Keep in mind that this is only required for files with _procedural_ code, i.e. not files that only contain a class or similar construct.

There are varying opinions on this approach, but given it's requested by the plugin review team and is not a big deal to add, let's follow the pattern.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
