### PR TITLE
Revise migration pointer un-dismissal to work for all admins

### DIFF
--- a/load.php
+++ b/load.php
@@ -489,7 +489,8 @@ function perflab_run_module_activation_deactivation( $old_value, $value ) {
 			if ( ! wp_is_large_user_count() ) {
 				perflab_dismissed_wp_pointers( $current_user );
 			} else {
-				$current_user_roles = array_shift( $current_user->roles );
+				$current_user_roles = $current_user->roles;
+				$current_user_role  = array_shift( $current_user_roles );
 
 				$args = array(
 					'role'       => $current_user_roles,
@@ -524,20 +525,21 @@ function perflab_run_module_activation_deactivation( $old_value, $value ) {
 }
 
 /**
- * Handles dismissing a WordPress pointer.
+ * Reverts the module migration pointer dismissal for the given user.
  *
  * @since n.e.x.t
  *
  * @param WP_User $user The WP_User object.
  */
-function perflab_dismissed_wp_pointers( $user ) {
+function perflab_undismiss_module_migration_pointer( $user ) {
 	$dismissed = array_filter( explode( ',', (string) get_user_meta( $user->ID, 'dismissed_wp_pointers', true ) ) );
 
-	if ( ! in_array( 'perflab-module-migration-pointer', $dismissed, true ) ) {
+	$pointer_index = array_search( 'perflab-module-migration-pointer', $dismissed, true );
+	if ( false === $pointer_index ) {
 		return;
 	}
 
-	unset( $dismissed[ array_search( 'perflab-module-migration-pointer', $dismissed, true ) ] );
+	unset( $dismissed[ $pointer_index ] );
 	$dismissed = implode( ',', $dismissed );
 
 	update_user_meta( $user->ID, 'dismissed_wp_pointers', $dismissed );

--- a/load.php
+++ b/load.php
@@ -486,14 +486,14 @@ function perflab_run_module_activation_deactivation( $old_value, $value ) {
 			 * disables pointers for the current user only. Otherwise, disables
 			 * pointers for users with the same role as the current user.
 			 */
-			if ( ! wp_is_large_user_count() ) {
-				perflab_dismissed_wp_pointers( $current_user );
+			if ( wp_is_large_user_count() ) {
+				perflab_undismiss_module_migration_pointer( $current_user );
 			} else {
 				$current_user_roles = $current_user->roles;
 				$current_user_role  = array_shift( $current_user_roles );
 
 				$args = array(
-					'role'       => $current_user_roles,
+					'role'       => $current_user_role,
 					'meta_query' => array(
 						array(
 							'key'     => 'dismissed_wp_pointers',
@@ -506,7 +506,7 @@ function perflab_run_module_activation_deactivation( $old_value, $value ) {
 				$users = get_users( $args );
 
 				foreach ( $users as $user ) {
-					perflab_dismissed_wp_pointers( $user );
+					perflab_undismiss_module_migration_pointer( $user );
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/WordPress/performance/pull/915#discussion_r1432982498

Scenario that resolved by this PR:

> If we implement suggested changes. The behaviour with the migration pointer is as follows:
> 
> * Upon plugin release, the migration pointer becomes visible on the site.
> * When the non-technical team logs in, they see the migration pointer.
> * If they dismiss the pointer, it won't appear for them again.
> * However, the technical team, when logging in, never encounters this migration pointer.

That wouldn't be the case, maybe there was a misunderstanding or I didn't explain it well. The pointer wouldn't be dismissed for every user, it would only be "un-dismissed" for every user.

In other words:
* User A dismisses the pointer.
* User B still sees the pointer.
* User B performs the migration.
* Later, user B for some reason deactivates a standalone plugin and reactivates the corresponding module again.
* Now there's the difference:
    * Based on the current PR code, only user B would see the pointer again, but the problem applies to the entire site, so I think user A should see the pointer again as well.
    * In my proposal, both user B and user A would see the pointer again as a result of the change from user B, so user A would be aware of the problem and then could fix it (e.g. if user B goes on holidays).


## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
