### PR TITLE
Run build-cs composer install/update via post-install/update-cmd scripts

### DIFF
--- a/.github/workflows/php-test-standalone-plugins.yml
+++ b/.github/workflows/php-test-standalone-plugins.yml
@@ -66,14 +66,14 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
+      - name: npm install
+        run: npm ci
       - name: General debug information
         run: |
           npm --version
           node --version
           composer --version
           php -v
-      - name: npm install
-        run: npm ci
       - name: Building standalone plugins
         run: npm run build-plugins
       - name: Running single site standalone plugin integration tests

--- a/.github/workflows/php-test-standalone-plugins.yml
+++ b/.github/workflows/php-test-standalone-plugins.yml
@@ -66,14 +66,14 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - name: npm install
-        run: npm ci
       - name: General debug information
         run: |
           npm --version
           node --version
           composer --version
           php -v
+      - name: npm install
+        run: npm ci
       - name: Building standalone plugins
         run: npm run build-plugins
       - name: Running single site standalone plugin integration tests

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -67,6 +67,9 @@ jobs:
         run: npm ci
       - name: Install WordPress
         run: npm run wp-env start
+        # Note that `composer update` is required instead of `composer install`
+        # for the sake of PHP versions older than 8.1, which is the version of
+        # PHP that the composer.lock was created for.
       - name: Composer update
         run: npm run wp-env run tests-cli -- --env-cwd="wp-content/plugins/$(basename $(pwd))" composer update --no-interaction
       - name: Running single site unit tests

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -58,13 +58,22 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v3
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
       - name: Setup Node.js (.nvmrc)
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - name: Composer update
-        run: composer update
+      - name: General debug information
+        run: |
+          npm --version
+          node --version
+          composer --version
+          php -v
+      - name: Composer install
+        run: composer install
       - name: npm install
         run: npm ci
       - name: Install WordPress

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -58,22 +58,13 @@ jobs:
     steps:
       - uses: styfle/cancel-workflow-action@0.11.0
       - uses: actions/checkout@v3
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
       - name: Setup Node.js (.nvmrc)
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - name: General debug information
-        run: |
-          npm --version
-          node --version
-          composer --version
-          php -v
-      - name: Composer install
-        run: composer install
+      - name: Composer update
+        run: composer update
       - name: npm install
         run: npm ci
       - name: Install WordPress

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install WordPress
         run: npm run wp-env start
       - name: Composer install
-        run: npm run wp-env run tests-cli -- --env-cwd='wp-content/plugins/$(basename $(pwd))' composer install --no-interaction
+        run: npm run wp-env run tests-cli -- --env-cwd="wp-content/plugins/$(basename $(pwd))" composer install --no-interaction
       - name: Running single site unit tests
         run: npm run test-php
       - name: Running multisite unit tests

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install WordPress
         run: npm run wp-env start
       - name: Composer install
-        run: npm run wp-env run tests-cli --env-cwd='wp-content/plugins/$(basename $(pwd))' composer install --no-interaction
+        run: npm run wp-env run tests-cli -- --env-cwd='wp-content/plugins/$(basename $(pwd))' composer install --no-interaction
       - name: Running single site unit tests
         run: npm run test-php
       - name: Running multisite unit tests

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -63,12 +63,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: npm
-      - name: Composer update
-        run: composer update
       - name: npm install
         run: npm ci
       - name: Install WordPress
         run: npm run wp-env start
+      - name: Composer install
+        run: npm run wp-env run tests-cli --env-cwd='wp-content/plugins/$(basename $(pwd))' composer install --no-interaction
       - name: Running single site unit tests
         run: npm run test-php
       - name: Running multisite unit tests

--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -67,8 +67,8 @@ jobs:
         run: npm ci
       - name: Install WordPress
         run: npm run wp-env start
