### PR TITLE
Removes outdated pieces of Speculation Rules logic that are no longer needed as of Chrome 121

### DIFF
--- a/modules/js-and-css/speculation-rules/helper.php
+++ b/modules/js-and-css/speculation-rules/helper.php
@@ -42,17 +42,7 @@ function plsr_get_speculation_rules() {
 	// Ensure that there are no duplicates and that the base paths cannot be removed.
 	$href_exclude_paths = array_unique(
 		array_map(
-			static function ( $exclude_path ) use ( $prefixer ) {
-				$exclude_path = $prefixer->prefix_path_pattern( $exclude_path );
-
-				/*
-				 * TODO: Remove this eventually as it's no longer needed in Chrome 121+.
-				 * See:
-				 * * https://github.com/whatwg/urlpattern/issues/179
-				 * * https://chromium-review.googlesource.com/c/chromium/src/+/4975595
-				 */
-				return $exclude_path . '\\?*#*';
-			},
+			array( $prefixer, 'prefix_path_pattern' ),
 			array_merge(
 				$base_href_exclude_paths,
 				$href_exclude_paths
@@ -67,7 +57,7 @@ function plsr_get_speculation_rules() {
 				'and' => array(
 					// Prerender any URLs within the same site.
 					array(
-						'href_matches' => $prefixer->prefix_path_pattern( '/*\\?*' ),
+						'href_matches' => $prefixer->prefix_path_pattern( '/*' ),
 					),
 					// Except for WP login and admin URLs.
 					array(

--- a/modules/js-and-css/speculation-rules/hooks.php
+++ b/modules/js-and-css/speculation-rules/hooks.php
@@ -25,25 +25,3 @@ function plsr_print_speculation_rules() {
 	);
 }
 add_action( 'wp_footer', 'plsr_print_speculation_rules' );
-
-/**
- * Prints the tag to opt in to the Chrome origin trial if the token constant is defined.
- *
- * After opting in to the origin trial via https://github.com/WICG/nav-speculation/blob/main/chrome-2023q1-experiment-overview.md,
- * please set your token in a `PLSR_ORIGIN_TRIAL_TOKEN` constant, e.g. in `wp-config.php`.
- *
- * This function is here temporarily and will eventually be removed.
- *
- * @since n.e.x.t
- * @access private
- * @ignore
- */
-function plsr_print_origin_trial_opt_in() {
-	if ( ! defined( 'PLSR_ORIGIN_TRIAL_TOKEN' ) || ! PLSR_ORIGIN_TRIAL_TOKEN ) {
-		return;
-	}
-	?>
-	<meta http-equiv="origin-trial" content="<?php echo esc_attr( PLSR_ORIGIN_TRIAL_TOKEN ); ?>">
-	<?php
-}
-add_action( 'wp_head', 'plsr_print_origin_trial_opt_in' );

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
@@ -27,8 +27,8 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 
 		$this->assertSameSets(
 			array(
-				'/wp-login.php\\?*#*',
-				'/wp-admin/*\\?*#*',
+				'/wp-login.php',
+				'/wp-admin/*',
 			),
 			$href_exclude_paths
 		);
@@ -47,9 +47,9 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		// Ensure the base exclude paths are still present and that the custom path was formatted correctly.
 		$this->assertSameSets(
 			array(
-				'/wp-login.php\\?*#*',
-				'/wp-admin/*\\?*#*',
-				'/custom-file.php\\?*#*',
+				'/wp-login.php',
+				'/wp-admin/*',
+				'/custom-file.php',
 			),
 			$href_exclude_paths
 		);

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-helper-test.php
@@ -49,7 +49,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			array(
 				'/wp-login.php\\?*#*',
 				'/wp-admin/*\\?*#*',
-				'/custom-file.php\\?*#*'
+				'/custom-file.php\\?*#*',
 			),
 			$href_exclude_paths
 		);

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-test.php
@@ -13,8 +13,5 @@ class Speculation_Rules_Tests extends WP_UnitTestCase {
 
 		// Check the tag.
 		$this->assertStringContainsString( '<script type="speculationrules">', $output );
-
-		// Check that backslashes are correctly included.
-		$this->assertStringContainsString( '\\?*#*', $output );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #909

## Relevant technical choices

* Removes the origin trial logic.
* Removes wildcard path suffixes per https://github.com/whatwg/urlpattern/issues/179.
* Includes #937, just to prevent irrelevant lint failure.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
