### PR TITLE
Remove admin bar skipping logic in favor of varying URL metrics by user being logged-in

### DIFF
--- a/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
+++ b/modules/images/image-loading-optimization/class-ilo-html-tag-processor.php
@@ -7,9 +7,12 @@
  */
 
 /**
- * Processor leveraging WP_HTML_Tag_Processor which gathers breadcrumbs which can be obtained as XPath while iterating the open_tags() generator.
+ * Processor leveraging WP_HTML_Tag_Processor which gathers breadcrumbs for computing XPaths while iterating the open_tags() generator.
  *
  * Eventually this class should be made largely obsolete once `WP_HTML_Processor` is fully implemented to support all HTML tags.
+ * Note that the admin bar is skipped over since its presence throws off the XPath indices and its presence is irrelevant for
+ * the purposes of optimizing normal frontend responses: a logged-in user with the admin bar showing should be able to gather
+ * URL metrics which can be used for logged-out visitors.
  *
  * @since n.e.x.t
  * @access private
@@ -171,6 +174,8 @@ final class ILO_HTML_Tag_Processor {
 	public function open_tags(): Generator {
 		$p = $this->processor;
 
+		$inside_admin_bar_depth = 0;
+
 		/*
 		 * The keys for the following two arrays correspond to each other. Given the following document:
 		 *
@@ -214,15 +219,20 @@ final class ILO_HTML_Tag_Processor {
 					++$this->open_stack_indices[ $level ];
 				}
 
-				// Only increment the tag index at this level only if it isn't the admin bar, since the presence of the
-				// admin bar can throw off the indices.
-				if ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' ) {
+				// Decrement the index if this is the admin bar element so that it will be invisible in XPaths.
+				$is_admin_bar = ( 'DIV' === $tag_name && $p->get_attribute( 'id' ) === 'wpadminbar' );
+				if ( $is_admin_bar ) {
 					--$this->open_stack_indices[ $level ];
 				}
 
-				// Now that the breadcrumbs are constructed, yield the tag name so that they can be queried if desired.
-				// Other mutations may be performed to the open tag's attributes by the callee at this point as well.
-				yield $tag_name;
+				// Skip over the admin bar and its descendents.
+				if ( $is_admin_bar || $inside_admin_bar_depth > 0 ) {
+					++$inside_admin_bar_depth;
+				} else {
+					// Now that the breadcrumbs are constructed, yield the tag name so that they can be queried if desired.
+					// Other mutations may be performed to the open tag's attributes by the callee at this point as well.
+					yield $tag_name;
+				}
 
 				// Immediately pop off self-closing and raw text tags.
 				if (
@@ -233,6 +243,9 @@ final class ILO_HTML_Tag_Processor {
 					( $p->has_self_closing_flag() && $this->is_foreign_element() )
 				) {
 					array_pop( $this->open_stack_tags );
+					if ( $inside_admin_bar_depth > 0 ) {
+						--$inside_admin_bar_depth;
+					}
 				}
 			} else {
 				// If the closing tag is for self-closing or raw text tag, we ignore it since it was already handled above.
@@ -245,23 +258,49 @@ final class ILO_HTML_Tag_Processor {
 				}
 
 				$popped_tag_name = array_pop( $this->open_stack_tags );
-				if ( $popped_tag_name !== $tag_name && function_exists( 'wp_trigger_error' ) ) {
-					wp_trigger_error(
-						__METHOD__,
-						esc_html(
-							sprintf(
-								/* translators: 1: Popped tag name, 2: Closing tag name */
-								__( 'Expected popped tag stack element %1$s to match the currently visited closing tag %2$s.', 'performance-lab' ),
-								$popped_tag_name,
-								$tag_name
-							)
+				if ( $popped_tag_name !== $tag_name ) {
+					$this->warn(
+						sprintf(
+							/* translators: 1: Popped tag name, 2: Closing tag name */
+							__( 'Expected popped tag stack element %1$s to match the currently visited closing tag %2$s.', 'performance-lab' ),
+							$popped_tag_name,
+							$tag_name
 						)
 					);
+				}
+
+				if ( $inside_admin_bar_depth > 0 ) {
+					--$inside_admin_bar_depth;
+					if ( 0 === $inside_admin_bar_depth && 'DIV' !== $tag_name ) {
+						$this->warn(
+							sprintf(
+								/* translators: 1: Current tag name, 2: Closing tag name DIV */
+								__( 'Expected closing %1$s tag to rather be the closing %2$s tag for the admin bar.', 'performance-lab' ),
+								$tag_name,
+								'DIV'
+							)
+						);
+					}
 				}
 
 				array_splice( $this->open_stack_indices, count( $this->open_stack_tags ) + 1 );
 			}
 		}
