### PR TITLE
Fix new WPCS violation after trunk refresh

### DIFF
--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
@@ -49,7 +49,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			array(
 				'/wp-login.php\\?*#*',
 				'/wp-admin/*\\?*#*',
-				'/custom-file.php\\?*#*'
+				'/custom-file.php\\?*#*',
 			),
 			$href_exclude_paths
 		);


### PR DESCRIPTION
## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
