### PR TITLE
Sanitize metric name for `Server-Timing` header

### DIFF
--- a/server-timing/class-perflab-server-timing.php
+++ b/server-timing/class-perflab-server-timing.php
@@ -260,7 +260,7 @@ class Perflab_Server_Timing {
 		}
 
 		// See https://github.com/WordPress/performance/issues/955.
-		$name = str_replace( '/', '-', $metric->get_slug() );
+		$name = preg_replace( '/[^!#$%&\'*+\-.^_`|~0-9a-zA-Z]/', '-', $metric->get_slug() );
 
 		return sprintf( 'wp-%1$s;dur=%2$s', $name, $value );
 	}

--- a/server-timing/class-perflab-server-timing.php
+++ b/server-timing/class-perflab-server-timing.php
@@ -95,7 +95,7 @@ class Perflab_Server_Timing {
 			return;
 		}
 
-		// See https://github.com/WordPress/performance/issues/955
+		// See https://github.com/WordPress/performance/issues/955.
 		$sanitized_slug = str_replace( '/', '-', $metric_slug );
 
 		$this->registered_metrics[ $metric_slug ]      = new Perflab_Server_Timing_Metric( $sanitized_slug );

--- a/server-timing/class-perflab-server-timing.php
+++ b/server-timing/class-perflab-server-timing.php
@@ -95,10 +95,7 @@ class Perflab_Server_Timing {
 			return;
 		}
 
-		// See https://github.com/WordPress/performance/issues/955.
-		$sanitized_slug = str_replace( '/', '-', $metric_slug );
-
-		$this->registered_metrics[ $metric_slug ]      = new Perflab_Server_Timing_Metric( $sanitized_slug );
+		$this->registered_metrics[ $metric_slug ]      = new Perflab_Server_Timing_Metric( $metric_slug );
 		$this->registered_metrics_data[ $metric_slug ] = $args;
 
 		// If the current user has already been determined and they lack the necessary access,
@@ -261,6 +258,10 @@ class Perflab_Server_Timing {
 		if ( is_float( $value ) ) {
 			$value = round( $value, 2 );
 		}
-		return sprintf( 'wp-%1$s;dur=%2$s', $metric->get_slug(), $value );
+
+		// See https://github.com/WordPress/performance/issues/955.
+		$name = str_replace( '/', '-', $metric->get_slug() );
+
+		return sprintf( 'wp-%1$s;dur=%2$s', $name, $value );
 	}
 }

--- a/server-timing/class-perflab-server-timing.php
+++ b/server-timing/class-perflab-server-timing.php
@@ -95,7 +95,10 @@ class Perflab_Server_Timing {
 			return;
 		}
 
-		$this->registered_metrics[ $metric_slug ]      = new Perflab_Server_Timing_Metric( $metric_slug );
+		// See https://github.com/WordPress/performance/issues/955
+		$sanitized_slug = str_replace( '/', '-', $metric_slug );
+
+		$this->registered_metrics[ $metric_slug ]      = new Perflab_Server_Timing_Metric( $sanitized_slug );
 		$this->registered_metrics_data[ $metric_slug ] = $args;
 
 		// If the current user has already been determined and they lack the necessary access,

--- a/tests/server-timing/perflab-server-timing-tests.php
+++ b/tests/server-timing/perflab-server-timing-tests.php
@@ -10,6 +10,9 @@
  */
 class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
+	/**
+	 * @var Perflab_Server_Timing
+	 */
 	private $server_timing;
 
 	private static $admin_id;
@@ -117,6 +120,19 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric( 'metric-to-check-for', self::$dummy_args );
 		$this->assertTrue( $this->server_timing->has_registered_metric( 'metric-to-check-for' ), 'Metric should be available after registration' );
+	}
+
+	public function test_register_metric_replaces_slashes() {
+		$this->server_timing->register_metric(
+			'foo/bar/baz',
+			array(
+				'measure_callback' => static function ( $metric ) {
+					$metric->set_value( 123 );
+				},
+				'access_cap'       => 'exist',
+			)
+		);
+		$this->assertSame( 'wp-foo-bar-baz;dur=123', $this->server_timing->get_header() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

Ensures metric name does not contain invalid characters such as "/".

Fixes #955

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
