### PR TITLE
Improve conditions Props Bot runs under.

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -1,10 +1,10 @@
 name: Props Bot
 
 on:
-  # This event runs anytime a PR is (re)opened, updated, or labeled.
+  # This event runs anytime a PR is (re)opened, updated, marked ready for review, or labeled.
   # GitHub does not allow filtering the `labeled` event by a specific label.
   # However, the logic below will short-circuit the workflow when the `props-bot` label is not the one being added.
-  # Note: The pull_request_target event is uesed instead of pull_request because this workflow needs permission to comment
+  # Note: The pull_request_target event is used instead of pull_request because this workflow needs permission to comment
   # on the pull request. Because this event grants extra permissions to `GITHUB_TOKEN`, any code changes within the PR
   # should be considered untrusted. See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/.
   pull_request_target:
@@ -13,13 +13,13 @@ on:
       - synchronize
       - reopened
       - labeled
+      - ready_for_review
   # This event runs anytime a comment is added or deleted.
   # You cannot filter this event for PR comments only.
   # However, the logic below does short-circuit the workflow for issues.
   issue_comment:
     type:
       - created
-      - deleted
   # This event will run everytime a new PR review is initially submitted.
   pull_request_review:
     types:
@@ -28,7 +28,6 @@ on:
   pull_request_review_comment:
     types:
       - created
-      - deleted
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
@@ -55,17 +54,20 @@ jobs:
       pull-requests: write
       contents: read
     timeout-minutes: 20
-    # The job should only run if:
+    # The job will run when pull requests are open, ready for review and:
     #
-    # - A pull request review is created or commented on.
-    # - An issue comment is added to a pull request.
-    # - A pull request is opened, synchronized, or reopened.
+    # - A comment is added to the pull request.
+    # - A review is created or commented on.
+    # - The pull request is opened, synchronized, marked ready for review, or reopened.
     # - The `props-bot` label is added to the pull request.
     if: |
-      contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
-      ( github.event_name == 'issue_comment' && github.event.issue.pull_request ) ||
-      github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
-      'props-bot' == github.event.label.name
+      (
+        github.event_name == 'issue_comment' && github.event.issue.pull_request ||
+        contains( fromJSON( '["pull_request_review", "pull_request_review_comment"]' ), github.event_name ) ||
+        github.event_name == 'pull_request_target' && github.event.action != 'labeled' ||
+        'props-bot' == github.event.label.name
+      ) &&
+      ( ! github.event.pull_request.draft && github.event.pull_request.state == 'open' || ! github.event.issue.draft && github.event.issue.state == 'open' )
 
     steps:
       - name: Gather a list of contributors


### PR DESCRIPTION
## Summary

This improves the logic controlling when Props Bot runs to:
- not run for draft PRs.
- not run when comments are deleted (this should hardly ever happen).
- not run on closed PRs.