### PR TITLE
Add Speculation Rules settings and UI

### DIFF
--- a/modules/js-and-css/speculation-rules/helper.php
+++ b/modules/js-and-css/speculation-rules/helper.php
@@ -60,7 +60,11 @@ function plsr_get_speculation_rules() {
 		)
 	);
 
-	$prerender_rules = array(
+	$option    = get_option( 'plsr_speculation_rules' );
+	$mode      = $option['mode'];
+	$eagerness = $option['eagerness'];
+
+	$rules = array(
 		array(
 			'source'    => 'document',
 			'where'     => array(
@@ -83,9 +87,9 @@ function plsr_get_speculation_rules() {
 					),
 				),
 			),
-			'eagerness' => 'moderate',
+			'eagerness' => $eagerness,
 		),
 	);
 
-	return array( 'prerender' => $prerender_rules );
+	return array( $mode => $rules );
 }

--- a/modules/js-and-css/speculation-rules/helper.php
+++ b/modules/js-and-css/speculation-rules/helper.php
@@ -83,17 +83,20 @@ function plsr_get_speculation_rules() {
 							'href_matches' => $href_exclude_paths,
 						),
 					),
-					// And except for any links marked with a class to not prerender.
-					array(
-						'not' => array(
-							'selector_matches' => '.no-prerender',
-						),
-					),
 				),
 			),
 			'eagerness' => $eagerness,
 		),
 	);
+
+	// Allow adding a class on any links to prevent prerendering.
+	if ( 'prerender' === $mode ) {
+		$rules[0]['where']['and'][] = array(
+			'not' => array(
+				'selector_matches' => '.no-prerender',
+			),
+		);
+	}
 
 	return array( $mode => $rules );
 }

--- a/modules/js-and-css/speculation-rules/helper.php
+++ b/modules/js-and-css/speculation-rules/helper.php
@@ -60,7 +60,11 @@ function plsr_get_speculation_rules() {
 		)
 	);
 
-	$option    = get_option( 'plsr_speculation_rules' );
+	$option = get_option( 'plsr_speculation_rules' );
+	if ( ! $option ) {
+		$option = plsr_get_setting_default();
+	}
+
 	$mode      = $option['mode'];
 	$eagerness = $option['eagerness'];
 

--- a/modules/js-and-css/speculation-rules/helper.php
+++ b/modules/js-and-css/speculation-rules/helper.php
@@ -51,8 +51,15 @@ function plsr_get_speculation_rules() {
 	);
 
 	$option = get_option( 'plsr_speculation_rules' );
