### PR TITLE
Auto-sizes: Disallow direct file access

### DIFF
--- a/modules/images/auto-sizes/load.php
+++ b/modules/images/auto-sizes/load.php
@@ -8,6 +8,11 @@
  * @since n.e.x.t
  */
 
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Define the constant.
 if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Disallows direct file access.

## Relevant technical choices

This implements the common pattern of bailing early if `ABSPATH` is not defined, following the suggestion when this was submitted to the WP Plugin repo.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
