### PR TITLE
Fix optimizing pages with stale URL metrics

### DIFF
--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -101,6 +101,13 @@ function ilo_construct_preload_links( array $lcp_elements_by_minimum_viewport_wi
 
 		// Skip constructing a link if it is missing required attributes.
 		if ( empty( $link_attributes['href'] ) && empty( $link_attributes['imagesrcset'] ) ) {
+			_doing_it_wrong(
+				__FUNCTION__,
+				esc_html(
+					__( 'Attempted to construct preload link without an available href or imagesrcset. Supplied LCP element: ', 'performance-lab' ) . wp_json_encode( $lcp_element )
+				),
+				''
+			);
 			continue;
 		}
 

--- a/modules/images/image-loading-optimization/optimization.php
+++ b/modules/images/image-loading-optimization/optimization.php
@@ -173,14 +173,14 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 	$all_breakpoints_have_url_metrics        = count( array_filter( $url_metrics_grouped_by_breakpoint ) ) === count( $breakpoint_max_widths ) + 1;
 
 	/**
-	 * Optimized lookup of the LCP element for a viewport width by XPath.
+	 * Optimized lookup of the LCP element viewport widths by XPath.
 	 *
-	 * @var array<string, int[]> $lcp_element_minimum_viewport_width_by_xpath
+	 * @var array<string, int[]> $lcp_element_minimum_viewport_widths_by_xpath
 	 */
-	$lcp_element_minimum_viewport_width_by_xpath = array();
+	$lcp_element_minimum_viewport_widths_by_xpath = array();
 	foreach ( $lcp_elements_by_minimum_viewport_widths as $minimum_viewport_width => $lcp_element ) {
 		if ( false !== $lcp_element ) {
-			$lcp_element_minimum_viewport_width_by_xpath[ $lcp_element['xpath'] ][] = $minimum_viewport_width;
+			$lcp_element_minimum_viewport_widths_by_xpath[ $lcp_element['xpath'] ][] = $minimum_viewport_width;
 		}
 	}
 
@@ -274,7 +274,7 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 		// TODO: Conversely, if an image is the LCP element for one breakpoint but not another, add loading=lazy. This won't hurt performance since the image is being preloaded.
 
 		// Capture the attributes from the LCP elements to use in preload links.
-		if ( isset( $lcp_element_minimum_viewport_width_by_xpath[ $xpath ] ) ) {
+		if ( isset( $lcp_element_minimum_viewport_widths_by_xpath[ $xpath ] ) ) {
 			$detected_lcp_element_xpaths[ $xpath ] = true;
 
 			if ( $is_img_tag ) {
@@ -285,11 +285,11 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 						$img_attributes[ $attr_name ] = $value;
 					}
 				}
-				foreach ( $lcp_element_minimum_viewport_width_by_xpath[ $xpath ] as $minimum_viewport_width ) {
+				foreach ( $lcp_element_minimum_viewport_widths_by_xpath[ $xpath ] as $minimum_viewport_width ) {
 					$lcp_elements_by_minimum_viewport_widths[ $minimum_viewport_width ]['img_attributes'] = $img_attributes;
 				}
 			} elseif ( $background_image_url ) {
-				foreach ( $lcp_element_minimum_viewport_width_by_xpath[ $xpath ] as $minimum_viewport_width ) {
+				foreach ( $lcp_element_minimum_viewport_widths_by_xpath[ $xpath ] as $minimum_viewport_width ) {
 					$lcp_elements_by_minimum_viewport_widths[ $minimum_viewport_width ]['background_image'] = $background_image_url;
 				}
 			}
@@ -303,9 +303,9 @@ function ilo_optimize_template_output_buffer( string $buffer ): string {
 
 	// If there were any LCP elements captured in URL Metrics that no longer exist in the document, we need to behave as
 	// if they didn't exist in the first place as there is nothing that can be preloaded.
-	foreach ( array_keys( $lcp_element_minimum_viewport_width_by_xpath ) as $xpath ) {
+	foreach ( array_keys( $lcp_element_minimum_viewport_widths_by_xpath ) as $xpath ) {
 		if ( empty( $detected_lcp_element_xpaths[ $xpath ] ) ) {
-			foreach ( $lcp_element_minimum_viewport_width_by_xpath[ $xpath ] as $minimum_viewport_width ) {
+			foreach ( $lcp_element_minimum_viewport_widths_by_xpath[ $xpath ] as $minimum_viewport_width ) {
 				$lcp_elements_by_minimum_viewport_widths[ $minimum_viewport_width ] = false;
 			}
 		}

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -870,6 +870,114 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 					</html>
 				',
 			),
+
+			'different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale' => array(
+				'set_up'   => function () {
+					add_filter(
+						'ilo_breakpoint_max_widths',
+						static function () {
+							return array( 480, 600, 782 );
+						}
+					);
+
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							500,
+							array(
+								array(
+									'isLCP' => true,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							650,
+							array(
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							800,
+							array(
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => true,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							800,
+							array(
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+				},
+				'buffer'   => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							<img src="https://example.com/mobile-logo.png" alt="Mobile Logo" width="600" height="600">
+							<p>New paragraph since URL Metrics were captured!</p>
+							<img src="https://example.com/desktop-logo.png" alt="Desktop Logo" width="600" height="600">
+						</body>
+					</html>
+				',
+				'expected' => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+							<link as="image" data-ilo-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (min-width: 481px) and (max-width: 600px)" rel="preload"/>
+							<script type="module">/* import detect ... */</script>
+						</head>
+						<body>
+							<img alt="Mobile Logo" data-ilo-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
+							<p>New paragraph since URL Metrics were captured!</p>
+							<img alt="Desktop Logo" data-ilo-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[2][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+						</body>
+					</html>
+				',
+			),
 		);
 	}
 

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -764,6 +764,112 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 				',
 			),
 
+			'different-lcp-elements-for-two-non-consecutive-breakpoints' => array(
+				'set_up'   => function () {
+					add_filter(
+						'ilo_breakpoint_max_widths',
+						static function () {
+							return array( 480, 600, 782 );
+						}
+					);
+
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							400,
+							array(
+								array(
+									'isLCP' => true,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							500,
+							array(
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							700,
+							array(
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => true,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+					ilo_store_url_metric(
+						home_url( '/' ),
+						ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() ),
+						$this->get_validated_url_metric(
+							800,
+							array(
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+								),
+								array(
+									'isLCP' => false,
+									'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]',
+								),
+							)
+						)
+					);
+				},
+				'buffer'   => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							<img src="https://example.com/mobile-logo.png" alt="Mobile Logo" width="600" height="600">
+							<img src="https://example.com/desktop-logo.png" alt="Desktop Logo" width="600" height="600">
+						</body>
+					</html>
+				',
+				'expected' => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+							<link as="image" data-ilo-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (max-width: 480px)" rel="preload"/>
+							<link as="image" data-ilo-added-tag="" fetchpriority="high" href="https://example.com/desktop-logo.png" media="screen and (min-width: 601px) and (max-width: 782px)" rel="preload"/>
+							<script type="module">/* import detect ... */</script>
+						</head>
+						<body>
+							<img alt="Mobile Logo" data-ilo-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
+							<img alt="Desktop Logo" data-ilo-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+						</body>
+					</html>
+				',
+			),
 		);
 	}
 

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -442,6 +442,55 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 				',
 			),
 
+			'common-lcp-image-with-stale-sample-data'     => array(
+				'set_up'   => function () {
+					$slug = ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() );
+					$sample_size = ilo_get_url_metrics_breakpoint_sample_size();
+					foreach ( array_merge( ilo_get_breakpoint_max_widths(), array( 1000 ) ) as $viewport_width ) {
+						for ( $i = 0; $i < $sample_size; $i++ ) {
+							ilo_store_url_metric(
+								home_url( '/' ),
+								$slug,
+								$this->get_validated_url_metric(
+									$viewport_width,
+									array(
+										array(
+											'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+											'isLCP' => true,
+										),
+									)
+								)
+							);
+						}
+					}
+				},
+				'buffer'   => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							<script>/* Something injected with wp_body_open */</script>
+							<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800">
+						</body>
+					</html>
+				',
+				// The preload link should be absent because the URL Metrics were collected before the script was printed at wp_body_open, causing the XPath to no longer be valid.
+				'expected' => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							<script>/* Something injected with wp_body_open */</script>
+							<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800">
+						</body>
+					</html>
+				',
+			),
+
 			'common-lcp-background-image-with-fully-populated-sample-data' => array(
 				'set_up'   => function () {
 					$slug = ilo_get_url_metrics_slug( ilo_get_normalized_query_vars() );


### PR DESCRIPTION
## Summary

When testing I sometimes discovered an unexpected warning in the console:

> ⚠️ `<link rel=preload>` has an invalid `href` value

It turns out that this is closely related to #974. What was happening is that URL Metrics had been recorded for a page in which the admin bar was present, but then I opened the same URL in an incognito window where the admin bar was not present. At this point, the XPaths in the stored URL Metrics are invalid because the indices are offset by the absence of the admin bar. These LCP elements from the stale URL Metrics were being passed into `ilo_construct_preload_links()` without the the `img_attributes` or `background_image` which are obtained from the document while iterating over the tags. So then it would construct a preload `link` tag without those required attributes.

## Relevant technical choices

To rectify this, we need to keep track of the LCP elements from the stored URL Metrics which are actually discovered while iterating over the document. If any is absent, then it must be set to `false` as if there had been no LCP image detected at all. This will in turn cause `ilo_construct_preload_links()` to skip over it. Additionally, `ilo_construct_preload_links()` is amended to also check for attempting to construct a preload `link` without an `href` (or `imagesrcset`) attribute, in which case it emits a `_doing_it_wrong()` error.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
