### PR TITLE
Update `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Performance Lab plugin! Compl
 
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the Performance Lab plugin must follow these requirements:
 
-- **WordPress**: As of Performance Lab v1.6.0, released October 17, 2022, the plugin's minimum WordPress version requirement is 6.0.
+- **WordPress**: As of Performance Lab v2.7.0, released October 16, 2023, the plugin's minimum WordPress version requirement is 6.3.
 - **PHP**: Always match the latest WordPress version. The minimum required version right now is 7.0.
 
 


### PR DESCRIPTION
## Summary

In PR #851, we increased the minimum required WordPress version to 6.3. Therefore, it is necessary to update the `CONTRIBUTING.md` file to reflect this change.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
