### PR TITLE
Add Image Loading Optimization module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,3 +53,8 @@
 /modules/images/dominant-color-images                                       @pbearne @spacedmonkey
 /tests/modules/images/dominant-color-images                                 @pbearne @spacedmonkey
 /tests/testdata/modules/images/dominant-color-images                        @pbearne @spacedmonkey
+
+# Module: Image Loading Optimization
+/modules/images/image-loading-optimization                                  @westonruter
+/tests/modules/images/image-loading-optimization                            @westonruter
+/tests/testdata/modules/images/image-loading-optimization                   @westonruter

--- a/admin/server-timing.php
+++ b/admin/server-timing.php
@@ -43,16 +43,18 @@ add_action( 'admin_menu', 'perflab_add_server_timing_page' );
  * @since 2.6.0
  */
 function perflab_load_server_timing_page() {
-	/*
-	 * This settings section technically includes a field, however it is directly rendered as part of the section
-	 * callback due to requiring custom markup.
-	 */
-	add_settings_section(
-		'output-buffering',
-		__( 'Output Buffering', 'performance-lab' ),
-		'perflab_render_server_timing_page_output_buffering_section',
-		PERFLAB_SERVER_TIMING_SCREEN
-	);
+	if ( ! has_filter( 'template_include', 'image_loading_optimization_buffer_output' ) ) {
+		/*
+		 * This settings section technically includes a field, however it is directly rendered as part of the section
+		 * callback due to requiring custom markup.
+		 */
+		add_settings_section(
+			'output-buffering',
+			__( 'Output Buffering', 'performance-lab' ),
+			'perflab_render_server_timing_page_output_buffering_section',
+			PERFLAB_SERVER_TIMING_SCREEN
+		);
+	}
 
 	// Minor style tweaks to improve appearance similar to other core settings screen instances.
 	add_action(
@@ -93,7 +95,7 @@ function perflab_load_server_timing_page() {
 				);
 				?>
 			</p>
-			<?php if ( ! perflab_server_timing_use_output_buffer() ) : ?>
+			<?php if ( ! perflab_server_timing_use_output_buffer() && ! has_filter( 'template_include', 'image_loading_optimization_buffer_output' ) ) : ?>
 				<p>
 					<?php
 					echo wp_kses(

--- a/modules/images/image-loading-optimization/helper.php
+++ b/modules/images/image-loading-optimization/helper.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Helper functions used for Image Loading Optimization.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}

--- a/modules/images/image-loading-optimization/hooks.php
+++ b/modules/images/image-loading-optimization/hooks.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Hook callbacks used for Image Loading Optimization.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Starts output buffering at the end of the 'template_include' filter.
+ *
+ * This is to implement #43258 in core.
+ *
+ * This is a hack which would eventually be replaced with something like this in wp-includes/template-loader.php:
+ *
+ * ```
+ *          $template = apply_filters( 'template_include', $template );
+ *     +    ob_start( 'wp_template_output_buffer_callback' );
+ *          if ( $template ) {
+ *              include $template;
+ *          } elseif ( current_user_can( 'switch_themes' ) ) {
+ * ```
+ *
+ * @since n.e.x.t
+ * @link https://core.trac.wordpress.org/ticket/43258
+ *
+ * @param mixed $passthrough Optional. Filter value. Default null.
+ * @return mixed Unmodified value of $passthrough.
+ */
+function image_loading_optimization_buffer_output( $passthrough = null ) {
+	ob_start(
+		static function ( $output ) {
+			/**
+			 * Filters the template output buffer prior to sending to the client.
+			 *
+			 * @param string $output Output buffer.
+			 * @return string Filtered output buffer.
+			 */
+			return apply_filters( 'perflab_template_output_buffer', $output );
+		}
+	);
+	return $passthrough;
+}
+add_filter( 'template_include', 'image_loading_optimization_buffer_output', PHP_INT_MAX );

--- a/modules/images/image-loading-optimization/load.php
+++ b/modules/images/image-loading-optimization/load.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Module Name: Image Loading Optimization
+ * Description: Improves accuracy of optimizing the loading of the LCP image by leveraging client-side detection with real user metrics. Also enables output buffering of template rendering which can be filtered.
+ * Experimental: Yes
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+// Do not load the code if it is already loaded through another means.
+if ( function_exists( 'image_loading_optimization_buffer_output' ) ) {
+	return;
+}
+
+require_once __DIR__ . '/helper.php';
+require_once __DIR__ . '/hooks.php';

--- a/modules/images/image-loading-optimization/load.php
+++ b/modules/images/image-loading-optimization/load.php
@@ -8,6 +8,13 @@
  * @since n.e.x.t
  */
 
+// Define the constant.
+if ( defined( 'IMAGE_LOADING_OPTIMIZATION_VERSION' ) ) {
+	return;
+}
+
+define( 'IMAGE_LOADING_OPTIMIZATION_VERSION', 'Performance Lab ' . PERFLAB_VERSION );
+
 // Do not load the code if it is already loaded through another means.
 if ( function_exists( 'image_loading_optimization_buffer_output' ) ) {
 	return;

--- a/tests/admin/server-timing-tests.php
+++ b/tests/admin/server-timing-tests.php
@@ -48,8 +48,12 @@ class Admin_Server_Timing_Tests extends WP_UnitTestCase {
 
 		perflab_load_server_timing_page();
 		$this->assertArrayHasKey( PERFLAB_SERVER_TIMING_SCREEN, $wp_settings_sections );
+		$expected_sections = array( 'benchmarking' );
+		if ( ! has_filter( 'template_include', 'image_loading_optimization_buffer_output' ) ) {
+			$expected_sections[] = 'output-buffering';
+		}
 		$this->assertEqualSets(
-			array( 'output-buffering', 'benchmarking' ),
+			$expected_sections,
 			array_keys( $wp_settings_sections[ PERFLAB_SERVER_TIMING_SCREEN ] )
 		);
 		$this->assertEqualSets(

--- a/tests/modules/images/image-loading-optimization/load-tests.php
+++ b/tests/modules/images/image-loading-optimization/load-tests.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for image-loading-optimization module load.php.
+ *
+ * @package performance-lab
+ * @group   image-loading-optimization
+ */
+
+use PerformanceLab\Tests\TestCase\ImagesTestCase;
+
+class Image_Loading_Optimization_Load_Tests extends ImagesTestCase {
+
+	/**
+	 * Make sure the hook is added.
+	 *
+	 * @test
+	 */
+	public function it_is_hooking_output_buffering_at_template_include() {
+		$this->assertEquals( PHP_INT_MAX, has_filter( 'template_include', 'image_loading_optimization_buffer_output' ) );
+	}
+
+	/**
+	 * Make output is buffered and that it is also filtered.
+	 *
+	 * @test
+	 * @covers ::image_loading_optimization_buffer_output
+	 */
+	public function it_buffers_and_filters_output() {
+		$original = 'Hello World!';
+		$expected = '¡Hola Mundo!';
+
+		// In order to test, a wrapping output buffer is required because ob_get_clean() does not invoke the output
+		// buffer callback. See <https://stackoverflow.com/a/61439514/93579>.
+		ob_start();
+
+		add_filter(
+			'perflab_template_output_buffer',
+			function ( $buffer ) use ( $original, $expected ) {
+				$this->assertSame( $original, $buffer );
+				return $expected;
+			}
+		);
+
+		$original_ob_level = ob_get_level();
+		image_loading_optimization_buffer_output();
+		$this->assertSame( $original_ob_level + 1, ob_get_level(), 'Expected call to ob_start().' );
+		echo $original;
+
+		ob_end_flush(); // Flushing invokes the output buffer callback.
+
+		$buffer = ob_get_clean(); // Get the buffer from our wrapper output buffer.
+		$this->assertSame( $expected, $buffer );
+	}
+}


### PR DESCRIPTION
## Summary

Add scaffolding for new Image Loading Module with some key basic functionality, namely the output buffering of template renders and the introduction of a filter for that buffered output.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #805

## Relevant technical choices

When the module is active, the output buffering UI elements for Server Timing are omitted since the Image Loading Optimization module always does output buffering. Similarly, when the module is running, Server Timing will wait to send the header at the end of the new `perflab_template_output_buffer` filter.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
