### PR TITLE
Add failure checks to Embed Optimizer

### DIFF
--- a/tests/modules/js-and-css/embed-optimizer/embed-optimizer-test.php
+++ b/tests/modules/js-and-css/embed-optimizer/embed-optimizer-test.php
@@ -11,9 +11,10 @@ class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 	/**
 	 * Test that the oEmbed HTML is filtered.
 	 *
-	 * @dataProvider test_filter_oembed_html_data
+	 * @covers ::embed_optimizer_filter_oembed_html
+	 * @dataProvider get_data_to_test_filter_oembed_html_data
 	 */
-	public function test__filter_oembed_html( $html, $expected = null ) {
+	public function test_embed_optimizer_filter_oembed_html( string $html, string $expected = null ) {
 		if ( null === $expected ) {
 			$expected = $html; // No change.
 		}
@@ -25,7 +26,7 @@ class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 	 *
 	 * @return array
 	 */
-	public function test_filter_oembed_html_data() {
+	public function get_data_to_test_filter_oembed_html_data(): array {
 		return array(
 			// A single iframe.
 			array(

--- a/tests/modules/js-and-css/embed-optimizer/embed-optimizer-test.php
+++ b/tests/modules/js-and-css/embed-optimizer/embed-optimizer-test.php
@@ -12,6 +12,7 @@ class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 	 * Test that the oEmbed HTML is filtered.
 	 *
 	 * @covers ::embed_optimizer_filter_oembed_html
+	 * @covers ::embed_optimizer_lazy_load_scripts
 	 * @dataProvider get_data_to_test_filter_oembed_html_data
 	 */
 	public function test_embed_optimizer_filter_oembed_html( string $html, string $expected = null ) {

--- a/tests/modules/js-and-css/embed-optimizer/embed-optimizer-test.php
+++ b/tests/modules/js-and-css/embed-optimizer/embed-optimizer-test.php
@@ -117,6 +117,18 @@ class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 				'<iframe title="New in Chrome 111: View transitions API, CSS color level 4 and more!" width="500" height="281" src="https://www.youtube.com/embed/cscwgzz85Og?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>',
 				'<iframe loading="lazy" title="New in Chrome 111: View transitions API, CSS color level 4 and more!" width="500" height="281" src="https://www.youtube.com/embed/cscwgzz85Og?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>',
 			),
+
+			// Hypothetical embed using an external script module.
+			array(
+				'<div class="example-embed"></div><script type="module" src="https://example.com/embed.mjs"></script>',
+				'<div class="example-embed"></div><script data-lazy-embed-src="https://example.com/embed.mjs" type="module" ></script>',
+			),
+
+			// Hypothetical embed using a traditional text/javascript external script.
+			array(
+				'<div class="example-embed"></div><script type="text/javascript" src="https://example.com/embed.js"></script>',
+				'<div class="example-embed"></div><script data-lazy-embed-src="https://example.com/embed.js" type="text/javascript" ></script>',
+			),
 		);
 	}
 }


### PR DESCRIPTION
## Summary

This adds some sanity checks for the HTML Tag Processor to catch a rare case where it would fail to set a bookmark or seek to a bookmark. (I was experiencing such a failure but it seemed due to running a broken alpha state of 6.5.)

It also tidies up the tests by:

* fixing the method name for the data provider
* add some PHP typing
* add `@covers`

## Relevant technical choices

A wrapper for `wp_trigger_error()` is used since it was introduced in WP 6.4.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
