### PR TITLE
Prepare the auto-sizes module as a standalone plugin

### DIFF
--- a/modules/images/auto-sizes/hooks.php
+++ b/modules/images/auto-sizes/hooks.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param array $attr Attributes for the image markup.
  * @return array The filtered attributes for the image markup.
  */
-function performance_lab_auto_sizes_attr( $attr ) {
+function auto_sizes_update_image_attributes( $attr ) {
 	// Bail early if the image is not lazy-loaded.
 	if ( ! isset( $attr['loading'] ) || 'lazy' !== $attr['loading'] ) {
 		return $attr;
@@ -38,7 +38,7 @@ function performance_lab_auto_sizes_attr( $attr ) {
 
 	return $attr;
 }
-add_filter( 'wp_get_attachment_image_attributes', 'performance_lab_auto_sizes_attr' );
+add_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' );
 
 /**
  * Adds auto to the sizes attribute to the image, if applicable.
@@ -48,7 +48,7 @@ add_filter( 'wp_get_attachment_image_attributes', 'performance_lab_auto_sizes_at
  * @param string $html The HTML image tag markup being filtered.
  * @return string The filtered HTML image tag markup.
  */
-function performance_lab_auto_sizes_img_tag( $html ) {
+function auto_sizes_update_content_img_tag( $html ) {
 	// Bail early if the image is not lazy-loaded.
 	if ( false === strpos( $html, 'loading="lazy"' ) ) {
 		return $html;
@@ -68,4 +68,4 @@ function performance_lab_auto_sizes_img_tag( $html ) {
 
 	return $html;
 }
-add_filter( 'wp_content_img_tag', 'performance_lab_auto_sizes_img_tag' );
+add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );

--- a/modules/images/auto-sizes/hooks.php
+++ b/modules/images/auto-sizes/hooks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Hook callbacks used for Auto Sizes for Lazy-loaded Images.
+ * Hook callbacks used for Auto-sizes for Lazy-loaded Images.
  *
  * @package performance-lab
  * @since n.e.x.t

--- a/modules/images/auto-sizes/load.php
+++ b/modules/images/auto-sizes/load.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Module Name: Auto Sizes for Lazy-loaded Images.
+ * Module Name: Auto Sizes for Lazy-loaded Images
  * Description: Implements auto sizes for lazy loaded images.
  * Experimental: Yes
  *

--- a/modules/images/auto-sizes/load.php
+++ b/modules/images/auto-sizes/load.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Module Name: Auto Sizes for Lazy-loaded Images
- * Description: Implements auto sizes for lazy loaded images.
+ * Module Name: Auto-sizes for Lazy-loaded Images
+ * Description: This plugin implements the HTML spec for adding `sizes="auto"` to lazy-loaded images.
  * Experimental: Yes
  *
  * @package performance-lab

--- a/modules/images/auto-sizes/readme.txt
+++ b/modules/images/auto-sizes/readme.txt
@@ -1,4 +1,4 @@
-=== Auto Sizes for Lazy-loaded Images ===
+=== Auto-sizes for Lazy-loaded Images ===
 
 Contributors:      wordpressdotorg
 Requires at least: 6.4
@@ -7,28 +7,28 @@ Requires PHP:      7.0
 Stable tag:        1.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, auto sizes
+Tags:              performance, images, auto-sizes
 
 Adds support for automatically calculating the sizes attribute for lazy-loaded images.
 
 == Description ==
 
-This plugin implements the HTML spec for `sizes="auto"` for lazy-loaded images.
-For background, see: https://github.com/whatwg/html/issues/4654
+This plugin implements the HTML spec for adding `sizes="auto"` to lazy-loaded images.
+For background, see: https://github.com/whatwg/html/issues/4654.
 
 == Installation ==
 
 = Installation from within WordPress =
 
 1. Visit **Plugins > Add New**.
-2. Search for **Auto Sizes for Lazy-loaded Images**.
-3. Install and activate the **Auto Sizes for Lazy-loaded Images** plugin.
+2. Search for **Auto-sizes for Lazy-loaded Images**.
+3. Install and activate the **Auto-sizes for Lazy-loaded Images** plugin.
 
 = Manual installation =
 
 1. Upload the entire `auto-sizes` folder to the `/wp-content/plugins/` directory.
 2. Visit **Plugins**.
-3. Activate the **Auto Sizes for Lazy-loaded Images** plugin.
+3. Activate the **Auto-sizes for Lazy-loaded Images** plugin.
 
 == Frequently Asked Questions ==
 
@@ -50,4 +50,4 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.0.0 =
 
-* Initial release of the Auto Sizes for Lazy-loaded Images plugin as a standalone plugin. ([904](https://github.com/WordPress/performance/pull/904))
+* Initial release of the Auto-sizes for Lazy-loaded Images plugin as a standalone plugin. ([904](https://github.com/WordPress/performance/pull/904))

--- a/modules/images/auto-sizes/readme.txt
+++ b/modules/images/auto-sizes/readme.txt
@@ -1,0 +1,53 @@
+=== Auto Sizes for Lazy-loaded Images ===
+
+Contributors:      wordpressdotorg
+Requires at least: 6.4
+Tested up to:      6.4
+Requires PHP:      7.0
+Stable tag:        1.0.0
+License:           GPLv2 or later
+License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+Tags:              performance, images, auto sizes
+
+Adds support for automatically calculating the sizes attribute for lazy-loaded images.
+
+== Description ==
+
+This plugin implements the HTML spec for auto sizes for lazy-loaded images.
+For background, see: https://github.com/whatwg/html/issues/4654
+
+== Installation ==
+
+= Installation from within WordPress =
+
+1. Visit **Plugins > Add New**.
+2. Search for **Auto Sizes for Lazy-loaded Images**.
+3. Install and activate the **Auto Sizes for Lazy-loaded Images** plugin.
+
+= Manual installation =
+
+1. Upload the entire `auto-sizes` folder to the `/wp-content/plugins/` directory.
+2. Visit **Plugins**.
+3. Activate the **Auto Sizes for Lazy-loaded Images** plugin.
+
+== Frequently Asked Questions ==
+
+= Where can I submit my plugin feedback? =
+
+Feedback is encouraged and much appreciated, especially since this plugin may contain future WordPress core features. If you have suggestions or requests for new features, you can [submit them as an issue in the WordPress Performance Team's GitHub repository](https://github.com/WordPress/performance/issues/new/choose). If you need help with troubleshooting or have a question about the plugin, please [create a new topic on our support forum](https://wordpress.org/support/plugin/auto-sizes/#new-topic-0).
+
+= Where can I report security bugs? =
+
+The Performance team and WordPress community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please visit the [WordPress HackerOne](https://hackerone.com/wordpress) program.
+
+= How can I contribute to the plugin? =
+
+Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
+
+== Changelog ==
+
+= 1.0.0 =
+
+* Initial release of the Auto Sizes for Lazy-loaded Images plugin as a standalone plugin. ([904](https://github.com/WordPress/performance/pull/904))

--- a/modules/images/auto-sizes/readme.txt
+++ b/modules/images/auto-sizes/readme.txt
@@ -13,7 +13,7 @@ Adds support for automatically calculating the sizes attribute for lazy-loaded i
 
 == Description ==
 
-This plugin implements the HTML spec for auto sizes for lazy-loaded images.
+This plugin implements the HTML spec for `sizes="auto"` for lazy-loaded images.
 For background, see: https://github.com/whatwg/html/issues/4654
 
 == Installation ==

--- a/tests/modules/images/auto-sizes/auto-sizes-test.php
+++ b/tests/modules/images/auto-sizes/auto-sizes-test.php
@@ -35,7 +35,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	/**
 	 * Test generated markup for an image with lazy loading gets auto sizes.
 	 *
-	 * @covers ::performance_lab_auto_sizes_attr
+	 * @covers ::auto_sizes_update_image_attributes
 	 */
 	public function test_image_with_lazy_loading_has_auto_sizes() {
 		$this->assertStringContainsString(
@@ -47,7 +47,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	/**
 	 * Test generated markup for an image without lazy loading does not get auto sizes.
 	 *
-	 * @covers ::performance_lab_auto_sizes_attr
+	 * @covers ::auto_sizes_update_image_attributes
 	 */
 	public function test_image_without_lazy_loading_does_not_have_auto_sizes() {
 		$this->assertStringContainsString(
@@ -59,7 +59,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	/**
 	 * Test content filtered markup with lazy loading gets auto sizes.
 	 *
-	 * @covers ::performance_lab_auto_sizes_img_tag
+	 * @covers ::auto_sizes_update_content_img_tag
 	 */
 	public function test_content_image_with_lazy_loading_has_auto_sizes() {
 		// Force lazy loading attribute.
@@ -76,7 +76,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	/**
 	 * Test content filtered markup without lazy loading does not get auto sizes.
 	 *
-	 * @covers ::performance_lab_auto_sizes_img_tag
+	 * @covers ::auto_sizes_update_content_img_tag
 	 */
 	public function test_content_image_without_lazy_loading_does_not_have_auto_sizes() {
 		// Disable lazy loading attribute.

--- a/tests/modules/images/auto-sizes/auto-sizes-test.php
+++ b/tests/modules/images/auto-sizes/auto-sizes-test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for the Auto Sizes for Lazy-loaded Images module.
+ * Tests for the Auto-sizes for Lazy-loaded Images module.
  *
  * @package performance-lab
  * @group   auto-sizes
@@ -33,7 +33,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test generated markup for an image with lazy loading gets auto sizes.
+	 * Test generated markup for an image with lazy loading gets auto-sizes.
 	 *
 	 * @covers ::auto_sizes_update_image_attributes
 	 */
@@ -45,7 +45,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test generated markup for an image without lazy loading does not get auto sizes.
+	 * Test generated markup for an image without lazy loading does not get auto-sizes.
 	 *
 	 * @covers ::auto_sizes_update_image_attributes
 	 */
@@ -57,7 +57,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test content filtered markup with lazy loading gets auto sizes.
+	 * Test content filtered markup with lazy loading gets auto-sizes.
 	 *
 	 * @covers ::auto_sizes_update_content_img_tag
 	 */
@@ -74,7 +74,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test content filtered markup without lazy loading does not get auto sizes.
+	 * Test content filtered markup without lazy loading does not get auto-sizes.
 	 *
 	 * @covers ::auto_sizes_update_content_img_tag
 	 */


### PR DESCRIPTION
## Summary

This updates the auto-sizes module feature to prepare for merging into trunk. Included in this change:

- Updates the hook function names
- Adds a plugin readme.txt file to the module folder
- Fixes the Plugin header name

See: #904 

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
