### PR TITLE
Update PHPCS formatting in tests

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,9 +6,7 @@
 	<config name="testVersion" value="7.0-"/>
 
 	<rule ref="WordPress-Docs"/>
-	<rule ref="WordPress-Extra">
-		<exclude-pattern>tests/*</exclude-pattern>
-	</rule>
+	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress.WP.I18n"/>
 	<config name="text_domain" value="performance-lab,default"/>
 
@@ -71,6 +69,38 @@
 	</rule>
 	<rule ref="PHPCompatibility.FunctionDeclarations.NewReturnTypeDeclarations.boolFound">
 		<exclude-pattern>tests/utils/*</exclude-pattern>
+	</rule>
+
+	<!-- Ignore inapplicable WordPress-Extra sniffs in tests. -->
+	<rule ref="WordPress.WP.EnqueuedResourceParameters">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.WP.AlternativeFunctions.unlink_unlink">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.WP.GlobalVariablesOverride.Prohibited">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.PHP.DevelopmentFunctions.error_log_var_export">
+		<exclude-pattern>tests/*</exclude-pattern>
+	</rule>
+
+	<!-- Exceptions for variable name casing. -->
+	<rule ref="WordPress.NamingConventions.ValidVariableName">
+		<properties>
+			<property name="allowed_custom_properties" type="array">
+				<element value="nodeValue"/>
+				<element value="parentNode"/>
+				<element value="createTextNode"/>
+				<element value="textContent"/>
+			</property>
+		</properties>
 	</rule>
 
 	<rule ref="SlevomatCodingStandard.Functions.StaticClosure" />

--- a/tests/admin/load-tests.php
+++ b/tests/admin/load-tests.php
@@ -11,21 +11,21 @@
 class Admin_Load_Tests extends WP_UnitTestCase {
 
 	private static $demo_modules = array(
-		'js-and-css/demo-module-1' => array(
+		'js-and-css/demo-module-1'  => array(
 			'name'         => 'Demo Module 1',
 			'description'  => 'This is the description for demo module 1.',
 			'experimental' => false,
 			'focus'        => 'js-and-css',
 			'slug'         => 'demo-module-1',
 		),
-		'something/demo-module-2'  => array(
+		'something/demo-module-2'   => array(
 			'name'         => 'Demo Module 2',
 			'description'  => 'This is the description for demo module 2.',
 			'experimental' => true,
 			'focus'        => 'something',
 			'slug'         => 'demo-module-2',
 		),
-		'images/demo-module-3'     => array(
+		'images/demo-module-3'      => array(
 			'name'         => 'Demo Module 3',
 			'description'  => 'This is the description for demo module 3.',
 			'experimental' => false,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,7 +41,7 @@ $GLOBALS['wp_tests_options'] = array(
 require_once $_test_root . '/includes/functions.php';
 tests_add_filter(
 	'plugins_loaded',
-	static function() {
+	static function () {
 		require_once TESTS_PLUGIN_DIR . '/admin/load.php';
 		require_once TESTS_PLUGIN_DIR . '/admin/server-timing.php';
 		require_once TESTS_PLUGIN_DIR . '/admin/plugins.php';

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -78,7 +78,7 @@ class Load_Tests extends WP_UnitTestCase {
 		$has_passed_default = false;
 		add_filter(
 			'default_option_' . PERFLAB_MODULES_SETTING,
-			static function( $default, $option, $passed_default ) use ( &$has_passed_default ) {
+			static function ( $default, $option, $passed_default ) use ( &$has_passed_default ) {
 				// This callback just records whether there is a default value being passed.
 				$has_passed_default = $passed_default;
 				return $default;
@@ -134,7 +134,7 @@ class Load_Tests extends WP_UnitTestCase {
 		$expected_active_modules = array_keys(
 			array_filter(
 				perflab_get_modules_setting_default(),
-				static function( $module_settings ) {
+				static function ( $module_settings ) {
 					return $module_settings['enabled'];
 				}
 			)
@@ -158,7 +158,7 @@ class Load_Tests extends WP_UnitTestCase {
 		array_pop( $active_modules );
 		add_filter(
 			'perflab_active_modules',
-			static function() use ( $active_modules ) {
+			static function () use ( $active_modules ) {
 				return $active_modules;
 			}
 		);
@@ -236,7 +236,7 @@ class Load_Tests extends WP_UnitTestCase {
 		$default_enabled_modules = require PERFLAB_PLUGIN_DIR_PATH . 'default-enabled-modules.php';
 		return array_reduce(
 			$default_enabled_modules,
-			static function( $module_settings, $module_dir ) {
+			static function ( $module_settings, $module_dir ) {
 				$module_settings[ $module_dir ] = array( 'enabled' => true );
 				return $module_settings;
 			},
@@ -319,13 +319,13 @@ class Load_Tests extends WP_UnitTestCase {
 
 		add_filter(
 			'filesystem_method_file',
-			static function() {
+			static function () {
 				return __DIR__ . '/utils/Filesystem/WP_Filesystem_MockFilesystem.php';
 			}
 		);
 		add_filter(
 			'filesystem_method',
-			static function() {
+			static function () {
 				return 'MockFilesystem';
 			}
 		);

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -78,10 +78,10 @@ class Load_Tests extends WP_UnitTestCase {
 		$has_passed_default = false;
 		add_filter(
 			'default_option_' . PERFLAB_MODULES_SETTING,
-			static function ( $default, $option, $passed_default ) use ( &$has_passed_default ) {
+			static function ( $current_default, $option, $passed_default ) use ( &$has_passed_default ) {
 				// This callback just records whether there is a default value being passed.
 				$has_passed_default = $passed_default;
-				return $default;
+				return $current_default;
 			},
 			10,
 			3

--- a/tests/modules/database/audit-autoloaded-options/audit-autoloaded-options-test.php
+++ b/tests/modules/database/audit-autoloaded-options/audit-autoloaded-options-test.php
@@ -86,4 +86,3 @@ class Audit_Autoloaded_Options_Tests extends WP_UnitTestCase {
 		delete_option( self::AUTOLOADED_OPTION_KEY );
 	}
 }
-

--- a/tests/modules/images/dominant-color-images/dominant-color-test.php
+++ b/tests/modules/images/dominant-color-images/dominant-color-test.php
@@ -92,7 +92,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 
 		$filtered_image_tags_added = dominant_color_img_tag_add_dominant_color( $filtered_image_mock_lazy_load, 'the_content', $attachment_id );
 
-		$this->assertStringContainsString( 'data-has-transparency="' . json_encode( $expected_transparency ) . '"', $filtered_image_tags_added );
+		$this->assertStringContainsString( 'data-has-transparency="' . wp_json_encode( $expected_transparency ) . '"', $filtered_image_tags_added );
 
 		foreach ( $expected_color as $color ) {
 			if ( false !== strpos( $color, $filtered_image_tags_added ) ) {

--- a/tests/modules/images/dominant-color-images/dominant-color-test.php
+++ b/tests/modules/images/dominant-color-images/dominant-color-test.php
@@ -210,7 +210,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	public function test_dominant_color_update_attachment_image_attributes( $style_attr, $expected ) {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/dominant-color-images/red.jpg' );
 
-		$attachment_image = wp_get_attachment_image( $attachment_id, 'full', '', array( "style" => $style_attr )  );
+		$attachment_image = wp_get_attachment_image( $attachment_id, 'full', '', array( 'style' => $style_attr ) );
 		$this->assertStringContainsString( $expected, $attachment_image );
 	}
 

--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -520,7 +520,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		$result = null;
 		add_action(
 			'wp_head',
-			static function() use ( &$result ) {
+			static function () use ( &$result ) {
 				$result = webp_uploads_in_frontend_body();
 			}
 		);

--- a/tests/modules/images/webp-uploads/load-tests.php
+++ b/tests/modules/images/webp-uploads/load-tests.php
@@ -544,7 +544,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		add_filter(
 			'webp_uploads_content_image_mimes',
-			static function( $mime_types ) {
+			static function ( $mime_types ) {
 				unset( $mime_types[ array_search( 'image/webp', $mime_types, true ) ] );
 				return $mime_types;
 			}
@@ -733,7 +733,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 
 		add_filter(
 			'webp_uploads_pre_replace_additional_image_source',
-			static function() {
+			static function () {
 				return '<img src="https://ia600200.us.archive.org/16/items/SPD-SLRSY-1867/hubblesite_2001_06.jpg">';
 			}
 		);
@@ -899,7 +899,7 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	public function it_should_create_mime_types_for_allowed_sizes_only_via_filter() {
 		add_filter(
 			'webp_uploads_image_sizes_with_additional_mime_type_support',
-			static function( $sizes ) {
+			static function ( $sizes ) {
 				$sizes['allowed_size_400x300'] = true;
 				return $sizes;
 			}

--- a/tests/modules/images/webp-uploads/rest-api-tests.php
+++ b/tests/modules/images/webp-uploads/rest-api-tests.php
@@ -24,7 +24,7 @@ class WebP_Uploads_REST_API_Tests extends WP_UnitTestCase {
 
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			static function( $transforms ) {
+			static function ( $transforms ) {
 				$transforms['image/jpeg'] = array( 'image/jpeg', 'image/webp' );
 				return $transforms;
 			}

--- a/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -101,7 +101,7 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 		$expected_path = WP_CONTENT_DIR . '/themes/test-theme/style.css';
 		add_filter(
 			'content_url',
-			static function ( $url ) {
+			static function () {
 				return site_url() . '/content';
 			}
 		);

--- a/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -101,12 +101,10 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 		$expected_path = WP_CONTENT_DIR . '/themes/test-theme/style.css';
 		add_filter(
 			'content_url',
-			static function( $url ) {
+			static function ( $url ) {
 				return site_url() . '/content';
 			}
 		);
 		$this->assertSame( $expected_path, perflab_aea_get_path_from_resource_url( $test_url ) );
 	}
-
 }
-

--- a/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -78,7 +78,6 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 			),
 			$transient
 		);
-
 	}
 
 	/**
@@ -287,4 +286,3 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		return Site_Health_Mock_Responses::return_aea_enqueued_css_assets_test_callback_more_than_threshold( $number_of_assets );
 	}
 }
-

--- a/tests/server-timing/load-tests.php
+++ b/tests/server-timing/load-tests.php
@@ -25,7 +25,7 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 		perflab_server_timing_register_metric(
 			'test-metric',
 			array(
-				'measure_callback' => static function( $metric ) {
+				'measure_callback' => static function ( $metric ) {
 					$metric->set_value( 100 );
 				},
 				'access_cap'       => 'exist',
@@ -42,7 +42,7 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_perflab_wrap_server_timing() {
-		$cb = static function() {
+		$cb = static function () {
 			return 123;
 		};
 
@@ -64,7 +64,7 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 
 		// Reset relevant globals.
 		$wp_registered_settings = array();
-		$new_allowed_options = array();
+		$new_allowed_options    = array();
 
 		perflab_register_server_timing_setting();
 
@@ -103,37 +103,61 @@ class Server_Timing_Load_Tests extends WP_UnitTestCase {
 			),
 			'empty list, array'                           => array(
 				array( 'benchmarking_actions' => array() ),
-				array( 'benchmarking_actions' => array(), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array(),
+					'output_buffering'     => false,
+				),
 			),
 			'empty list, string'                          => array(
 				array( 'benchmarking_actions' => '' ),
-				array( 'benchmarking_actions' => array(), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array(),
+					'output_buffering'     => false,
+				),
 			),
 			'empty list, string with whitespace'          => array(
 				array( 'benchmarking_actions' => ' ' ),
-				array( 'benchmarking_actions' => array(), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array(),
+					'output_buffering'     => false,
+				),
 			),
 			'regular list, array'                         => array(
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ) ),
-				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ),
+					'output_buffering'     => false,
+				),
 			),
 			'regular list, string'                        => array(
 				array( 'benchmarking_actions' => "after_setup_theme\ninit\nwp_loaded" ),
-				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ),
+					'output_buffering'     => false,
+				),
 			),
 			'regular list, string with whitespace'        => array(
 				array( 'benchmarking_actions' => "after_setup_  theme \ninit \n\nwp_loaded\n" ),
-				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ),
+					'output_buffering'     => false,
+				),
 			),
 			'regular list, array with duplicates'         => array(
 				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded', 'init' ) ),
-				array( 'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array( 'after_setup_theme', 'init', 'wp_loaded' ),
+					'output_buffering'     => false,
+				),
 			),
 			'regular list, array with special hook chars' => array(
 				array( 'benchmarking_actions' => array( 'namespace/hookname', 'namespace.hookname' ) ),
-				array( 'benchmarking_actions' => array( 'namespace/hookname', 'namespace.hookname' ), 'output_buffering' => false ),
+				array(
+					'benchmarking_actions' => array( 'namespace/hookname', 'namespace.hookname' ),
+					'output_buffering'     => false,
+				),
 			),
-			'output buffering enabled' => array(
+			'output buffering enabled'                    => array(
 				array( 'output_buffering' => 'on' ),
 				array( 'output_buffering' => true ),
 			),

--- a/tests/server-timing/perflab-server-timing-tests.php
+++ b/tests/server-timing/perflab-server-timing-tests.php
@@ -38,7 +38,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 		$this->server_timing->register_metric(
 			'test-metric',
 			array(
-				'measure_callback' => static function() use ( &$called ) {
+				'measure_callback' => static function () use ( &$called ) {
 					$called = true;
 				},
 				'access_cap'       => 'exist',
@@ -52,7 +52,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 	public function test_register_metric_runs_measure_callback_based_on_access_cap() {
 		$called = false;
 		$args   = array(
-			'measure_callback' => static function() use ( &$called ) {
+			'measure_callback' => static function () use ( &$called ) {
 				$called = true;
 			},
 			'access_cap'       => 'manage_options', // Admin capability.
@@ -130,13 +130,13 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 	}
 
 	public function data_get_header() {
-		$measure_42         = static function( $metric ) {
+		$measure_42         = static function ( $metric ) {
 			$metric->set_value( 42 );
 		};
-		$measure_300        = static function( $metric ) {
+		$measure_300        = static function ( $metric ) {
 			$metric->set_value( 300 );
 		};
-		$measure_12point345 = static function( $metric ) {
+		$measure_12point345 = static function ( $metric ) {
 			$metric->set_value( 12.345 );
 		};
 
@@ -188,23 +188,23 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 	}
 
 	public function get_data_to_test_use_output_buffer() {
-		$enable_option = static function () {
-			$option = (array) get_option( PERFLAB_SERVER_TIMING_SETTING );
+		$enable_option  = static function () {
+			$option                     = (array) get_option( PERFLAB_SERVER_TIMING_SETTING );
 			$option['output_buffering'] = true;
 			update_option( PERFLAB_SERVER_TIMING_SETTING, $option );
 		};
 		$disable_option = static function () {
-			$option = (array) get_option( PERFLAB_SERVER_TIMING_SETTING );
+			$option                     = (array) get_option( PERFLAB_SERVER_TIMING_SETTING );
 			$option['output_buffering'] = false;
 			update_option( PERFLAB_SERVER_TIMING_SETTING, $option );
 		};
 
 		return array(
-			'default' => array(
+			'default'         => array(
 				'set_up'   => static function () {},
 				'expected' => false,
 			),
-			'option-enabled' => array(
+			'option-enabled'  => array(
 				'set_up'   => $enable_option,
 				'expected' => true,
 			),
@@ -212,7 +212,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 				'set_up'   => $disable_option,
 				'expected' => false,
 			),
-			'filter-enabled' => array(
+			'filter-enabled'  => array(
 				'set_up'   => static function () use ( $disable_option ) {
 					$disable_option();
 					add_filter( 'perflab_server_timing_use_output_buffer', '__return_true' );

--- a/tests/testdata/demo-modules/check-error/demo-module-4/can-load.php
+++ b/tests/testdata/demo-modules/check-error/demo-module-4/can-load.php
@@ -6,5 +6,5 @@
  */
 
 return static function () {
-    return new WP_Error( 'cannot_load_module', esc_html__( 'The module cannot be loaded.', 'performance-lab' ) );
+	return new WP_Error( 'cannot_load_module', esc_html__( 'The module cannot be loaded.', 'performance-lab' ) );
 };