+	}
+
+	/**
+	 * Warns of bad markup.
+	 *
+	 * @param string $message Warning message.
+	 */
+	private function warn( string $message ) {
+		if ( ! function_exists( 'wp_trigger_error' ) ) {
+			return;
+		}
+		wp_trigger_error(
+			__CLASS__ . '::open_tags',
+			esc_html( $message )
+		);
 	}
 
 	/**

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -7,8 +7,6 @@ const consoleLogPrefix = '[Image Loading Optimization]';
 
 const storageLockTimeSessionKey = 'iloStorageLockTime';
 
-const adminBarId = 'wpadminbar';
-
 /**
  * Checks whether storage is locked.
  *
@@ -199,10 +197,6 @@ export default async function detect( {
 		log( 'Proceeding with detection' );
 	}
 
-	// Obtain the admin bar element because we don't want to detect elements inside of it.
-	const adminBar =
-		/** @type {?HTMLDivElement} */ doc.getElementById( adminBarId );
-
 	// TODO: This query no longer needs to be done as early as possible since the server is adding the breadcrumbs.
 	const breadcrumbedElements =
 		doc.body.querySelectorAll( '[data-ilo-xpath]' );
@@ -260,9 +254,7 @@ export default async function detect( {
 			);
 
 			for ( const element of breadcrumbedElementsMap.keys() ) {
-				if ( ! adminBar || ! adminBar.contains( element ) ) {
-					intersectionObserver.observe( element );
-				}
+				intersectionObserver.observe( element );
 			}
 		} );
 

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -31,10 +31,6 @@ add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
 /**
  * Determines whether the current response can be optimized.
  *
- * Only search results are not eligible by default for optimization. This is because there is no predictability in
- * whether posts in the loop will have featured images assigned or not. If a theme template for search results doesn't
- * even show featured images, then this isn't an issue.
- *
  * @since n.e.x.t
  * @access private
  *
@@ -42,12 +38,18 @@ add_action( 'wp', 'ilo_maybe_add_template_output_buffer_filter' );
  */
 function ilo_can_optimize_response(): bool {
 	$able = ! (
-		// Since the URL space is infinite.
+		// Since there is no predictability in whether posts in the loop will have featured images assigned or not. If a
+		// theme template for search results doesn't even show featured images, then this wouldn't be an issue.
 		is_search() ||
 		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
 		is_customize_preview() ||
-		// The images detected in the response body of a POST request cannot, by definition, be cached.
-		'GET' !== $_SERVER['REQUEST_METHOD']
+		// Since the images detected in the response body of a POST request cannot, by definition, be cached.
+		'GET' !== $_SERVER['REQUEST_METHOD'] ||
+		// The aim is to optimize pages for the majority of site visitors, not those who administer the site. For admin
+		// users, additional elements will be present like the script from wp_customize_support_script() which will
+		// interfere with the XPath indices. Note that ilo_get_normalized_query_vars() is varied by is_user_logged_in()
+		// so membership sites and e-commerce sites will still be able to be optimized for their normal visitors.
+		current_user_can( 'customize' )
 	);
 
 	/**

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -57,7 +57,7 @@ function ilo_get_normalized_query_vars(): array {
 		);
 	}
 
-	// Vary URL metrics by whether the user is logged-in since additional elements may be present.
+	// Vary URL metrics by whether the user is logged in since additional elements may be present.
 	if ( is_user_logged_in() ) {
 		$normalized_query_vars['user_logged_in'] = true;
 	}

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -57,6 +57,11 @@ function ilo_get_normalized_query_vars(): array {
 		);
 	}
 
+	// Vary URL metrics by whether the user is logged-in since additional elements may be present.
+	if ( is_user_logged_in() ) {
+		$normalized_query_vars['user_logged_in'] = true;
+	}
+
 	return $normalized_query_vars;
 }
 

--- a/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
@@ -9,19 +9,8 @@
  */
 class ILO_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 
-	private function get_admin_bar_markup(): string {
-		return <<<HTML
-			<div id="wpadminbar" class="nojq nojs">
-				<div class="quicklinks" id="wp-toolbar" role="navigation" aria-label="Toolbar">
-					<ul id='wp-admin-bar-root-default' class="ab-top-menu"><li id='wp-admin-bar-wp-logo' class="menupop"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/about.php'><span class="ab-icon" aria-hidden="true"></span><span class="screen-reader-text">About WordPress</span></a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-wp-logo-default' class="ab-submenu"><li id='wp-admin-bar-about'><a class='ab-item' href='http://localhost:8888/wp-admin/about.php'>About WordPress</a></li><li id='wp-admin-bar-contribute'><a class='ab-item' href='http://localhost:8888/wp-admin/contribute.php'>Get Involved</a></li></ul><ul id='wp-admin-bar-wp-logo-external' class="ab-sub-secondary ab-submenu"><li id='wp-admin-bar-wporg'><a class='ab-item' href='https://wordpress.org/'>WordPress.org</a></li><li id='wp-admin-bar-documentation'><a class='ab-item' href='https://wordpress.org/documentation/'>Documentation</a></li><li id='wp-admin-bar-learn'><a class='ab-item' href='https://learn.wordpress.org/'>Learn WordPress</a></li><li id='wp-admin-bar-support-forums'><a class='ab-item' href='https://wordpress.org/support/forums/'>Support</a></li><li id='wp-admin-bar-feedback'><a class='ab-item' href='https://wordpress.org/support/forum/requests-and-feedback'>Feedback</a></li></ul></div></li><li id='wp-admin-bar-site-name' class="menupop"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/'>performance</a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-site-name-default' class="ab-submenu"><li id='wp-admin-bar-dashboard'><a class='ab-item' href='http://localhost:8888/wp-admin/'>Dashboard</a></li><li id='wp-admin-bar-plugins'><a class='ab-item' href='http://localhost:8888/wp-admin/plugins.php'>Plugins</a></li></ul><ul id='wp-admin-bar-appearance' class="ab-submenu"><li id='wp-admin-bar-themes'><a class='ab-item' href='http://localhost:8888/wp-admin/themes.php'>Themes</a></li></ul></div></li><li id='wp-admin-bar-site-editor'><a class='ab-item' href='http://localhost:8888/wp-admin/site-editor.php?postType=wp_template&#038;postId=twentytwentythree//single'>Edit site</a></li><li id='wp-admin-bar-comments'><a class='ab-item' href='http://localhost:8888/wp-admin/edit-comments.php'><span class="ab-icon" aria-hidden="true"></span><span class="ab-label awaiting-mod pending-count count-0" aria-hidden="true">0</span><span class="screen-reader-text comments-in-moderation-text">0 Comments in moderation</span></a></li><li id='wp-admin-bar-new-content' class="menupop"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/post-new.php'><span class="ab-icon" aria-hidden="true"></span><span class="ab-label">New</span></a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-new-content-default' class="ab-submenu"><li id='wp-admin-bar-new-post'><a class='ab-item' href='http://localhost:8888/wp-admin/post-new.php'>Post</a></li><li id='wp-admin-bar-new-media'><a class='ab-item' href='http://localhost:8888/wp-admin/media-new.php'>Media</a></li><li id='wp-admin-bar-new-page'><a class='ab-item' href='http://localhost:8888/wp-admin/post-new.php?post_type=page'>Page</a></li><li id='wp-admin-bar-new-user'><a class='ab-item' href='http://localhost:8888/wp-admin/user-new.php'>User</a></li></ul></div></li><li id='wp-admin-bar-edit'><a class='ab-item' href='http://localhost:8888/wp-admin/post.php?post=7&#038;action=edit'>Edit Post</a></li></ul><ul id='wp-admin-bar-top-secondary' class="ab-top-secondary ab-top-menu"><li id='wp-admin-bar-search' class="admin-bar-search"><div class="ab-item ab-empty-item" tabindex="-1"><form action="http://localhost:8888/" method="get" id="adminbarsearch"><input class="adminbar-input" name="s" id="adminbar-search" type="text" value="" maxlength="150" /><label for="adminbar-search" class="screen-reader-text">Search</label><input type="submit" class="adminbar-button" value="Search" /></form></div></li><li id='wp-admin-bar-my-account' class="menupop with-avatar"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/profile.php'>Howdy, <span class="display-name">admin</span><img alt='' src='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=26&#038;d=mm&#038;r=g' srcset='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=52&#038;d=mm&#038;r=g 2x' class='avatar avatar-26 photo' height='26' width='26' loading='lazy' decoding='async'/></a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-user-actions' class="ab-submenu"><li id='wp-admin-bar-user-info'><a class='ab-item' tabindex="-1" href='http://localhost:8888/wp-admin/profile.php'><img alt='' src='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=64&#038;d=mm&#038;r=g' srcset='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=128&#038;d=mm&#038;r=g 2x' class='avatar avatar-64 photo' height='64' width='64' loading='lazy' decoding='async'/><span class='display-name'>admin</span></a></li><li id='wp-admin-bar-edit-profile'><a class='ab-item' href='http://localhost:8888/wp-admin/profile.php'>Edit Profile</a></li><li id='wp-admin-bar-logout'><a class='ab-item' href='http://localhost:8888/wp-login.php?action=logout&#038;_wpnonce=a4d55eb7a9'>Log Out</a></li></ul></div></li></ul>
-				</div>
-				<a class="screen-reader-shortcut" href="http://localhost:8888/wp-login.php?action=logout&#038;_wpnonce=a4d55eb7a9">Log Out</a>
-			</div>
-HTML;
-	}
-
 	public function data_provider_sample_documents(): array {
-		$datasets = array(
+		return array(
 			'well-formed-html'   => array(
 				'document'  => '
 					<!DOCTYPE html>
@@ -296,23 +285,6 @@ HTML;
 				),
 			),
 		);
-
-		$all_datasets = array();
-		foreach ( $datasets as $key => $dataset ) {
-			$all_datasets[ $key ] = $dataset;
-
-			// Inject the admin bar at the beginning of the body and the Customizer support script.
-			$dataset['document'] = preg_replace(
-				'#<body[^>]*>#',
-				'$0' . get_echo( 'wp_customize_support_script' ) . $this->get_admin_bar_markup(),
-				$dataset['document']
-			);
-
-			// Add the admin bar variant as a new dataset.
-			$all_datasets[ "$key-with-adminbar" ] = $dataset;
-		}
-
-		return $all_datasets;
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
@@ -9,8 +9,19 @@
  */
 class ILO_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 
+	private function get_admin_bar_markup(): string {
+		return <<<HTML
+			<div id="wpadminbar" class="nojq nojs">
+				<div class="quicklinks" id="wp-toolbar" role="navigation" aria-label="Toolbar">
+					<ul id='wp-admin-bar-root-default' class="ab-top-menu"><li id='wp-admin-bar-wp-logo' class="menupop"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/about.php'><span class="ab-icon" aria-hidden="true"></span><span class="screen-reader-text">About WordPress</span></a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-wp-logo-default' class="ab-submenu"><li id='wp-admin-bar-about'><a class='ab-item' href='http://localhost:8888/wp-admin/about.php'>About WordPress</a></li><li id='wp-admin-bar-contribute'><a class='ab-item' href='http://localhost:8888/wp-admin/contribute.php'>Get Involved</a></li></ul><ul id='wp-admin-bar-wp-logo-external' class="ab-sub-secondary ab-submenu"><li id='wp-admin-bar-wporg'><a class='ab-item' href='https://wordpress.org/'>WordPress.org</a></li><li id='wp-admin-bar-documentation'><a class='ab-item' href='https://wordpress.org/documentation/'>Documentation</a></li><li id='wp-admin-bar-learn'><a class='ab-item' href='https://learn.wordpress.org/'>Learn WordPress</a></li><li id='wp-admin-bar-support-forums'><a class='ab-item' href='https://wordpress.org/support/forums/'>Support</a></li><li id='wp-admin-bar-feedback'><a class='ab-item' href='https://wordpress.org/support/forum/requests-and-feedback'>Feedback</a></li></ul></div></li><li id='wp-admin-bar-site-name' class="menupop"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/'>performance</a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-site-name-default' class="ab-submenu"><li id='wp-admin-bar-dashboard'><a class='ab-item' href='http://localhost:8888/wp-admin/'>Dashboard</a></li><li id='wp-admin-bar-plugins'><a class='ab-item' href='http://localhost:8888/wp-admin/plugins.php'>Plugins</a></li></ul><ul id='wp-admin-bar-appearance' class="ab-submenu"><li id='wp-admin-bar-themes'><a class='ab-item' href='http://localhost:8888/wp-admin/themes.php'>Themes</a></li></ul></div></li><li id='wp-admin-bar-site-editor'><a class='ab-item' href='http://localhost:8888/wp-admin/site-editor.php?postType=wp_template&#038;postId=twentytwentythree//single'>Edit site</a></li><li id='wp-admin-bar-comments'><a class='ab-item' href='http://localhost:8888/wp-admin/edit-comments.php'><span class="ab-icon" aria-hidden="true"></span><span class="ab-label awaiting-mod pending-count count-0" aria-hidden="true">0</span><span class="screen-reader-text comments-in-moderation-text">0 Comments in moderation</span></a></li><li id='wp-admin-bar-new-content' class="menupop"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/post-new.php'><span class="ab-icon" aria-hidden="true"></span><span class="ab-label">New</span></a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-new-content-default' class="ab-submenu"><li id='wp-admin-bar-new-post'><a class='ab-item' href='http://localhost:8888/wp-admin/post-new.php'>Post</a></li><li id='wp-admin-bar-new-media'><a class='ab-item' href='http://localhost:8888/wp-admin/media-new.php'>Media</a></li><li id='wp-admin-bar-new-page'><a class='ab-item' href='http://localhost:8888/wp-admin/post-new.php?post_type=page'>Page</a></li><li id='wp-admin-bar-new-user'><a class='ab-item' href='http://localhost:8888/wp-admin/user-new.php'>User</a></li></ul></div></li><li id='wp-admin-bar-edit'><a class='ab-item' href='http://localhost:8888/wp-admin/post.php?post=7&#038;action=edit'>Edit Post</a></li></ul><ul id='wp-admin-bar-top-secondary' class="ab-top-secondary ab-top-menu"><li id='wp-admin-bar-search' class="admin-bar-search"><div class="ab-item ab-empty-item" tabindex="-1"><form action="http://localhost:8888/" method="get" id="adminbarsearch"><input class="adminbar-input" name="s" id="adminbar-search" type="text" value="" maxlength="150" /><label for="adminbar-search" class="screen-reader-text">Search</label><input type="submit" class="adminbar-button" value="Search" /></form></div></li><li id='wp-admin-bar-my-account' class="menupop with-avatar"><a class='ab-item' aria-haspopup="true" href='http://localhost:8888/wp-admin/profile.php'>Howdy, <span class="display-name">admin</span><img alt='' src='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=26&#038;d=mm&#038;r=g' srcset='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=52&#038;d=mm&#038;r=g 2x' class='avatar avatar-26 photo' height='26' width='26' loading='lazy' decoding='async'/></a><div class="ab-sub-wrapper"><ul id='wp-admin-bar-user-actions' class="ab-submenu"><li id='wp-admin-bar-user-info'><a class='ab-item' tabindex="-1" href='http://localhost:8888/wp-admin/profile.php'><img alt='' src='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=64&#038;d=mm&#038;r=g' srcset='http://2.gravatar.com/avatar/ea8b076b398ee48b71cfaecf898c582b?s=128&#038;d=mm&#038;r=g 2x' class='avatar avatar-64 photo' height='64' width='64' loading='lazy' decoding='async'/><span class='display-name'>admin</span></a></li><li id='wp-admin-bar-edit-profile'><a class='ab-item' href='http://localhost:8888/wp-admin/profile.php'>Edit Profile</a></li><li id='wp-admin-bar-logout'><a class='ab-item' href='http://localhost:8888/wp-login.php?action=logout&#038;_wpnonce=a4d55eb7a9'>Log Out</a></li></ul></div></li></ul>
+				</div>
+				<a class="screen-reader-shortcut" href="http://localhost:8888/wp-login.php?action=logout&#038;_wpnonce=a4d55eb7a9">Log Out</a>
+			</div>
+HTML;
+	}
+
 	public function data_provider_sample_documents(): array {
-		return array(
+		$datasets = array(
 			'well-formed-html'   => array(
 				'document'  => '
 					<!DOCTYPE html>
@@ -285,6 +296,23 @@ class ILO_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 				),
 			),
 		);
+
+		$all_datasets = array();
+		foreach ( $datasets as $key => $dataset ) {
+			$all_datasets[ $key ] = $dataset;
+
+			// Inject the admin bar at the beginning of the body.
+			$dataset['document'] = preg_replace(
+				'#<body[^>]*>#',
+				'$0' . $this->get_admin_bar_markup(),
+				$dataset['document']
+			);
+
+			// Add the admin bar variant as a new dataset.
+			$all_datasets[ "$key-with-adminbar" ] = $dataset;
+		}
+
+		return $all_datasets;
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
@@ -301,10 +301,10 @@ HTML;
 		foreach ( $datasets as $key => $dataset ) {
 			$all_datasets[ $key ] = $dataset;
 
-			// Inject the admin bar at the beginning of the body.
+			// Inject the admin bar at the beginning of the body and the Customizer support script.
 			$dataset['document'] = preg_replace(
 				'#<body[^>]*>#',
-				'$0' . $this->get_admin_bar_markup(),
+				'$0' . get_echo( 'wp_customize_support_script' ) . $this->get_admin_bar_markup(),
 				$dataset['document']
 			);
 

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -10,13 +10,18 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 
 	private $original_request_uri;
 
+	private $original_request_method;
+
 	public function set_up() {
-		$this->original_request_uri = $_SERVER['REQUEST_URI'];
+		$this->original_request_uri    = $_SERVER['REQUEST_URI'];
+		$this->original_request_method = $_SERVER['REQUEST_METHOD'];
 		parent::set_up();
 	}
 
 	public function tear_down() {
-		$_SERVER['REQUEST_URI'] = $this->original_request_uri;
+		$_SERVER['REQUEST_URI']    = $this->original_request_uri;
+		$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
+		unset( $GLOBALS['wp_customize'] );
 		parent::tear_down();
 	}
 
@@ -82,6 +87,20 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 				'set_up'   => function () {
 					$this->go_to( home_url( '/' ) );
 					$_SERVER['REQUEST_METHOD'] = 'POST';
+				},
+				'expected' => false,
+			),
+			'subscriber_user'    => array(
+				'set_up'   => function () {
+					wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+					$this->go_to( home_url( '/' ) );
+				},
+				'expected' => true,
+			),
+			'admin_user'         => array(
+				'set_up'   => function () {
+					wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+					$this->go_to( home_url( '/' ) );
 				},
 				'expected' => false,
 			),

--- a/tests/modules/images/image-loading-optimization/storage/data-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/data-tests.php
@@ -88,6 +88,13 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 					return array( 'error' => 404 );
 				},
 			),
+			'logged-in'    => array(
+				'set_up' => function () {
+					wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
+					$this->go_to( home_url( '/' ) );
+					return array( 'user_logged_in' => true );
+				},
+			),
 		);
 	}
 


### PR DESCRIPTION
The original aim was for the XPaths gathered for URL metrics when a user is logged-in to be re-used for optimizing responses for logged-out users, and vice-versa. In order to accomplish this, it was necessary to skip over the admin bar element so that the indices in the XPaths are not affected by its presence. Nevertheless, I found that this is not sufficient as there are other elements which may be conditionally printed at `wp_body_open` when the user is logged-in, namely `wp_customize_support_script()` (for example). 

Therefore, I've decided to no longer try skipping over the admin bar when calculating XPaths. Instead, the URL Metrics are now varied by whether or not the user is logged-in. This should be more robust to properly optimize pages that have additional elements that appear for logged-in users on e-commerce and membership sites. 

Lastly, this PR opts to disable optimization entirely when the user is an administrator (whether they can `customize` which is the cap check used to print `wp_customize_support_script()`). When a user is an administrator it is likely that there may be additional elements added inline on the page (e.g. edit post links or edit comment links) which would cause the XPaths captured in URL Metrics to not apply properly to non-admin users. Additionally, the purpose of the optimization is to optimize the experience of the majority of visitors to the site, and not to optimize the loading experience of admin users (who likely already have the assets cached anyway).

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
