### PR TITLE
Force HTML5 script theme support when printing JSON script

### DIFF
--- a/modules/js-and-css/speculation-rules/hooks.php
+++ b/modules/js-and-css/speculation-rules/hooks.php
@@ -20,7 +20,11 @@ function plsr_print_speculation_rules() {
 	}
 
 	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/56313>.
-	$needs_html5_workaround = ! current_theme_supports( 'html5', 'script' );
+	$needs_html5_workaround = (
+		! current_theme_supports( 'html5', 'script' ) &&
+		version_compare( get_bloginfo( 'version' ), '6.4', '>=' ) &&
+		version_compare( get_bloginfo( 'version' ), '6.5', '<' )
+	);
 	if ( $needs_html5_workaround ) {
 		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];
 		add_theme_support( 'html5', array( 'script' ) );

--- a/modules/js-and-css/speculation-rules/hooks.php
+++ b/modules/js-and-css/speculation-rules/hooks.php
@@ -19,6 +19,7 @@ function plsr_print_speculation_rules() {
 		return;
 	}
 
+	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/56313>.
 	$needs_html5_workaround = ! current_theme_supports( 'html5', 'script' );
 	if ( $needs_html5_workaround ) {
 		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];

--- a/modules/js-and-css/speculation-rules/hooks.php
+++ b/modules/js-and-css/speculation-rules/hooks.php
@@ -22,8 +22,8 @@ function plsr_print_speculation_rules() {
 	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/56313>.
 	$needs_html5_workaround = (
 		! current_theme_supports( 'html5', 'script' ) &&
-		version_compare( get_bloginfo( 'version' ), '6.4', '>=' ) &&
-		version_compare( get_bloginfo( 'version' ), '6.5', '<' )
+		version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.4', '>=' ) &&
+		version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.5', '<' )
 	);
 	if ( $needs_html5_workaround ) {
 		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];

--- a/modules/js-and-css/speculation-rules/hooks.php
+++ b/modules/js-and-css/speculation-rules/hooks.php
@@ -19,9 +19,19 @@ function plsr_print_speculation_rules() {
 		return;
 	}
 
+	$is_html5 = current_theme_supports( 'html5', 'script' );
+	if ( ! $is_html5 ) {
+		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];
+		add_theme_support( 'html5', array( 'script' ) );
+	}
+
 	wp_print_inline_script_tag(
 		wp_json_encode( $rules ),
 		array( 'type' => 'speculationrules' )
 	);
+
+	if ( ! $is_html5 ) {
+		$GLOBALS['_wp_theme_features'] = $backup_wp_theme_features; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
 }
 add_action( 'wp_footer', 'plsr_print_speculation_rules' );

--- a/modules/js-and-css/speculation-rules/hooks.php
+++ b/modules/js-and-css/speculation-rules/hooks.php
@@ -19,8 +19,8 @@ function plsr_print_speculation_rules() {
 		return;
 	}
 
-	$is_html5 = current_theme_supports( 'html5', 'script' );
-	if ( ! $is_html5 ) {
+	$needs_html5_workaround = ! current_theme_supports( 'html5', 'script' );
+	if ( $needs_html5_workaround ) {
 		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];
 		add_theme_support( 'html5', array( 'script' ) );
 	}
@@ -30,7 +30,7 @@ function plsr_print_speculation_rules() {
 		array( 'type' => 'speculationrules' )
 	);
 
-	if ( ! $is_html5 ) {
+	if ( $needs_html5_workaround ) {
 		$GLOBALS['_wp_theme_features'] = $backup_wp_theme_features; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 }

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-test.php
@@ -8,6 +8,18 @@
 
 class Speculation_Rules_Tests extends WP_UnitTestCase {
 
+	private $original_wp_theme_features = array();
+
+	public function set_up() {
+		parent::set_up();
+		$this->original_wp_theme_features = $GLOBALS['_wp_theme_features'];
+	}
+
+	public function tear_down() {
+		$GLOBALS['_wp_theme_features'] = $this->original_wp_theme_features;
+		parent::tear_down();
+	}
+
 	public function data_provider_to_test_print_speculation_rules(): array {
 		return array(
 			'xhtml' => array(

--- a/tests/modules/js-and-css/speculation-rules/speculation-rules-test.php
+++ b/tests/modules/js-and-css/speculation-rules/speculation-rules-test.php
@@ -8,10 +8,40 @@
 
 class Speculation_Rules_Tests extends WP_UnitTestCase {
 
-	public function test_plsr_print_speculation_rules() {
-		$output = get_echo( 'plsr_print_speculation_rules' );
+	public function data_provider_to_test_print_speculation_rules(): array {
+		return array(
+			'xhtml' => array(
+				'html5_support' => false,
+			),
+			'html5' => array(
+				'html5_support' => true,
+			),
+		);
+	}
 
-		// Check the tag.
+	/**
+	 * @dataProvider data_provider_to_test_print_speculation_rules
+	 */
+	public function test_plsr_print_speculation_rules_without_html5_support( bool $html5_support ) {
+		if ( $html5_support ) {
+			add_theme_support( 'html5', array( 'script' ) );
+		} else {
+			remove_theme_support( 'html5' );
+		}
+
+		$output = get_echo( 'plsr_print_speculation_rules' );
 		$this->assertStringContainsString( '<script type="speculationrules">', $output );
+
+		$json  = str_replace( array( '<script type="speculationrules">', '</script>' ), '', $output );
+		$rules = json_decode( $json, true );
+		$this->assertIsArray( $rules );
+		$this->assertArrayHasKey( 'prerender', $rules );
+
+		// Make sure that theme support was restored.
+		if ( $html5_support ) {
+			$this->assertStringNotContainsString( '/* <![CDATA[ */', wp_get_inline_script_tag( '/*...*/' ) );
+		} else {
+			$this->assertStringContainsString( '/* <![CDATA[ */', wp_get_inline_script_tag( '/*...*/' ) );
+		}
 	}
 }


### PR DESCRIPTION
## Summary

When a theme doesn't declare theme support for HTML5 scripts, the JSON `script` is currently output with some XHTML compatibility wrappers:

```html
<script type="speculationrules">
/* <![CDATA[ */
{"prerender":[{"source":"document","where":{"and":[{"href_matches":"\/*"},{"not":{"href_matches":["\/wp-login.php","\/wp-admin\/*"]}},{"not":{"selector_matches":".no-prerender"}}]},"eagerness":"moderate"}]}
/* ]]> */
</script>
```

This breaks the parsing of the JSON. The `/* <![CDATA[ */` and `/* ]]> */` need to be omitted from JSON output. 

## Relevant technical choices

This needs to be fixed in core (ticket and PR pending), but a quick workaround is to temporarily override the `$_wp_theme_features` global with the theme support added.

**Update:** See core ticket: https://core.trac.wordpress.org/ticket/60320

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
