### PR TITLE
Merge 2.6.1 release back into `trunk`

### DIFF
--- a/load.php
+++ b/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance modules.
  * Requires at least: 6.1
  * Requires PHP: 5.6
- * Version: 2.6.0
+ * Version: 2.6.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '2.6.0' );
+define( 'PERFLAB_VERSION', '2.6.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_MODULES_SETTING', 'perflab_modules_settings' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.1
 Tested up to:      6.3
 Requires PHP:      5.6
-Stable tag:        2.6.0
+Stable tag:        2.6.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, javascript, site health, measurement, object caching
@@ -79,6 +79,16 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the WebP Uploads module will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.6.1 =
+
+**Bug Fixes**
+
+* Infrastructure: Remove PHPStan config file from plugin directory. ([816](https://github.com/WordPress/performance/pull/816))
+
+**Documentation**
+
+* Infrastructure: Add standalone plugin assets. ([815](https://github.com/WordPress/performance/pull/815))
 
 = 2.6.0 =
 


### PR DESCRIPTION
## Summary

Fixes #836

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
