### PR TITLE
Update test to use non-AVIF format since now supported in 6.5-alpha

### DIFF
--- a/tests/modules/images/webp-uploads/helper-tests.php
+++ b/tests/modules/images/webp-uploads/helper-tests.php
@@ -233,7 +233,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object(
 			TESTS_PLUGIN_DIR . '/tests/testdata/modules/images/leaves.jpg'
 		);
-		$result        = webp_uploads_generate_image_size( $attachment_id, 'medium', 'image/avif' );
+		$result        = webp_uploads_generate_image_size( $attachment_id, 'medium', 'image/vnd.zbrush.pcx' );
 		$this->assertWPError( $result );
 		$this->assertSame( 'image_mime_type_invalid', $result->get_error_code() );
 	}


### PR DESCRIPTION
Now that AVIF support just landed in WP trunk via Core-51228, we need to use a different image format to check for an invalid MIME type. This fixes a unit test failure on 6.5-alpha.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
