### PR TITLE
Wait until idle before starting detection

### DIFF
--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -200,7 +200,7 @@ export default async function detect( {
 
 	// As an alternative to this, the ilo_print_detection_script() function can short-circuit if the
 	// ilo_is_url_metric_storage_locked() function returns true. However, the downside with that is page caching could
-	// result in metrics being missed being gathered when a user navigates around a site and primes the page cache.
+	// result in metrics missed from being gathered when a user navigates around a site and primes the page cache.
 	if ( isStorageLocked( currentTime, storageLockTTL ) ) {
 		if ( isDebug ) {
 			warn( 'Aborted detection due to storage being locked.' );

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -155,16 +155,6 @@ export default async function detect( {
 } ) {
 	const currentTime = getCurrentTime();
 
-	// As an alternative to this, the ilo_print_detection_script() function can short-circuit if the
-	// ilo_is_url_metric_storage_locked() function returns true. However, the downside with that is page caching could
-	// result in metrics being missed being gathered when a user navigates around a site and primes the page cache.
-	if ( isStorageLocked( currentTime, storageLockTTL ) ) {
-		if ( isDebug ) {
-			warn( 'Aborted detection due to storage being locked.' );
-		}
-		return;
-	}
-
 	// Abort running detection logic if it was served in a cached page.
 	if ( currentTime - serveTime > detectionTimeWindow ) {
 		if ( isDebug ) {
@@ -206,6 +196,16 @@ export default async function detect( {
 		await new Promise( ( resolve ) => {
 			requestIdleCallback( resolve );
 		} );
+	}
+
+	// As an alternative to this, the ilo_print_detection_script() function can short-circuit if the
+	// ilo_is_url_metric_storage_locked() function returns true. However, the downside with that is page caching could
+	// result in metrics being missed being gathered when a user navigates around a site and primes the page cache.
+	if ( isStorageLocked( currentTime, storageLockTTL ) ) {
+		if ( isDebug ) {
+			warn( 'Aborted detection due to storage being locked.' );
+		}
+		return;
 	}
 
 	// Prevent detection when page is not scrolled to the initial viewport.

--- a/modules/images/image-loading-optimization/detection/detect.js
+++ b/modules/images/image-loading-optimization/detection/detect.js
@@ -175,8 +175,40 @@ export default async function detect( {
 		return;
 	}
 
+	// Abort if the current viewport is not among those which need URL metrics.
+	if ( ! isViewportNeeded( win.innerWidth, neededMinimumViewportWidths ) ) {
+		if ( isDebug ) {
+			log( 'No need for URL metrics from the current viewport.' );
+		}
+		return;
+	}
+
+	// Ensure the DOM is loaded (although it surely already is since we're executing in a module).
+	await new Promise( ( resolve ) => {
+		if ( doc.readyState !== 'loading' ) {
+			resolve();
+		} else {
+			doc.addEventListener( 'DOMContentLoaded', resolve, { once: true } );
+		}
+	} );
+
+	// Wait until the resources on the page have fully loaded.
+	await new Promise( ( resolve ) => {
+		if ( doc.readyState === 'complete' ) {
+			resolve();
+		} else {
+			win.addEventListener( 'load', resolve, { once: true } );
+		}
+	} );
+
+	// Wait yet further until idle.
+	if ( typeof requestIdleCallback === 'function' ) {
+		await new Promise( ( resolve ) => {
+			requestIdleCallback( resolve );
+		} );
+	}
+
 	// Prevent detection when page is not scrolled to the initial viewport.
-	// TODO: Does this cause layout/reflow? https://gist.github.com/paulirish/5d52fb081b3570c81e3a
 	if ( doc.documentElement.scrollTop > 0 ) {
 		if ( isDebug ) {
 			warn(
@@ -186,18 +218,10 @@ export default async function detect( {
 		return;
 	}
 
-	if ( ! isViewportNeeded( win.innerWidth, neededMinimumViewportWidths ) ) {
-		if ( isDebug ) {
-			log( 'No need for URL metrics from the current viewport.' );
-		}
-		return;
-	}
-
 	if ( isDebug ) {
 		log( 'Proceeding with detection' );
 	}
 
-	// TODO: This query no longer needs to be done as early as possible since the server is adding the breadcrumbs.
 	const breadcrumbedElements =
 		doc.body.querySelectorAll( '[data-ilo-xpath]' );
 
@@ -211,15 +235,6 @@ export default async function detect( {
 			( element ) => [ element, element.dataset.iloXpath ]
 		)
 	);
-
-	// Ensure the DOM is loaded (although it surely already is since we're executing in a module).
-	await new Promise( ( resolve ) => {
-		if ( doc.readyState !== 'loading' ) {
-			resolve();
-		} else {
-			doc.addEventListener( 'DOMContentLoaded', resolve, { once: true } );
-		}
-	} );
 
 	/** @type {IntersectionObserverEntry[]} */
 	const elementIntersections = [];
@@ -286,15 +301,6 @@ export default async function detect( {
 		);
 	} );
 
-	// Wait until the resources on the page have fully loaded.
-	await new Promise( ( resolve ) => {
-		if ( doc.readyState === 'complete' ) {
-			resolve();
-		} else {
-			win.addEventListener( 'load', resolve, { once: true } );
-		}
-	} );
-
 	// Stop observing.
 	disconnectIntersectionObserver();
 	if ( isDebug ) {
@@ -348,7 +354,11 @@ export default async function detect( {
 		log( 'URL metrics:', urlMetrics );
 	}
 
-	// TODO: Wait until idle? Yield to main?
+	// Yield to main before sending data to server to further break up task.
+	await new Promise( ( resolve ) => {
+		setTimeout( resolve, 0 );
+	} );
+
 	try {
 		const response = await fetch( restApiEndpoint, {
 			method: 'POST',


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #894

This rearranges the detection logic to defer doing any DOM operations until after the page has fully loaded _and_ the CPU is idle. Additionally, it now yields to main before initiating the fetch request to submit the data to the server, additionally breaking up tasks.

## Performance Profiles

With 6X CPU throttling, the plugin active with the change applied shows a marginal improvement where tasks are further broken up.

### [Trace without ILO](https://trace.cafe/t/MQaZChmr2W)

![Screenshot 2024-02-09 10 55 19](https://github.com/WordPress/performance/assets/134745/0d75eb8e-1c49-4f9c-b253-7f5e2ca2788c)

### [Trace with ILO before change](https://trace.cafe/t/yPGKS2Q4jq)

![Screenshot 2024-02-09 10 56 49](https://github.com/WordPress/performance/assets/134745/31b1235c-cf10-4594-8c90-090b52de54b0)

### [Trace with ILO after change](https://trace.cafe/t/ueXDnq73Dl)

![Screenshot 2024-02-09 10 57 57](https://github.com/WordPress/performance/assets/134745/6b31851b-b466-432e-8b8b-d38e79713aca)

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
