### PR TITLE
Rely on server-side breadcrumbs for detection and optimization

### DIFF
--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -226,19 +226,14 @@ final class ILO_HTML_Tag_Processor {
 	/**
 	 * Gets breadcrumbs for the current open tag.
 	 *
-	 * Breadcrumbs are constructed to match the format from detect.js.
+	 * A breadcrumb consists of a tag name and its sibling index.
 	 *
-	 * TODO: Consider rather each breadcrumb being a (tag,index) tuple.
-	 *
-	 * @return array<array{tag: string, index: int}> Breadcrumbs.
+	 * @return array<array{string, int}> Breadcrumbs.
 	 */
 	public function get_breadcrumbs(): array {
 		$breadcrumbs = array();
 		foreach ( $this->open_stack_tags as $i => $breadcrumb_tag_name ) {
-			$breadcrumbs[] = array(
-				'tag'   => $breadcrumb_tag_name,
-				'index' => $this->open_stack_indices[ $i ],
-			);
+			$breadcrumbs[] = array( $breadcrumb_tag_name, $this->open_stack_indices[ $i ] );
 		}
 		return $breadcrumbs;
 	}

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -239,6 +239,9 @@ final class ILO_HTML_Tag_Processor {
 	/**
 	 * Gets XPath for the current open tag.
 	 *
+	 * It would be nicer if this were like `/html[1]/body[2]` but in XPath the position() here refers to the
+	 * index of the preceding node set. So it has to rather be written `/*[1][self::html]/*[2][self::body]`.
+	 *
 	 * @return string XPath.
 	 */
 	public function get_xpath(): string {

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -89,6 +89,14 @@ final class ILO_HTML_Tag_Processor {
 	);
 
 	/**
+	 * Pattern for valid XPath subset for breadcrumb.
+	 *
+	 * @see self::get_xpath()
+	 * @var string
+	 */
+	const XPATH_PATTERN = '^(/\*\[\d+\]\[self::.+?\])+$';
+
+	/**
 	 * Open stack tags.
 	 *
 	 * @var string[]

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -7,7 +7,7 @@
  */
 
 /**
- * Processor leveraging WP_HTML_Tag_Processor which gathers breadcrumbs which can be queried while iterating the open_tags() generator.
+ * Processor leveraging WP_HTML_Tag_Processor which gathers breadcrumbs which can be obtained as XPath while iterating the open_tags() generator.
  *
  * Eventually this class should be made largely obsolete once `WP_HTML_Processor` is fully implemented to support all HTML tags.
  *
@@ -228,14 +228,25 @@ final class ILO_HTML_Tag_Processor {
 	 *
 	 * A breadcrumb consists of a tag name and its sibling index.
 	 *
-	 * @return array<array{string, int}> Breadcrumbs.
+	 * @return Generator<array{string, int}> Breadcrumb.
 	 */
-	public function get_breadcrumbs(): array {
-		$breadcrumbs = array();
+	private function get_breadcrumbs(): Generator {
 		foreach ( $this->open_stack_tags as $i => $breadcrumb_tag_name ) {
-			$breadcrumbs[] = array( $breadcrumb_tag_name, $this->open_stack_indices[ $i ] );
+			yield array( $breadcrumb_tag_name, $this->open_stack_indices[ $i ] );
 		}
-		return $breadcrumbs;
+	}
+
+	/**
+	 * Gets XPath for the current node.
+	 *
+	 * @return string XPath.
+	 */
+	public function get_xpath(): string {
+		$xpath = '';
+		foreach ( $this->get_breadcrumbs() as list( $tag_name, $index ) ) {
+			$xpath .= sprintf( '/*[%d][self::%s]', $index, $tag_name );
+		}
+		return $xpath;
 	}
 
 	/**

--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -237,7 +237,7 @@ final class ILO_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Gets XPath for the current node.
+	 * Gets XPath for the current open tag.
 	 *
 	 * @return string XPath.
 	 */

--- a/modules/images/image-loading-optimization/detection.php
+++ b/modules/images/image-loading-optimization/detection.php
@@ -23,10 +23,18 @@ function ilo_print_detection_script() {
 
 	$query_vars = ilo_get_normalized_query_vars();
 	$slug       = ilo_get_url_metrics_slug( $query_vars );
+	$post       = ilo_get_url_metrics_post( $slug );
 	$microtime  = microtime( true );
 
+	// TODO: Eliminate this conditional in favor of calling ilo_print_detection_script() inside of ilo_optimize_template_output_buffer() if $needs_detection.
 	// Abort if we already have all the sample size we need for all breakpoints.
-	$needed_minimum_viewport_widths = ilo_get_needed_minimum_viewport_widths_now_for_slug( $slug );
+	$needed_minimum_viewport_widths = ilo_get_needed_minimum_viewport_widths(
+		$post ? ilo_parse_stored_url_metrics( $post ) : array(),
+		microtime( true ),
+		ilo_get_breakpoint_max_widths(),
+		ilo_get_url_metrics_breakpoint_sample_size(),
+		ilo_get_url_metric_freshness_ttl()
+	);
 	if ( ! ilo_needs_url_metric_for_breakpoint( $needed_minimum_viewport_widths ) ) {
 		return;
 	}

--- a/modules/images/image-loading-optimization/detection.php
+++ b/modules/images/image-loading-optimization/detection.php
@@ -15,30 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since n.e.x.t
  * @access private
+ *
+ * @param string                       $slug                           URL metrics slug.
+ * @param array<int, array{int, bool}> $needed_minimum_viewport_widths Array of tuples mapping minimum viewport width to whether URL metric(s) are needed.
  */
-function ilo_print_detection_script() {
-	if ( ! ilo_can_optimize_response() ) {
-		return;
-	}
-
-	$query_vars = ilo_get_normalized_query_vars();
-	$slug       = ilo_get_url_metrics_slug( $query_vars );
-	$post       = ilo_get_url_metrics_post( $slug );
-	$microtime  = microtime( true );
-
-	// TODO: Eliminate this conditional in favor of calling ilo_print_detection_script() inside of ilo_optimize_template_output_buffer() if $needs_detection.
-	// Abort if we already have all the sample size we need for all breakpoints.
-	$needed_minimum_viewport_widths = ilo_get_needed_minimum_viewport_widths(
-		$post ? ilo_parse_stored_url_metrics( $post ) : array(),
-		microtime( true ),
-		ilo_get_breakpoint_max_widths(),
-		ilo_get_url_metrics_breakpoint_sample_size(),
-		ilo_get_url_metric_freshness_ttl()
-	);
-	if ( ! ilo_needs_url_metric_for_breakpoint( $needed_minimum_viewport_widths ) ) {
-		return;
-	}
-
+function ilo_get_detection_script( string $slug, array $needed_minimum_viewport_widths ): string {
 	/**
 	 * Filters the time window between serve time and run time in which loading detection is allowed to run.
 	 *
@@ -55,7 +36,7 @@ function ilo_print_detection_script() {
 	$detection_time_window = apply_filters( 'perflab_image_loading_detection_time_window', 5000 );
 
 	$detect_args = array(
-		'serveTime'                   => $microtime * 1000, // In milliseconds for comparison with `Date.now()` in JavaScript.
+		'serveTime'                   => microtime( true ) * 1000, // In milliseconds for comparison with `Date.now()` in JavaScript.
 		'detectionTimeWindow'         => $detection_time_window,
 		'isDebug'                     => WP_DEBUG,
 		'restApiEndpoint'             => rest_url( ILO_REST_API_NAMESPACE . ILO_URL_METRICS_ROUTE ),
@@ -65,7 +46,7 @@ function ilo_print_detection_script() {
 		'neededMinimumViewportWidths' => $needed_minimum_viewport_widths,
 		'storageLockTTL'              => ilo_get_url_metric_storage_lock_ttl(),
 	);
-	wp_print_inline_script_tag(
+	return wp_get_inline_script_tag(
 		sprintf(
 			'import detect from %s; detect( %s );',
 			wp_json_encode( add_query_arg( 'ver', IMAGE_LOADING_OPTIMIZATION_VERSION, plugin_dir_url( __FILE__ ) . 'detection/detect.js' ) ),
@@ -74,4 +55,3 @@ function ilo_print_detection_script() {
 		array( 'type' => 'module' )
 	);
 }
-add_action( 'wp_print_footer_scripts', 'ilo_print_detection_script' );

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -209,7 +209,7 @@ export default async function detect( {
 	// We do the same for elements with background images which are not data: URLs.
 	// TODO: Re-enable background image support when server-side is implemented.
 	// const breadcrumbedElementsWithBackgrounds = Array.from(
-	// 	doc.body.querySelectorAll( '[data-ilo-breadcrumbs][style*="background"]' )
+	// 	doc.body.querySelectorAll( '[data-ilo-xpath][style*="background"]' )
 	// ).filter( ( /** @type {Element} */ el ) =>
 	// 	/url\(\s*['"](?!=data:)/.test( el.style.backgroundImage )
 	// );

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -79,16 +79,10 @@ function error( ...message ) {
 }
 
 /**
- * @typedef {Object} Breadcrumb
- * @property {number} index - Index of element among sibling elements.
- * @property {string} tag   - Tag name.
- */
-
-/**
  * @typedef {Object} ElementMetrics
  * @property {boolean}         isLCP              - Whether it is the LCP candidate.
  * @property {boolean}         isLCPCandidate     - Whether it is among the LCP candidates.
- * @property {Breadcrumb[]}    breadcrumbs        - Breadcrumbs.
+ * @property {string}          xpath              - XPath.
  * @property {number}          intersectionRatio  - Intersection ratio.
  * @property {DOMRectReadOnly} intersectionRect   - Intersection rectangle.
  * @property {DOMRectReadOnly} boundingClientRect - Bounding client rectangle.
@@ -209,7 +203,7 @@ export default async function detect( {
 
 	// TODO: This query no longer needs to be done as early as possible since the server is adding the breadcrumbs.
 	const breadcrumbedImages = doc.body.querySelectorAll(
-		'img[data-ilo-breadcrumbs]' // TODO: Or 'data-ilo-xpath'.
+		'img[data-ilo-xpath]'
 	);
 
 	// We do the same for elements with background images which are not data: URLs.
@@ -227,9 +221,9 @@ export default async function detect( {
 		].map(
 			/**
 			 * @param {HTMLElement} element
-			 * @return {[HTMLElement, string]} Tuple of element and its breadcrumbs.
+			 * @return {[HTMLElement, string]} Tuple of element and its XPath.
 			 */
-			( element ) => [ element, element.dataset.iloBreadcrumbs ] // TODO: Rename to iloXpath.
+			( element ) => [ element, element.dataset.iloXpath ]
 		)
 	);
 
@@ -343,12 +337,10 @@ export default async function detect( {
 	const lcpMetric = lcpMetricCandidates.at( -1 );
 
 	for ( const elementIntersection of elementIntersections ) {
-		const breadcrumbs = breadcrumbedElementsMap.get(
-			elementIntersection.target
-		);
-		if ( ! breadcrumbs ) {
+		const xpath = breadcrumbedElementsMap.get( elementIntersection.target );
+		if ( ! xpath ) {
 			if ( isDebug ) {
-				error( 'Unable to look up breadcrumbs for element' );
+				error( 'Unable to look up XPath for element' );
 			}
 			continue;
 		}
@@ -364,7 +356,7 @@ export default async function detect( {
 					lcpMetricCandidate.entries[ 0 ]?.element ===
 					elementIntersection.target
 			),
-			breadcrumbs,
+			xpath,
 			intersectionRatio: elementIntersection.intersectionRatio,
 			intersectionRect: elementIntersection.intersectionRect,
 			boundingClientRect: elementIntersection.boundingClientRect,

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -86,7 +86,7 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
  * Gets XPath from a breadcrumbs array.
  *
  * @param array<array{string, int}> $breadcrumbs Breadcrumbs.
- * @return string Breadcrumb XPath.
+ * @return string XPath.
  */
 function ilo_get_breadcrumbs_xpath( array $breadcrumbs ): string {
 	return implode(
@@ -143,7 +143,7 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 	$lcp_element_minimum_viewport_width_by_xpath = array();
 	foreach ( $lcp_elements_by_minimum_viewport_widths as $minimum_viewport_width => $lcp_element ) {
 		if ( false !== $lcp_element ) {
-			$lcp_element_minimum_viewport_width_by_xpath[ $lcp_element['breadcrumbs'] ][] = $minimum_viewport_width; // TODO: Rename 'breadcrumbs' to 'xpath'.
+			$lcp_element_minimum_viewport_width_by_xpath[ $lcp_element['xpath'] ][] = $minimum_viewport_width;
 		}
 	}
 
@@ -171,10 +171,10 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 			continue;
 		}
 
-		$breadcrumbs_xpath = ilo_get_breadcrumbs_xpath( $processor->get_breadcrumbs() );
+		$xpath = ilo_get_breadcrumbs_xpath( $processor->get_breadcrumbs() );
 
 		// Ensure the fetchpriority attribute is set on the element properly.
-		if ( $common_lcp_element && $breadcrumbs_xpath === $common_lcp_element['breadcrumbs'] ) { // TODO: Rename 'breadcrumbs' to 'xpath'.
+		if ( $common_lcp_element && $xpath === $common_lcp_element['xpath'] ) {
 			if ( 'high' === $processor->get_attribute( 'fetchpriority' ) ) {
 				$processor->set_attribute( 'data-ilo-fetchpriority-already-added', true );
 			} else {
@@ -195,18 +195,18 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 		}
 
 		// Capture the attributes from the LCP elements to use in preload links.
-		if ( isset( $lcp_element_minimum_viewport_width_by_xpath[ $breadcrumbs_xpath ] ) ) {
+		if ( isset( $lcp_element_minimum_viewport_width_by_xpath[ $xpath ] ) ) {
 			$attributes = array();
 			foreach ( array( 'src', 'srcset', 'sizes', 'crossorigin', 'integrity' ) as $attr_name ) {
 				$attributes[ $attr_name ] = $processor->get_attribute( $attr_name );
 			}
-			foreach ( $lcp_element_minimum_viewport_width_by_xpath[ $breadcrumbs_xpath ] as $minimum_viewport_width ) {
+			foreach ( $lcp_element_minimum_viewport_width_by_xpath[ $xpath ] as $minimum_viewport_width ) {
 				$lcp_elements_by_minimum_viewport_widths[ $minimum_viewport_width ]['attributes'] = $attributes;
 			}
 		}
 
 		if ( $needs_detection ) {
-			$processor->set_attribute( 'data-ilo-breadcrumbs', $breadcrumbs_xpath );
+			$processor->set_attribute( 'data-ilo-xpath', $xpath );
 		}
 	}
 	$buffer = $processor->get_updated_html();

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -83,26 +83,6 @@ function ilo_construct_preload_links( array $lcp_images_by_minimum_viewport_widt
 }
 
 /**
- * Gets XPath from a breadcrumbs array.
- *
- * @param array<array{string, int}> $breadcrumbs Breadcrumbs.
- * @return string XPath.
- */
-function ilo_get_breadcrumbs_xpath( array $breadcrumbs ): string {
-	return implode(
-		'',
-		array_map(
-			static function ( $breadcrumb ) {
-				// It would be nicer if this were like `/html[1]/body[2]` but in XPath the position() here refers to the
-				// index of the preceding node set. So it has to rather be written `/*[1][self::html]/*[2][self::body]`.
-				return sprintf( '/*[%d][self::%s]', $breadcrumb[1], $breadcrumb[0] );
-			},
-			$breadcrumbs
-		)
-	);
-}
-
-/**
  * Optimizes template output buffer.
  *
  * @since n.e.x.t
@@ -165,7 +145,7 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 			continue;
 		}
 
-		$xpath = ilo_get_breadcrumbs_xpath( $processor->get_breadcrumbs() );
+		$xpath = $processor->get_xpath();
 
 		// Ensure the fetchpriority attribute is set on the element properly.
 		if ( $common_lcp_element && $xpath === $common_lcp_element['xpath'] ) {

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -325,10 +325,10 @@ function ilo_get_lcp_elements_by_minimum_viewport_widths( array $grouped_url_met
 					continue;
 				}
 
-				$i = array_search( $element['breadcrumbs'], $seen_breadcrumbs, true );
+				$i = array_search( $element['xpath'], $seen_breadcrumbs, true );
 				if ( false === $i ) {
 					$i                       = count( $seen_breadcrumbs );
-					$seen_breadcrumbs[ $i ]  = $element['breadcrumbs'];
+					$seen_breadcrumbs[ $i ]  = $element['xpath'];
 					$breadcrumb_counts[ $i ] = 0;
 				}
 
@@ -361,7 +361,7 @@ function ilo_get_lcp_elements_by_minimum_viewport_widths( array $grouped_url_met
 				( is_array( $prev_lcp_element ) && is_array( $lcp_element )
 					?
 					// This breakpoint and previous breakpoint had LCP element, and they were not the same element.
-					$prev_lcp_element['breadcrumbs'] !== $lcp_element['breadcrumbs']
+					$prev_lcp_element['xpath'] !== $lcp_element['xpath']
 					:
 					// This LCP element and the last LCP element were not the same. In this case, either variable may be
 					// false or an array, but both cannot be an array. If both are false, we don't want to include since
@@ -422,6 +422,7 @@ function ilo_get_needed_minimum_viewport_widths( array $url_metrics, float $curr
  * @access private
  *
  * @see ilo_get_needed_minimum_viewport_widths()
+ * @todo This is not being used at the moment.
  *
  * @param array $url_metrics URL metrics slug.
  * @return array<int, array{int, bool}> Array of tuples mapping minimum viewport width to whether URL metric(s) are needed.

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -414,30 +414,6 @@ function ilo_get_needed_minimum_viewport_widths( array $url_metrics, float $curr
 }
 
 /**
- * Gets needed minimum viewport widths by slug for the current time.
- *
- * This is a convenience wrapper on top of ilo_get_needed_minimum_viewport_widths() to reduce code duplication.
- *
- * @since n.e.x.t
- * @access private
- *
- * @see ilo_get_needed_minimum_viewport_widths()
- * @todo This is not being used at the moment.
- *
- * @param array $url_metrics URL metrics slug.
- * @return array<int, array{int, bool}> Array of tuples mapping minimum viewport width to whether URL metric(s) are needed.
- */
-function ilo_get_needed_minimum_viewport_widths_now_for_slug( array $url_metrics ): array {
-	return ilo_get_needed_minimum_viewport_widths(
-		$url_metrics,
-		microtime( true ),
-		ilo_get_breakpoint_max_widths(),
-		ilo_get_url_metrics_breakpoint_sample_size(),
-		ilo_get_url_metric_freshness_ttl()
-	);
-}
-
-/**
  * Checks whether there is a URL metric needed for one of the breakpoints.
  *
  * @since n.e.x.t

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -423,13 +423,12 @@ function ilo_get_needed_minimum_viewport_widths( array $url_metrics, float $curr
  *
  * @see ilo_get_needed_minimum_viewport_widths()
  *
- * @param string $slug URL metrics slug.
+ * @param array $url_metrics URL metrics slug.
  * @return array<int, array{int, bool}> Array of tuples mapping minimum viewport width to whether URL metric(s) are needed.
  */
-function ilo_get_needed_minimum_viewport_widths_now_for_slug( string $slug ): array {
-	$post = ilo_get_url_metrics_post( $slug );
+function ilo_get_needed_minimum_viewport_widths_now_for_slug( array $url_metrics ): array {
 	return ilo_get_needed_minimum_viewport_widths(
-		$post instanceof WP_Post ? ilo_parse_stored_url_metrics( $post ) : array(),
+		$url_metrics,
 		microtime( true ),
 		ilo_get_breakpoint_max_widths(),
 		ilo_get_url_metrics_breakpoint_sample_size(),

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -133,7 +133,7 @@ function ilo_register_endpoint() {
 							'xpath'              => array(
 								'type'     => 'string',
 								'required' => true,
-								'pattern'  => '^(/\*\[\d+\]\[self::.+?\])+$', // e.g. `/*[1][self::html]/*[2][self::body]`.
+								'pattern'  => '^(/\*\[\d+\]\[self::.+?\])+$', // See ILO_HTML_Tag_Processor::get_xpath() for format.
 							),
 							'intersectionRatio'  => array(
 								'type'     => 'number',

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -133,7 +133,7 @@ function ilo_register_endpoint() {
 							'xpath'              => array(
 								'type'     => 'string',
 								'required' => true,
-								'pattern'  => '^(/\*\[\d+\]\[self::.+?\])+$', // See ILO_HTML_Tag_Processor::get_xpath() for format.
+								'pattern'  => ILO_HTML_Tag_Processor::XPATH_PATTERN,
 							),
 							'intersectionRatio'  => array(
 								'type'     => 'number',

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -131,23 +131,9 @@ function ilo_register_endpoint() {
 								'type' => 'bool',
 							),
 							'breadcrumbs'        => array(
-								'type'     => 'array',
+								'type'     => 'string',
 								'required' => true,
-								'items'    => array(
-									'type'       => 'object',
-									'properties' => array(
-										'tag'   => array(
-											'type'     => 'string',
-											'required' => true,
-											'pattern'  => '^[a-zA-Z0-9-]+$',
-										),
-										'index' => array(
-											'type'     => 'int',
-											'required' => true,
-											'minimum'  => 0,
-										),
-									),
-								),
+								'pattern'  => '^(/\*\[\d+\]\[self::.+?\])+$', // e.g. `/*[1][self::html]/*[2][self::body]`.
 							),
 							'intersectionRatio'  => array(
 								'type'     => 'number',
@@ -176,7 +162,15 @@ add_action( 'rest_api_init', 'ilo_register_endpoint' );
  * @return WP_REST_Response|WP_Error Response.
  */
 function ilo_handle_rest_request( WP_REST_Request $request ) {
-	$needed_minimum_viewport_widths = ilo_get_needed_minimum_viewport_widths_now_for_slug( $request->get_param( 'slug' ) );
+	$post = ilo_get_url_metrics_post( $request->get_param( 'slug' ) );
+
+	$needed_minimum_viewport_widths = ilo_get_needed_minimum_viewport_widths(
+		$post ? ilo_parse_stored_url_metrics( $post ) : array(),
+		microtime( true ),
+		ilo_get_breakpoint_max_widths(),
+		ilo_get_url_metrics_breakpoint_sample_size(),
+		ilo_get_url_metric_freshness_ttl()
+	);
 	if ( ! ilo_needs_url_metric_for_breakpoint( $needed_minimum_viewport_widths ) ) {
 		return new WP_Error(
 			'no_url_metric_needed',

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -130,7 +130,7 @@ function ilo_register_endpoint() {
 							'isLCPCandidate'     => array(
 								'type' => 'bool',
 							),
-							'breadcrumbs'        => array(
+							'xpath'              => array(
 								'type'     => 'string',
 								'required' => true,
 								'pattern'  => '^(/\*\[\d+\]\[self::.+?\])+$', // e.g. `/*[1][self::html]/*[2][self::body]`.


### PR DESCRIPTION
## Summary

See https://github.com/WordPress/performance/issues/869.

Eliminate client-side computation of element breadcrumbs in favor of generating them server-side while processing the output buffer. Breadcrumbs are serialized as XPath and added to image elements as a `data-ilo-xpath` attribute. This data attribute is used by the detection script instead of generating breadcrumbs client-side. Lastly, the detection script is now injected as part of the output buffer processing instead of a separate `wp_footer` code path.

## Relevant technical choices

This improves the reliability of connecting elements from client-side detection with server-side optimization by exclusively computing breadcrumbs XPath on the server. This eliminates the issue encountered in #884 in which JavaScript injecting a new element. Namely it address the following todo from https://github.com/WordPress/performance/pull/884#issuecomment-1817577551:

> Improve handling of breadcrumb generation when there the document structure varies either due to admin bar being present or due to client-side logic. Currently breadcrumbs have to explicitly skip over the admin bar element to ignore it. Similarly, the client-side breadcrumb logic has to skip over `.skip-link.screen-reader-text` which is injected by `wp_enqueue_block_template_skip_link()`. This issue of client-side mutated elements is particularly problematic, which may require server-side tagging of elements with their breadcrumbs which would eliminate needing to also do that calculation on the client. But this would mean extraneous `data-` attributes on all images. When detection isn't needed, the tag processor could strip those attributes out before sending back the buffer. We may need to monitor this to see how much of a problem it is, such as by checking various themes to see what degree they inject elements to mess up breadcrumbs. As another alternative, we may consider relying on IDs and class names for breadcrumbs rather than element indices, although JS here too can cause problems by modifying the class names.

As part of this, XPath strings are used throughout the module rather than comparing breadcrumbs arrays.

Additionally, instead of injecting the detection script at `wp_footer` and then having some of the same conditions during output buffer processing for optimization, the detection script is now injected during optimization.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
