### PR TITLE
Include missing jQuery dependency.

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -580,7 +580,7 @@ function perflab_enqueue_modules_page_scripts() {
 	wp_enqueue_script(
 		'perflab-plugin-management',
 		plugin_dir_url( __FILE__ ) . 'js/perflab-plugin-management.js',
-		array(),
+		array( 'jquery' ),
 		'1.0.0',
 		array(
 			'in_footer' => true,


### PR DESCRIPTION
## Summary

This fixes a very minor, mostly theoretical bug. The `perflab-plugin-management.js` script relies on jQuery, but doesn't declare it as a dependency in PHP. Realistically this doesn't lead to any problem at this point, since jQuery is loaded in most of WP Admin anyway. But it still makes sense to fix this.

This PR uses `no milestone` to not include it in changelogs, since for end users this bug is not relevant - it only will be if we don't fix it now :)

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
