### PR TITLE
Publish Dominant Color Images standalone plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,4 +1,8 @@
 {
+  "images/dominant-color-images": {
+    "slug": "dominant-color-images",
+    "version": "1.0.0"
+  },
   "images/fetchpriority": {
     "slug": "fetchpriority",
     "version": "1.1.1"


### PR DESCRIPTION
## Summary

Fixes #637

Readme and brand assets are already present for the plugin. So adding it to `plugins.json` is all that is left. 🎉 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
