### PR TITLE
Fix JS linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,17 @@ const config = {
 		...( wpConfig?.rules || {} ),
 		'jsdoc/valid-types': 'off',
 	},
+	env: {
+		browser: true,
+	},
+	globals: {
+		scheduler: false,
+	},
+	ignorePatterns: [
+		'/vendor',
+		'/node_modules',
+		'/modules/images/webp-uploads/fallback.js', // TODO: Issues need to be fixed here.
+	],
 };
 
 module.exports = config;

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,9 +12,6 @@ const config = {
 	env: {
 		browser: true,
 	},
-	globals: {
-		scheduler: false,
-	},
 	ignorePatterns: [ '/vendor', '/node_modules' ],
 };
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,11 +15,7 @@ const config = {
 	globals: {
 		scheduler: false,
 	},
-	ignorePatterns: [
-		'/vendor',
-		'/node_modules',
-		'/modules/images/webp-uploads/fallback.js', // TODO: Issues need to be fixed here.
-	],
+	ignorePatterns: [ '/vendor', '/node_modules' ],
 };
 
 module.exports = config;

--- a/admin/js/perflab-module-migration-notice.js
+++ b/admin/js/perflab-module-migration-notice.js
@@ -1,3 +1,6 @@
+/* eslint camelcase: "off", no-alert: "off" */
+/* global perflab_module_migration_notice:false */
+
 ( function ( document ) {
 	document.addEventListener( 'DOMContentLoaded', function () {
 		document.addEventListener( 'click', function ( event ) {

--- a/admin/js/perflab-module-migration-notice.js
+++ b/admin/js/perflab-module-migration-notice.js
@@ -26,7 +26,10 @@
 					.then( function ( response ) {
 						if ( ! response.ok ) {
 							throw new Error(
-								wp.i18n.__( 'Network response was not ok.', 'performance-lab' )
+								wp.i18n.__(
+									'Network response was not ok.',
+									'performance-lab'
+								)
 							);
 						}
 						return response.json();

--- a/admin/js/perflab-plugin-management.js
+++ b/admin/js/perflab-plugin-management.js
@@ -1,16 +1,22 @@
 ( function ( $, document ) {
-	$( document ).ajaxComplete( function( event, xhr, settings ) {
+	$( document ).ajaxComplete( function ( event, xhr, settings ) {
 		// Check if this is the 'install-plugin' request.
-		if ( settings.data && typeof settings.data === 'string' && settings.data.includes( 'action=install-plugin' ) ) {
+		if (
+			settings.data &&
+			typeof settings.data === 'string' &&
+			settings.data.includes( 'action=install-plugin' )
+		) {
 			var params = new URLSearchParams( settings.data );
-			var slug = params.get('slug');
+			var slug = params.get( 'slug' );
 
 			// Check if 'slug' was found and output the value.
 			if ( ! slug ) {
 				return;
 			}
 
-			var target_element = $( '.wpp-standalone-plugins a[data-slug="' + slug + '"]' );
+			var target_element = $(
+				'.wpp-standalone-plugins a[data-slug="' + slug + '"]'
+			);
 			if ( ! target_element ) {
 				return;
 			}
@@ -20,12 +26,14 @@
 			 * so we set a 1.5 timeout here to ensure our changes get updated after
 			 * the core changes have taken place.
 			 */
-			setTimeout( function() {
+			setTimeout( function () {
 				var plugin_url = target_element.attr( 'href' );
 				if ( ! plugin_url ) {
 					return;
 				}
-				var nonce = target_element.attr( 'data-plugin-activation-nonce' );
+				var nonce = target_element.attr(
+					'data-plugin-activation-nonce'
+				);
 				var plugin_slug = target_element.attr( 'data-slug' );
 				var url = new URL( plugin_url );
 				url.searchParams.set( 'action', 'perflab_activate_plugin' );

--- a/admin/js/perflab-plugin-management.js
+++ b/admin/js/perflab-plugin-management.js
@@ -1,3 +1,6 @@
+/* eslint no-var: "off", camelcase: "off" */
+/* global jQuery:false */
+
 ( function ( $, document ) {
 	$( document ).ajaxComplete( function ( event, xhr, settings ) {
 		// Check if this is the 'install-plugin' request.

--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -1,8 +1,10 @@
+/* eslint no-var: "off", camelcase: "off" */
+
 window.wpPerfLab = window.wpPerfLab || {};
 
 ( function ( document ) {
 	window.wpPerfLab.webpUploadsFallbackWebpImages = function ( media ) {
-		for ( var i = 0; i < media.length; i++ ) {
+		for ( let i = 0; i < media.length; i++ ) {
 			try {
 				var image = media[ i ],
 					media_details = image.media_details,
@@ -19,7 +21,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 					'img.wp-image-' + image.id
 				);
 
-				for ( var j = 0; j < images.length; j++ ) {
+				for ( let j = 0; j < images.length; j++ ) {
 					var src = images[ j ].src;
 
 					// If there are sources but no sizes, then attempt to replace src through sources. In that case, there is nothing more to replace.
@@ -41,7 +43,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 
 					var srcset = images[ j ].getAttribute( 'srcset' );
 
-					for ( var k = 0; k < sizes_keys.length; k++ ) {
+					for ( let k = 0; k < sizes_keys.length; k++ ) {
 						var media_sizes_sources =
 							sizes[ sizes_keys[ k ] ].sources;
 						if (
@@ -92,7 +94,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 
 	var loadMediaDetails = function ( nodes ) {
 		var ids = [];
-		for ( var i = 0; i < nodes.length; i++ ) {
+		for ( let i = 0; i < nodes.length; i++ ) {
 			var node = nodes[ i ];
 			var srcset = node.getAttribute( 'srcset' ) || '';
 
@@ -115,12 +117,12 @@ window.wpPerfLab = window.wpPerfLab || {};
 		}
 
 		for (
-			var page = 0, pages = Math.ceil( ids.length / 100 );
+			let page = 0, pages = Math.ceil( ids.length / 100 );
 			page < pages;
 			page++
 		) {
 			var pageIds = [];
-			for ( var i = 0; i < 100 && i + page * 100 < ids.length; i++ ) {
+			for ( let i = 0; i < 100 && i + page * 100 < ids.length; i++ ) {
 				pageIds.push( ids[ i + page * 100 ] );
 			}
 
@@ -142,7 +144,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 
 		// Start the mutation observer to update images added dynamically.
 		var observer = new MutationObserver( function ( mutationList ) {
-			for ( var i = 0; i < mutationList.length; i++ ) {
+			for ( let i = 0; i < mutationList.length; i++ ) {
 				loadMediaDetails( mutationList[ i ].addedNodes );
 			}
 		} );

--- a/modules/images/webp-uploads/fallback.js
+++ b/modules/images/webp-uploads/fallback.js
@@ -1,31 +1,39 @@
 window.wpPerfLab = window.wpPerfLab || {};
 
-( function( document ) {
-	window.wpPerfLab.webpUploadsFallbackWebpImages = function( media ) {
+( function ( document ) {
+	window.wpPerfLab.webpUploadsFallbackWebpImages = function ( media ) {
 		for ( var i = 0; i < media.length; i++ ) {
 			try {
-				var image         = media[ i ],
+				var image = media[ i ],
 					media_details = image.media_details,
 					media_sources = media_details.sources,
-					sizes         = media_details.sizes,
-					sizes_keys    = Object.keys( sizes );
+					sizes = media_details.sizes,
+					sizes_keys = Object.keys( sizes );
 
 				// If the full image has no JPEG version available, no sub-size will have JPEG available either.
-				if ( sizes.full && ! sizes.full.sources['image/jpeg'] ) {
+				if ( sizes.full && ! sizes.full.sources[ 'image/jpeg' ] ) {
 					continue;
 				}
 
-				var images = document.querySelectorAll( 'img.wp-image-' + image.id );
+				var images = document.querySelectorAll(
+					'img.wp-image-' + image.id
+				);
 
 				for ( var j = 0; j < images.length; j++ ) {
-
 					var src = images[ j ].src;
 
 					// If there are sources but no sizes, then attempt to replace src through sources. In that case, there is nothing more to replace.
 					if ( media_sources && ! sizes_keys.length ) {
 						// Only modify src if available and the relevant sources are set.
-						if ( src && media_sources['image/webp'] && media_sources['image/jpeg'] ) {
-							src = src.replace( media_sources['image/webp'].file, media_sources['image/jpeg'].file );
+						if (
+							src &&
+							media_sources[ 'image/webp' ] &&
+							media_sources[ 'image/jpeg' ]
+						) {
+							src = src.replace(
+								media_sources[ 'image/webp' ].file,
+								media_sources[ 'image/jpeg' ].file
+							);
 							images[ j ].setAttribute( 'src', src );
 						}
 						continue;
@@ -34,14 +42,23 @@ window.wpPerfLab = window.wpPerfLab || {};
 					var srcset = images[ j ].getAttribute( 'srcset' );
 
 					for ( var k = 0; k < sizes_keys.length; k++ ) {
-						var media_sizes_sources = sizes[ sizes_keys[ k ] ].sources;
-						if ( ! media_sizes_sources || ! media_sizes_sources['image/webp'] || ! media_sizes_sources['image/jpeg'] ) {
+						var media_sizes_sources =
+							sizes[ sizes_keys[ k ] ].sources;
+						if (
+							! media_sizes_sources ||
+							! media_sizes_sources[ 'image/webp' ] ||
+							! media_sizes_sources[ 'image/jpeg' ]
+						) {
 							continue;
 						}
 
 						// Check to see if the image src has any size set, then update it.
-						if ( media_sizes_sources['image/webp'].source_url === src ) {
-							src = media_sizes_sources['image/jpeg'].source_url;
+						if (
+							media_sizes_sources[ 'image/webp' ].source_url ===
+							src
+						) {
+							src =
+								media_sizes_sources[ 'image/jpeg' ].source_url;
 
 							// If there is no srcset and the src has been replaced, there is nothing more to replace.
 							if ( ! srcset ) {
@@ -50,7 +67,10 @@ window.wpPerfLab = window.wpPerfLab || {};
 						}
 
 						if ( srcset ) {
-							srcset = srcset.replace( media_sizes_sources['image/webp'].source_url, media_sizes_sources['image/jpeg'].source_url );
+							srcset = srcset.replace(
+								media_sizes_sources[ 'image/webp' ].source_url,
+								media_sizes_sources[ 'image/jpeg' ].source_url
+							);
 						}
 					}
 
@@ -62,40 +82,52 @@ window.wpPerfLab = window.wpPerfLab || {};
 						images[ j ].setAttribute( 'src', src );
 					}
 				}
-			} catch ( e ) {
-			}
+			} catch ( e ) {}
 		}
 	};
 
-	var restApi = document.getElementById( 'webpUploadsFallbackWebpImages' ).getAttribute( 'data-rest-api' );
+	var restApi = document
+		.getElementById( 'webpUploadsFallbackWebpImages' )
+		.getAttribute( 'data-rest-api' );
 
-	var loadMediaDetails = function( nodes ) {
+	var loadMediaDetails = function ( nodes ) {
 		var ids = [];
 		for ( var i = 0; i < nodes.length; i++ ) {
 			var node = nodes[ i ];
 			var srcset = node.getAttribute( 'srcset' ) || '';
 
 			if (
-				node.nodeName !== "IMG" ||
-				( ! node.src.match( /\.webp$/i ) && ! srcset.match( /\.webp\s+/ ) )
+				node.nodeName !== 'IMG' ||
+				( ! node.src.match( /\.webp$/i ) &&
+					! srcset.match( /\.webp\s+/ ) )
 			) {
 				continue;
 			}
 
 			var attachment = node.className.match( /wp-image-(\d+)/i );
-			if ( attachment && attachment[1] && ids.indexOf( attachment[1] ) === -1 ) {
-				ids.push( attachment[1] );
+			if (
+				attachment &&
+				attachment[ 1 ] &&
+				ids.indexOf( attachment[ 1 ] ) === -1
+			) {
+				ids.push( attachment[ 1 ] );
 			}
 		}
 
-		for ( var page = 0, pages = Math.ceil( ids.length / 100 ); page < pages; page++ ) {
+		for (
+			var page = 0, pages = Math.ceil( ids.length / 100 );
+			page < pages;
+			page++
+		) {
 			var pageIds = [];
 			for ( var i = 0; i < 100 && i + page * 100 < ids.length; i++ ) {
 				pageIds.push( ids[ i + page * 100 ] );
 			}
 
 			var jsonp = document.createElement( 'script' );
-			var restPath = 'wp/v2/media/?_fields=id,media_details&_jsonp=wpPerfLab.webpUploadsFallbackWebpImages&per_page=100&include=' + pageIds.join( ',' );
+			var restPath =
+				'wp/v2/media/?_fields=id,media_details&_jsonp=wpPerfLab.webpUploadsFallbackWebpImages&per_page=100&include=' +
+				pageIds.join( ',' );
 			if ( -1 !== restApi.indexOf( '?' ) ) {
 				restPath = restPath.replace( '?', '&' );
 			}
@@ -109,7 +141,7 @@ window.wpPerfLab = window.wpPerfLab || {};
 		loadMediaDetails( document.querySelectorAll( 'img' ) );
 
 		// Start the mutation observer to update images added dynamically.
-		var observer = new MutationObserver( function( mutationList ) {
+		var observer = new MutationObserver( function ( mutationList ) {
 			for ( var i = 0; i < mutationList.length; i++ ) {
 				loadMediaDetails( mutationList[ i ].addedNodes );
 			}
@@ -119,6 +151,5 @@ window.wpPerfLab = window.wpPerfLab || {};
 			subtree: true,
 			childList: true,
 		} );
-	} catch ( e ) {
-	}
+	} catch ( e ) {}
 } )( document );

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "test-plugins": "./bin/plugin/cli.js test-plugins",
     "test-plugins-multisite": "./bin/plugin/cli.js test-plugins --sitetype=multi",
     "enabled-modules": "./bin/plugin/cli.js enabled-modules",
-    "format-js": "wp-scripts format ./bin",
-    "lint-js": "wp-scripts lint-js ./bin",
+    "format-js": "wp-scripts format",
+    "lint-js": "wp-scripts lint-js",
     "format-php": "wp-env run composer run-script format",
     "phpstan": "wp-env run composer run-script phpstan",
     "prelint-php": "wp-env run composer 'install --no-interaction'",
@@ -44,6 +44,9 @@
     "*.php": [
       "composer run-script lint",
       "composer run-script phpstan"
+    ],
+    "*.js": [
+      "npm run lint-js"
     ]
   }
 }


### PR DESCRIPTION
## Summary

This cherry-picks changes from `feature/image-loading-optimization` to fix linting of JS files that aren't inside of `bin`.

## Relevant technical choices

* Include `browser` in `env` for ESLint.
* Include JS files in `lint-staged`.
* Run `format-js` on the JS files.
* Include all JS files when running `lint-js` not just `bin`.
* Disable certain ESLint rules which do not need to be fixed.
* Fix `no-redeclare` ESLint error by using `let` in `for` loops.


## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
