### PR TITLE
Include standalone plugin slugs in generator tag

### DIFF
--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -48,10 +48,8 @@ function perflab_query_plugin_info( string $plugin_slug ) {
  * @return array List of WPP standalone plugins as slugs.
  */
 function perflab_get_standalone_plugins() {
-	return array(
-		'webp-uploads',
-		'performant-translations',
-		'dominant-color-images',
+	return array_keys(
+		perflab_get_standalone_plugins_constants( 'plugins' )
 	);
 }
 
@@ -65,7 +63,7 @@ function perflab_get_standalone_plugins() {
 function perflab_get_active_modules_with_standalone_plugins() {
 	$modules = perflab_get_module_settings();
 	return array_filter(
-		array_keys( perflab_get_standalone_plugins_constants() ),
+		array_keys( perflab_get_standalone_plugins_constants( 'modules' ) ),
 		static function ( $module ) use ( $modules ) {
 			return ! empty( $modules[ $module ] ) && $modules[ $module ]['enabled'];
 		}

--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -49,7 +49,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
  */
 function perflab_get_standalone_plugins() {
 	return array_keys(
-		perflab_get_standalone_plugins_constants( 'plugins' )
+		perflab_get_standalone_plugin_version_constants( 'plugins' )
 	);
 }
 
@@ -63,7 +63,7 @@ function perflab_get_standalone_plugins() {
 function perflab_get_active_modules_with_standalone_plugins() {
 	$modules = perflab_get_module_settings();
 	return array_filter(
-		array_keys( perflab_get_standalone_plugins_constants( 'modules' ) ),
+		array_keys( perflab_get_standalone_plugin_version_constants( 'modules' ) ),
 		static function ( $module ) use ( $modules ) {
 			return ! empty( $modules[ $module ] ) && $modules[ $module ]['enabled'];
 		}

--- a/load.php
+++ b/load.php
@@ -213,7 +213,7 @@ function perflab_get_generator_content() {
 	$active_and_valid_modules = array_filter( perflab_get_active_modules(), 'perflab_is_valid_module' );
 
 	$active_plugins = array();
-	foreach ( perflab_get_standalone_plugins_constants( 'plugins' ) as $plugin_slug => $constant_name ) {
+	foreach ( perflab_get_standalone_plugin_version_constants( 'plugins' ) as $plugin_slug => $constant_name ) {
 		if ( defined( $constant_name ) && ! str_starts_with( constant( $constant_name ), 'Performance Lab ' ) ) {
 			$active_plugins[] = $plugin_slug;
 		}
@@ -285,7 +285,7 @@ function perflab_can_load_module( $module ) {
  * @return bool Whether the module has already been loaded by a separate plugin.
  */
 function perflab_is_standalone_plugin_loaded( $module ) {
-	$standalone_plugins_constants = perflab_get_standalone_plugins_constants( 'modules' );
+	$standalone_plugins_constants = perflab_get_standalone_plugin_version_constants( 'modules' );
 	if (
 		isset( $standalone_plugins_constants[ $module ] ) &&
 		defined( $standalone_plugins_constants[ $module ] ) &&
@@ -297,22 +297,42 @@ function perflab_is_standalone_plugin_loaded( $module ) {
 }
 
 /**
- * Gets the standalone plugin constants used for each module / plugin.
+ * Gets the standalone plugin constants used for each module with a standalone plugin.
  *
  * @since 2.2.0
- * @since n.e.x.t The `$type` parameter was added.
+ * @deprecated n.e.x.t
  *
- * @param string $type Optional. Either 'modules' or 'plugins'. Default 'modules'.
- * @return array<string, string> Map of module path / plugin slug and the version constant used.
+ * @return array Map of module path to version constant used.
  */
-function perflab_get_standalone_plugins_constants( $type = 'modules' ) {
-	if ( 'modules' === $type ) {
+function perflab_get_standalone_plugins_constants() {
+	_deprecated_function( __FUNCTION__, 'Performance Lab n.e.x.t', "perflab_get_standalone_plugin_version_constants( 'modules' )" );
+	return perflab_get_standalone_plugin_version_constants( 'modules' );
+}
+
+/**
+ * Gets the standalone plugin constants used for each available standalone plugin, or module with a standalone plugin.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $source Optional. Either 'plugins' or 'modules'. Default 'plugins'.
+ * @return array<string, string> Map of plugin slug / module path and the version constant used.
+ */
+function perflab_get_standalone_plugin_version_constants( $source = 'plugins' ) {
+	if ( 'modules' === $source ) {
+		/*
+		 * This list includes all modules which are also available as standalone plugins,
+		 * as `$module_dir => $version_constant` pairs.
+		 */
 		return array(
 			'images/dominant-color-images' => 'DOMINANT_COLOR_IMAGES_VERSION',
 			'images/webp-uploads'          => 'WEBP_UPLOADS_VERSION',
 		);
 	}
 
+	/*
+	 * This list includes all standalone plugins that are part of the Performance Lab project,
+	 * as `$plugin_slug => $version_constant` pairs.
+	 */
 	return array(
 		'webp-uploads'            => 'WEBP_UPLOADS_VERSION',
 		'dominant-color-images'   => 'DOMINANT_COLOR_IMAGES_VERSION',

--- a/load.php
+++ b/load.php
@@ -207,14 +207,23 @@ function perflab_is_valid_module( $module ) {
  * This attribute is then used in {@see perflab_render_generator()}.
  *
  * @since 1.1.0
+ * @since n.e.x.t The generator tag now includes the active standalone plugin slugs.
  */
 function perflab_get_generator_content() {
 	$active_and_valid_modules = array_filter( perflab_get_active_modules(), 'perflab_is_valid_module' );
 
+	$active_plugins = array();
+	foreach ( perflab_get_standalone_plugins_constants( 'plugins' ) as $plugin_slug => $constant_name ) {
+		if ( defined( $constant_name ) && ! str_starts_with( constant( $constant_name ), 'Performance Lab ' ) ) {
+			$active_plugins[] = $plugin_slug;
+		}
+	}
+
 	return sprintf(
-		'Performance Lab %1$s; modules: %2$s',
+		'Performance Lab %1$s; modules: %2$s; plugins: %3$s',
 		PERFLAB_VERSION,
-		implode( ', ', $active_and_valid_modules )
+		implode( ', ', $active_and_valid_modules ),
+		implode( ', ', $active_plugins )
 	);
 }
 
@@ -276,7 +285,7 @@ function perflab_can_load_module( $module ) {
  * @return bool Whether the module has already been loaded by a separate plugin.
  */
 function perflab_is_standalone_plugin_loaded( $module ) {
-	$standalone_plugins_constants = perflab_get_standalone_plugins_constants();
+	$standalone_plugins_constants = perflab_get_standalone_plugins_constants( 'modules' );
 	if (
 		isset( $standalone_plugins_constants[ $module ] ) &&
 		defined( $standalone_plugins_constants[ $module ] ) &&
@@ -291,13 +300,23 @@ function perflab_is_standalone_plugin_loaded( $module ) {
  * Gets the standalone plugin constants used for each module / plugin.
  *
  * @since 2.2.0
+ * @since n.e.x.t The `$type` parameter was added.
  *
- * @return array Map of module path to version constant used.
+ * @param string $type Optional. Either 'modules' or 'plugins'. Default 'modules'.
+ * @return array Map of module path / plugin slug and the version constant used.
  */
-function perflab_get_standalone_plugins_constants() {
+function perflab_get_standalone_plugins_constants( $type = 'modules' ) {
+	if ( 'modules' === $type ) {
+		return array(
+			'images/dominant-color-images' => 'DOMINANT_COLOR_IMAGES_VERSION',
+			'images/webp-uploads'          => 'WEBP_UPLOADS_VERSION',
+		);
+	}
+
 	return array(
-		'images/dominant-color-images' => 'DOMINANT_COLOR_IMAGES_VERSION',
-		'images/webp-uploads'          => 'WEBP_UPLOADS_VERSION',
+		'webp-uploads'            => 'WEBP_UPLOADS_VERSION',
+		'dominant-color-images'   => 'DOMINANT_COLOR_IMAGES_VERSION',
+		'performant-translations' => 'PERFORMANT_TRANSLATIONS_VERSION',
 	);
 }
 

--- a/load.php
+++ b/load.php
@@ -300,12 +300,12 @@ function perflab_is_standalone_plugin_loaded( $module ) {
  * Gets the standalone plugin constants used for each module with a standalone plugin.
  *
  * @since 2.2.0
- * @deprecated n.e.x.t
+ * @deprecated 2.9.0
  *
  * @return array Map of module path to version constant used.
  */
 function perflab_get_standalone_plugins_constants() {
-	_deprecated_function( __FUNCTION__, 'Performance Lab n.e.x.t', "perflab_get_standalone_plugin_version_constants( 'modules' )" );
+	_deprecated_function( __FUNCTION__, 'Performance Lab 2.9.0', "perflab_get_standalone_plugin_version_constants( 'modules' )" );
 	return perflab_get_standalone_plugin_version_constants( 'modules' );
 }
 

--- a/load.php
+++ b/load.php
@@ -303,7 +303,7 @@ function perflab_is_standalone_plugin_loaded( $module ) {
  * @since n.e.x.t The `$type` parameter was added.
  *
  * @param string $type Optional. Either 'modules' or 'plugins'. Default 'modules'.
- * @return array Map of module path / plugin slug and the version constant used.
+ * @return array<string, string> Map of module path / plugin slug and the version constant used.
  */
 function perflab_get_standalone_plugins_constants( $type = 'modules' ) {
 	if ( 'modules' === $type ) {

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -171,7 +171,7 @@ class Load_Tests extends WP_UnitTestCase {
 	public function test_perflab_render_generator() {
 		// Assert generator tag is rendered. Content does not matter, so just use no modules active.
 		add_filter( 'perflab_active_modules', '__return_empty_array' );
-		$expected = '<meta name="generator" content="Performance Lab ' . PERFLAB_VERSION . '; modules: ">' . "\n";
+		$expected = '<meta name="generator" content="Performance Lab ' . PERFLAB_VERSION . '; modules: ; plugins: ">' . "\n";
 		$output   = get_echo( 'perflab_render_generator' );
 		$this->assertSame( $expected, $output );
 

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -163,7 +163,7 @@ class Load_Tests extends WP_UnitTestCase {
 			}
 		);
 		$active_modules = array_filter( perflab_get_active_modules(), 'perflab_is_valid_module' );
-		$expected       = 'Performance Lab ' . PERFLAB_VERSION . '; modules: ' . implode( ', ', $active_modules );
+		$expected       = 'Performance Lab ' . PERFLAB_VERSION . '; modules: ' . implode( ', ', $active_modules ) . '; plugins: ';
 		$content        = perflab_get_generator_content();
 		$this->assertSame( $expected, $content );
 	}


### PR DESCRIPTION
## Summary

The Performance Lab generator tag has historically only included the active modules. Now that most Performance Lab features will be made available via plugins, the tag should receive support for that, including both the active modules and active plugins.

With this PR, the tag will now look like:
```
Performance Lab %1$s; modules: %2$s; plugins: %3$s
```

Alternatively (or even additionally), every standalone plugin could come with a generator tag of its own. While that is simple to implement, it's probably overhead worth avoiding, having to put that code into every plugin. Keeping just one generator also makes sense from the perspective of the Performance Lab plugin acting as the central "orchestrator" for the WordPress Performance Team's features.

## Relevant technical choices

* The `perflab_get_standalone_plugins_constants()` has been expanded to support lookup of the constants from either modules or plugins. As a side benefit, this centralizes the logic nicely to maintain the list only in one function, as `perflab_get_standalone_plugins()` now makes use of that rather than having its own list.
* Modules are already only included if their relevant standalone plugin _isn't_ active too. So that alone guarantees there are no duplicates.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
