### PR TITLE
Optimize the loading of images using stored URL metrics

### DIFF
--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -10,6 +10,7 @@
  * Subclass of WP_HTML_Tag_Processor that adds support for breadcrumbs and a visiting callback.
  *
  * @since n.e.x.t
+ * @access private
  */
 class ILO_HTML_Tag_Processor {
 

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -218,14 +218,14 @@ class ILO_HTML_Tag_Processor {
 	 *
 	 * Breadcrumbs are constructed to match the format from detect.js.
 	 *
-	 * @return array<array{tagName: string, index: int}> Breadcrumbs.
+	 * @return array<array{tag: string, index: int}> Breadcrumbs.
 	 */
 	public function get_breadcrumbs(): array {
 		$breadcrumbs = array();
 		foreach ( $this->open_stack_tags as $i => $breadcrumb_tag_name ) {
 			$breadcrumbs[] = array(
-				'tagName' => $breadcrumb_tag_name, // TODO: Just 'tag'.
-				'index'   => $this->open_stack_indices[ $i ],
+				'tag'   => $breadcrumb_tag_name,
+				'index' => $this->open_stack_indices[ $i ],
 			);
 		}
 		return $breadcrumbs;

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Image Loading Optimization: ILO_HTML_Tag_Processor class
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * Subclass of WP_HTML_Tag_Processor that adds support for breadcrumbs and a visiting callback.
+ *
+ * @since n.e.x.t
+ */
+class ILO_HTML_Tag_Processor {
+
+	/**
+	 * HTML elements that are self-closing.
+	 *
+	 * @link https://www.w3.org/TR/html5/syntax.html#serializing-html-fragments
+	 * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L206-L232
+	 *
+	 * @var string[]
+	 */
+	const SELF_CLOSING_TAGS = array(
+		'AREA',
+		'BASE',
+		'BASEFONT',
+		'BGSOUND',
+		'BR',
+		'COL',
+		'EMBED',
+		'FRAME',
+		'HR',
+		'IMG',
+		'INPUT',
+		'KEYGEN',
+		'LINK',
+		'META',
+		'PARAM',
+		'SOURCE',
+		'TRACK',
+		'WBR',
+	);
+
+	/**
+	 * The set of HTML tags whose presence will implicitly close a <p> element.
+	 * For example '<p>foo<h1>bar</h1>' should parse the same as '<p>foo</p><h1>bar</h1>'.
+	 *
+	 * @link https://www.w3.org/TR/html-markup/p.html
+	 * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L262-L293
+	 */
+	const P_CLOSING_TAGS = array(
+		'ADDRESS',
+		'ARTICLE',
+		'ASIDE',
+		'BLOCKQUOTE',
+		'DIR',
+		'DL',
+		'FIELDSET',
+		'FOOTER',
+		'FORM',
+		'H1',
+		'H2',
+		'H3',
+		'H4',
+		'H5',
+		'H6',
+		'HEADER',
+		'HR',
+		'MENU',
+		'NAV',
+		'OL',
+		'P',
+		'PRE',
+		'SECTION',
+		'TABLE',
+		'UL',
+	);
+
+	/**
+	 * Open stack tags.
+	 *
+	 * @var string[]
+	 */
+	private $open_stack_tags = array();
+
+	/**
+	 * Open stag indices.
+	 *
+	 * @var int[]
+	 */
+	private $open_stack_indices = array();
+
+	/**
+	 * Processor.
+	 *
+	 * @var WP_HTML_Tag_Processor
+	 */
+	private $processor;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $html HTML to process.
+	 */
+	public function __construct( string $html ) {
+		$this->processor = new WP_HTML_Tag_Processor( $html );
+	}
+
+	/**
+	 * Walk over the document.
+	 *
+	 * Whenever an open tag is encountered, invoke the supplied $open_tag_callback and pass the tag name and breadcrumbs.
+	 *
+	 * @param Closure $open_tag_callback Open tag callback. The processor instance is passed as the sole argument.
+	 */
+	public function walk( Closure $open_tag_callback ) {
+		$p = $this->processor;
+
+		/*
+		 * The keys for the following two arrays correspond to each other. Given the following document:
+		 *
+		 * <html>
+		 *   <head>
+		 *   </head>
+		 *   <body>
+		 *     <p>Hello!</p>
+		 *     <img src="lcp.png">
+		 *   </body>
+		 * </html>
+		 *
+		 * The two upon processing the IMG element, the two arrays should be equal to the following:
+		 *
+		 * $open_stack_tags    = array( 'HTML', 'BODY', 'IMG' );
+		 * $open_stack_indices = array( 0, 1, 1 );
+		 */
+		$this->open_stack_tags    = array();
+		$this->open_stack_indices = array();
+		while ( $p->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+			$tag_name = $p->get_tag();
+			if ( ! $p->is_tag_closer() ) {
+
+				// Close an open P tag when a P-closing tag is encountered.
+				if ( in_array( $tag_name, self::P_CLOSING_TAGS, true ) ) {
+					$i = array_search( 'P', $this->open_stack_tags, true );
+					if ( false !== $i ) {
+						array_splice( $this->open_stack_tags, $i );
+						array_splice( $this->open_stack_indices, count( $this->open_stack_tags ) );
+					}
+				}
+
+				$level                   = count( $this->open_stack_tags );
+				$this->open_stack_tags[] = $tag_name;
+
+				if ( ! isset( $this->open_stack_indices[ $level ] ) ) {
+					$this->open_stack_indices[ $level ] = 0;
+				} else {
+					++$this->open_stack_indices[ $level ];
+				}
+
+				// TODO: We should consider not collecting metrics when the admin bar is shown and the user is logged-in.
+				// Only increment the tag index at this level only if it isn't the admin bar, since the presence of the
+				// admin bar can throw off the indices.
+				if ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' ) {
+					--$this->open_stack_indices[ $level ];
+				}
+
+				// Invoke the callback to do processing.
+				$open_tag_callback( $tag_name, $this->get_breadcrumbs() );
+
+				// Immediately pop off self-closing tags.
+				if ( in_array( $tag_name, self::SELF_CLOSING_TAGS, true ) ) {
+					array_pop( $this->open_stack_tags );
+				}
+			} else {
+				// If the closing tag is for self-closing tag, we ignore it since it was already handled above.
+				if ( in_array( $tag_name, self::SELF_CLOSING_TAGS, true ) ) {
+					continue;
+				}
+
+				// Since SVG and MathML can have a lot more self-closing/empty tags, potentially pop off the stack until getting to the open tag.
+				$did_splice = false;
+				if ( 'SVG' === $tag_name || 'MATH' === $tag_name ) {
+					$i = array_search( $tag_name, $this->open_stack_tags, true );
+					if ( false !== $i ) {
+						array_splice( $this->open_stack_tags, $i );
+						$did_splice = true;
+					}
+				}
+
+				if ( ! $did_splice ) {
+					$popped_tag_name = array_pop( $this->open_stack_tags );
+					if ( $popped_tag_name !== $tag_name ) {
+						error_log( "Expected popped tag stack element $popped_tag_name to match the currently visited closing tag $tag_name." ); // phpcs:ignore
+					}
+				}
+				array_splice( $this->open_stack_indices, count( $this->open_stack_tags ) + 1 );
+			}
+		}
+	}
+
+	/**
+	 * Returns the uppercase name of the matched tag.
+	 *
+	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
+	 *
+	 * @see WP_HTML_Tag_Processor::get_tag()
+	 *
+	 * @return string|null Name of currently matched tag in input HTML, or `null` if none found.
+	 */
+	public function get_tag() {
+		return $this->processor->get_tag();
+	}
+
+	/**
+	 * Gets breadcrumbs for the current open tag.
+	 *
+	 * Breadcrumbs are constructed to match the format from detect.js.
+	 *
+	 * @return array<array{tagName: string, index: int}> Breadcrumbs.
+	 */
+	public function get_breadcrumbs(): array {
+		$breadcrumbs = array();
+		foreach ( $this->open_stack_tags as $i => $breadcrumb_tag_name ) {
+			$breadcrumbs[] = array(
+				'tagName' => $breadcrumb_tag_name, // TODO: Just 'tag'.
+				'index'   => $this->open_stack_indices[ $i ],
+			);
+		}
+		return $breadcrumbs;
+	}
+
+	/**
+	 * Removes the fetchpriority attribute from the current node being walked over.
+	 *
+	 * Also sets an attribute to indicate that the attribute was removed.
+	 *
+	 * @return bool Whether an attribute was removed.
+	 */
+	public function remove_fetchpriority_attribute(): bool {
+		$p = $this->processor;
+		if ( $p->get_attribute( 'fetchpriority' ) ) {
+			$p->set_attribute( 'data-ilo-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
+			return $p->remove_attribute( 'fetchpriority' );
+		} else {
+			return false;
+		}
+	}
+
+	/**
+	 * Returns the value of a requested attribute from a matched tag opener if that attribute exists.
+	 *
+	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
+	 *
+	 * @see WP_HTML_Tag_Processor::get_attribute()
+	 *
+	 * @param string $name Name of attribute whose value is requested.
+	 * @return string|true|null Value of attribute or `null` if not available. Boolean attributes return `true`.
+	 */
+	public function get_attribute( string $name ) {
+		return $this->processor->get_attribute( $name );
+	}
+
+	/**
+	 * Updates or creates a new attribute on the currently matched tag with the passed value.
+	 *
+	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
+	 *
+	 * @see WP_HTML_Tag_Processor::set_attribute()
+	 *
+	 * @param string      $name  The attribute name to target.
+	 * @param string|bool $value The new attribute value.
+	 * @return bool Whether an attribute value was set.
+	 */
+	public function set_attribute( string $name, $value ): bool {
+		return $this->processor->set_attribute( $name, $value );
+	}
+
+	/**
+	 * Removes an attribute from the currently-matched tag.
+	 *
+	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
+	 *
+	 * @see WP_HTML_Tag_Processor::remove_attribute()
+	 *
+	 * @param string $name The attribute name to remove.
+	 * @return bool Whether an attribute was removed.
+	 */
+	public function remove_attribute( string $name ): bool {
+		return $this->processor->remove_attribute( $name );
+	}
+
+	/**
+	 * Returns the string representation of the HTML Tag Processor.
+	 *
+	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
+	 *
+	 * @see WP_HTML_Tag_Processor::get_updated_html()
+	 *
+	 * @return string The processed HTML.
+	 */
+	public function get_updated_html(): string {
+		return $this->processor->get_updated_html();
+	}
+}

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -112,9 +112,9 @@ class ILO_HTML_Tag_Processor {
 	 *
 	 * Whenever an open tag is encountered, invoke the supplied $open_tag_callback and pass the tag name and breadcrumbs.
 	 *
-	 * @param Closure $open_tag_callback Open tag callback. The processor instance is passed as the sole argument.
+	 * @param callable $open_tag_callback Open tag callback. The processor instance is passed as the sole argument.
 	 */
-	public function walk( Closure $open_tag_callback ) {
+	public function walk( callable $open_tag_callback ) {
 		$p = $this->processor;
 
 		/*

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -7,7 +7,9 @@
  */
 
 /**
- * Processor leveraging WP_HTML_Tag_Processor which gathers breadcrumbs which can be queried while iterating the open_tags() generator .
+ * Processor leveraging WP_HTML_Tag_Processor which gathers breadcrumbs which can be queried while iterating the open_tags() generator.
+ *
+ * Eventually this class should be made largely obsolete once `WP_HTML_Processor` is fully implemented to support all HTML tags.
  *
  * @since n.e.x.t
  * @access private

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -15,29 +15,30 @@
 final class ILO_HTML_Tag_Processor {
 
 	/**
-	 * HTML elements that are self-closing.
+	 * HTML void tags (i.e. those which are self-closing).
 	 *
-	 * @link https://www.w3.org/TR/html5/syntax.html#serializing-html-fragments
-	 * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L206-L232
+	 * @link https://html.spec.whatwg.org/multipage/syntax.html#void-elements
+	 * @see WP_HTML_Processor::is_void()
+	 * @todo Reuse `WP_HTML_Processor::is_void()` once WordPress 6.4 is the minimum-supported version.
 	 *
 	 * @var string[]
 	 */
-	const SELF_CLOSING_TAGS = array(
+	const VOID_TAGS = array(
 		'AREA',
 		'BASE',
-		'BASEFONT',
-		'BGSOUND',
+		'BASEFONT', // Obsolete.
+		'BGSOUND', // Obsolete.
 		'BR',
 		'COL',
 		'EMBED',
-		'FRAME',
+		'FRAME', // Deprecated.
 		'HR',
 		'IMG',
 		'INPUT',
-		'KEYGEN',
+		'KEYGEN', // Obsolete.
 		'LINK',
 		'META',
-		'PARAM',
+		'PARAM', // Deprecated.
 		'SOURCE',
 		'TRACK',
 		'WBR',
@@ -47,8 +48,7 @@ final class ILO_HTML_Tag_Processor {
 	 * The set of HTML tags whose presence will implicitly close a <p> element.
 	 * For example '<p>foo<h1>bar</h1>' should parse the same as '<p>foo</p><h1>bar</h1>'.
 	 *
-	 * @link https://www.w3.org/TR/html-markup/p.html
-	 * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L262-L293
+	 * @link https://html.spec.whatwg.org/multipage/grouping-content.html#the-p-element
 	 *
 	 * @var string[]
 	 */
@@ -57,9 +57,12 @@ final class ILO_HTML_Tag_Processor {
 		'ARTICLE',
 		'ASIDE',
 		'BLOCKQUOTE',
-		'DIR',
+		'DETAILS',
+		'DIV',
 		'DL',
 		'FIELDSET',
+		'FIGCAPTION',
+		'FIGURE',
 		'FOOTER',
 		'FORM',
 		'H1',
@@ -69,12 +72,15 @@ final class ILO_HTML_Tag_Processor {
 		'H5',
 		'H6',
 		'HEADER',
+		'HGROUP',
 		'HR',
+		'MAIN',
 		'MENU',
 		'NAV',
 		'OL',
 		'P',
 		'PRE',
+		'SEARCH',
 		'SECTION',
 		'TABLE',
 		'UL',
@@ -176,12 +182,12 @@ final class ILO_HTML_Tag_Processor {
 				yield $tag_name;
 
 				// Immediately pop off self-closing tags.
-				if ( in_array( $tag_name, self::SELF_CLOSING_TAGS, true ) ) {
+				if ( in_array( $tag_name, self::VOID_TAGS, true ) ) {
 					array_pop( $this->open_stack_tags );
 				}
 			} else {
 				// If the closing tag is for self-closing tag, we ignore it since it was already handled above.
-				if ( in_array( $tag_name, self::SELF_CLOSING_TAGS, true ) ) {
+				if ( in_array( $tag_name, self::VOID_TAGS, true ) ) {
 					continue;
 				}
 

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -235,23 +235,6 @@ class ILO_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Removes the fetchpriority attribute from the current node being walked over.
-	 *
-	 * Also sets an attribute to indicate that the attribute was removed.
-	 *
-	 * @return bool Whether an attribute was removed.
-	 */
-	public function remove_fetchpriority_attribute(): bool {
-		$p = $this->processor;
-		if ( $p->get_attribute( 'fetchpriority' ) ) {
-			$p->set_attribute( 'data-ilo-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
-			return $p->remove_attribute( 'fetchpriority' );
-		} else {
-			return false;
-		}
-	}
-
-	/**
 	 * Returns the value of a requested attribute from a matched tag opener if that attribute exists.
 	 *
 	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -7,12 +7,12 @@
  */
 
 /**
- * Subclass of WP_HTML_Tag_Processor that adds support for breadcrumbs and a visiting callback.
+ * Processor leveraging WP_HTML_Tag_Processor which walks over a document and gathers breadcrumbs and invokes a callback for each open tag.
  *
  * @since n.e.x.t
  * @access private
  */
-class ILO_HTML_Tag_Processor {
+final class ILO_HTML_Tag_Processor {
 
 	/**
 	 * HTML elements that are self-closing.
@@ -193,8 +193,18 @@ class ILO_HTML_Tag_Processor {
 
 				if ( ! $did_splice ) {
 					$popped_tag_name = array_pop( $this->open_stack_tags );
-					if ( $popped_tag_name !== $tag_name ) {
-						error_log( "Expected popped tag stack element $popped_tag_name to match the currently visited closing tag $tag_name." ); // phpcs:ignore
+					if ( $popped_tag_name !== $tag_name && function_exists( 'wp_trigger_error' ) ) {
+						wp_trigger_error(
+							__METHOD__,
+							esc_html(
+								sprintf(
+									/* translators: 1: Popped tag name, 2: Closing tag name */
+									__( 'Expected popped tag stack element %1$s to match the currently visited closing tag %2$s.', 'performance-lab' ),
+									$popped_tag_name,
+									$tag_name
+								)
+							)
+						);
 					}
 				}
 				array_splice( $this->open_stack_indices, count( $this->open_stack_tags ) + 1 );

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -142,6 +142,8 @@ class ILO_HTML_Tag_Processor {
 			if ( ! $p->is_tag_closer() ) {
 
 				// Close an open P tag when a P-closing tag is encountered.
+				// TODO: There are quite a few more cases of optional closing tags: https://html.spec.whatwg.org/multipage/syntax.html#optional-tags
+				// Nevertheless, given WordPress's legacy of XHTML compatibility, the lack of closing tags may not be common enough to warrant worrying about any of them.
 				if ( in_array( $tag_name, self::P_CLOSING_TAGS, true ) ) {
 					$i = array_search( 'P', $this->open_stack_tags, true );
 					if ( false !== $i ) {

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -49,6 +49,8 @@ final class ILO_HTML_Tag_Processor {
 	 *
 	 * @link https://www.w3.org/TR/html-markup/p.html
 	 * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L262-L293
+	 *
+	 * @var string[]
 	 */
 	const P_CLOSING_TAGS = array(
 		'ADDRESS',

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -228,6 +228,8 @@ final class ILO_HTML_Tag_Processor {
 	 *
 	 * Breadcrumbs are constructed to match the format from detect.js.
 	 *
+	 * TODO: Consider rather each breadcrumb being a (tag,index) tuple.
+	 *
 	 * @return array<array{tag: string, index: int}> Breadcrumbs.
 	 */
 	public function get_breadcrumbs(): array {

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -133,7 +133,7 @@ final class ILO_HTML_Tag_Processor {
 		 *   </body>
 		 * </html>
 		 *
-		 * The two upon processing the IMG element, the two arrays should be equal to the following:
+		 * Upon processing the IMG element, the two arrays should be equal to the following:
 		 *
 		 * $open_stack_tags    = array( 'HTML', 'BODY', 'IMG' );
 		 * $open_stack_indices = array( 0, 1, 1 );

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -170,7 +170,6 @@ final class ILO_HTML_Tag_Processor {
 					++$this->open_stack_indices[ $level ];
 				}
 
-				// TODO: We should consider not collecting metrics when the admin bar is shown and the user is logged-in.
 				// Only increment the tag index at this level only if it isn't the admin bar, since the presence of the
 				// admin bar can throw off the indices.
 				if ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' ) {

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -116,6 +116,15 @@ function getElementIndex( element ) {
 	const children = [ ...element.parentElement.children ];
 	let index = children.indexOf( element );
 	if ( children.includes( document.getElementById( adminBarId ) ) ) {
+		// TODO: Should detection just be turned off when is_user_logged_in()?
+		--index;
+	}
+	if (
+		children.includes(
+			document.querySelector( '.skip-link.screen-reader-text' )
+		)
+	) {
+		// TODO: This is not good.
 		--index;
 	}
 	return index;

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -118,7 +118,6 @@ function getElementIndex( element ) {
 	const children = [ ...element.parentElement.children ];
 	let index = children.indexOf( element );
 	if ( children.includes( document.getElementById( adminBarId ) ) ) {
-		// TODO: Should detection just be turned off when is_user_logged_in()?
 		--index;
 	}
 	if (

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -80,8 +80,8 @@ function error( ...message ) {
 
 /**
  * @typedef {Object} Breadcrumb
- * @property {number} index   - Index of element among sibling elements.
- * @property {string} tagName - Tag name.
+ * @property {number} index - Index of element among sibling elements.
+ * @property {string} tag   - Tag name.
  */
 
 /**
@@ -146,7 +146,7 @@ function getBreadcrumbs( leafElement ) {
 	let element = leafElement;
 	while ( element instanceof Element ) {
 		breadcrumbs.unshift( {
-			tagName: element.tagName,
+			tag: element.tagName,
 			index: getElementIndex( element ),
 		} );
 		element = element.parentElement;

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -7,6 +7,8 @@ const consoleLogPrefix = '[Image Loading Optimization]';
 
 const storageLockTimeSessionKey = 'iloStorageLockTime';
 
+const adminBarId = 'wpadminbar';
+
 /**
  * Checks whether storage is locked.
  *
@@ -111,7 +113,12 @@ function getElementIndex( element ) {
 	if ( ! element.parentElement ) {
 		return 0;
 	}
-	return [ ...element.parentElement.children ].indexOf( element );
+	const children = [ ...element.parentElement.children ];
+	let index = children.indexOf( element );
+	if ( children.includes( document.getElementById( adminBarId ) ) ) {
+		--index;
+	}
+	return index;
 }
 
 /**
@@ -238,7 +245,7 @@ export default async function detect( {
 
 	// Obtain the admin bar element because we don't want to detect elements inside of it.
 	const adminBar =
-		/** @type {?HTMLDivElement} */ doc.getElementById( 'wpadminbar' );
+		/** @type {?HTMLDivElement} */ doc.getElementById( adminBarId );
 
 	// We need to capture the original elements and their breadcrumbs as early as possible in case JavaScript is
 	// mutating the DOM from the original HTML rendered by the server, in which case the breadcrumbs obtained from the

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -106,6 +106,8 @@ function error( ...message ) {
 /**
  * Gets element index among siblings.
  *
+ * @todo Eliminate this in favor of doing all breadcrumb generation exclusively on the server.
+ *
  * @param {Element} element Element.
  * @return {number} Index.
  */
@@ -124,7 +126,6 @@ function getElementIndex( element ) {
 			document.querySelector( '.skip-link.screen-reader-text' )
 		)
 	) {
-		// TODO: This is not good.
 		--index;
 	}
 	return index;
@@ -132,6 +133,8 @@ function getElementIndex( element ) {
 
 /**
  * Gets breadcrumbs for a given element.
+ *
+ * @todo Eliminate this in favor of doing all breadcrumb generation exclusively on the server.
  *
  * @param {Element} leafElement
  * @return {Breadcrumb[]} Breadcrumbs.
@@ -271,6 +274,7 @@ export default async function detect( {
 	/** @type {Map<Element, Breadcrumb[]>} */
 	const breadcrumbedElementsMap = new Map(
 		[ ...breadcrumbedImages, ...breadcrumbedElementsWithBackgrounds ].map(
+			// TODO: Instead of generating breadcrumbs here, rely instead on server-generated breadcrumbs that are added to a data attribute by the server.
 			( element ) => [ element, getBreadcrumbs( element ) ]
 		)
 	);

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -265,15 +265,18 @@ export default async function detect( {
 	const breadcrumbedImages = doc.body.querySelectorAll( 'img' );
 
 	// We do the same for elements with background images which are not data: URLs.
-	const breadcrumbedElementsWithBackgrounds = Array.from(
-		doc.body.querySelectorAll( '[style*="background"]' )
-	).filter( ( /** @type {Element} */ el ) =>
-		/url\(\s*['"](?!=data:)/.test( el.style.backgroundImage )
-	);
+	// TODO: Re-enable background image support when server-side is implemented.
+	// const breadcrumbedElementsWithBackgrounds = Array.from(
+	// 	doc.body.querySelectorAll( '[style*="background"]' )
+	// ).filter( ( /** @type {Element} */ el ) =>
+	// 	/url\(\s*['"](?!=data:)/.test( el.style.backgroundImage )
+	// );
 
 	/** @type {Map<Element, Breadcrumb[]>} */
 	const breadcrumbedElementsMap = new Map(
-		[ ...breadcrumbedImages, ...breadcrumbedElementsWithBackgrounds ].map(
+		[
+			...breadcrumbedImages /*, ...breadcrumbedElementsWithBackgrounds*/,
+		].map(
 			// TODO: Instead of generating breadcrumbs here, rely instead on server-generated breadcrumbs that are added to a data attribute by the server.
 			( element ) => [ element, getBreadcrumbs( element ) ]
 		)

--- a/modules/images/image-loading-optimization/hooks.php
+++ b/modules/images/image-loading-optimization/hooks.php
@@ -41,7 +41,7 @@ function ilo_buffer_output( string $passthrough ): string {
 			 * @param string $output Output buffer.
 			 * @return string Filtered output buffer.
 			 */
-			return (string) apply_filters( 'perflab_template_output_buffer', $output );
+			return (string) apply_filters( 'ilo_template_output_buffer', $output );
 		}
 	);
 	return $passthrough;

--- a/modules/images/image-loading-optimization/load.php
+++ b/modules/images/image-loading-optimization/load.php
@@ -25,4 +25,5 @@ require_once __DIR__ . '/storage/rest-api.php';
 
 require_once __DIR__ . '/detection.php';
 
+require_once __DIR__ . '/class-ilo-html-tag-processor.php';
 require_once __DIR__ . '/optimization.php';

--- a/modules/images/image-loading-optimization/load.php
+++ b/modules/images/image-loading-optimization/load.php
@@ -24,3 +24,5 @@ require_once __DIR__ . '/storage/data.php';
 require_once __DIR__ . '/storage/rest-api.php';
 
 require_once __DIR__ . '/detection.php';
+
+require_once __DIR__ . '/optimization.php';

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -10,8 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-require_once __DIR__ . '/class-ilo-html-tag-processor.php';
-
 /**
  * Adds template output buffer filter for optimization if eligible.
  *

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -163,9 +163,14 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 			if ( 'high' === $processor->get_attribute( 'fetchpriority' ) ) {
 				$processor->set_attribute( 'data-ilo-fetchpriority-already-added', true );
 			} else {
-				// TODO: When optimizing lazy-loading, this should also remove any `loading` attribute here.
 				$processor->set_attribute( 'fetchpriority', 'high' );
 				$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
+			}
+
+			// Never include loading=lazy on the LCP image common across all breakpoints.
+			if ( 'lazy' === $processor->get_attribute( 'loading' ) ) {
+				$processor->set_attribute( 'data-ilo-removed-loading', $processor->get_attribute( 'loading' ) );
+				$processor->remove_attribute( 'loading' );
 			}
 		} elseif ( $all_breakpoints_have_url_metrics && $processor->get_attribute( 'fetchpriority' ) ) {
 			// Note: The $all_breakpoints_have_url_metrics condition here allows for server-side heuristics to

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -52,10 +52,12 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
 		}
 
 		// Add media query if it's going to be something other than just `min-width: 0px`.
-		if ( $minimum_viewport_widths[ $i ] > 0 || isset( $minimum_viewport_widths[ $i + 1 ] ) ) {
-			$media_query = sprintf( '( min-width: %dpx )', $minimum_viewport_widths[ $i ] );
-			if ( isset( $minimum_viewport_widths[ $i + 1 ] ) ) {
-				$media_query .= sprintf( ' and ( max-width: %dpx )', $minimum_viewport_widths[ $i + 1 ] - 1 );
+		$minimum_viewport_width = $minimum_viewport_widths[ $i ];
+		$maximum_viewport_width = isset( $minimum_viewport_widths[ $i + 1 ] ) ? $minimum_viewport_widths[ $i + 1 ] - 1 : null;
+		if ( $minimum_viewport_width > 0 || null !== $maximum_viewport_width ) {
+			$media_query = sprintf( '( min-width: %dpx )', $minimum_viewport_width );
+			if ( null !== $maximum_viewport_width ) {
+				$media_query .= sprintf( ' and ( max-width: %dpx )', $maximum_viewport_width );
 			}
 			$img_attributes['media'] = $media_query;
 		}

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -107,9 +107,12 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 					}
 
 					if ( $processor->get_breadcrumbs() === $lcp_element['breadcrumbs'] ) {
-						// TODO: If it already has the attribute, include an attribute to indicate server-side heuristics were successful.
-						$processor->set_attribute( 'fetchpriority', 'high' );
-						$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
+						if ( 'high' === $processor->get_attribute( 'fetchpriority' ) ) {
+							$processor->set_attribute( 'data-ilo-fetchpriority-already-added', true );
+						} else {
+							$processor->set_attribute( 'fetchpriority', 'high' );
+							$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
+						}
 					} else {
 						$processor->remove_fetchpriority_attribute();
 					}

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -47,12 +47,14 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
 			unset( $img_attributes['src'] );
 		}
 
-		// Add media query.
-		$media_query = sprintf( 'screen and ( min-width: %dpx )', $minimum_viewport_widths[ $i ] );
-		if ( isset( $minimum_viewport_widths[ $i + 1 ] ) ) {
-			$media_query .= sprintf( ' and ( max-width: %dpx )', $minimum_viewport_widths[ $i + 1 ] - 1 );
+		// Add media query if it's going to be something other than just `min-width: 0px`.
+		if ( $minimum_viewport_widths[ $i ] > 0 || isset( $minimum_viewport_widths[ $i + 1 ] ) ) {
+			$media_query = sprintf( '( min-width: %dpx )', $minimum_viewport_widths[ $i ] );
+			if ( isset( $minimum_viewport_widths[ $i + 1 ] ) ) {
+				$media_query .= sprintf( ' and ( max-width: %dpx )', $minimum_viewport_widths[ $i + 1 ] - 1 );
+			}
+			$img_attributes['media'] = $media_query;
 		}
-		$img_attributes['media'] = $media_query;
 
 		// Construct preload link.
 		$link_tag = '<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image"';

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -130,7 +130,7 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 	foreach ( $lcp_elements_by_minimum_viewport_widths as $minimum_viewport_width => $lcp_element ) {
 		if ( false !== $lcp_element ) {
 			$breadcrumb_string = ilo_construct_breadcrumbs_string( $lcp_element['breadcrumbs'] );
-			$lcp_element_minimum_viewport_width_by_breadcrumb[ $breadcrumb_string ] = $minimum_viewport_width;
+			$lcp_element_minimum_viewport_width_by_breadcrumb[ $breadcrumb_string ][] = $minimum_viewport_width;
 		}
 	}
 
@@ -186,8 +186,9 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 			foreach ( array( 'src', 'srcset', 'sizes', 'crossorigin', 'integrity' ) as $attr_name ) {
 				$attributes[ $attr_name ] = $processor->get_attribute( $attr_name );
 			}
-			$minimum_viewport_width = $lcp_element_minimum_viewport_width_by_breadcrumb[ $breadcrumb_string ];
-			$lcp_elements_by_minimum_viewport_widths[ $minimum_viewport_width ]['attributes'] = $attributes;
+			foreach ( $lcp_element_minimum_viewport_width_by_breadcrumb[ $breadcrumb_string ] as $minimum_viewport_width ) {
+				$lcp_elements_by_minimum_viewport_widths[ $minimum_viewport_width ]['attributes'] = $attributes;
+			}
 		}
 	}
 	$buffer = $processor->get_updated_html();

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -14,6 +14,9 @@ require_once __DIR__ . '/class-ilo-html-tag-processor.php';
 
 /**
  * Adds template output buffer filter for optimization if eligible.
+ *
+ * @since n.e.x.t
+ * @access private
  */
 function ilo_maybe_add_template_output_buffer_filter() {
 	if ( ! ilo_can_optimize_response() ) {
@@ -25,6 +28,9 @@ add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
 
 /**
  * Constructs preload links.
+ *
+ * @since n.e.x.t
+ * @access private
  *
  * @param array $lcp_images_by_minimum_viewport_widths LCP images keyed by minimum viewport width, amended with attributes key for the IMG attributes.
  * @return string Markup for one or more preload link tags.
@@ -78,6 +84,9 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
 
 /**
  * Optimizes template output buffer.
+ *
+ * @since n.e.x.t
+ * @access private
  *
  * @param string $buffer Template output buffer.
  * @return string Filtered template output buffer.

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -95,74 +95,71 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 	$url_metrics_grouped_by_breakpoint       = ilo_group_url_metrics_by_breakpoint( $url_metrics, $breakpoint_max_widths );
 	$lcp_elements_by_minimum_viewport_widths = ilo_get_lcp_elements_by_minimum_viewport_widths( $url_metrics_grouped_by_breakpoint );
 
-	if ( ! empty( $lcp_elements_by_minimum_viewport_widths ) ) {
+	// TODO: Handle case when the LCP element is not an image at all, but rather a background-image.
+	// Use the fetchpriority attribute on the image when all breakpoints have the same LCP element.
+	if (
+		// All breakpoints share the same LCP element (or all have none at all).
+		1 === count( $lcp_elements_by_minimum_viewport_widths )
+		&&
+		// The breakpoints don't share a common lack of an LCP element.
+		! in_array( false, $lcp_elements_by_minimum_viewport_widths, true )
+		&&
+		// All breakpoints have URL metrics being reported.
+		count( array_filter( $url_metrics_grouped_by_breakpoint ) ) === count( $breakpoint_max_widths ) + 1
+	) {
+		$lcp_element = current( $lcp_elements_by_minimum_viewport_widths );
 
-		// TODO: Handle case when the LCP element is not an image at all, but rather a background-image.
-		// Use the fetchpriority attribute on the image when all breakpoints have the same LCP element.
-		if (
-			// All breakpoints share the same LCP element (or all have none at all).
-			1 === count( $lcp_elements_by_minimum_viewport_widths )
-			&&
-			// The breakpoints don't share a common lack of an LCP element.
-			! in_array( false, $lcp_elements_by_minimum_viewport_widths, true )
-			&&
-			// All breakpoints have URL metrics being reported.
-			count( array_filter( $url_metrics_grouped_by_breakpoint ) ) === count( $breakpoint_max_widths ) + 1
-		) {
-			$lcp_element = current( $lcp_elements_by_minimum_viewport_widths );
+		$processor = new ILO_HTML_Tag_Processor( $buffer );
+		$processor->walk(
+			static function () use ( $processor, $lcp_element ) {
+				if ( $processor->get_tag() !== 'IMG' ) {
+					return;
+				}
 
-			$processor = new ILO_HTML_Tag_Processor( $buffer );
-			$processor->walk(
-				static function () use ( $processor, $lcp_element ) {
-					if ( $processor->get_tag() !== 'IMG' ) {
-						return;
-					}
-
-					if ( $processor->get_breadcrumbs() === $lcp_element['breadcrumbs'] ) {
-						if ( 'high' === $processor->get_attribute( 'fetchpriority' ) ) {
-							$processor->set_attribute( 'data-ilo-fetchpriority-already-added', true );
-						} else {
-							$processor->set_attribute( 'fetchpriority', 'high' );
-							$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
-						}
+				if ( $processor->get_breadcrumbs() === $lcp_element['breadcrumbs'] ) {
+					if ( 'high' === $processor->get_attribute( 'fetchpriority' ) ) {
+						$processor->set_attribute( 'data-ilo-fetchpriority-already-added', true );
 					} else {
-						$processor->remove_fetchpriority_attribute();
+						$processor->set_attribute( 'fetchpriority', 'high' );
+						$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
 					}
-				}
-			);
-			$buffer = $processor->get_updated_html();
-
-			// TODO: We could also add the preload links here.
-		} else {
-			// If there is not exactly one LCP element, we need to remove fetchpriority from all images while also
-			// capturing the attributes from the LCP element which we can then use for preload links.
-			$processor = new ILO_HTML_Tag_Processor( $buffer );
-			$processor->walk(
-				static function () use ( $processor, &$lcp_elements_by_minimum_viewport_widths ) {
-					if ( $processor->get_tag() !== 'IMG' ) {
-						return;
-					}
-
+				} else {
 					$processor->remove_fetchpriority_attribute();
+				}
+			}
+		);
+		$buffer = $processor->get_updated_html();
 
-					// Capture the attributes from the LCP elements to use in preload links.
-					foreach ( $lcp_elements_by_minimum_viewport_widths as &$lcp_element ) {
-						if ( $lcp_element && $lcp_element['breadcrumbs'] === $processor->get_breadcrumbs() ) {
-							$lcp_element['attributes'] = array();
-							foreach ( array( 'src', 'srcset', 'sizes', 'crossorigin', 'integrity' ) as $attr_name ) {
-								$lcp_element['attributes'][ $attr_name ] = $processor->get_attribute( $attr_name );
-							}
+		// TODO: We could also add the preload links here.
+	} else {
+		// If there is not exactly one LCP element, we need to remove fetchpriority from all images while also
+		// capturing the attributes from the LCP element which we can then use for preload links.
+		$processor = new ILO_HTML_Tag_Processor( $buffer );
+		$processor->walk(
+			static function () use ( $processor, &$lcp_elements_by_minimum_viewport_widths ) {
+				if ( $processor->get_tag() !== 'IMG' ) {
+					return;
+				}
+
+				$processor->remove_fetchpriority_attribute();
+
+				// Capture the attributes from the LCP elements to use in preload links.
+				foreach ( $lcp_elements_by_minimum_viewport_widths as &$lcp_element ) {
+					if ( $lcp_element && $lcp_element['breadcrumbs'] === $processor->get_breadcrumbs() ) {
+						$lcp_element['attributes'] = array();
+						foreach ( array( 'src', 'srcset', 'sizes', 'crossorigin', 'integrity' ) as $attr_name ) {
+							$lcp_element['attributes'][ $attr_name ] = $processor->get_attribute( $attr_name );
 						}
 					}
 				}
-			);
-			$buffer = $processor->get_updated_html();
+			}
+		);
+		$buffer = $processor->get_updated_html();
 
-			$preload_links = ilo_construct_preload_links( $lcp_elements_by_minimum_viewport_widths );
+		$preload_links = ilo_construct_preload_links( $lcp_elements_by_minimum_viewport_widths );
 
-			// TODO: In the future, WP_HTML_Processor could be used to do this injection. However, given the simple replacement here this is not essential.
-			$buffer = preg_replace( '#(?=</HEAD>)#i', $preload_links, $buffer, 1 );
-		}
+		// TODO: In the future, WP_HTML_Processor could be used to do this injection. However, given the simple replacement here this is not essential.
+		$buffer = preg_replace( '#(?=</HEAD>)#i', $preload_links, $buffer, 1 );
 	}
 
 	return $buffer;

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -83,7 +83,7 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
 function ilo_optimize_template_output_buffer( string $buffer ): string {
 	$slug        = ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() );
 	$post        = ilo_get_url_metrics_post( $slug );
-	$url_metrics = ilo_parse_stored_url_metrics( $post );
+	$url_metrics = $post ? ilo_parse_stored_url_metrics( $post ) : array(); // TODO: If $post is null, short circuit?
 
 	$lcp_images_by_minimum_viewport_widths = ilo_get_lcp_elements_by_minimum_viewport_widths( $url_metrics, ilo_get_breakpoint_max_widths() );
 

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -10,69 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-/**
- * HTML elements that are self-closing.
- *
- * @link https://www.w3.org/TR/html5/syntax.html#serializing-html-fragments
- * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L206-L232
- *
- * @var string[]
- */
-const ILO_SELF_CLOSING_TAGS = array(
-	'AREA',
-	'BASE',
-	'BASEFONT',
-	'BGSOUND',
-	'BR',
-	'COL',
-	'EMBED',
-	'FRAME',
-	'HR',
-	'IMG',
-	'INPUT',
-	'KEYGEN',
-	'LINK',
-	'META',
-	'PARAM',
-	'SOURCE',
-	'TRACK',
-	'WBR',
-);
-
-/**
- * The set of HTML tags whose presence will implicitly close a <p> element.
- * For example '<p>foo<h1>bar</h1>' should parse the same as '<p>foo</p><h1>bar</h1>'.
- *
- * @link https://www.w3.org/TR/html-markup/p.html
- * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L262-L293
- */
-const ILO_P_CLOSING_TAGS = array(
-	'ADDRESS',
-	'ARTICLE',
-	'ASIDE',
-	'BLOCKQUOTE',
-	'DIR',
-	'DL',
-	'FIELDSET',
-	'FOOTER',
-	'FORM',
-	'H1',
-	'H2',
-	'H3',
-	'H4',
-	'H5',
-	'H6',
-	'HEADER',
-	'HR',
-	'MENU',
-	'NAV',
-	'OL',
-	'P',
-	'PRE',
-	'SECTION',
-	'TABLE',
-	'UL',
-);
+require_once __DIR__ . '/class-ilo-html-tag-processor.php';
 
 /**
  * Adds template output buffer filter for optimization if eligible.
@@ -137,122 +75,6 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
 }
 
 /**
- * Walks the provided HTML document, invoking the callback at each open tag.
- *
- * @param string   $html              Complete HTML document.
- * @param callable $open_tag_callback Callback to invoke at each open tag. Callback is passed instance of
- *                                    WP_HTML_Tag_Processor as well as the breadcrumbs for the current element.
- * @return string Updated HTML if modified by callback.
- */
-function ilo_walk_document( string $html, callable $open_tag_callback ): string {
-	$p = new WP_HTML_Tag_Processor( $html );
-
-	/*
-	 * The keys for the following two arrays correspond to each other. Given the following document:
-	 *
-	 * <html>
-	 *   <head>
-	 *   </head>
-	 *   <body>
-	 *     <p>Hello!</p>
-	 *     <img src="lcp.png">
-	 *   </body>
-	 * </html>
-	 *
-	 * The two upon processing the IMG element, the two arrays should be equal to the following:
-	 *
-	 * $open_stack_tags    = array( 'HTML', 'BODY', 'IMG' );
-	 * $open_stack_indices = array( 0, 1, 1 );
-	 */
-	$open_stack_tags    = array();
-	$open_stack_indices = array();
-	while ( $p->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
-		$tag_name = $p->get_tag();
-		if ( ! $p->is_tag_closer() ) {
-
-			// Close an open P tag when a P-closing tag is encountered.
-			if ( in_array( $tag_name, ILO_P_CLOSING_TAGS, true ) ) {
-				$i = array_search( 'P', $open_stack_tags, true );
-				if ( false !== $i ) {
-					array_splice( $open_stack_tags, $i );
-					array_splice( $open_stack_indices, count( $open_stack_tags ) );
-				}
-			}
-
-			$level             = count( $open_stack_tags );
-			$open_stack_tags[] = $tag_name;
-
-			if ( ! isset( $open_stack_indices[ $level ] ) ) {
-				$open_stack_indices[ $level ] = 0;
-			} else {
-				++$open_stack_indices[ $level ];
-			}
-
-			// TODO: We should consider not collecting metrics when the admin bar is shown and the user is logged-in.
-			// Only increment the tag index at this level only if it isn't the admin bar, since the presence of the
-			// admin bar can throw off the indices.
-			if ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' ) {
-				--$open_stack_indices[ $level ];
-			}
-
-			// Construct the breadcrumbs to match the format from detect.js.
-			$breadcrumbs = array();
-			foreach ( $open_stack_tags as $i => $breadcrumb_tag_name ) {
-				$breadcrumbs[] = array(
-					'tagName' => $breadcrumb_tag_name,
-					'index'   => $open_stack_indices[ $i ],
-				);
-			}
-
-			// Invoke the callback to do processing.
-			$open_tag_callback( $p, $breadcrumbs );
-
-			// Immediately pop off self-closing tags.
-			if ( in_array( $tag_name, ILO_SELF_CLOSING_TAGS, true ) ) {
-				array_pop( $open_stack_tags );
-			}
-		} else {
-			// If the closing tag is for self-closing tag, we ignore it since it was already handled above.
-			if ( in_array( $tag_name, ILO_SELF_CLOSING_TAGS, true ) ) {
-				continue;
-			}
-
-			// Since SVG and MathML can have a lot more self-closing/empty tags, potentially pop off the stack until getting to the open tag.
-			$did_splice = false;
-			if ( 'SVG' === $tag_name || 'MATH' === $tag_name ) {
-				$i = array_search( $tag_name, $open_stack_tags, true );
-				if ( false !== $i ) {
-					array_splice( $open_stack_tags, $i );
-					$did_splice = true;
-				}
-			}
-
-			if ( ! $did_splice ) {
-				$popped_tag_name = array_pop( $open_stack_tags );
-				if ( $popped_tag_name !== $tag_name ) {
-					error_log( "Expected popped tag stack element {$popped_tag_name} to match the currently visited closing tag $tag_name." ); // phpcs:ignore
-				}
-			}
-			array_splice( $open_stack_indices, count( $open_stack_tags ) + 1 );
-		}
-	}
-
-	return $p->get_updated_html();
-}
-
-/**
- * Removes fetchpriority from the current tag if present.
- *
- * @param WP_HTML_Tag_Processor $p Processor instance.
- */
-function ilo_remove_fetchpriority_from_current_tag_processor_node( WP_HTML_Tag_Processor $p ) {
-	if ( $p->get_attribute( 'fetchpriority' ) ) {
-		$p->set_attribute( 'data-ilo-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
-		$p->remove_attribute( 'fetchpriority' );
-	}
-}
-
-/**
  * Optimizes template output buffer.
  *
  * @param string $buffer Template output buffer.
@@ -272,45 +94,50 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 		if ( 1 === count( $lcp_images_by_minimum_viewport_widths ) && 1 === count( $breakpoint_lcp_images ) ) {
 			$lcp_element = current( $lcp_images_by_minimum_viewport_widths );
 
-			$buffer = ilo_walk_document(
-				$buffer,
-				static function ( WP_HTML_Tag_Processor $p, array $breadcrumbs ) use ( $lcp_element ) {
-					if ( 'IMG' !== $p->get_tag() ) {
+			$processor = new ILO_HTML_Tag_Processor( $buffer );
+			$processor->walk(
+				static function () use ( $processor, $lcp_element ) {
+					if ( $processor->get_tag() !== 'IMG' ) {
 						return;
 					}
-					if ( $breadcrumbs === $lcp_element['breadcrumbs'] ) {
-						$p->set_attribute( 'fetchpriority', 'high' );
-						$p->set_attribute( 'data-ilo-added-fetchpriority', true );
+
+					if ( $processor->get_breadcrumbs() === $lcp_element['breadcrumbs'] ) {
+						$processor->set_attribute( 'fetchpriority', 'high' );
+						$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
 					} else {
-						ilo_remove_fetchpriority_from_current_tag_processor_node( $p );
+						$processor->remove_fetchpriority_attribute();
 					}
 				}
 			);
+			$buffer = $processor->get_updated_html();
+
 			// TODO: We could also add the preload links here.
 		} else {
 			// If there is not exactly one LCP element, we need to remove fetchpriority from all images while also
 			// capturing the attributes from the LCP element which we can then use for preload links.
-			$buffer = ilo_walk_document(
-				$buffer,
-				static function ( WP_HTML_Tag_Processor $p, array $breadcrumbs ) use ( &$lcp_images_by_minimum_viewport_widths ) {
-					if ( 'IMG' !== $p->get_tag() ) {
+			$processor = new ILO_HTML_Tag_Processor( $buffer );
+			$processor->walk(
+				static function () use ( $processor, &$lcp_images_by_minimum_viewport_widths ) {
+					if ( $processor->get_tag() !== 'IMG' ) {
 						return;
 					}
-					ilo_remove_fetchpriority_from_current_tag_processor_node( $p );
 
-					// Capture the attributes from the LCP element to use in preload links.
-					if ( count( $lcp_images_by_minimum_viewport_widths ) > 1 ) {
+					$processor->remove_fetchpriority_attribute();
+
+					// Capture the attributes from the LCP elements to use in preload links.
+					if ( count( $lcp_images_by_minimum_viewport_widths ) > 1 ) { // TODO: Why?
 						foreach ( $lcp_images_by_minimum_viewport_widths as &$lcp_element ) {
-							if ( $lcp_element && $lcp_element['breadcrumbs'] === $breadcrumbs ) {
+							if ( $lcp_element && $lcp_element['breadcrumbs'] === $processor->get_breadcrumbs() ) {
 								$lcp_element['attributes'] = array();
 								foreach ( array( 'src', 'srcset', 'sizes', 'crossorigin', 'integrity' ) as $attr_name ) {
-									$lcp_element['attributes'][ $attr_name ] = $p->get_attribute( $attr_name );
+									$lcp_element['attributes'][ $attr_name ] = $processor->get_attribute( $attr_name );
 								}
 							}
 						}
 					}
 				}
 			);
+			$buffer = $processor->get_updated_html();
 
 			$preload_links = ilo_construct_preload_links( $lcp_images_by_minimum_viewport_widths );
 

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -33,7 +33,7 @@ add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
  * @access private
  *
  * @param array $lcp_images_by_minimum_viewport_widths LCP images keyed by minimum viewport width, amended with attributes key for the IMG attributes.
- * @return string Markup for one or more preload link tags.
+ * @return string Markup for zero or more preload link tags.
  */
 function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widths ): string {
 	$preload_links = array();

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -128,12 +128,12 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
 
 			$link_tag .= sprintf( ' %s="%s"', $name, esc_attr( $value ) );
 		}
-		$link_tag .= '>';
+		$link_tag .= ">\n";
 
 		$preload_links[] = $link_tag;
 	}
 
-	return implode( "\n", $preload_links );
+	return implode( '', $preload_links );
 }
 
 /**
@@ -314,7 +314,8 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 
 			$preload_links = ilo_construct_preload_links( $lcp_images_by_minimum_viewport_widths );
 
-			$buffer = str_replace( '</head>', $preload_links . '</head>', $buffer );
+			// TODO: In the future, WP_HTML_Processor could be used to do this injection. However, given the simple replacement here this is not essential.
+			$buffer = preg_replace( '#(?=</head>)#', $preload_links, $buffer, 1 );
 		}
 	}
 

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Optimizing for image loading optimization.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Adds template output buffer filter for optimization if eligible.
+ */
+function ilo_maybe_add_template_output_buffer_filter() {
+	if ( ! ilo_can_optimize_response() ) {
+		return;
+	}
+	add_filter( 'ilo_template_output_buffer', 'ilo_optimize_template_output_buffer' );
+}
+add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
+
+/**
+ * Optimizes template output buffer.
+ *
+ * @param string $buffer Template output buffer.
+ * @return string Filtered template output buffer.
+ */
+function ilo_optimize_template_output_buffer( string $buffer ): string {
+	$slug         = ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() );
+	$post         = ilo_get_url_metrics_post( $slug );
+	$page_metrics = ilo_parse_stored_url_metrics( $post );
+
+	$lcp_images_by_minimum_viewport_widths = ilo_get_lcp_elements_by_minimum_viewport_widths( $page_metrics, ilo_get_breakpoint_max_widths() );
+
+	if ( ! empty( $lcp_images_by_minimum_viewport_widths ) ) {
+		if ( count( $lcp_images_by_minimum_viewport_widths ) !== 1 ) {
+			$p = new WP_HTML_Tag_Processor( $buffer );
+			while ( $p->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+				if ( $p->get_attribute( 'fetchpriority' ) ) {
+					$p->set_attribute( 'data-wp-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
+					$p->remove_attribute( 'fetchpriority' );
+				}
+			}
+			$buffer = $p->get_updated_html();
+		}
+	}
+
+	return $buffer;
+}

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -140,7 +140,7 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 		// All breakpoints share the same LCP element (or all have none at all).
 		1 === count( $lcp_elements_by_minimum_viewport_widths )
 		&&
-		// The breakpoints don't share a common lack of an LCP element.
+		// The breakpoints don't share a common lack of an LCP image.
 		! in_array( false, $lcp_elements_by_minimum_viewport_widths, true )
 		&&
 		// All breakpoints have URL metrics being reported.

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -36,6 +36,7 @@ add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
 function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widths ): string {
 	$preload_links = array();
 
+	// This uses a for loop to be able to access the following element within the iteration, using a numeric index.
 	$minimum_viewport_widths = array_keys( $lcp_images_by_minimum_viewport_widths );
 	for ( $i = 0, $len = count( $minimum_viewport_widths ); $i < $len; $i++ ) {
 		$lcp_element = $lcp_images_by_minimum_viewport_widths[ $minimum_viewport_widths[ $i ] ];

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -85,26 +85,66 @@ function ilo_maybe_add_template_output_buffer_filter() {
 }
 add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
 
+/**
+ * Constructs preload links.
+ *
+ * @param array $lcp_images_by_minimum_viewport_widths LCP images keyed by minimum viewport width, amended with attributes key for the IMG attributes.
+ * @return string Markup for one or more preload link tags.
+ */
 function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widths ): string {
+	$preload_links = array();
+
 	$minimum_viewport_widths = array_keys( $lcp_images_by_minimum_viewport_widths );
 	for ( $i = 0, $len = count( $minimum_viewport_widths ); $i < $len; $i++ ) {
 		$lcp_element = $lcp_images_by_minimum_viewport_widths[ $minimum_viewport_widths[ $i ] ];
-		if ( false === $lcp_element ) {
+		if ( false === $lcp_element || empty( $lcp_element['attributes'] ) ) {
 			// No LCP element at this breakpoint, so nothing to preload.
 			continue;
 		}
 
+		$img_attributes = $lcp_element['attributes'];
+
+		// Prevent preloading src for browsers that don't support imagesrcset on the link element.
+		if ( isset( $img_attributes['src'], $img_attributes['srcset'] ) ) {
+			unset( $img_attributes['src'] );
+		}
+
+		// Add media query.
 		$media_query = sprintf( 'screen and ( min-width: %dpx )', $minimum_viewport_widths[ $i ] );
 		if ( isset( $minimum_viewport_widths[ $i + 1 ] ) ) {
 			$media_query .= sprintf( ' and ( max-width: %dpx )', $minimum_viewport_widths[ $i + 1 ] - 1 );
 		}
+		$img_attributes['media'] = $media_query;
 
+		// Construct preload link.
+		$link_tag = '<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image"';
+		foreach ( array_filter( $img_attributes ) as $name => $value ) {
+			// Map img attribute name to link attribute name.
+			if ( 'srcset' === $name || 'sizes' === $name ) {
+				$name = 'image' . $name;
+			} elseif ( 'src' === $name ) {
+				$name = 'href';
+			}
+
+			$link_tag .= sprintf( ' %s="%s"', $name, esc_attr( $value ) );
+		}
+		$link_tag .= '>';
+
+		$preload_links[] = $link_tag;
 	}
 
-	return '';
+	return implode( "\n", $preload_links );
 }
 
-function ilo_find_element_by_breadcrumbs( string $html, array $breadcrumbs ): array {
+/**
+ * Walks the provided HTML document, invoking the callback at each open tag.
+ *
+ * @param string   $html              Complete HTML document.
+ * @param callable $open_tag_callback Callback to invoke at each open tag. Callback is passed instance of
+ *                                    WP_HTML_Tag_Processor as well as the breadcrumbs for the current element.
+ * @return string Updated HTML if modified by callback.
+ */
+function ilo_walk_document( string $html, callable $open_tag_callback ): string {
 	$p = new WP_HTML_Tag_Processor( $html );
 
 	/*
@@ -144,13 +184,28 @@ function ilo_find_element_by_breadcrumbs( string $html, array $breadcrumbs ): ar
 
 			if ( ! isset( $open_stack_indices[ $level ] ) ) {
 				$open_stack_indices[ $level ] = 0;
-			} elseif ( ! ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' ) ) {
-				// Only increment the tag index at this level only if it isn't the admin bar, since the presence of the
-				// admin bar can throw off the indices.
+			} else {
 				++$open_stack_indices[ $level ];
 			}
 
-			// TODO: Now check if $open_stack matches breadcrumbs.
+			// TODO: We should consider not collecting metrics when the admin bar is shown and the user is logged-in.
+			// Only increment the tag index at this level only if it isn't the admin bar, since the presence of the
+			// admin bar can throw off the indices.
+			if ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' ) {
+				--$open_stack_indices[ $level ];
+			}
+
+			// Construct the breadcrumbs to match the format from detect.js.
+			$breadcrumbs = array();
+			foreach ( $open_stack_tags as $i => $breadcrumb_tag_name ) {
+				$breadcrumbs[] = array(
+					'tagName' => $breadcrumb_tag_name,
+					'index'   => $open_stack_indices[ $i ],
+				);
+			}
+
+			// Invoke the callback to do processing.
+			$open_tag_callback( $p, $breadcrumbs );
 
 			// Immediately pop off self-closing tags.
 			if ( in_array( $tag_name, ILO_SELF_CLOSING_TAGS, true ) ) {
@@ -180,24 +235,21 @@ function ilo_find_element_by_breadcrumbs( string $html, array $breadcrumbs ): ar
 			}
 			array_splice( $open_stack_indices, count( $open_stack_tags ) + 1 );
 		}
-
-		// ...
-		$src    = $p->get_attribute( 'src' );
-		$srcset = $p->get_attribute( 'srcset' );
 	}
 
-	return array();
+	return $p->get_updated_html();
 }
 
-function ilo_remove_fetchpriority_from_all_images( string $html ): string {
-	$p = new WP_HTML_Tag_Processor( $html );
-	while ( $p->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
-		if ( $p->get_attribute( 'fetchpriority' ) ) {
-			$p->set_attribute( 'data-wp-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
-			$p->remove_attribute( 'fetchpriority' );
-		}
+/**
+ * Removes fetchpriority from the current tag if present.
+ *
+ * @param WP_HTML_Tag_Processor $p Processor instance.
+ */
+function ilo_remove_fetchpriority_from_current_tag_processor_node( WP_HTML_Tag_Processor $p ) {
+	if ( $p->get_attribute( 'fetchpriority' ) ) {
+		$p->set_attribute( 'data-ilo-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
+		$p->remove_attribute( 'fetchpriority' );
 	}
-	return $p->get_updated_html();
 }
 
 /**
@@ -213,30 +265,58 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 
 	$lcp_images_by_minimum_viewport_widths = ilo_get_lcp_elements_by_minimum_viewport_widths( $url_metrics, ilo_get_breakpoint_max_widths() );
 
-	// TODO: We need to walk the document to find the breadcrumbs.
 	if ( ! empty( $lcp_images_by_minimum_viewport_widths ) ) {
-		$breakpoint_count_with_lcp_images = count( array_filter( $lcp_images_by_minimum_viewport_widths ) );
+		$breakpoint_lcp_images = array_filter( $lcp_images_by_minimum_viewport_widths );
 
-		if ( 1 === count( $lcp_images_by_minimum_viewport_widths ) && 1 === $breakpoint_count_with_lcp_images ) {
-			// If there is exactly one LCP image for all breakpoints, ensure fetchpriority is set on that image only.
-			$buffer = ilo_remove_fetchpriority_from_all_images( $buffer );
-
+		// If there is exactly one LCP image for all breakpoints, ensure fetchpriority is set on that image only.
+		if ( 1 === count( $lcp_images_by_minimum_viewport_widths ) && 1 === count( $breakpoint_lcp_images ) ) {
 			$lcp_element = current( $lcp_images_by_minimum_viewport_widths );
 
-		} elseif ( 0 === $breakpoint_count_with_lcp_images ) {
-			// If there are no LCP images, remove fetchpriority from all images.
-			$buffer = ilo_remove_fetchpriority_from_all_images( $buffer );
+			$buffer = ilo_walk_document(
+				$buffer,
+				static function ( WP_HTML_Tag_Processor $p, array $breadcrumbs ) use ( $lcp_element ) {
+					if ( 'IMG' !== $p->get_tag() ) {
+						return;
+					}
+					if ( $breadcrumbs === $lcp_element['breadcrumbs'] ) {
+						$p->set_attribute( 'fetchpriority', 'high' );
+						$p->set_attribute( 'data-ilo-added-fetchpriority', true );
+					} else {
+						ilo_remove_fetchpriority_from_current_tag_processor_node( $p );
+					}
+				}
+			);
+			// TODO: We could also add the preload links here.
 		} else {
-			// Otherwise, there are two or more breakpoints have different LCP images, so we must remove fetchpriority
-			// from all images and add breakpoint-specific preload links.
-			$buffer = ilo_remove_fetchpriority_from_all_images( $buffer );
+			// If there is not exactly one LCP element, we need to remove fetchpriority from all images while also
+			// capturing the attributes from the LCP element which we can then use for preload links.
+			$buffer = ilo_walk_document(
+				$buffer,
+				static function ( WP_HTML_Tag_Processor $p, array $breadcrumbs ) use ( &$lcp_images_by_minimum_viewport_widths ) {
+					if ( 'IMG' !== $p->get_tag() ) {
+						return;
+					}
+					ilo_remove_fetchpriority_from_current_tag_processor_node( $p );
 
-			// TODO: We need to locate the elements by their breadcrumbs.
-			ilo_construct_preload_links( $lcp_images_by_minimum_viewport_widths );
+					// Capture the attributes from the LCP element to use in preload links.
+					if ( count( $lcp_images_by_minimum_viewport_widths ) > 1 ) {
+						foreach ( $lcp_images_by_minimum_viewport_widths as &$lcp_element ) {
+							if ( $lcp_element && $lcp_element['breadcrumbs'] === $breadcrumbs ) {
+								$lcp_element['attributes'] = array();
+								foreach ( array( 'src', 'srcset', 'sizes', 'crossorigin', 'integrity' ) as $attr_name ) {
+									$lcp_element['attributes'][ $attr_name ] = $p->get_attribute( $attr_name );
+								}
+							}
+						}
+					}
+				}
+			);
 
+			$preload_links = ilo_construct_preload_links( $lcp_images_by_minimum_viewport_widths );
+
+			$buffer = str_replace( '</head>', $preload_links . '</head>', $buffer );
 		}
 	}
 
 	return $buffer;
 }
-

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -11,6 +11,70 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * HTML elements that are self-closing.
+ *
+ * @link https://www.w3.org/TR/html5/syntax.html#serializing-html-fragments
+ * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L206-L232
+ *
+ * @var string[]
+ */
+const ILO_SELF_CLOSING_TAGS = array(
+	'AREA',
+	'BASE',
+	'BASEFONT',
+	'BGSOUND',
+	'BR',
+	'COL',
+	'EMBED',
+	'FRAME',
+	'HR',
+	'IMG',
+	'INPUT',
+	'KEYGEN',
+	'LINK',
+	'META',
+	'PARAM',
+	'SOURCE',
+	'TRACK',
+	'WBR',
+);
+
+/**
+ * The set of HTML tags whose presence will implicitly close a <p> element.
+ * For example '<p>foo<h1>bar</h1>' should parse the same as '<p>foo</p><h1>bar</h1>'.
+ *
+ * @link https://www.w3.org/TR/html-markup/p.html
+ * @link https://github.com/ampproject/amp-toolbox-php/blob/c79a0fe558a3c042aee4789bbf33376cca7a733d/src/Html/Tag.php#L262-L293
+ */
+const ILO_P_CLOSING_TAGS = array(
+	'ADDRESS',
+	'ARTICLE',
+	'ASIDE',
+	'BLOCKQUOTE',
+	'DIR',
+	'DL',
+	'FIELDSET',
+	'FOOTER',
+	'FORM',
+	'H1',
+	'H2',
+	'H3',
+	'H4',
+	'H5',
+	'H6',
+	'HEADER',
+	'HR',
+	'MENU',
+	'NAV',
+	'OL',
+	'P',
+	'PRE',
+	'SECTION',
+	'TABLE',
+	'UL',
+);
+
+/**
  * Adds template output buffer filter for optimization if eligible.
  */
 function ilo_maybe_add_template_output_buffer_filter() {
@@ -21,6 +85,121 @@ function ilo_maybe_add_template_output_buffer_filter() {
 }
 add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
 
+function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widths ): string {
+	$minimum_viewport_widths = array_keys( $lcp_images_by_minimum_viewport_widths );
+	for ( $i = 0, $len = count( $minimum_viewport_widths ); $i < $len; $i++ ) {
+		$lcp_element = $lcp_images_by_minimum_viewport_widths[ $minimum_viewport_widths[ $i ] ];
+		if ( false === $lcp_element ) {
+			// No LCP element at this breakpoint, so nothing to preload.
+			continue;
+		}
+
+		$media_query = sprintf( 'screen and ( min-width: %dpx )', $minimum_viewport_widths[ $i ] );
+		if ( isset( $minimum_viewport_widths[ $i + 1 ] ) ) {
+			$media_query .= sprintf( ' and ( max-width: %dpx )', $minimum_viewport_widths[ $i + 1 ] - 1 );
+		}
+
+	}
+
+	return '';
+}
+
+function ilo_find_element_by_breadcrumbs( string $html, array $breadcrumbs ): array {
+	$p = new WP_HTML_Tag_Processor( $html );
+
+	/*
+	 * The keys for the following two arrays correspond to each other. Given the following document:
+	 *
+	 * <html>
+	 *   <head>
+	 *   </head>
+	 *   <body>
+	 *     <p>Hello!</p>
+	 *     <img src="lcp.png">
+	 *   </body>
+	 * </html>
+	 *
+	 * The two upon processing the IMG element, the two arrays should be equal to the following:
+	 *
+	 * $open_stack_tags    = array( 'HTML', 'BODY', 'IMG' );
+	 * $open_stack_indices = array( 0, 1, 1 );
+	 */
+	$open_stack_tags    = array();
+	$open_stack_indices = array();
+	while ( $p->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+		$tag_name = $p->get_tag();
+		if ( ! $p->is_tag_closer() ) {
+
+			// Close an open P tag when a P-closing tag is encountered.
+			if ( in_array( $tag_name, ILO_P_CLOSING_TAGS, true ) ) {
+				$i = array_search( 'P', $open_stack_tags, true );
+				if ( false !== $i ) {
+					array_splice( $open_stack_tags, $i );
+					array_splice( $open_stack_indices, count( $open_stack_tags ) );
+				}
+			}
+
+			$level             = count( $open_stack_tags );
+			$open_stack_tags[] = $tag_name;
+
+			if ( ! isset( $open_stack_indices[ $level ] ) ) {
+				$open_stack_indices[ $level ] = 0;
+			} elseif ( ! ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' ) ) {
+				// Only increment the tag index at this level only if it isn't the admin bar, since the presence of the
+				// admin bar can throw off the indices.
+				++$open_stack_indices[ $level ];
+			}
+
+			// TODO: Now check if $open_stack matches breadcrumbs.
+
+			// Immediately pop off self-closing tags.
+			if ( in_array( $tag_name, ILO_SELF_CLOSING_TAGS, true ) ) {
+				array_pop( $open_stack_tags );
+			}
+		} else {
+			// If the closing tag is for self-closing tag, we ignore it since it was already handled above.
+			if ( in_array( $tag_name, ILO_SELF_CLOSING_TAGS, true ) ) {
+				continue;
+			}
+
+			// Since SVG and MathML can have a lot more self-closing/empty tags, potentially pop off the stack until getting to the open tag.
+			$did_splice = false;
+			if ( 'SVG' === $tag_name || 'MATH' === $tag_name ) {
+				$i = array_search( $tag_name, $open_stack_tags, true );
+				if ( false !== $i ) {
+					array_splice( $open_stack_tags, $i );
+					$did_splice = true;
+				}
+			}
+
+			if ( ! $did_splice ) {
+				$popped_tag_name = array_pop( $open_stack_tags );
+				if ( $popped_tag_name !== $tag_name ) {
+					error_log( "Expected popped tag stack element {$popped_tag_name} to match the currently visited closing tag $tag_name." ); // phpcs:ignore
+				}
+			}
+			array_splice( $open_stack_indices, count( $open_stack_tags ) + 1 );
+		}
+
+		// ...
+		$src    = $p->get_attribute( 'src' );
+		$srcset = $p->get_attribute( 'srcset' );
+	}
+
+	return array();
+}
+
+function ilo_remove_fetchpriority_from_all_images( string $html ): string {
+	$p = new WP_HTML_Tag_Processor( $html );
+	while ( $p->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+		if ( $p->get_attribute( 'fetchpriority' ) ) {
+			$p->set_attribute( 'data-wp-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
+			$p->remove_attribute( 'fetchpriority' );
+		}
+	}
+	return $p->get_updated_html();
+}
+
 /**
  * Optimizes template output buffer.
  *
@@ -28,24 +207,36 @@ add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
  * @return string Filtered template output buffer.
  */
 function ilo_optimize_template_output_buffer( string $buffer ): string {
-	$slug         = ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() );
-	$post         = ilo_get_url_metrics_post( $slug );
-	$page_metrics = ilo_parse_stored_url_metrics( $post );
+	$slug        = ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() );
+	$post        = ilo_get_url_metrics_post( $slug );
+	$url_metrics = ilo_parse_stored_url_metrics( $post );
 
-	$lcp_images_by_minimum_viewport_widths = ilo_get_lcp_elements_by_minimum_viewport_widths( $page_metrics, ilo_get_breakpoint_max_widths() );
+	$lcp_images_by_minimum_viewport_widths = ilo_get_lcp_elements_by_minimum_viewport_widths( $url_metrics, ilo_get_breakpoint_max_widths() );
 
+	// TODO: We need to walk the document to find the breadcrumbs.
 	if ( ! empty( $lcp_images_by_minimum_viewport_widths ) ) {
-		if ( count( $lcp_images_by_minimum_viewport_widths ) !== 1 ) {
-			$p = new WP_HTML_Tag_Processor( $buffer );
-			while ( $p->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
-				if ( $p->get_attribute( 'fetchpriority' ) ) {
-					$p->set_attribute( 'data-wp-removed-fetchpriority', $p->get_attribute( 'fetchpriority' ) );
-					$p->remove_attribute( 'fetchpriority' );
-				}
-			}
-			$buffer = $p->get_updated_html();
+		$breakpoint_count_with_lcp_images = count( array_filter( $lcp_images_by_minimum_viewport_widths ) );
+
+		if ( 1 === count( $lcp_images_by_minimum_viewport_widths ) && 1 === $breakpoint_count_with_lcp_images ) {
+			// If there is exactly one LCP image for all breakpoints, ensure fetchpriority is set on that image only.
+			$buffer = ilo_remove_fetchpriority_from_all_images( $buffer );
+
+			$lcp_element = current( $lcp_images_by_minimum_viewport_widths );
+
+		} elseif ( 0 === $breakpoint_count_with_lcp_images ) {
+			// If there are no LCP images, remove fetchpriority from all images.
+			$buffer = ilo_remove_fetchpriority_from_all_images( $buffer );
+		} else {
+			// Otherwise, there are two or more breakpoints have different LCP images, so we must remove fetchpriority
+			// from all images and add breakpoint-specific preload links.
+			$buffer = ilo_remove_fetchpriority_from_all_images( $buffer );
+
+			// TODO: We need to locate the elements by their breadcrumbs.
+			ilo_construct_preload_links( $lcp_images_by_minimum_viewport_widths );
+
 		}
 	}
 
 	return $buffer;
 }
+

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -134,6 +134,7 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 			if ( 'high' === $processor->get_attribute( 'fetchpriority' ) ) {
 				$processor->set_attribute( 'data-ilo-fetchpriority-already-added', true );
 			} else {
+				// TODO: When optimizing lazy-loading, this should also remove any `loading` attribute here.
 				$processor->set_attribute( 'fetchpriority', 'high' );
 				$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
 			}

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -139,8 +139,9 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 					$processor->set_attribute( 'fetchpriority', 'high' );
 					$processor->set_attribute( 'data-ilo-added-fetchpriority', true );
 				}
-			} else {
-				$processor->remove_fetchpriority_attribute();
+			} elseif ( $processor->get_attribute( 'fetchpriority' ) ) {
+				$processor->set_attribute( 'data-ilo-removed-fetchpriority', $processor->get_attribute( 'fetchpriority' ) );
+				$processor->remove_attribute( 'fetchpriority' );
 			}
 
 			// Capture the attributes from the LCP elements to use in preload links.

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -315,7 +315,7 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 			$preload_links = ilo_construct_preload_links( $lcp_images_by_minimum_viewport_widths );
 
 			// TODO: In the future, WP_HTML_Processor could be used to do this injection. However, given the simple replacement here this is not essential.
-			$buffer = preg_replace( '#(?=</head>)#', $preload_links, $buffer, 1 );
+			$buffer = preg_replace( '#(?=</HEAD>)#i', $preload_links, $buffer, 1 );
 		}
 	}
 

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -186,8 +186,17 @@ function ilo_unshift_url_metrics( array $url_metrics, array $validated_url_metri
  *  3. 481-576 (phablets)
  *  4. >576 (desktop)
  *
+ * The default breakpoints are reused from Gutenberg where the _breakpoints.scss file includes these variables:
+ *
+ *     $break-medium: 782px; // adminbar goes big
+ *     $break-small: 600px;
+ *     $break-mobile: 480px;
+ *
+ * These breakpoints appear to be used the most in media queries that affect frontend styles.
+ *
  * @since n.e.x.t
  * @access private
+ * @link https://github.com/WordPress/gutenberg/blob/093d52cbfd3e2c140843d3fb91ad3d03330320a5/packages/base-styles/_breakpoints.scss#L11-L13
  *
  * @return int[] Breakpoint max widths, sorted in ascending order.
  */
@@ -200,9 +209,11 @@ function ilo_get_breakpoint_max_widths(): array {
 		/**
 		 * Filters the breakpoint max widths to group URL metrics for various viewports.
 		 *
+		 * @since n.e.x.t
+		 *
 		 * @param int[] $breakpoint_max_widths Max widths for viewport breakpoints.
 		 */
-		(array) apply_filters( 'ilo_breakpoint_max_widths', array( 480 ) )
+		(array) apply_filters( 'ilo_breakpoint_max_widths', array( 480, 600, 782 ) )
 	);
 
 	sort( $breakpoint_max_widths );

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -303,12 +303,10 @@ function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpo
  * breakpoint, then the array value is an array representing that element, including its breadcrumbs. If two adjoining
  * breakpoints have the same value, then the latter is dropped.
  *
- * @param array $url_metrics           URL metrics.
- * @param int[] $breakpoint_max_widths Breakpoint max widths.
+ * @param array $grouped_url_metrics URL metrics grouped by breakpoint. See `ilo_group_url_metrics_by_breakpoint()`.
  * @return array LCP elements keyed by its minimum viewport width. If there is no LCP element at a breakpoint, then `false` is used.
  */
-function ilo_get_lcp_elements_by_minimum_viewport_widths( array $url_metrics, array $breakpoint_max_widths ): array {
-	$grouped_url_metrics = ilo_group_url_metrics_by_breakpoint( $url_metrics, $breakpoint_max_widths );
+function ilo_get_lcp_elements_by_minimum_viewport_widths( array $grouped_url_metrics ): array {
 
 	$lcp_element_by_viewport_minimum_width = array();
 	foreach ( $grouped_url_metrics as $viewport_minimum_width => $breakpoint_url_metrics ) {

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -349,7 +349,7 @@ function ilo_get_lcp_elements_by_minimum_viewport_widths( array $grouped_url_met
 		}
 	}
 
-	// Now we need to merge the breakpoints when there is an LCP element common between them.
+	// Now merge the breakpoints when there is an LCP element common between them.
 	$prev_lcp_element = null;
 	return array_filter(
 		$lcp_element_by_viewport_minimum_width,

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -303,6 +303,9 @@ function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpo
  * breakpoint, then the array value is an array representing that element, including its breadcrumbs. If two adjoining
  * breakpoints have the same value, then the latter is dropped.
  *
+ * @since n.e.x.t
+ * @access private
+ *
  * @param array $grouped_url_metrics URL metrics grouped by breakpoint. See `ilo_group_url_metrics_by_breakpoint()`.
  * @return array LCP elements keyed by its minimum viewport width. If there is no LCP element at a breakpoint, then `false` is used.
  */

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -337,15 +337,15 @@ function ilo_get_lcp_elements_by_minimum_viewport_widths( array $url_metrics, ar
 	}
 
 	// Now we need to merge the breakpoints when there is an LCP element common between them.
-	$reduced_breadcrumbs     = array();
-	$last_breadcrumb_element = null;
-	foreach ( $lcp_element_by_viewport_minimum_width as $viewport_minimum_width => $lcp_element ) {
-		if ( ! $last_breadcrumb_element || $lcp_element['breadcrumbs'] !== $last_breadcrumb_element['breadcrumbs'] ) {
-			$reduced_breadcrumbs[ $viewport_minimum_width ] = $lcp_element;
-			$last_breadcrumb_element                        = $lcp_element;
+	$last_lcp_element = null;
+	return array_filter(
+		$lcp_element_by_viewport_minimum_width,
+		static function ( $lcp_element ) use ( &$last_lcp_element ) {
+			$include          = ( ! $last_lcp_element || $last_lcp_element['breadcrumbs'] !== $lcp_element['breadcrumbs'] );
+			$last_lcp_element = $lcp_element;
+			return $include;
 		}
-	}
-	return $reduced_breadcrumbs;
+	);
 }
 
 /**

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -305,7 +305,7 @@ function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpo
  *
  * @param array $url_metrics           URL metrics.
  * @param int[] $breakpoint_max_widths Breakpoint max widths.
- * @return array LCP elements keyed by its minimum viewport width.
+ * @return array LCP elements keyed by its minimum viewport width. If there is no LCP element at a breakpoint, then `false` is used.
  */
 function ilo_get_lcp_elements_by_minimum_viewport_widths( array $url_metrics, array $breakpoint_max_widths ): array {
 	$grouped_url_metrics = ilo_group_url_metrics_by_breakpoint( $url_metrics, $breakpoint_max_widths );

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -293,6 +293,8 @@ function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpo
  *
  * The array keys are the minimum viewport width required for the element to be LCP.
  *
+ * @TODO: If there is no LCP element at a given breakpoint, make sure to return null?
+ *
  * @param array $url_metrics           URL metrics.
  * @param int[] $breakpoint_max_widths Breakpoint max widths.
  * @return array LCP elements keyed by its minimum viewport width.

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -44,7 +44,14 @@ function ilo_get_url_metric_freshness_ttl(): int {
  * @return bool Whether response can be optimized.
  */
 function ilo_can_optimize_response(): bool {
-	$able = ! is_search();
+	$able = ! (
+		// Since the URL space is infinite.
+		is_search() ||
+		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
+		is_customize_preview() ||
+		// The images detected in the response body of a POST request cannot, by definition, be cached.
+		'GET' !== $_SERVER['REQUEST_METHOD']
+	);
 
 	/**
 	 * Filters whether the current response can be optimized.

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -342,27 +342,27 @@ function ilo_get_lcp_elements_by_minimum_viewport_widths( array $url_metrics, ar
 	}
 
 	// Now we need to merge the breakpoints when there is an LCP element common between them.
-	$last_lcp_element = null;
+	$prev_lcp_element = null;
 	return array_filter(
 		$lcp_element_by_viewport_minimum_width,
-		static function ( $lcp_element ) use ( &$last_lcp_element ) {
+		static function ( $lcp_element ) use ( &$prev_lcp_element ) {
 			$include = (
 				// First element in list.
-				null === $last_lcp_element
+				null === $prev_lcp_element
 				||
-				( is_array( $last_lcp_element ) && is_array( $lcp_element )
+				( is_array( $prev_lcp_element ) && is_array( $lcp_element )
 					?
 					// This breakpoint and previous breakpoint had LCP element, and they were not the same element.
-					$last_lcp_element['breadcrumbs'] !== $lcp_element['breadcrumbs']
+					$prev_lcp_element['breadcrumbs'] !== $lcp_element['breadcrumbs']
 					:
 					// This LCP element and the last LCP element were not the same. In this case, either variable may be
 					// false or an array, but both cannot be an array. If both are false, we don't want to include since
 					// it is the same. If one is an array and the other is false, then do want to include because this
 					// indicates a difference at this breakpoint.
-					$last_lcp_element !== $lcp_element
+					$prev_lcp_element !== $lcp_element
 				)
 			);
-			$last_lcp_element = $lcp_element;
+			$prev_lcp_element = $lcp_element;
 			return $include;
 		}
 	);

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -136,12 +136,12 @@ function ilo_register_endpoint() {
 								'items'    => array(
 									'type'       => 'object',
 									'properties' => array(
-										'tagName' => array( // TODO: Should this just be 'tag' instead?
+										'tag'   => array(
 											'type'     => 'string',
 											'required' => true,
 											'pattern'  => '^[a-zA-Z0-9-]+$',
 										),
-										'index'   => array(
+										'index' => array(
 											'type'     => 'int',
 											'required' => true,
 											'minimum'  => 0,

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -136,7 +136,7 @@ function ilo_register_endpoint() {
 								'items'    => array(
 									'type'       => 'object',
 									'properties' => array(
-										'tagName' => array(
+										'tagName' => array( // TODO: Should this just be 'tag' instead?
 											'type'     => 'string',
 											'required' => true,
 											'pattern'  => '^[a-zA-Z0-9-]+$',

--- a/server-timing/class-perflab-server-timing.php
+++ b/server-timing/class-perflab-server-timing.php
@@ -230,7 +230,7 @@ class Perflab_Server_Timing {
 			// It feels better if this could rather be replaced with add_action( 'shutdown', [ $this, 'send_header' ] )
 			// However, this does not work because the buffer is sent before the shutdown callback is executed.
 			add_filter(
-				'perflab_template_output_buffer',
+				'ilo_template_output_buffer',
 				function ( $buffer ) {
 					$this->send_header();
 					return $buffer;

--- a/tests/modules/images/image-loading-optimization/load-tests.php
+++ b/tests/modules/images/image-loading-optimization/load-tests.php
@@ -34,7 +34,7 @@ class Image_Loading_Optimization_Load_Tests extends ImagesTestCase {
 		ob_start();
 
 		add_filter(
-			'perflab_template_output_buffer',
+			'ilo_template_output_buffer',
 			function ( $buffer ) use ( $original, $expected ) {
 				$this->assertSame( $original, $buffer );
 				return $expected;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #872 as part of #869.

This implements the optimization of image loading based on the client-side detection (https://github.com/WordPress/performance/pull/876) that has been stored (https://github.com/WordPress/performance/pull/878).

_This is fully functional and able to be tested in a WP install._

## Relevant technical choices

When a response is eligible for being optimized, an output buffer filter is added to apply optimizations. This involves looking up the `ilo_url_metrics` post containing the stored URL metrics, and when present groupong the URL metrics into the breakpoints (480px, 600px, 782px). If all breakpoints have URL metrics collected and all share the same image as LCP element, then `fetchpriority=high` is set on this image while being removed from all other images. If all breakpoints don't have URL metrics collected yet, then the `fetchpriority` attribute added by server-side heuristics is not removed. Certain data attributes are also added to elements so we can track what operations are being performed:

Attribute | Condition
--|--
`data-ilo-added-fetchpriority` | When the `fetchpriority` attribute is added to an element.
`data-ilo-removed-fetchpriority` | When the `fetchpriority` attribute is removed from an element.
`data-ilo-fetchpriority-already-added` | When WordPress's existing server-side heuristics have already set `fetchpriority=high` on the LCP image, then the `data-ilo-removed-fetchpriority` attribute is added.
`data-ilo-added-tag` | Present on the `preload` links which are injected at the end of the `head`.

When the `fetchpriority` attribute is added, a `data-ilo-added-fetchpriority` attribute is also added so we can keep track of what operations it is doing. 

Whenever there are URL metrics available, `preload` links are also added for the LCP image in each breakpoint. This is particularly important when different breakpoints have different LCP elements (even none at all), as in such cases the `fetchpriority` attribute must be removed from each breakpoint-specific LCP image element. This is also useful for when breakpoints don't have URL metrics collected yet, as otherwise `fetchpriority=high` could be erroneously added to the wrong image for the current viewport. 

In order to apply the `fetchpriority` optimizations to the page and to collect the attributes from `IMG` elements for use in preload links, the `WP_HTML_Tag_Processor` class is leveraged, although it is not used directly. An `ILO_HTML_Tag_Processor` class is used which incorporates `WP_HTML_Tag_Processor` (by composition instead of extension). This processor is similar to `WP_HTML_Tag_Processor` except it is more constrained. It provides a generator method called `open_tags()`; while iterating over this generator, the breadcrumbs for the current open tag can be obtained via the `get_breadcrumbs()` method. Otherwise, the following methods from the underlying `WP_HTML_Tag_Processor` are exposed: 

* `get_attribute()`
* `set_attribute()`
* `remove_attribute()`
* `get_updated_html()`

Importantly, the `next_tag()` and `seek()` methods are not exposed since in order to correctly compute breadcrumbs the processor must proceed forward through the entire document visiting all open and closing tags.

Tip: The following command deletes all `ilo_url_metrics` posts:

```bash
npm run wp-env run cli -- post delete --force $( npm run --silent wp-env run cli -- post list --post_type=ilo_url_metrics --format=ids 2> /dev/null )
```

### Other changes

* Besides the existing 480px breakpoint, additional breakpoints of 600px and 782px have been added. These three breakpoints correspond to the `mobile`, `small`, and `medium` breakpoints that are defined in Gutenberg's [`_breakpoints.css`](https://github.com/WordPress/gutenberg/blob/093d52cbfd3e2c140843d3fb91ad3d03330320a5/packages/base-styles/_breakpoints.scss#L11-L13).
* Detection and optimization by default do not run now in the Customizer preview or in response to a non-`GET` request (e.g. a `POST` request).
* Breadcrumb calculation has been updated to disregard the presence of the Admin Bar. Similarly, client-side detection logic has been updated to account for JS injection of the `.skip-link.screen-reader-text` element, which throws off generation of breadcrumbs on the client to match breadcrumbs generated on the server. In reality, the generation of breadcrumbs client-side is fragile and in a subsequent PR I intend to rely on server-side breadcrumb generation exclusively.
* Some additional `preflab_` prefixes have been replaced with `ilo_`.
* The `tagName` key has been replaced with `tag` in breadcrumbs.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
