### PR TITLE
Fix Plugin card UI and thickbox issue

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -529,6 +529,8 @@ function perflab_enqueue_modules_page_scripts() {
 
 	wp_enqueue_script( 'thickbox' );
 	wp_enqueue_style( 'thickbox' );
+
+	wp_enqueue_script( 'plugin-install' );
 }
 
 /**

--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -15,7 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since n.e.x.t
  *
  * @param string $plugin_slug The string identifier for the plugin in questions slug.
- *
  * @return array Array of plugin data, or empty if none/error.
  */
 function perflab_query_plugin_info( string $plugin_slug ) {
@@ -46,7 +45,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
  *
  * @since n.e.x.t
  *
- * @return array of wpp standalone plugins as slugs.
+ * @return array List of WPP standalone plugins as slugs.
  */
 function perflab_get_standalone_plugins() {
 	return array(
@@ -76,7 +75,7 @@ function perflab_render_plugins_ui() {
 		return;
 	}
 	?>
-	<div class="wrap">
+	<div class="wrap plugin-install-php">
 		<h1><?php esc_html_e( 'Performance Plugins', 'performance-lab' ); ?></h1>
 		<p><?php esc_html_e( 'The following standalone performance plugins are available for installation.', 'performance-lab' ); ?></p>
 		<div class="wrap">


### PR DESCRIPTION
## Summary

This PR fixed the plugin card UI issue and the auto resize thickbox popup issue.
- The plugin card is not equal height as per the install plugin screen.

**Before**
<img width="1542" alt="Screenshot 2023-12-05 at 11 09 42 AM" src="https://github.com/WordPress/performance/assets/10103365/0276ff5d-c36d-49d4-b1a0-084c8654dab4">

**After**
<img width="1529" alt="Screenshot 2023-12-05 at 11 10 30 AM" src="https://github.com/WordPress/performance/assets/10103365/fe3a7b6c-0352-4c8c-995c-3ffa66b6eb1d">

- The popup is not auto resize when the screen is big or small.

**Before**
<img width="1537" alt="Screenshot 2023-12-05 at 11 10 03 AM" src="https://github.com/WordPress/performance/assets/10103365/7960e689-8c68-40d7-a426-598b199d87f9">

**After**
<img width="1561" alt="Screenshot 2023-12-05 at 11 10 51 AM" src="https://github.com/WordPress/performance/assets/10103365/e3c52394-f4e1-4d42-ba41-6b4215070fd1">

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
