### PR TITLE
Allow module `can-load.php` callbacks to return a `WP_Error` with more information

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -141,7 +141,7 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 			<?php echo esc_html( $module_data['name'] ); ?>
 		</legend>
 		<label for="<?php echo esc_attr( "{$base_id}_enabled" ); ?>">
-			<?php if ( ! is_wp_error( $can_load_module ) && ! $is_standalone_plugin_loaded ) { ?>
+			<?php if ( $can_load_module && ! is_wp_error( $can_load_module ) && ! $is_standalone_plugin_loaded ) { ?>
 				<input type="checkbox" id="<?php echo esc_attr( "{$base_id}_enabled" ); ?>" name="<?php echo esc_attr( "{$base_name}[enabled]" ); ?>" aria-describedby="<?php echo esc_attr( "{$base_id}_description" ); ?>" value="1"<?php checked( $enabled ); ?>>
 				<?php
 				if ( $module_data['experimental'] ) {

--- a/admin/load.php
+++ b/admin/load.php
@@ -141,7 +141,7 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 			<?php echo esc_html( $module_data['name'] ); ?>
 		</legend>
 		<label for="<?php echo esc_attr( "{$base_id}_enabled" ); ?>">
-			<?php if ( $can_load_module && ! $is_standalone_plugin_loaded ) { ?>
+			<?php if ( ! is_wp_error( $can_load_module ) && ! $is_standalone_plugin_loaded ) { ?>
 				<input type="checkbox" id="<?php echo esc_attr( "{$base_id}_enabled" ); ?>" name="<?php echo esc_attr( "{$base_name}[enabled]" ); ?>" aria-describedby="<?php echo esc_attr( "{$base_id}_description" ); ?>" value="1"<?php checked( $enabled ); ?>>
 				<?php
 				if ( $module_data['experimental'] ) {
@@ -167,6 +167,8 @@ function perflab_render_modules_page_field( $module_slug, $module_data, $module_
 				<?php
 				if ( $is_standalone_plugin_loaded ) {
 					esc_html_e( 'The module cannot be managed with Performance Lab since it is already active as a standalone plugin.', 'performance-lab' );
+				} elseif ( is_wp_error( $can_load_module ) ) {
+					echo esc_html( $can_load_module->get_error_message() );
 				} else {
 					printf(
 						/* translators: %s: module name */

--- a/load.php
+++ b/load.php
@@ -197,7 +197,8 @@ function perflab_is_valid_module( $module ) {
 	}
 
 	// Do not load module if it cannot be loaded, e.g. if it was already merged and is available in WordPress core.
-	return perflab_can_load_module( $module );
+	$can_load_module = perflab_can_load_module( $module );
+	return is_wp_error( $can_load_module ) ? false : $can_load_module;
 }
 
 /**
@@ -237,7 +238,7 @@ add_action( 'wp_head', 'perflab_render_generator' );
  * @since 1.3.0
  *
  * @param string $module Slug of the module.
- * @return bool Whether the module can be loaded or not.
+ * @return bool|WP_Error True or false based on whether the module can be loaded or not, or an error on failure.
  */
 function perflab_can_load_module( $module ) {
 	$module_load_file = PERFLAB_PLUGIN_DIR_PATH . 'modules/' . $module . '/can-load.php';
@@ -253,6 +254,11 @@ function perflab_can_load_module( $module ) {
 	// If the `can-load.php` file is invalid and does not return a closure, assume the module can be loaded.
 	if ( ! is_callable( $module ) ) {
 		return true;
+	}
+
+	// Check if can load return an error.
+	if ( is_wp_error( $module() ) ) {
+		return $module();
 	}
 
 	// Call the closure to determine whether the module can be loaded.

--- a/load.php
+++ b/load.php
@@ -236,9 +236,10 @@ add_action( 'wp_head', 'perflab_render_generator' );
  * Checks whether the given module can be loaded in the current environment.
  *
  * @since 1.3.0
+ * @since n.e.x.t The function may now alternatively return a WP_Error.
  *
  * @param string $module Slug of the module.
- * @return bool|WP_Error True or false based on whether the module can be loaded or not, or an error on failure.
+ * @return bool|WP_Error True if the module can be loaded, or false or a WP_Error with more concrete information otherwise.
  */
 function perflab_can_load_module( $module ) {
 	$module_load_file = PERFLAB_PLUGIN_DIR_PATH . 'modules/' . $module . '/can-load.php';

--- a/load.php
+++ b/load.php
@@ -198,7 +198,7 @@ function perflab_is_valid_module( $module ) {
 
 	// Do not load module if it cannot be loaded, e.g. if it was already merged and is available in WordPress core.
 	$can_load_module = perflab_can_load_module( $module );
-	return is_wp_error( $can_load_module ) ? false : $can_load_module;
+	return $can_load_module && ! is_wp_error( $can_load_module );
 }
 
 /**
@@ -256,13 +256,14 @@ function perflab_can_load_module( $module ) {
 		return true;
 	}
 
-	// Check if can load return an error.
-	if ( is_wp_error( $module() ) ) {
-		return $module();
+	// Call the closure to determine whether the module can be loaded.
+	$result = $module();
+
+	if ( is_wp_error( $result ) ) {
+		return $result;
 	}
 
-	// Call the closure to determine whether the module can be loaded.
-	return (bool) $module();
+	return (bool) $result;
 }
 
 /**

--- a/modules/database/audit-autoloaded-options/can-load.php
+++ b/modules/database/audit-autoloaded-options/can-load.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 return static function () {
 	if ( ! has_filter( 'user_has_cap', 'wp_maybe_grant_site_health_caps' ) ) {
-		return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+		return new WP_Error( 'cannot_load_module', esc_html__( 'The module cannot be loaded since the Site Health feature is disabled.', 'performance-lab' ) );
 	} else {
 		return true;
 	}

--- a/modules/database/audit-autoloaded-options/can-load.php
+++ b/modules/database/audit-autoloaded-options/can-load.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Can load function to determine if Site Health module is supported or not.
+ *
+ * @since   n.e.x.t
+ * @package performance-lab
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+return static function () {
+	if ( ! has_filter( 'user_has_cap', 'wp_maybe_grant_site_health_caps' ) ) {
+		return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+	} else {
+		return true;
+	}
+};

--- a/modules/images/webp-support/can-load.php
+++ b/modules/images/webp-support/can-load.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 return static function () {
 	if ( ! has_filter( 'user_has_cap', 'wp_maybe_grant_site_health_caps' ) ) {
-		return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+		return new WP_Error( 'cannot_load_module', esc_html__( 'The module cannot be loaded since the Site Health feature is disabled.', 'performance-lab' ) );
 	} else {
 		return true;
 	}

--- a/modules/images/webp-support/can-load.php
+++ b/modules/images/webp-support/can-load.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Can load function to determine if Site Health module is supported or not.
+ *
+ * @since   n.e.x.t
+ * @package performance-lab
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+return static function () {
+	if ( ! has_filter( 'user_has_cap', 'wp_maybe_grant_site_health_caps' ) ) {
+		return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+	} else {
+		return true;
+	}
+};

--- a/modules/js-and-css/audit-enqueued-assets/can-load.php
+++ b/modules/js-and-css/audit-enqueued-assets/can-load.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 return static function () {
 	if ( ! has_filter( 'user_has_cap', 'wp_maybe_grant_site_health_caps' ) ) {
-		return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+		return new WP_Error( 'cannot_load_module', esc_html__( 'The module cannot be loaded since the Site Health feature is disabled.', 'performance-lab' ) );
 	} else {
 		return true;
 	}

--- a/modules/js-and-css/audit-enqueued-assets/can-load.php
+++ b/modules/js-and-css/audit-enqueued-assets/can-load.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Can load function to determine if Site Health module is supported or not.
+ *
+ * @since   n.e.x.t
+ * @package performance-lab
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+return static function () {
+	if ( ! has_filter( 'user_has_cap', 'wp_maybe_grant_site_health_caps' ) ) {
+		return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+	} else {
+		return true;
+	}
+};

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -32,6 +32,13 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 			'focus'        => 'images',
 			'slug'         => 'demo-module-3',
 		),
+		'check-error/demo-module-4' => array(
+			'name'         => 'Demo Module 4',
+			'description'  => 'This is the description for demo module 4.',
+			'experimental' => false,
+			'focus'        => 'check-error',
+			'slug'         => 'demo-module-4',
+		),
 	);
 
 	private static $demo_focus_areas = array(
@@ -157,7 +164,7 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 			array_keys( $wp_settings_fields[ PERFLAB_MODULES_SCREEN ]['js-and-css'] )
 		);
 		$this->assertEqualSets(
-			array( 'something/demo-module-2' ),
+			array( 'something/demo-module-2', 'check-error/demo-module-4' ),
 			array_keys( $wp_settings_fields[ PERFLAB_MODULES_SCREEN ]['other'] )
 		);
 	}

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -196,6 +196,7 @@ class Load_Tests extends WP_UnitTestCase {
 			array( '../tests/testdata/demo-modules/js-and-css/demo-module-1', false ),
 			array( '../tests/testdata/demo-modules/something/demo-module-2', true ),
 			array( '../tests/testdata/demo-modules/images/demo-module-3', true ),
+			array( '../tests/testdata/demo-modules/check-error/demo-module-4', false ),
 		);
 	}
 
@@ -212,6 +213,12 @@ class Load_Tests extends WP_UnitTestCase {
 			array( '../tests/testdata/demo-modules/something/demo-module-2', true ),
 			array( '../tests/testdata/demo-modules/images/demo-module-3', true ),
 		);
+	}
+
+	public function test_perflab_can_load_module_with_not_loaded_module() {
+		$can_load_module = perflab_can_load_module( '../tests/testdata/demo-modules/check-error/demo-module-4' );
+		$this->assertInstanceOf( 'WP_Error', $can_load_module );
+		$this->assertSame( 'module_not_loaded', $can_load_module->get_error_code() );
 	}
 
 	public function test_perflab_activate_module() {

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -218,7 +218,7 @@ class Load_Tests extends WP_UnitTestCase {
 	public function test_perflab_can_load_module_with_not_loaded_module() {
 		$can_load_module = perflab_can_load_module( '../tests/testdata/demo-modules/check-error/demo-module-4' );
 		$this->assertInstanceOf( 'WP_Error', $can_load_module );
-		$this->assertSame( 'module_not_loaded', $can_load_module->get_error_code() );
+		$this->assertSame( 'cannot_load_module', $can_load_module->get_error_code() );
 	}
 
 	public function test_perflab_activate_module() {

--- a/tests/testdata/demo-modules/check-error/demo-module-4/can-load.php
+++ b/tests/testdata/demo-modules/check-error/demo-module-4/can-load.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Can load function to determine if Site Health module is supported or not.
+ *
+ * @package performance-lab
+ */
+
+return static function () {
+    return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+};

--- a/tests/testdata/demo-modules/check-error/demo-module-4/can-load.php
+++ b/tests/testdata/demo-modules/check-error/demo-module-4/can-load.php
@@ -6,5 +6,5 @@
  */
 
 return static function () {
-    return new WP_Error( 'module_not_loaded', esc_html__( 'The module cannot be loaded with Performance Lab since it is disabled.', 'performance-lab' ) );
+    return new WP_Error( 'cannot_load_module', esc_html__( 'The module cannot be loaded.', 'performance-lab' ) );
 };

--- a/tests/testdata/demo-modules/check-error/demo-module-4/load.php
+++ b/tests/testdata/demo-modules/check-error/demo-module-4/load.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Module Name: Demo Module 4
+ * Description: This is the description for demo module 4.
+ * Experimental: No
+ *
+ * @package performance-lab
+ */
+
+// This is a demo module and does nothing.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Followup work discussed here: https://github.com/WordPress/performance/issues/885#issuecomment-1832314272

This PR updates  can load infrastructure so that it will support the custom message.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