--- a/tests/testdata/demo-modules/something/demo-module-2/activate.php
+++ b/tests/testdata/demo-modules/something/demo-module-2/activate.php
@@ -6,6 +6,6 @@
  * @package performance-lab
  */
 
-return static function() {
+return static function () {
 	update_option( 'test_demo_module_activation_status', 'activated' );
 };

--- a/tests/testdata/demo-modules/something/demo-module-2/deactivate.php
+++ b/tests/testdata/demo-modules/something/demo-module-2/deactivate.php
@@ -6,6 +6,6 @@
  * @package performance-lab
  */
 
-return static function() {
+return static function () {
 	update_option( 'test_demo_module_activation_status', 'deactivated' );
 };

--- a/tests/testdata/modules/site-health/audit-enqueued-assets/class-audit-assets-transients-set.php
+++ b/tests/testdata/modules/site-health/audit-enqueued-assets/class-audit-assets-transients-set.php
@@ -62,4 +62,3 @@ class Audit_Assets_Transients_Set {
 		delete_transient( self::STYLES_TRANSIENT );
 	}
 }
-

--- a/tests/testdata/modules/site-health/audit-enqueued-assets/class-site-health-mock-responses.php
+++ b/tests/testdata/modules/site-health/audit-enqueued-assets/class-site-health-mock-responses.php
@@ -177,4 +177,3 @@ class Site_Health_Mock_Responses {
 		return $result;
 	}
 }
