### PR TITLE
Fix test failures due to WP 6.4 change

### DIFF
--- a/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -93,8 +93,12 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 
 		Audit_Assets_Transients_Set::set_style_transient_with_data( 3 );
 
-		// Avoids echoing styles.
+		// Avoid deprecation warning due to related change in WordPress 6.4.
+		if ( has_action( 'wp_print_styles', 'print_emoji_styles' ) ) {
+			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		}
 		get_echo( 'wp_print_styles' );
+
 		perflab_aea_audit_enqueued_styles();
 		$transient = get_transient( 'aea_enqueued_front_page_styles' );
 		$this->assertIsArray( $transient );
@@ -139,6 +143,11 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		$style .= "\tbackground: red;\n";
 		$style .= '}';
 		wp_add_inline_style( 'style1', $style );
+
+		// Avoid deprecation warning due to related change in WordPress 6.4.
+		if ( has_action( 'wp_print_styles', 'print_emoji_styles' ) ) {
+			remove_action( 'wp_print_styles', 'print_emoji_styles' );
+		}
 		get_echo( 'wp_print_styles' );
 
 		perflab_aea_audit_enqueued_styles();

--- a/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -94,9 +94,7 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		Audit_Assets_Transients_Set::set_style_transient_with_data( 3 );
 
 		// Avoid deprecation warning due to related change in WordPress 6.4.
-		if ( has_action( 'wp_print_styles', 'print_emoji_styles' ) ) {
-			remove_action( 'wp_print_styles', 'print_emoji_styles' );
-		}
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 		get_echo( 'wp_print_styles' );
 
 		perflab_aea_audit_enqueued_styles();
@@ -145,9 +143,7 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		wp_add_inline_style( 'style1', $style );
 
 		// Avoid deprecation warning due to related change in WordPress 6.4.
-		if ( has_action( 'wp_print_styles', 'print_emoji_styles' ) ) {
-			remove_action( 'wp_print_styles', 'print_emoji_styles' );
-		}
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 		get_echo( 'wp_print_styles' );
 
 		perflab_aea_audit_enqueued_styles();


### PR DESCRIPTION
## Summary

As of the WordPress 6.4 release, our unit tests are failing. This hasn't happened _yet_ in `trunk`, but only because no PRs have been opened since the release. It is however obvious in https://github.com/WordPress/performance/actions/runs/6851370708/job/18627496026?pr=864.

The failures happen simply because of deprecation warnings for `print_emoji_styles()` which per core behavior remains added as a callback for the `wp_print_styles` action but normally gets removed via another core function before it would be executed. In certain custom situations though (such as tests), it may be necessary to manually remove it. Even core itself does that for example in https://github.com/WordPress/wordpress-develop/blob/d66ef46847e2340c613d0a01c36d4fcc4b5f3a6b/src/wp-includes/block-editor.php#L363.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
