### PR TITLE
Bump WPCS to v3.0.0

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -83,7 +83,7 @@ function perflab_load_modules_page( $modules = null, $focus_areas = null ) {
 		add_settings_field(
 			$module_slug,
 			$module_data['name'],
-			static function() use ( $module_slug, $module_data, $module_settings ) {
+			static function () use ( $module_slug, $module_data, $module_settings ) {
 				perflab_render_modules_page_field( $module_slug, $module_data, $module_settings );
 			},
 			PERFLAB_MODULES_SCREEN,
@@ -238,7 +238,7 @@ function perflab_get_modules( $modules_root = null ) {
 
 	// Modules are organized as {focus}/{module-slug} in the modules folder.
 	if ( $modules_dir ) {
-		// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+		// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 		while ( ( $focus = readdir( $modules_dir ) ) !== false ) {
 			if ( '.' === substr( $focus, 0, 1 ) ) {
 				continue;
@@ -253,7 +253,7 @@ function perflab_get_modules( $modules_root = null ) {
 			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			$focus_dir = @opendir( $modules_root . '/' . $focus );
 			if ( $focus_dir ) {
-				// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+				// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 				while ( ( $file = readdir( $focus_dir ) ) !== false ) {
 					// Unlike plugins, modules must be in a directory.
 					if ( ! is_dir( $modules_root . '/' . $focus . '/' . $file ) ) {
@@ -264,7 +264,7 @@ function perflab_get_modules( $modules_root = null ) {
 					// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 					$module_dir = @opendir( $modules_root . '/' . $focus . '/' . $file );
 					if ( $module_dir ) {
-						// phpcs:ignore WordPress.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
+						// phpcs:ignore Generic.CodeAnalysis.AssignmentInCondition.FoundInWhileCondition
 						while ( ( $subfile = readdir( $module_dir ) ) !== false ) {
 							if ( '.' === substr( $subfile, 0, 1 ) ) {
 								continue;
@@ -304,7 +304,7 @@ function perflab_get_modules( $modules_root = null ) {
 
 	uasort(
 		$modules,
-		static function( $a, $b ) {
+		static function ( $a, $b ) {
 			return strnatcasecmp( $a['name'], $b['name'] );
 		}
 	);

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -46,7 +46,7 @@ function perflab_load_server_timing_page() {
 	add_settings_section(
 		'benchmarking',
 		__( 'Benchmarking', 'performance-lab' ),
-		static function() {
+		static function () {
 			?>
 			<p>
 				<?php
@@ -94,7 +94,7 @@ function perflab_load_server_timing_page() {
 	add_settings_field(
 		'benchmarking_actions',
 		__( 'Actions', 'performance-lab' ),
-		static function() {
+		static function () {
 			perflab_render_server_timing_page_field( 'benchmarking_actions' );
 		},
 		PERFLAB_SERVER_TIMING_SCREEN,
@@ -104,7 +104,7 @@ function perflab_load_server_timing_page() {
 	add_settings_field(
 		'benchmarking_filters',
 		__( 'Filters', 'performance-lab' ),
-		static function() {
+		static function () {
 			perflab_render_server_timing_page_field( 'benchmarking_filters' );
 		},
 		PERFLAB_SERVER_TIMING_SCREEN,

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "phpunit/phpunit": "^4|^5|^6|^7|^8|^9",
     "squizlabs/php_codesniffer": "^3.5",
     "szepeviktor/phpstan-wordpress": "^1.3.0",
-    "wp-coding-standards/wpcs": "^2.2",
+    "wp-coding-standards/wpcs": "^3.0.0",
     "wp-phpunit/wp-phpunit": "^5.8",
     "yoast/phpunit-polyfills": "^1.0",
     "phpstan/phpstan-phpunit": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55dbdd3922ea5308bfcf62ffb3e25ee9",
+    "content-hash": "af12c1c917e1df50223c40d56c19e571",
     "packages": [
         {
             "name": "composer/installers",
@@ -636,6 +636,142 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
             "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "61a9be9f74a53735f7c421d7de8dc64fa80488e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/61a9be9f74a53735f7c421d7de8dc64fa80488e6",
+                "reference": "61a9be9f74a53735f7c421d7de8dc64fa80488e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-07-19T19:40:11+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -2585,30 +2721,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
+                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -2625,6 +2769,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -2632,7 +2777,7 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "time": "2023-08-21T14:28:38+00:00"
         },
         {
             "name": "wp-phpunit/wp-phpunit",
@@ -2752,5 +2897,5 @@
         "php": ">=5.6|^7|^8"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/load.php
+++ b/load.php
@@ -70,7 +70,7 @@ function perflab_get_modules_setting_default() {
 		$default_enabled_modules = require PERFLAB_PLUGIN_DIR_PATH . 'default-enabled-modules.php';
 		$default_option          = array_reduce(
 			$default_enabled_modules,
-			static function( $module_settings, $module_dir ) {
+			static function ( $module_settings, $module_dir ) {
 				$module_settings[ $module_dir ] = array( 'enabled' => true );
 				return $module_settings;
 			},
@@ -97,7 +97,7 @@ function perflab_sanitize_modules_setting( $value ) {
 	// Ensure that every element is an array with an 'enabled' key.
 	return array_filter(
 		array_map(
-			static function( $module_settings ) {
+			static function ( $module_settings ) {
 				if ( ! is_array( $module_settings ) ) {
 					return array();
 				}
@@ -152,7 +152,7 @@ function perflab_get_active_modules() {
 	$modules = array_keys(
 		array_filter(
 			perflab_get_module_settings(),
-			static function( $module_settings ) {
+			static function ( $module_settings ) {
 				return isset( $module_settings['enabled'] ) && $module_settings['enabled'];
 			}
 		)
@@ -531,7 +531,7 @@ add_action(
 	 * @param string $option Name of the option to add.
 	 * @param mixed  $value  Value of the option.
 	 */
-	static function( $option, $value ) {
+	static function ( $option, $value ) {
 		perflab_run_module_activation_deactivation( perflab_get_modules_setting_default(), $value );
 	},
 	10,

--- a/modules/images/fetchpriority/can-load.php
+++ b/modules/images/fetchpriority/can-load.php
@@ -10,6 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-return static function() {
+return static function () {
 	return ! function_exists( 'wp_get_loading_optimization_attributes' );
 };

--- a/modules/images/fetchpriority/hooks.php
+++ b/modules/images/fetchpriority/hooks.php
@@ -76,7 +76,7 @@ add_action( 'wp_head', 'fetchpriority_render_generator' );
 if ( function_exists( 'wp_get_loading_optimization_attributes' ) && ! str_starts_with( FETCHPRIORITY_VERSION, 'Performance Lab ' ) ) {
 	add_action(
 		'admin_notices',
-		static function() {
+		static function () {
 			?>
 			<div class="notice notice-warning">
 				<p>

--- a/modules/images/webp-uploads/can-load.php
+++ b/modules/images/webp-uploads/can-load.php
@@ -10,6 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-return static function() {
+return static function () {
 	return ! function_exists( 'wp_image_use_alternate_mime_types' );
 };

--- a/modules/images/webp-uploads/load.php
+++ b/modules/images/webp-uploads/load.php
@@ -24,7 +24,7 @@ if ( function_exists( 'webp_uploads_create_sources_property' ) ) {
 if ( ! require __DIR__ . '/can-load.php' ) {
 	add_action(
 		'admin_notices',
-		static function() {
+		static function () {
 			printf(
 				'<div class="notice notice-error"><p>%s</p></div>',
 				esc_html__( 'The WebP Uploads feature cannot be loaded from within the plugin since it is already merged into WordPress core.', 'performance-lab' )

--- a/modules/images/webp-uploads/rest-api.php
+++ b/modules/images/webp-uploads/rest-api.php
@@ -17,10 +17,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @param WP_REST_Response $response The original response object.
  * @param WP_Post          $post     The post object.
- * @param WP_REST_Request  $request  The request object.
  * @return WP_REST_Response A new response object for the attachment with additional sources.
  */
-function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Post $post, WP_REST_Request $request ) {
+function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Post $post ) {
 	$data = $response->get_data();
 	if ( ! isset( $data['media_details'] ) || ! is_array( $data['media_details'] ) || ! isset( $data['media_details']['sizes'] ) || ! is_array( $data['media_details']['sizes'] ) ) {
 		return $response;
@@ -51,4 +50,4 @@ function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Pos
 
 	return rest_ensure_response( $data );
 }
-add_filter( 'rest_prepare_attachment', 'webp_uploads_update_rest_attachment', 10, 3 );
+add_filter( 'rest_prepare_attachment', 'webp_uploads_update_rest_attachment', 10, 2 );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -56,8 +56,9 @@
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 
-	<!-- Do not apply filename rules for unit tests -->
+	<!-- Do not apply filename rules for unit tests and object cache -->
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>server-timing/object-cache.copy.php</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
@@ -73,10 +74,4 @@
 	</rule>
 
 	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />
-
-	<!--
-	Prevent errors caused by WordPress Coding Standards not supporting PHP 8.0+.
-	See https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
-	-->
-	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 </ruleset>

--- a/server-timing/class-perflab-server-timing.php
+++ b/server-timing/class-perflab-server-timing.php
@@ -165,7 +165,7 @@ class Perflab_Server_Timing {
 		// Get all metric header values, as long as the current user has access to the metric.
 		$metric_header_values = array_filter(
 			array_map(
-				function( Perflab_Server_Timing_Metric $metric ) {
+				function ( Perflab_Server_Timing_Metric $metric ) {
 					// Check the registered capability here to ensure no metric without access is exposed.
 					if ( ! current_user_can( $this->registered_metrics_data[ $metric->get_slug() ]['access_cap'] ) ) {
 						return null;
@@ -175,7 +175,7 @@ class Perflab_Server_Timing {
 				},
 				$this->registered_metrics
 			),
-			static function( $value ) {
+			static function ( $value ) {
 				return null !== $value;
 			}
 		);
@@ -228,7 +228,7 @@ class Perflab_Server_Timing {
 		}
 
 		ob_start(
-			function( $output ) {
+			function ( $output ) {
 				$this->send_header();
 				return $output;
 			}

--- a/server-timing/defaults.php
+++ b/server-timing/defaults.php
@@ -23,12 +23,12 @@ if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING
  * @since 1.8.0
  */
 function perflab_register_default_server_timing_before_template_metrics() {
-	$calculate_before_template_metrics = static function() {
+	$calculate_before_template_metrics = static function () {
 		// WordPress execution prior to serving the template.
 		perflab_server_timing_register_metric(
 			'before-template',
 			array(
-				'measure_callback' => static function( $metric ) {
+				'measure_callback' => static function ( $metric ) {
 					// The 'timestart' global is set right at the beginning of WordPress execution.
 					$metric->set_value( ( microtime( true ) - $GLOBALS['timestart'] ) * 1000.0 );
 				},
@@ -42,7 +42,7 @@ function perflab_register_default_server_timing_before_template_metrics() {
 			perflab_server_timing_register_metric(
 				'before-template-db-queries',
 				array(
-					'measure_callback' => static function( $metric ) {
+					'measure_callback' => static function ( $metric ) {
 						// This should never happen, but some odd database implementations may be doing it wrong.
 						if ( ! isset( $GLOBALS['wpdb']->queries ) || ! is_array( $GLOBALS['wpdb']->queries ) ) {
 							return;
@@ -51,7 +51,7 @@ function perflab_register_default_server_timing_before_template_metrics() {
 						// Store this value in a global to later subtract it from total query time after template.
 						$GLOBALS['perflab_query_time_before_template'] = array_reduce(
 							$GLOBALS['wpdb']->queries,
-							static function( $acc, $query ) {
+							static function ( $acc, $query ) {
 								return $acc + $query[1];
 							},
 							0.0
@@ -70,7 +70,7 @@ function perflab_register_default_server_timing_before_template_metrics() {
 	// modify the value prior to the check.
 	add_filter(
 		'template_include',
-		static function( $passthrough ) use ( $calculate_before_template_metrics ) {
+		static function ( $passthrough ) use ( $calculate_before_template_metrics ) {
 			if ( perflab_server_timing_use_output_buffer() ) {
 				$calculate_before_template_metrics();
 			}
@@ -80,7 +80,7 @@ function perflab_register_default_server_timing_before_template_metrics() {
 	);
 	add_action(
 		'perflab_server_timing_send_header',
-		static function() use ( $calculate_before_template_metrics ) {
+		static function () use ( $calculate_before_template_metrics ) {
 			if ( ! perflab_server_timing_use_output_buffer() ) {
 				$calculate_before_template_metrics();
 			}
@@ -94,7 +94,7 @@ function perflab_register_default_server_timing_before_template_metrics() {
 	if ( PERFLAB_OBJECT_CACHE_DROPIN_VERSION ) {
 		add_filter(
 			'query',
-			static function( $query ) {
+			static function ( $query ) {
 				global $wpdb;
 				if ( "SELECT option_name, option_value FROM $wpdb->options WHERE autoload = 'yes'" !== $query ) {
 					return $query;
@@ -106,11 +106,11 @@ function perflab_register_default_server_timing_before_template_metrics() {
 				perflab_server_timing_register_metric(
 					'load-alloptions-query',
 					array(
-						'measure_callback' => static function( $metric ) {
+						'measure_callback' => static function ( $metric ) {
 							$metric->measure_before();
 							add_filter(
 								'pre_cache_alloptions',
-								static function( $passthrough ) use ( $metric ) {
+								static function ( $passthrough ) use ( $metric ) {
 									$metric->measure_after();
 									return $passthrough;
 								}
@@ -143,12 +143,12 @@ function perflab_register_default_server_timing_template_metrics() {
 
 	add_filter(
 		'template_include',
-		static function( $passthrough = null ) {
+		static function ( $passthrough = null ) {
 			// WordPress execution while serving the template.
 			perflab_server_timing_register_metric(
 				'template',
 				array(
-					'measure_callback' => static function( $metric ) {
+					'measure_callback' => static function ( $metric ) {
 						$metric->measure_before();
 						add_action( 'perflab_server_timing_send_header', array( $metric, 'measure_after' ), PHP_INT_MAX );
 					},
@@ -163,12 +163,12 @@ function perflab_register_default_server_timing_template_metrics() {
 
 	add_action(
 		'perflab_server_timing_send_header',
-		static function() {
+		static function () {
 			// WordPress total load time.
 			perflab_server_timing_register_metric(
 				'total',
 				array(
-					'measure_callback' => static function( $metric ) {
+					'measure_callback' => static function ( $metric ) {
 						// The 'timestart' global is set right at the beginning of WordPress execution.
 						$metric->set_value( ( microtime( true ) - $GLOBALS['timestart'] ) * 1000.0 );
 					},
@@ -182,12 +182,12 @@ function perflab_register_default_server_timing_template_metrics() {
 	if ( defined( 'SAVEQUERIES' ) && SAVEQUERIES ) {
 		add_action(
 			'perflab_server_timing_send_header',
-			static function() {
+			static function () {
 				// WordPress database query time within template.
 				perflab_server_timing_register_metric(
 					'template-db-queries',
 					array(
-						'measure_callback' => static function( $metric ) {
+						'measure_callback' => static function ( $metric ) {
 							// This global should typically be set when this is called, but check just in case.
 							if ( ! isset( $GLOBALS['perflab_query_time_before_template'] ) ) {
 								return;
@@ -200,7 +200,7 @@ function perflab_register_default_server_timing_template_metrics() {
 
 							$total_query_time = array_reduce(
 								$GLOBALS['wpdb']->queries,
-								static function( $acc, $query ) {
+								static function ( $acc, $query ) {
 									return $acc + $query[1];
 								},
 								0.0
@@ -265,7 +265,7 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 	 */
 	add_action(
 		'all',
-		static function( $hook_name ) use ( $hooks_to_measure ) {
+		static function ( $hook_name ) use ( $hooks_to_measure ) {
 			if ( ! isset( $hooks_to_measure[ $hook_name ] ) ) {
 				return;
 			}
@@ -277,17 +277,17 @@ function perflab_register_additional_server_timing_metrics_from_setting() {
 				return;
 			}
 
-			$measure_callback = static function( $metric ) use ( $hook_name, $hook_type ) {
+			$measure_callback = static function ( $metric ) use ( $hook_name, $hook_type ) {
 				$metric->measure_before();
 
 				if ( 'action' === $hook_type ) {
-					$cb = static function() use ( $metric, $hook_name, &$cb ) {
+					$cb = static function () use ( $metric, $hook_name, &$cb ) {
 						$metric->measure_after();
 						remove_action( $hook_name, $cb, PHP_INT_MAX );
 					};
 					add_action( $hook_name, $cb, PHP_INT_MAX );
 				} else {
-					$cb = static function( $passthrough ) use ( $metric, $hook_name, &$cb ) {
+					$cb = static function ( $passthrough ) use ( $metric, $hook_name, &$cb ) {
 						$metric->measure_after();
 						remove_filter( $hook_name, $cb, PHP_INT_MAX );
 						return $passthrough;

--- a/server-timing/load.php
+++ b/server-timing/load.php
@@ -96,7 +96,7 @@ function perflab_server_timing_use_output_buffer() {
  * @return callable Callback function that will run $callback and measure its execution time once called.
  */
 function perflab_wrap_server_timing( $callback, $metric_slug, $access_cap ) {
-	return static function( ...$callback_args ) use ( $callback, $metric_slug, $access_cap ) {
+	return static function ( ...$callback_args ) use ( $callback, $metric_slug, $access_cap ) {
 		// Gain access to Perflab_Server_Timing_Metric instance.
 		$server_timing_metric = null;
 
@@ -106,7 +106,7 @@ function perflab_wrap_server_timing( $callback, $metric_slug, $access_cap ) {
 			perflab_server_timing_register_metric(
 				$metric_slug,
 				array(
-					'measure_callback' => static function( $metric ) use ( &$server_timing_metric ) {
+					'measure_callback' => static function ( $metric ) use ( &$server_timing_metric ) {
 						$server_timing_metric = $metric;
 					},
 					'access_cap'       => $access_cap,
@@ -183,7 +183,7 @@ function perflab_sanitize_server_timing_setting( $value ) {
 			array_unique(
 				array_filter(
 					array_map(
-						static function( $hookname ) {
+						static function ( $hookname ) {
 							/*
 							 * Allow any characters except whitespace.
 							 * While most hooks use a limited set of characters, hook names in plugins are not


### PR DESCRIPTION
## Summary
The latest version of [WPCS 3.0.0](https://make.wordpress.org/core/2023/08/21/wordpresscs-3-0-0-is-now-available/) is released yesterday.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
