### PR TITLE
Add standalone plugin version constants for auto-sizes and speculation-rules

### DIFF
--- a/load.php
+++ b/load.php
@@ -337,6 +337,8 @@ function perflab_get_standalone_plugin_version_constants( $source = 'plugins' ) 
 		'webp-uploads'            => 'WEBP_UPLOADS_VERSION',
 		'dominant-color-images'   => 'DOMINANT_COLOR_IMAGES_VERSION',
 		'performant-translations' => 'PERFORMANT_TRANSLATIONS_VERSION',
+		'auto-sizes'              => 'IMAGE_AUTO_SIZES_VERSION',
+		'speculation-rules'       => 'SPECULATION_RULES_VERSION',
 	);
 }
 


### PR DESCRIPTION
## Summary

Add slugs/constants to `perflab_get_standalone_plugin_version_constants()` so that the **Auto-sizes for Lazy-loaded Images** and **Speculation Rules** plugins will be recommended once 2.9.0 is released.

Before | After
-------|------
![image](https://github.com/WordPress/performance/assets/134745/d685c179-a048-479d-be5a-daa5282f28be) | ![image](https://github.com/WordPress/performance/assets/134745/86243829-4276-4bd6-bacc-07a916ea3fb6)

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
