### PR TITLE
Fix plugin deactivation link color

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -888,6 +888,10 @@ function perflab_print_modules_page_style() {
 		animation: rotation 2s infinite linear;
 		margin-left: 5px;
 	}
+	.plugin-action-buttons a[id^="deactivate-"] {
+		color: #b32d2e;
+		text-decoration: underline;
+	}
 </style>
 	<?php
 }

--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -194,13 +194,15 @@ function perflab_render_plugin_card( array $plugin_data ) {
 
 					$action_links[] = sprintf(
 						'<a href="%s" id="deactivate-%s" aria-label="%s">%s</a>',
-						add_query_arg(
-							array(
-								'_wpnonce' => wp_create_nonce( 'perflab_deactivate_plugin_' . $status['file'] ),
-								'action'   => 'perflab_deactivate_plugin',
-								'plugin'   => $status['file'],
-							),
-							network_admin_url( 'plugins.php' )
+						esc_url(
+							add_query_arg(
+								array(
+									'_wpnonce' => wp_create_nonce( 'perflab_deactivate_plugin_' . $status['file'] ),
+									'action'   => 'perflab_deactivate_plugin',
+									'plugin'   => $status['file'],
+								),
+								network_admin_url( 'plugins.php' )
+							)
 						),
 						esc_attr( $plugin_data['slug'] ),
 						/* translators: %s: Plugin name. */

--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -193,7 +193,7 @@ function perflab_render_plugin_card( array $plugin_data ) {
 					$context = $status['status'];
 
 					$action_links[] = sprintf(
-						'<a href="%s" id="deactivate-%s" aria-label="%s" style="color:red;text-decoration: underline;">%s</a>',
+						'<a href="%s" id="deactivate-%s" aria-label="%s">%s</a>',
 						add_query_arg(
 							array(
 								'_wpnonce' => wp_create_nonce( 'perflab_deactivate_plugin_' . $status['file'] ),


### PR DESCRIPTION
## Summary

The plugin deactivation link is currently bright red (via a simple `color: red` hard-coded in a `style` attribute). This is not a good color choice, as it is very bright and doesn't follow the WordPress admin color scheme. It should instead use `#b32d2e` which is used for other deactivation links on a white background (e.g. in the plugins list table).

This PR fixes that, and as part of it also avoids the `style` attribute and instead colocates the style with the other styles for the admin page.

This PR uses `no milestone` to not include it in changelogs, since for end users this bug is not relevant - it only will be if we don't fix it now :)

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
