### PR TITLE
Reset admin pointer dismissal for module migration when the user activates a module

### DIFF
--- a/load.php
+++ b/load.php
@@ -462,6 +462,27 @@ function perflab_run_module_activation_deactivation( $old_value, $value ) {
 			if ( ! empty( $module_settings['enabled'] ) && ( empty( $old_value[ $module ] ) || empty( $old_value[ $module ]['enabled'] ) ) ) {
 				perflab_activate_module( PERFLAB_PLUGIN_DIR_PATH . 'modules/' . $module );
 			}
+
+			// Check whether it is necessary to display an admin pointer to prompt the user to migrate.
+			$plugin_slug        = basename( $module );
+			$standalone_plugins = perflab_get_standalone_plugins();
+
+			// Plugin slug should be in standalone plugins list.
+			if ( ! in_array( $plugin_slug, $standalone_plugins, true ) ) {
+				continue;
+			}
+
+			$current_user = get_current_user_id();
+			$dismissed    = array_filter( explode( ',', (string) get_user_meta( $current_user, 'dismissed_wp_pointers', true ) ) );
+
+			if ( ! in_array( 'perflab-module-migration-pointer', $dismissed, true ) ) {
+				continue;
+			}
+
+			unset( $dismissed[ array_search( 'perflab-module-migration-pointer', $dismissed, true ) ] );
+			$dismissed = implode( ',', $dismissed );
+
+			update_user_meta( $current_user, 'dismissed_wp_pointers', $dismissed );
 		}
 	}
 

--- a/load.php
+++ b/load.php
@@ -458,14 +458,14 @@ function perflab_run_module_activation_deactivation( $old_value, $value ) {
 
 	// Get the list of modules that were activated, and load the activate.php files if they exist.
 	if ( ! empty( $value ) ) {
-		$enable_module_migration_pointer = false;
+		$reset_migration_pointer_dismissals = false;
 		foreach ( $value as $module => $module_settings ) {
 			if ( ! empty( $module_settings['enabled'] ) && ( empty( $old_value[ $module ] ) || empty( $old_value[ $module ]['enabled'] ) ) ) {
 				perflab_activate_module( PERFLAB_PLUGIN_DIR_PATH . 'modules/' . $module );
-				$enable_module_migration_pointer = true;
+				$reset_migration_pointer_dismissals = true;
 			}
 		}
-		if ( $enable_module_migration_pointer ) {
+		if ( $reset_migration_pointer_dismissals ) {
 			// Retrieve a list of active modules with associated standalone plugins.
 			$active_modules_with_plugins = perflab_get_active_modules_with_standalone_plugins();
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/WordPress/performance/pull/910#issuecomment-1861395246

The PR introduced the capability to "un-dismiss" a pointer when a user activates a module. Within the code, the `perflab_run_module_activation_deactivation` function is utilized, triggered upon saving settings for the Performance Lab.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