-

--- a/tests/utils/Constraint/ImageHasSizeSource.php
+++ b/tests/utils/Constraint/ImageHasSizeSource.php
@@ -64,5 +64,4 @@ class ImageHasSizeSource extends ImageHasSource {
 
 		return $this->verify_sources( $metadata['sizes'][ $this->size ]['sources'] );
 	}
-
 }

--- a/tests/utils/Constraint/ImageHasSource.php
+++ b/tests/utils/Constraint/ImageHasSource.php
@@ -136,5 +136,4 @@ class ImageHasSource extends Constraint {
 	protected function failureDescription( $attachment_id ): string {
 		return sprintf( 'an image %s', $this->toString() );
 	}
-
 }

--- a/tests/utils/TestCase/ImagesTestCase.php
+++ b/tests/utils/TestCase/ImagesTestCase.php
@@ -116,7 +116,7 @@ abstract class ImagesTestCase extends WP_UnitTestCase {
 	public function opt_in_to_jpeg_and_webp() {
 		add_filter(
 			'webp_uploads_upload_image_mime_transforms',
-			static function( $transforms ) {
+			static function ( $transforms ) {
 				$transforms['image/jpeg'] = array( 'image/jpeg', 'image/webp' );
 				$transforms['image/webp'] = array( 'image/webp', 'image/jpeg' );
 				return $transforms;


### PR DESCRIPTION
## Summary

This cherry-picks changes from #898 to discontinue excluding WordPress-Extra sniffs from applying to tests, and add specific sniff exclusions. By allowing WordPress-Extra to apply, PHPCBF can do automatic formatting. PHPCS errors were fixed in other test files.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
