### PR TITLE
Add Spell Check action

### DIFF
--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,12 @@
+name: Spell Check
+
+on: [pull_request]
+
+jobs:
+  spell-checker:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Search for misspellings
+        uses: crate-ci/typos@master


### PR DESCRIPTION
Follow-up of #798

As per @joemcgill comment https://github.com/WordPress/performance/issues/798#issuecomment-1675191789 i added new CI for Spell Check that show error at the moment.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
