### PR TITLE
Follow-up: Minor changes for creating standalone plugins

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -390,8 +390,9 @@ function perflab_get_module_data( $module_file ) {
  * Handles the bootstrapping of the admin pointer.
  * Mainly jQuery code that is self-initialising.
  *
- * @param string $hook_suffix The current admin page.
  * @since 1.0.0
+ *
+ * @param string $hook_suffix The current admin page.
  */
 function perflab_admin_pointer( $hook_suffix ) {
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
@@ -483,6 +484,7 @@ function perflab_render_pointer( $pointer_id = 'perflab-admin-pointer', $args = 
  * This function is only used if the modules page exists and is accessible.
  *
  * @since 1.0.0
+ *
  * @see perflab_add_modules_page()
  *
  * @param array $links List of plugin action links HTML.
@@ -507,6 +509,7 @@ function perflab_plugin_action_links_add_settings( $links ) {
  * It runs before the dismiss-wp-pointer AJAX action is performed.
  *
  * @since 2.3.0
+ *
  * @see perflab_render_modules_pointer()
  */
 function perflab_dismiss_wp_pointer_wrapper() {

--- a/admin/load.php
+++ b/admin/load.php
@@ -59,9 +59,6 @@ function perflab_load_modules_page( $modules = null, $focus_areas = null ) {
 	// Handle style for settings page.
 	add_action( 'admin_head', 'perflab_print_modules_page_style' );
 
-	// Handle script for settings page.
-	add_action( 'admin_footer', 'perflab_print_plugin_activation_script' );
-
 	// Handle admin notices for settings page.
 	add_action( 'admin_notices', 'perflab_plugin_admin_notices' );
 
@@ -832,54 +829,4 @@ function perflab_print_modules_page_style() {
 	}
 </style>
 	<?php
-}
-
-/**
- * Callback function that print plugin activation script.
- *
- * @since n.e.x.t
- */
-function perflab_print_plugin_activation_script() {
-	$js = <<<JS
-( function( $ ) {
-	$( document ).ajaxComplete( function( event, xhr, settings ) {
-		// Check if this is the 'install-plugin' request.
-		if ( settings.data && typeof settings.data === 'string' && settings.data.includes( 'action=install-plugin' ) ) {
-			var params = new URLSearchParams( settings.data );
-			var slug = params.get('slug');
-
-			// Check if 'slug' was found and output the value.
-			if ( ! slug ) {
-				return;
-			}
-
-			var target_element = $( '.wpp-standalone-plugins a[data-slug="' + slug + '"]' );
-			if ( ! target_element ) {
-				return;
-			}
-
-			/*
-			 * WordPress core uses a 1s timeout for updating the activation link,
-			 * so we set a 1.5 timeout here to ensure our changes get updated after
-			 * the core changes have taken place.
-			 */
-			setTimeout( function() {
-				var plugin_url = target_element.attr( 'href' );
-				if ( ! plugin_url ) {
-					return;
-				}
-				var nonce = target_element.attr( 'data-plugin-activation-nonce' );
-				var plugin_slug = target_element.attr( 'data-slug' );
-				var url = new URL( plugin_url );
-				url.searchParams.set( 'action', 'perflab_activate_plugin' );
-				url.searchParams.set( '_wpnonce', nonce );
-				url.searchParams.set( 'plugin', plugin_slug );
-				target_element.attr( 'href', url.href );
-			}, 1500 );
-		}
-	} );
-} )( jQuery );
-JS;
-
-	wp_print_inline_script_tag( $js );
 }

--- a/admin/load.php
+++ b/admin/load.php
@@ -830,7 +830,6 @@ function perflab_print_modules_page_style() {
 </style>
 	<?php
 }
-add_action( 'admin_notices', 'perflab_plugin_admin_notices' );
 
 /**
  * Callback function that print plugin activation script.

--- a/admin/perflab-module-migration-notice.js
+++ b/admin/perflab-module-migration-notice.js
@@ -1,4 +1,41 @@
-( function ( document ) {
+( function ( $, document ) {
+	$( document ).ajaxComplete( function( event, xhr, settings ) {
+		// Check if this is the 'install-plugin' request.
+		if ( settings.data && typeof settings.data === 'string' && settings.data.includes( 'action=install-plugin' ) ) {
+			var params = new URLSearchParams( settings.data );
+			var slug = params.get('slug');
+
+			// Check if 'slug' was found and output the value.
+			if ( ! slug ) {
+				return;
+			}
+
+			var target_element = $( '.wpp-standalone-plugins a[data-slug="' + slug + '"]' );
+			if ( ! target_element ) {
+				return;
+			}
+
+			/*
+			 * WordPress core uses a 1s timeout for updating the activation link,
+			 * so we set a 1.5 timeout here to ensure our changes get updated after
+			 * the core changes have taken place.
+			 */
+			setTimeout( function() {
+				var plugin_url = target_element.attr( 'href' );
+				if ( ! plugin_url ) {
+					return;
+				}
+				var nonce = target_element.attr( 'data-plugin-activation-nonce' );
+				var plugin_slug = target_element.attr( 'data-slug' );
+				var url = new URL( plugin_url );
+				url.searchParams.set( 'action', 'perflab_activate_plugin' );
+				url.searchParams.set( '_wpnonce', nonce );
+				url.searchParams.set( 'plugin', plugin_slug );
+				target_element.attr( 'href', url.href );
+			}, 1500 );
+		}
+	} );
+
 	document.addEventListener( 'DOMContentLoaded', function () {
 		document.addEventListener( 'click', function ( event ) {
 			if (
@@ -47,4 +84,4 @@
 			}
 		} );
 	} );
-} )( document );
+} )( jQuery, document );


### PR DESCRIPTION
## Summary

Follow-up to #652 and #880

This PR do following changes:
- Remove duplicate admin notice call as it show notice on all admin pages.
- Fix some minor PHP documentation.
- Move inline script in to `perflab-module-migration-notice.js` file.


## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
