### PR TITLE
Prevent sending `Location` header during `test_perflab_aea_clean_aea_audit_action`

### DIFF
--- a/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -242,7 +242,23 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 		$_REQUEST['_wpnonce'] = wp_create_nonce( 'clean_aea_audit' );
 		$_GET['action']       = 'clean_aea_audit';
 		$this->current_user_can_view_site_health_checks_cap();
+		$redirected_url = null;
+		add_filter(
+			'wp_redirect',
+			static function ( $url ) use ( &$redirected_url ) {
+				$redirected_url = $url;
+				return false;
+			}
+		);
+		$_REQUEST['_wp_http_referer'] = add_query_arg(
+			array(
+				'_wpnonce' => 'foo',
+				'action'   => 'bar',
+			),
+			home_url( '/' )
+		);
 		perflab_aea_clean_aea_audit_action();
+		$this->assertSame( home_url( '/' ), $redirected_url );
 		$this->assertFalse( get_transient( 'aea_enqueued_front_page_scripts' ) );
 		$this->assertFalse( get_transient( 'aea_enqueued_front_page_styles' ) );
 	}


### PR DESCRIPTION
## Summary

In working on #898, I noticed PHPUnit failing with:

```
1) Audit_Enqueued_Assets_Tests::test_perflab_aea_clean_aea_audit_action
Cannot modify header information - headers already sent by (output started at /wordpress-phpunit/includes/bootstrap.php:265)

/var/www/html/wp-includes/pluggable.php:1435
/var/www/html/wp-includes/pluggable.php:1545
/var/www/html/wp-content/plugins/performance/modules/js-and-css/audit-enqueued-assets/hooks.php:138
/var/www/html/wp-content/plugins/performance/tests/modules/js-and-css/audit-enqueued-assets/audit-enqueued-assets-test.php:240
```

This is due to `wp_safe_redirect()` being called by `perflab_aea_clean_aea_audit_action()` which is attempting to send the `Location` header during testing. 

It's not clear to me why this unit test failure is not occurring in `trunk`. 

## Relevant technical choices

Prevent `wp_safe_redirect()` from sending the `Location` header via the `wp_redirect` filter in the unit test. Capture the redirected URL and test that it is as expected.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
