### PR TITLE
Allow disabling Server-Timing entirely using `PERFLAB_DISABLE_SERVER_TIMING` constant

### DIFF
--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -5,6 +5,15 @@
  * @package performance-lab
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+// Do not add any of the hooks if Server-Timing is disabled.
+if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {
+	return;
+}
+
 /**
  * Adds the Server-Timing page to the Tools menu.
  *

--- a/load.php
+++ b/load.php
@@ -316,8 +316,9 @@ add_action( 'plugins_loaded', 'perflab_load_active_and_valid_modules' );
  * This only runs in WP Admin to not have any potential performance impact on
  * the frontend.
  *
- * This function will short-circuit if the constant
- * 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is set as true.
+ * This function will short-circuit if at least one of the constants
+ * 'PERFLAB_DISABLE_SERVER_TIMING' or 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is
+ * set as true.
  *
  * @since 1.8.0
  * @since 2.1.0 No longer attempts to use two of the drop-ins together.
@@ -326,6 +327,11 @@ add_action( 'plugins_loaded', 'perflab_load_active_and_valid_modules' );
  */
 function perflab_maybe_set_object_cache_dropin() {
 	global $wp_filesystem;
+
+	// Bail if Server-Timing is disabled entirely.
+	if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {
+		return;
+	}
 
 	// Bail if disabled via constant.
 	if ( defined( 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' ) && PERFLAB_DISABLE_OBJECT_CACHE_DROPIN ) {

--- a/server-timing/defaults.php
+++ b/server-timing/defaults.php
@@ -10,6 +10,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+// Do not add any of the hooks if Server-Timing is disabled.
+if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {
+	return;
+}
+
 /**
  * Registers the default Server-Timing metrics for before rendering the template.
  *

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -37,7 +37,6 @@ function perflab_server_timing() {
 
 	return $server_timing;
 }
-
 add_action( 'wp_loaded', 'perflab_server_timing' );
 
 /**

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -10,6 +10,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+// Do not add any of the hooks if Server-Timing is disabled.
+if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {
+	return;
+}
+
 define( 'PERFLAB_SERVER_TIMING_SETTING', 'perflab_server_timing_settings' );
 define( 'PERFLAB_SERVER_TIMING_SCREEN', 'perflab-server-timing' );
 
@@ -32,6 +37,7 @@ function perflab_server_timing() {
 
 	return $server_timing;
 }
+
 add_action( 'wp_loaded', 'perflab_server_timing' );
 
 /**

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -32,6 +32,17 @@ function perflab_server_timing() {
 
 	if ( null === $server_timing ) {
 		$server_timing = new Perflab_Server_Timing();
+
+		/*
+		 * Do not add the hook for Server-Timing header output if it is entirely disabled.
+		 * While the constant checks on top of the file prevent this from happening by default, external code could
+		 * still call the `perflab_server_timing()` function. It needs to be ensured that such calls do not result in
+		 * fatal errors, but they should at least not lead to the header being output.
+		 */
+		if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {
+			return $server_timing;
+		}
+
 		add_filter( 'template_include', array( $server_timing, 'on_template_include' ), PHP_INT_MAX );
 	}
 

--- a/server-timing/object-cache.copy.php
+++ b/server-timing/object-cache.copy.php
@@ -41,12 +41,17 @@ if ( ! function_exists( 'perflab_load_server_timing_api_from_dropin' ) ) {
 	/**
 	 * Loads the Performance Lab Server-Timing API if available.
 	 *
-	 * This function will short-circuit if the constant
+	 * This function will short-circuit if at least one of the constants
+	 * 'PERFLAB_DISABLE_SERVER_TIMING' or
 	 * 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is set as true.
 	 *
 	 * @since 1.8.0
 	 */
 	function perflab_load_server_timing_api_from_dropin() {
+		if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {
+			return;
+		}
+
 		if ( defined( 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' ) && PERFLAB_DISABLE_OBJECT_CACHE_DROPIN ) {
 			return;
 		}


### PR DESCRIPTION
## Summary

Fixes #794

Note that the branch is based on the branch from #784 since it touches a lot of related code. Once that PR is merged, this one can have its base updated to `trunk`.

## Testing

1. Set constant `PERFLAB_DISABLE_SERVER_TIMING` to `true` in your `wp-config.php`.
2. Ensure that Server-Timing header is not present in response.
3. Ensure that _Tools > Server-Timing_ WP Admin screen is not available.
4. Ensure that, on a fresh install, the PL plugin's version of the `object-cache.php` drop-in is not placed.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