-	if ( ! $option ) {
+
+	/*
+	 * This logic is only relevant for edge-cases where the setting may not be registered,
+	 * a.k.a. defensive coding.
+	 */
+	if ( ! $option || ! is_array( $option ) ) {
 		$option = plsr_get_setting_default();
+	} else {
+		$option = array_merge( plsr_get_setting_default(), $option );
 	}
 
 	$mode      = $option['mode'];

--- a/modules/js-and-css/speculation-rules/load.php
+++ b/modules/js-and-css/speculation-rules/load.php
@@ -18,3 +18,4 @@ define( 'SPECULATION_RULES_VERSION', 'Performance Lab ' . PERFLAB_VERSION );
 require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';
+require_once __DIR__ . '/settings.php';

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -11,7 +11,7 @@
  *
  * @since n.e.x.t
  *
- * @return array Associative array of `$mode => $label` pairs.
+ * @return array<string, string> Associative array of `$mode => $label` pairs.
  */
 function plsr_get_mode_labels() {
 	return array(
@@ -25,7 +25,7 @@ function plsr_get_mode_labels() {
  *
  * @since n.e.x.t
  *
- * @return array Associative array of `$eagerness => $label` pairs.
+ * @return array<string, string> Associative array of `$eagerness => $label` pairs.
  */
 function plsr_get_eagerness_labels() {
 	return array(
@@ -55,7 +55,12 @@ function plsr_get_setting_default() {
  * @since n.e.x.t
  *
  * @param mixed $input Setting to sanitize.
- * @return array Sanitized setting, an associative array with 'mode' and 'eagerness' keys.
+ * @return array<string, string> {
+ *     Sanitized setting.
+ *
+ *     @type string $mode      Mode.
+ *     @type string $eagerness Eagerness.
+ * }
  */
 function plsr_sanitize_setting( $input ) {
 	$default_value = plsr_get_setting_default();

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -29,8 +29,8 @@ function plsr_get_mode_labels() {
  */
 function plsr_get_eagerness_labels() {
 	return array(
-		'conservative' => _x( 'Conservative (on click)', 'setting label', 'performance-lab' ),
-		'moderate'     => _x( 'Moderate (on hover)', 'setting label', 'performance-lab' ),
+		'conservative' => _x( 'Conservative (typically on click)', 'setting label', 'performance-lab' ),
+		'moderate'     => _x( 'Moderate (typically on hover)', 'setting label', 'performance-lab' ),
 		'eager'        => _x( 'Eager (on slightest suggestion)', 'setting label', 'performance-lab' ),
 	);
 }

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -140,7 +140,7 @@ function plsr_add_setting_ui() {
 	$fields = array(
 		'mode'      => array(
 			'title'       => __( 'Mode', 'performance-lab' ),
-			'description' => __( 'Prerendering will lead to faster load times than prefetching, however in case of interactive content prefetching may be a safer choice.', 'performance-lab' ),
+			'description' => __( 'Prerendering will lead to faster load times than prefetching. However, in case of interactive content, prefetching may be a safer choice.', 'performance-lab' ),
 		),
 		'eagerness' => array(
 			'title'       => __( 'Eagerness', 'performance-lab' ),

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -40,7 +40,12 @@ function plsr_get_eagerness_labels() {
  *
  * @since n.e.x.t
  *
- * @return array Default value, an associative array with 'mode' and 'eagerness' keys.
+ * @return array<string, string> {
+ *     Default setting value.
+ *
+ *     @type string $mode      Mode.
+ *     @type string $eagerness Eagerness.
+ * }
  */
 function plsr_get_setting_default() {
 	return array(
@@ -175,7 +180,13 @@ add_action( 'load-options-reading.php', 'plsr_add_setting_ui' );
  * @since n.e.x.t
  * @access private
  *
- * @param array $args Associative array with 'field', 'title', and optional 'description' keys.
+ * @param array<string, string> $args {
+ *     Associative array of arguments.
+ *
+ *     @type string $field       The slug of the sub setting controlled by the field.
+ *     @type string $title       The title for the field.
+ *     @type string $description Optional. A description to show for the field.
+ * }
  */
 function plsr_render_settings_field( array $args ) {
 	if ( empty( $args['field'] ) || empty( $args['title'] ) ) { // Invalid.

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -139,13 +139,13 @@ function plsr_add_setting_ui() {
 
 	$fields = array(
 		'mode'      => array(
-			'title'       => __( 'Mode', 'performance-lab' ),
+			'title'       => __( 'Speculation Mode', 'performance-lab' ),
 			'description' => __( 'Prerendering will lead to faster load times than prefetching. However, in case of interactive content, prefetching may be a safer choice.', 'performance-lab' ),
 		),
 		'eagerness' => array(
 			'title'       => __( 'Eagerness', 'performance-lab' ),
 			'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered.', 'performance-lab' )
-				. '<br>' . __( '"Eager" will have the minimum delay to start loading, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
+				. '<br>' . __( '"Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
 		),
 	);
 	foreach ( $fields as $slug => $args ) {

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -115,7 +115,7 @@ function plsr_register_setting() {
 							'enum'        => array_keys( plsr_get_mode_labels() ),
 						),
 						'eagerness' => array(
-							'description' => __( 'Whether to trigger on click (conservative), on hover (moderate), or on even the slight suggestion (eager) that the user may navigate to the URL.', 'performance-lab' ),
+							'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered. "Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_eagerness_labels() ),
 						),

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Settings functions used for Speculation Rules.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * Returns the available options for the Speculation Rules mode and their labels.
+ *
+ * @since n.e.x.t
+ *
+ * @return array Associative array of `$mode => $label` pairs.
+ */
+function plsr_get_mode_labels() {
+	return array(
+		'prefetch'  => _x( 'Prefetch', 'setting label', 'performance-lab' ),
+		'prerender' => _x( 'Prerender', 'setting label', 'performance-lab' ),
+	);
+}
+
+/**
+ * Returns the available options for the Speculation Rules eagerness and their labels.
+ *
+ * @since n.e.x.t
+ *
+ * @return array Associative array of `$eagerness => $label` pairs.
+ */
+function plsr_get_eagerness_labels() {
+	return array(
+		'conservative' => _x( 'Conservative (on click)', 'setting label', 'performance-lab' ),
+		'moderate'     => _x( 'Moderate (on hover)', 'setting label', 'performance-lab' ),
+		'eager'        => _x( 'Eager (on slightest suggestion)', 'setting label', 'performance-lab' ),
+	);
+}
+
+/**
+ * Returns the default setting value for Speculation Rules configuration.
+ *
+ * @since n.e.x.t
+ *
+ * @return array Default value, an associative array with 'mode' and 'eagerness' keys.
+ */
+function plsr_get_setting_default() {
+	return array(
+		'mode'      => 'prerender',
+		'eagerness' => 'moderate',
+	);
+}
+
+/**
+ * Sanitizes the setting for Speculation Rules configuration.
+ *
+ * @since n.e.x.t
+ *
+ * @param mixed $input Setting to sanitize.
+ * @return array Sanitized setting, an associative array with 'mode' and 'eagerness' keys.
+ */
+function plsr_sanitize_setting( $input ) {
+	$default_value = plsr_get_setting_default();
+
+	if ( ! is_array( $input ) ) {
+		return $default_value;
+	}
+
+	$mode_labels      = plsr_get_mode_labels();
+	$eagerness_labels = plsr_get_eagerness_labels();
+
+	// Ensure only valid keys are present.
+	$value = array_intersect_key( $input, $default_value );
+
+	// Set any missing or invalid values to their defaults.
+	if ( ! isset( $value['mode'] ) || ! isset( $mode_labels[ $value['mode'] ] ) ) {
+		$value['mode'] = $default_value['mode'];
+	}
+	if ( ! isset( $value['eagerness'] ) || ! isset( $eagerness_labels[ $value['eagerness'] ] ) ) {
+		$value['eagerness'] = $default_value['eagerness'];
+	}
+
+	return $value;
+}
+
+/**
+ * Registers setting to control Speculation Rules configuration.
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+function plsr_register_setting() {
+	register_setting(
+		'reading',
+		'plsr_speculation_rules',
+		array(
+			'type'              => 'object',
+			'description'       => __( 'Configuration for the Speculation Rules API.', 'performance-lab' ),
+			'sanitize_callback' => 'plsr_sanitize_setting',
+			'default'           => plsr_get_setting_default(),
+			'show_in_rest'      => array(
+				'schema' => array(
+					'properties' => array(
+						'mode'      => array(
+							'description' => __( 'Whether to prefetch or prerender URLs.', 'performance-lab' ),
+							'type'        => 'string',
+							'enum'        => array_keys( plsr_get_mode_labels() ),
+						),
+						'eagerness' => array(
+							'description' => __( 'Whether to trigger on click (conservative), on hover (moderate), or on even the slight suggestion (eager) that the user may navigate to the URL.', 'performance-lab' ),
+							'type'        => 'string',
+							'enum'        => array_keys( plsr_get_eagerness_labels() ),
+						),
+					),
+				),
+			),
+		)
+	);
+}
+add_action( 'init', 'plsr_register_setting' );
+
+/**
+ * Adds the settings sections and fields for the Speculation Rules configuration.
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+function plsr_add_setting_ui() {
+	add_settings_section(
+		'plsr_speculation_rules',
+		__( 'Speculation Rules', 'performance-lab' ),
+		static function () {
+			?>
+			<p class="description">
+				<?php esc_html_e( 'This section allows you to control how URLs that your users navigate to are speculatively loaded to improve performance.', 'performance-lab' ); ?>
+			</p>
+			<?php
+		},
+		'reading'
+	);
+
+	$fields = array(
+		'mode'      => array(
+			'title'       => __( 'Mode', 'performance-lab' ),
+			'description' => __( 'Prerendering will lead to faster load times than prefetching, however in case of interactive content prefetching may be a safer choice.', 'performance-lab' ),
+		),
+		'eagerness' => array(
+			'title'       => __( 'Eagerness', 'performance-lab' ),
+			'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered.', 'performance-lab' )
+				. '<br>' . __( '"Eager" is best from a performance perspective, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
+		),
+	);
+	foreach ( $fields as $slug => $args ) {
+		add_settings_field(
+			"plsr_speculation_rules_{$slug}",
+			$args['title'],
+			'plsr_render_settings_field',
+			'reading',
+			'plsr_speculation_rules',
+			array_merge(
+				array( 'field' => $slug ),
+				$args
+			)
+		);
+	}
+}
+add_action( 'load-options-reading.php', 'plsr_add_setting_ui' );
+
+/**
+ * Renders a settings field for the Speculation Rules configuration.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @param array $args Associative array with 'field', 'title', and optional 'description' keys.
+ */
+function plsr_render_settings_field( array $args ) {
+	if ( empty( $args['field'] ) || empty( $args['title'] ) ) { // Invalid.
+		return;
+	}
+
+	$option = get_option( 'plsr_speculation_rules' );
+	if ( ! isset( $option[ $args['field'] ] ) ) { // Invalid.
+		return;
+	}
+
+	$value   = $option[ $args['field'] ];
+	$choices = call_user_func( "plsr_get_{$args['field']}_labels" );
+
+	?>
+	<fieldset>
+		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
+		<?php
+		foreach ( $choices as $slug => $label ) {
+			?>
+			<p>
+				<label>
+					<input
+						name="<?php echo esc_attr( "plsr_speculation_rules[{$args['field']}]" ); ?>"
+						type="radio"
+						value="<?php echo esc_attr( $slug ); ?>"
+						<?php checked( $value, $slug ); ?>
+					>
+					<?php echo esc_html( $label ); ?>
+				</label>
+			</p>
+			<?php
+		}
+
+		if ( ! empty( $args['description'] ) ) {
+			?>
+			<p class="description">
+				<?php echo wp_kses( $args['description'], array( 'br' => array() ) ); ?>
+			</p>
+			<?php
+		}
+		?>
+	</fieldset>
+	<?php
+}

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -154,8 +154,7 @@ function plsr_add_setting_ui() {
 		),
 		'eagerness' => array(
 			'title'       => __( 'Eagerness', 'performance-lab' ),
-			'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered.', 'performance-lab' )
-				. '<br>' . __( '"Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
+			'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered. "Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
 		),
 	);
 	foreach ( $fields as $slug => $args ) {
@@ -223,8 +222,8 @@ function plsr_render_settings_field( array $args ) {
 
 		if ( ! empty( $args['description'] ) ) {
 			?>
-			<p class="description">
-				<?php echo wp_kses( $args['description'], array( 'br' => array() ) ); ?>
+			<p class="description" style="max-width: 800px;">
+				<?php echo esc_html( $args['description'] ); ?>
 			</p>
 			<?php
 		}

--- a/modules/js-and-css/speculation-rules/settings.php
+++ b/modules/js-and-css/speculation-rules/settings.php
@@ -145,7 +145,7 @@ function plsr_add_setting_ui() {
 		'eagerness' => array(
 			'title'       => __( 'Eagerness', 'performance-lab' ),
 			'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered.', 'performance-lab' )
-				. '<br>' . __( '"Eager" is best from a performance perspective, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
+				. '<br>' . __( '"Eager" will have the minimum delay to start loading, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'performance-lab' ),
 		),
 	);
 	foreach ( $fields as $slug => $args ) {

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
@@ -54,4 +54,40 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			$href_exclude_paths
 		);
 	}
+
+	public function test_plsr_get_speculation_rules_prerender() {
+		$rules = plsr_get_speculation_rules();
+
+		$this->assertArrayHasKey( 'prerender', $rules );
+		$this->assertCount( 3, $rules['prerender'][0]['where']['and'] );
+	}
+
+	public function test_plsr_get_speculation_rules_prefetch() {
+		update_option( 'plsr_speculation_rules', array( 'mode' => 'prefetch' ) );
+
+		$rules = plsr_get_speculation_rules();
+
+		$this->assertArrayHasKey( 'prefetch', $rules );
+		$this->assertCount( 2, $rules['prefetch'][0]['where']['and'] );
+	}
+
+	/**
+	 * @dataProvider data_plsr_get_speculation_rules_with_eagerness
+	 */
+	public function test_plsr_get_speculation_rules_with_eagerness( string $eagerness ) {
+		update_option( 'plsr_speculation_rules', array( 'eagerness' => $eagerness ) );
+
+		$rules = plsr_get_speculation_rules();
+
+		$this->assertArrayHasKey( 'prerender', $rules );
+		$this->assertSame( $eagerness, $rules['prerender'][0]['eagerness'] );
+	}
+
+	public function data_plsr_get_speculation_rules_with_eagerness() {
+		return array(
+			array( 'conservative' ),
+			array( 'moderate' ),
+			array( 'eager' ),
+		);
+	}
 }

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-settings-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-settings-test.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Tests for speculation-rules settings file.
+ *
+ * @package performance-lab
+ * @group speculation-rules
+ */
+
+class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
+
+	public function test_plsr_register_setting() {
+		$settings = get_registered_settings();
+		$this->assertArrayHasKey( 'plsr_speculation_rules', $settings );
+
+		unregister_setting( 'reading', 'plsr_speculation_rules' );
+		$settings = get_registered_settings();
+		$this->assertArrayNotHasKey( 'plsr_speculation_rules', $settings );
+
+		plsr_register_setting();
+		$settings = get_registered_settings();
+		$this->assertArrayHasKey( 'plsr_speculation_rules', $settings );
+	}
+
+	/**
+	 * @dataProvider data_plsr_sanitize_setting
+	 */
+	public function test_plsr_sanitize_setting( $input, array $expected ) {
+		$this->assertSameSets(
+			$expected,
+			plsr_sanitize_setting( $input )
+		);
+	}
+
+	public function data_plsr_sanitize_setting() {
+		$default_value = array(
+			'mode'      => 'prerender',
+			'eagerness' => 'moderate',
+		);
+
+		return array(
+			'invalid type null'   => array(
+				null,
+				$default_value,
+			),
+			'invalid type string' => array(
+				'prerender',
+				$default_value,
+			),
+			'missing fields'      => array(
+				array(),
+				$default_value,
+			),
+			'missing mode'        => array(
+				array( 'eagerness' => 'conservative' ),
+				array(
+					'mode'      => $default_value['mode'],
+					'eagerness' => 'conservative',
+				),
+			),
+			'missing eagerness'   => array(
+				array( 'mode' => 'prefetch' ),
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => $default_value['eagerness'],
+				),
+			),
+			'invalid mode'        => array(
+				array(
+					'mode'      => 'something',
+					'eagerness' => 'eager',
+				),
+				array(
+					'mode'      => 'prerender',
+					'eagerness' => 'eager',
+				),
+			),
+			'invalid eagerness'   => array(
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'something',
+				),
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'moderate',
+				),
+			),
+			'valid fields'        => array(
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+				array(
+					'mode'      => 'prefetch',
+					'eagerness' => 'conservative',
+				),
+			),
+		);
+	}
+}

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-settings-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-settings-test.php
@@ -9,9 +9,6 @@
 class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
 
 	public function test_plsr_register_setting() {
-		$settings = get_registered_settings();
-		$this->assertArrayHasKey( 'plsr_speculation_rules', $settings );
-
 		unregister_setting( 'reading', 'plsr_speculation_rules' );
 		$settings = get_registered_settings();
 		$this->assertArrayNotHasKey( 'plsr_speculation_rules', $settings );


### PR DESCRIPTION
## Summary

Fixes #906

## Relevant technical choices

* Setting uses an associative array, to avoid using multiple options in the database.
* UI to control the settings is added to _Settings > Reading_.
* See [the spec](https://wicg.github.io/nav-speculation/speculation-rules.html#valid-eagerness-strings) for additional context on the available choices.
* Test coverage is included.
* Includes #937, just to prevent irrelevant lint failure.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
