### PR TITLE
Updated Inline PHP Documentation

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -41,9 +41,9 @@ add_action( 'admin_menu', 'perflab_add_modules_page' );
 /**
  * Initializes settings sections and fields for the modules page.
  *
- * @global array $wp_settings_sections Registered WordPress settings sections.
- *
  * @since 1.0.0
+ * 
+ * @global array $wp_settings_sections Registered WordPress settings sections.
  *
  * @param array|null $modules     Associative array of available module data, keyed by module slug. By default, this
  *                                will rely on {@see perflab_get_modules()}.

--- a/admin/load.php
+++ b/admin/load.php
@@ -42,7 +42,7 @@ add_action( 'admin_menu', 'perflab_add_modules_page' );
  * Initializes settings sections and fields for the modules page.
  *
  * @since 1.0.0
- * 
+ *
  * @global array $wp_settings_sections Registered WordPress settings sections.
  *
  * @param array|null $modules     Associative array of available module data, keyed by module slug. By default, this

--- a/modules/database/audit-autoloaded-options/helper.php
+++ b/modules/database/audit-autoloaded-options/helper.php
@@ -95,6 +95,8 @@ function perflab_aao_autoloaded_options_test() {
  *
  * @since 1.0.0
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ * 
  * @return int autoloaded data in bytes.
  */
 function perflab_aao_autoloaded_options_size() {
@@ -107,6 +109,8 @@ function perflab_aao_autoloaded_options_size() {
  *
  * @since 1.5.0
  *
+ * @global wpdb $wpdb WordPress database abstraction object.
+ * 
  * @return array Autoloaded data as option names and their sizes.
  */
 function perflab_aao_query_autoloaded_options() {

--- a/modules/database/audit-autoloaded-options/helper.php
+++ b/modules/database/audit-autoloaded-options/helper.php
@@ -96,7 +96,7 @@ function perflab_aao_autoloaded_options_test() {
  * @since 1.0.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
- * 
+ *
  * @return int autoloaded data in bytes.
  */
 function perflab_aao_autoloaded_options_size() {
@@ -110,7 +110,7 @@ function perflab_aao_autoloaded_options_size() {
  * @since 1.5.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
- * 
+ *
  * @return array Autoloaded data as option names and their sizes.
  */
 function perflab_aao_query_autoloaded_options() {

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -289,7 +289,7 @@ function webp_uploads_get_content_image_mimes( $attachment_id, $context ) {
  * @since 1.3.0
  *
  * @global WP_Query $wp_query WordPress Query object.
- * 
+ *
  * @return bool True if in the <body> within a frontend request, false otherwise.
  */
 function webp_uploads_in_frontend_body() {

--- a/modules/images/webp-uploads/helper.php
+++ b/modules/images/webp-uploads/helper.php
@@ -288,6 +288,8 @@ function webp_uploads_get_content_image_mimes( $attachment_id, $context ) {
  *
  * @since 1.3.0
  *
+ * @global WP_Query $wp_query WordPress Query object.
+ * 
  * @return bool True if in the <body> within a frontend request, false otherwise.
  */
 function webp_uploads_in_frontend_body() {

--- a/modules/js-and-css/audit-enqueued-assets/hooks.php
+++ b/modules/js-and-css/audit-enqueued-assets/hooks.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * It will save information in a transient for 12 hours.
  *
  * @since 1.0.0
+ * 
+ * @global WP_Scripts $wp_scripts
  */
 function perflab_aea_audit_enqueued_scripts() {
 	if ( ! is_admin() && is_front_page() && current_user_can( 'view_site_health_checks' ) && false === get_transient( 'aea_enqueued_front_page_scripts' ) ) {
@@ -59,6 +61,8 @@ add_action( 'wp_footer', 'perflab_aea_audit_enqueued_scripts', PHP_INT_MAX );
  * It will save information in a transient for 12 hours.
  *
  * @since 1.0.0
+ * 
+ * @global WP_Styles  $wp_styles  The WP_Styles current instance.
  */
 function perflab_aea_audit_enqueued_styles() {
 	if ( ! is_admin() && is_front_page() && current_user_can( 'view_site_health_checks' ) && false === get_transient( 'aea_enqueued_front_page_styles' ) ) {

--- a/modules/js-and-css/audit-enqueued-assets/hooks.php
+++ b/modules/js-and-css/audit-enqueued-assets/hooks.php
@@ -61,7 +61,7 @@ add_action( 'wp_footer', 'perflab_aea_audit_enqueued_scripts', PHP_INT_MAX );
  * It will save information in a transient for 12 hours.
  *
  * @since 1.0.0
- * 
+ *
  * @global WP_Styles $wp_styles The WP_Styles current instance.
  */
 function perflab_aea_audit_enqueued_styles() {

--- a/modules/js-and-css/audit-enqueued-assets/hooks.php
+++ b/modules/js-and-css/audit-enqueued-assets/hooks.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * It will save information in a transient for 12 hours.
  *
  * @since 1.0.0
- * 
+ *
  * @global WP_Scripts $wp_scripts
  */
 function perflab_aea_audit_enqueued_scripts() {

--- a/modules/js-and-css/audit-enqueued-assets/hooks.php
+++ b/modules/js-and-css/audit-enqueued-assets/hooks.php
@@ -62,7 +62,7 @@ add_action( 'wp_footer', 'perflab_aea_audit_enqueued_scripts', PHP_INT_MAX );
  *
  * @since 1.0.0
  * 
- * @global WP_Styles  $wp_styles  The WP_Styles current instance.
+ * @global WP_Styles $wp_styles The WP_Styles current instance.
  */
 function perflab_aea_audit_enqueued_styles() {
 	if ( ! is_admin() && is_front_page() && current_user_can( 'view_site_health_checks' ) && false === get_transient( 'aea_enqueued_front_page_styles' ) ) {


### PR DESCRIPTION
Updated some inline documentation according to  [ PHP Documentation Standards ](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)

Closes https://github.com/WordPress/performance/issues/867