### PR TITLE
Update `CODEOWNERS`, removing inactive contributors and adding newer active contributors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # Documentation/Infrastructure
-/admin                                      @JustinyAhin @felixarntz
-/tests/admin                                @JustinyAhin @felixarntz
-/bin                                        @JustinyAhin @felixarntz
-/.github                                    @JustinyAhin @felixarntz
+/admin                                      @mukeshpanchal27 @felixarntz
+/tests/admin                                @mukeshpanchal27 @felixarntz
+/bin                                        @mukeshpanchal27 @felixarntz
+/.github                                    @mukeshpanchal27 @felixarntz
 
 # Focus: Database
 /modules/database                           @olliejones
@@ -15,9 +15,9 @@
 /tests/testdata/modules/images              @adamsilverstein @getsource
 
 # Focus: JS & CSS
-/modules/js-and-css                         @aristath @sgomes
-/tests/modules/js-and-css                   @aristath @sgomes
-/tests/testdata/modules/js-and-css          @aristath @sgomes
+/modules/js-and-css                         @westonruter
+/tests/modules/js-and-css                   @westonruter
+/tests/testdata/modules/js-and-css          @westonruter
 
 # Focus: Measurement
 /modules/measurement
@@ -30,19 +30,19 @@
 /tests/testdata/modules/object-cache        @tillkruss @spacedmonkey
 
 # Module: WebP Uploads
-/modules/images/webp-uploads                                                @adamsilverstein @felixarntz @mitogh
-/tests/modules/images/webp-uploads                                          @adamsilverstein @felixarntz @mitogh
-/tests/testdata/modules/images/webp-uploads                                 @adamsilverstein @felixarntz @mitogh
+/modules/images/webp-uploads                                                @adamsilverstein @felixarntz
+/tests/modules/images/webp-uploads                                          @adamsilverstein @felixarntz
+/tests/testdata/modules/images/webp-uploads                                 @adamsilverstein @felixarntz
 
 # Module: WebP Support Health Check
-/modules/images/webp-support                                                @adamsilverstein @kirtangajjar @mitogh
-/tests/modules/images/webp-support                                          @adamsilverstein @kirtangajjar @mitogh
-/tests/testdata/modules/images/webp-support                                 @adamsilverstein @kirtangajjar @mitogh
+/modules/images/webp-support                                                @adamsilverstein
+/tests/modules/images/webp-support                                          @adamsilverstein
+/tests/testdata/modules/images/webp-support                                 @adamsilverstein
 
 # Module: Autoloaded Options Health Check
-/modules/database/audit-autoloaded-options                                  @manuelRod
-/tests/modules/database/audit-autoloaded-options                            @manuelRod
-/tests/testdata/modules/database/audit-autoloaded-options                   @manuelRod
+/modules/database/audit-autoloaded-options                                  @manuelRod @felixarntz
+/tests/modules/database/audit-autoloaded-options                            @manuelRod @felixarntz
+/tests/testdata/modules/database/audit-autoloaded-options                   @manuelRod @felixarntz
 
 # Module: Enqueued Assets Health Check
 /modules/js-and-css/audit-enqueued-assets                                   @manuelRod

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,9 @@
 /tests/testdata/modules/database            @olliejones
 
 # Focus: Images
-/modules/images                             @adamsilverstein @getsource
-/tests/modules/images                       @adamsilverstein @getsource
-/tests/testdata/modules/images              @adamsilverstein @getsource
+/modules/images                             @adamsilverstein @getsource @joemcgill
+/tests/modules/images                       @adamsilverstein @getsource @joemcgill
+/tests/testdata/modules/images              @adamsilverstein @getsource @joemcgill
 
 # Focus: JS & CSS
 /modules/js-and-css                         @westonruter
@@ -20,9 +20,9 @@
 /tests/testdata/modules/js-and-css          @westonruter
 
 # Focus: Measurement
-/modules/measurement
-/tests/modules/measurement
-/tests/testdata/modules/measurement
+/modules/measurement                        @joemcgill
+/tests/modules/measurement                  @joemcgill
+/tests/testdata/modules/measurement         @joemcgill
 
 # Focus: Object Cache
 /modules/object-cache                       @tillkruss @spacedmonkey


### PR DESCRIPTION
## Summary

The `CODEOWNERS` file has been out of date for quite a while, including several contributors that haven't been active for more than 1 year. This leads to them being unnecessarily pinged, while active contributors may miss out on work their review would be helpful on.

This PR proposes updates to the file, removing any such inactive contributors and suggesting new owners as applicable. Please feel free to suggest additional or alternative code owners as part of your review.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