-      - name: Composer install
-        run: npm run wp-env run tests-cli -- --env-cwd="wp-content/plugins/$(basename $(pwd))" composer install --no-interaction
+      - name: Composer update
+        run: npm run wp-env run tests-cli -- --env-cwd="wp-content/plugins/$(basename $(pwd))" composer update --no-interaction
       - name: Running single site unit tests
         run: npm run test-php
       - name: Running multisite unit tests

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "php": ">=7|^8"
   },
   "scripts": {
-    "post-install-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8. You are running: '; php -v;  fi",
-    "post-update-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8 You are running: '; php -v; fi",
+    "post-install-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8.1. You are running: '; php -v;  fi",
+    "post-update-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8.1 You are running: '; php -v; fi",
     "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M -c phpstan.neon.dist",
     "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
     "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "php": ">=7|^8"
   },
   "scripts": {
-    "post-install-cmd": "composer --working-dir=build-cs install --no-interaction",
-    "post-update-cmd": "composer --working-dir=build-cs update --no-interaction",
+    "post-install-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8.'; fi",
+    "post-update-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8.'; fi",
     "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M -c phpstan.neon.dist",
     "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
     "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "php": ">=7|^8"
   },
   "scripts": {
-    "post-install-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8.1. You are running: '; php -v;  fi",
-    "post-update-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8.1 You are running: '; php -v; fi",
+    "post-install-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8.1+. You are running: '; php -v;  fi",
+    "post-update-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8.1+. You are running: '; php -v; fi",
     "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M -c phpstan.neon.dist",
     "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
     "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "php": ">=7|^8"
   },
   "scripts": {
-    "post-install-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8.'; fi",
-    "post-update-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8.'; fi",
+    "post-install-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8. You are running: '; php -v;  fi",
+    "post-update-cmd": "if [ $(php -r 'echo PHP_MAJOR_VERSION;') -ge 8 ]; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8 You are running: '; php -v; fi",
     "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M -c phpstan.neon.dist",
     "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
     "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,11 @@
     "php": ">=7|^8"
   },
   "scripts": {
-    "phpstan": [
-      "composer --working-dir=build-cs update --no-interaction",
-      "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M -c phpstan.neon.dist"
-    ],
-    "format": [
-      "composer --working-dir=build-cs update --no-interaction",
-      "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source"
-    ],
-    "lint": [
-      "composer --working-dir=build-cs update --no-interaction",
-      "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist"
-    ],
+    "post-install-cmd": "composer --working-dir=build-cs install --no-interaction",
+    "post-update-cmd": "composer --working-dir=build-cs update --no-interaction",
+    "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M -c phpstan.neon.dist",
+    "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
+    "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",
     "test": "phpunit -c phpunit.xml.dist --verbose",
     "test-multisite": "phpunit -c tests/multisite.xml --verbose"
   },

--- a/package.json
+++ b/package.json
@@ -31,11 +31,8 @@
     "lint-js": "wp-scripts lint-js",
     "format-php": "composer format",
     "phpstan": "composer phpstan",
-    "prelint-php": "wp-env run composer 'install --no-interaction'",
     "lint-php": "composer lint",
-    "pretest-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer update --no-interaction",
     "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer test",
-    "pretest-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer update --no-interaction",
     "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer test-multisite",
     "wp-env": "wp-env",
     "prepare": "husky install"


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #961

This fixes the composer scripts for `lint`, `phpstan`, and `format` if `composer install` has not been run in the `build-cs` directory before. It also speeds up running those scripts by avoiding running `composer update` with each call.

## Relevant technical choices

Adds a `post-install-cmd` in the root `composer.json` which runs `composer install` in the `build-cs` directory if the PHP version is at least 8.1. Likewise adds a `post-update-cmd` to call run `composer update` in that directory. Additionally, when running PHPUnit tests on the various versions of PHP in the GHA workflow, instead of calling `composer update` directly it instead calls `composer update` via `wp-env`.

This fixes an issue which was introduced in #544.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
