### PR TITLE
Introduce ILO_URL_Metric to encapsulate core data structure

### DIFF
--- a/modules/images/image-loading-optimization/class-ilo-data-validation-exception.php
+++ b/modules/images/image-loading-optimization/class-ilo-data-validation-exception.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Image Loading Optimization: ILO_Data_Validation_Exception class
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * Exception thrown when failing to validate URL metrics data.
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+final class ILO_Data_Validation_Exception extends Exception {}

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -9,12 +9,10 @@
 /**
  * Representation of the measurements taken from a single client's visit to a specific URL.
  *
- * @implements ArrayAccess<string, mixed>
- *
  * @since n.e.x.t
  * @access private
  */
-final class ILO_URL_Metric implements ArrayAccess, JsonSerializable {
+final class ILO_URL_Metric implements JsonSerializable {
 
 	/**
 	 * Gets JSON schema for URL Metric.
@@ -103,11 +101,11 @@ final class ILO_URL_Metric implements ArrayAccess, JsonSerializable {
 	}
 
 	/**
-	 * Validated data.
+	 * Data.
 	 *
 	 * @var array
 	 */
-	private $data;
+	private $data = array();
 
 	/**
 	 * Constructor.
@@ -121,68 +119,37 @@ final class ILO_URL_Metric implements ArrayAccess, JsonSerializable {
 		if ( ! $validated ) {
 			$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
 			if ( is_wp_error( $valid ) ) {
-				throw new Exception( $valid->get_error_message() );
+				throw new Exception( esc_html( $valid->get_error_message() ) );
 			}
 		}
 		$this->data = $data;
 	}
 
+	/**
+	 * Gets viewport width.
+	 *
+	 * @return int
+	 */
 	public function get_viewport_width(): int {
 		return $this->data['viewport']['width'];
 	}
 
+	/**
+	 * Gets timestamp.
+	 *
+	 * @return float
+	 */
 	public function get_timestamp(): float {
 		return $this->data['timestamp'];
 	}
 
+	/**
+	 * Gets elements.
+	 *
+	 * @return array
+	 */
 	public function get_elements(): array {
 		return $this->data['elements'];
-	}
-
-	/**
-	 * Checks if the offset exists.
-	 *
-	 * @param string $offset Offset.
-	 * @return bool Whether exists.
-	 */
-	public function offsetExists( $offset ): bool {
-		return isset( $this->data[ $offset ] );
-	}
-
-	/**
-	 * Gets offset.
-	 *
-	 * @throws Exception If the offset does not exist.
-	 *
-	 * @param string $offset Offset.
-	 * @return mixed Value.
-	 */
-	public function offsetGet( $offset ) {
-		if ( ! $this->offsetExists( $offset ) ) {
-			throw new Exception( sprintf( __( 'Unknown property %s on ILO_URL_Metric.', 'performance-lab' ), $offset ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-		}
-		return $this->data[ $offset ];
-	}
-
-	/**
-	 * Sets offset (disabled).
-	 *
-	 * @param string $offset Offset.
-	 * @param mixed  $value  Value.
-	 * @throws Exception
-	 */
-	public function offsetSet( $offset, $value ) {
-		throw new Exception( __( 'Cannot set properties on ILO_URL_Metric.', 'performance-lab' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
-	}
-
-	/**
-	 * Unsets offset (disabled).
-	 *
-	 * @param string $offset Offset.
-	 * @throws Exception
-	 */
-	public function offsetUnset( $offset ) {
-		throw new Exception( __( 'Cannot unset properties on ILO_URL_Metric.', 'performance-lab' ) );
 	}
 
 	/**

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -36,16 +36,13 @@ final class ILO_URL_Metric implements JsonSerializable {
 	 * Constructor.
 	 *
 	 * @param array $data      URL metric data.
-	 * @param bool  $validated Whether the data was already validated.
 	 *
-	 * @throws Exception When the input is invalid.
+	 * @throws ILO_Data_Validation_Exception When the input is invalid.
 	 */
-	public function __construct( array $data, bool $validated = false ) {
-		if ( ! $validated ) {
-			$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
-			if ( is_wp_error( $valid ) ) {
-				throw new Exception( esc_html( $valid->get_error_message() ) );
-			}
+	public function __construct( array $data ) {
+		$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
+		if ( is_wp_error( $valid ) ) {
+			throw new ILO_Data_Validation_Exception( esc_html( $valid->get_error_message() ) );
 		}
 		$this->data = $data;
 	}

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -35,7 +35,7 @@ final class ILO_URL_Metric implements JsonSerializable {
 	/**
 	 * Constructor.
 	 *
-	 * @param array $data      URL metric data.
+	 * @param array $data URL metric data.
 	 *
 	 * @throws ILO_Data_Validation_Exception When the input is invalid.
 	 */

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -53,7 +53,7 @@ final class ILO_URL_Metric implements JsonSerializable {
 	/**
 	 * Gets JSON schema for URL Metric.
 	 *
-	 * @return array
+	 * @return array Schema.
 	 */
 	public static function get_json_schema(): array {
 		$dom_rect_schema = array(

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -38,10 +38,10 @@ final class ILO_URL_Metric implements ArrayAccess, JsonSerializable {
 		);
 
 		return array(
-			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'ilo-url-metric',
-			'type'       => 'object',
-			'properties' => array(
+			'$schema'              => 'http://json-schema.org/draft-04/schema#',
+			'title'                => 'ilo-url-metric',
+			'type'                 => 'object',
+			'properties'           => array(
 				'viewport'  => array(
 					'description' => __( 'Viewport dimensions', 'performance-lab' ),
 					'type'        => 'object',
@@ -98,6 +98,7 @@ final class ILO_URL_Metric implements ArrayAccess, JsonSerializable {
 					),
 				),
 			),
+			'additionalProperties' => false,
 		);
 	}
 
@@ -113,12 +114,29 @@ final class ILO_URL_Metric implements ArrayAccess, JsonSerializable {
 	 *
 	 * @param array $data      URL metric data.
 	 * @param bool  $validated Whether the data was already validated.
+	 *
+	 * @throws Exception When the input is invalid.
 	 */
 	public function __construct( array $data, bool $validated = false ) {
 		if ( ! $validated ) {
-			// TODO: Validate.
+			$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
+			if ( is_wp_error( $valid ) ) {
+				throw new Exception( $valid->get_error_message() );
+			}
 		}
 		$this->data = $data;
+	}
+
+	public function get_viewport_width(): int {
+		return $this->data['viewport']['width'];
+	}
+
+	public function get_timestamp(): float {
+		return $this->data['timestamp'];
+	}
+
+	public function get_elements(): array {
+		return $this->data['elements'];
 	}
 
 	/**

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -33,6 +33,24 @@ final class ILO_URL_Metric implements JsonSerializable {
 	private $data;
 
 	/**
+	 * Constructor.
+	 *
+	 * @param array $data      URL metric data.
+	 * @param bool  $validated Whether the data was already validated.
+	 *
+	 * @throws Exception When the input is invalid.
+	 */
+	public function __construct( array $data, bool $validated = false ) {
+		if ( ! $validated ) {
+			$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
+			if ( is_wp_error( $valid ) ) {
+				throw new Exception( esc_html( $valid->get_error_message() ) );
+			}
+		}
+		$this->data = $data;
+	}
+
+	/**
 	 * Gets JSON schema for URL Metric.
 	 *
 	 * @return array
@@ -117,24 +135,6 @@ final class ILO_URL_Metric implements JsonSerializable {
 			),
 			'additionalProperties' => false,
 		);
-	}
-
-	/**
-	 * Constructor.
-	 *
-	 * @param array $data      URL metric data.
-	 * @param bool  $validated Whether the data was already validated.
-	 *
-	 * @throws Exception When the input is invalid.
-	 */
-	public function __construct( array $data, bool $validated = false ) {
-		if ( ! $validated ) {
-			$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
-			if ( is_wp_error( $valid ) ) {
-				throw new Exception( esc_html( $valid->get_error_message() ) );
-			}
-		}
-		$this->data = $data;
 	}
 
 	/**

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -21,8 +21,8 @@ final class ILO_URL_Metric implements JsonSerializable {
 	 */
 	public static function get_json_schema(): array {
 		$dom_rect_schema = array(
-			'type'       => 'object',
-			'properties' => array(
+			'type'                 => 'object',
+			'properties'           => array(
 				'width'  => array(
 					'type'    => 'number',
 					'minimum' => 0,
@@ -31,8 +31,9 @@ final class ILO_URL_Metric implements JsonSerializable {
 					'type'    => 'number',
 					'minimum' => 0,
 				),
-				// TODO: There are other properties to define if we need them: x, y, top, right, bottom, left.
 			),
+			// TODO: There are other properties to define if we need them: x, y, top, right, bottom, left.
+			'additionalProperties' => true,
 		);
 
 		return array(
@@ -69,8 +70,8 @@ final class ILO_URL_Metric implements JsonSerializable {
 					'required'    => true,
 					'items'       => array(
 						// See the ElementMetrics in detect.js.
-						'type'       => 'object',
-						'properties' => array(
+						'type'                 => 'object',
+						'properties'           => array(
 							'isLCP'              => array(
 								'type'     => 'boolean',
 								'required' => true,
@@ -92,6 +93,7 @@ final class ILO_URL_Metric implements JsonSerializable {
 							'intersectionRect'   => $dom_rect_schema,
 							'boundingClientRect' => $dom_rect_schema,
 						),
+						'additionalProperties' => false,
 					),
 				),
 			),
@@ -102,9 +104,20 @@ final class ILO_URL_Metric implements JsonSerializable {
 	/**
 	 * Data.
 	 *
-	 * @var array
+	 * @var array{
+	 *          timestamp: int,
+	 *          viewport: array{ width: int, height: int },
+	 *          elements: array<array{
+	 *              isLCP: bool,
+	 *              isLCPCandidate: bool,
+	 *              xpath: string,
+	 *              intersectionRatio: float,
+	 *              intersectionRect: array{ width: int, height: int },
+	 *              boundingClientRect: array{ width: int, height: int },
+	 *          }>
+	 *      }
 	 */
-	private $data = array();
+	private $data;
 
 	/**
 	 * Constructor.

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -158,7 +158,14 @@ final class ILO_URL_Metric implements JsonSerializable {
 	/**
 	 * Gets elements.
 	 *
-	 * @return array
+	 * @return array<array{
+	 *             isLCP: bool,
+	 *             isLCPCandidate: bool,
+	 *             xpath: string,
+	 *             intersectionRatio: float,
+	 *             intersectionRect: array{ width: int, height: int },
+	 *             boundingClientRect: array{ width: int, height: int },
+	 *         }>
 	 */
 	public function get_elements(): array {
 		return $this->data['elements'];

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -15,6 +15,24 @@
 final class ILO_URL_Metric implements JsonSerializable {
 
 	/**
+	 * Data.
+	 *
+	 * @var array{
+	 *          timestamp: int,
+	 *          viewport: array{ width: int, height: int },
+	 *          elements: array<array{
+	 *              isLCP: bool,
+	 *              isLCPCandidate: bool,
+	 *              xpath: string,
+	 *              intersectionRatio: float,
+	 *              intersectionRect: array{ width: int, height: int },
+	 *              boundingClientRect: array{ width: int, height: int },
+	 *          }>
+	 *      }
+	 */
+	private $data;
+
+	/**
 	 * Gets JSON schema for URL Metric.
 	 *
 	 * @return array
@@ -100,24 +118,6 @@ final class ILO_URL_Metric implements JsonSerializable {
 			'additionalProperties' => false,
 		);
 	}
-
-	/**
-	 * Data.
-	 *
-	 * @var array{
-	 *          timestamp: int,
-	 *          viewport: array{ width: int, height: int },
-	 *          elements: array<array{
-	 *              isLCP: bool,
-	 *              isLCPCandidate: bool,
-	 *              xpath: string,
-	 *              intersectionRatio: float,
-	 *              intersectionRect: array{ width: int, height: int },
-	 *              boundingClientRect: array{ width: int, height: int },
-	 *          }>
-	 *      }
-	 */
-	private $data;
 
 	/**
 	 * Constructor.

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -9,10 +9,12 @@
 /**
  * Representation of the measurements taken from a single client's visit to a specific URL.
  *
+ * @implements ArrayAccess<string, mixed>
+ *
  * @since n.e.x.t
  * @access private
  */
-final class ILO_URL_Metric {
+final class ILO_URL_Metric implements ArrayAccess, JsonSerializable {
 
 	/**
 	 * Gets JSON schema for URL Metric.
@@ -40,7 +42,7 @@ final class ILO_URL_Metric {
 			'title'      => 'ilo-url-metric',
 			'type'       => 'object',
 			'properties' => array(
-				'viewport' => array(
+				'viewport'  => array(
 					'description' => __( 'Viewport dimensions', 'performance-lab' ),
 					'type'        => 'object',
 					'required'    => true,
@@ -57,7 +59,14 @@ final class ILO_URL_Metric {
 						),
 					),
 				),
-				'elements' => array(
+				'timestamp' => array(
+					'description' => __( 'Timestamp at which the URL metric was captured.', 'performance-lab' ),
+					'type'        => 'number',
+					'readonly'    => true, // Use the server-provided timestamp.
+					'default'     => microtime( true ),
+					'minimum'     => 0,
+				),
+				'elements'  => array(
 					'description' => __( 'Element metrics', 'performance-lab' ),
 					'type'        => 'array',
 					'required'    => true,
@@ -90,5 +99,80 @@ final class ILO_URL_Metric {
 				),
 			),
 		);
+	}
+
+	/**
+	 * Validated data.
+	 *
+	 * @var array
+	 */
+	private $data;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $data      URL metric data.
+	 * @param bool  $validated Whether the data was already validated.
+	 */
+	public function __construct( array $data, bool $validated = false ) {
+		if ( ! $validated ) {
+			// TODO: Validate.
+		}
+		$this->data = $data;
+	}
+
+	/**
+	 * Checks if the offset exists.
+	 *
+	 * @param string $offset Offset.
+	 * @return bool Whether exists.
+	 */
+	public function offsetExists( $offset ): bool {
+		return isset( $this->data[ $offset ] );
+	}
+
+	/**
+	 * Gets offset.
+	 *
+	 * @throws Exception If the offset does not exist.
+	 *
+	 * @param string $offset Offset.
+	 * @return mixed Value.
+	 */
+	public function offsetGet( $offset ) {
+		if ( ! $this->offsetExists( $offset ) ) {
+			throw new Exception( sprintf( __( 'Unknown property %s on ILO_URL_Metric.', 'performance-lab' ), $offset ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+		return $this->data[ $offset ];
+	}
+
+	/**
+	 * Sets offset (disabled).
+	 *
+	 * @param string $offset Offset.
+	 * @param mixed  $value  Value.
+	 * @throws Exception
+	 */
+	public function offsetSet( $offset, $value ) {
+		throw new Exception( __( 'Cannot set properties on ILO_URL_Metric.', 'performance-lab' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped
+	}
+
+	/**
+	 * Unsets offset (disabled).
+	 *
+	 * @param string $offset Offset.
+	 * @throws Exception
+	 */
+	public function offsetUnset( $offset ) {
+		throw new Exception( __( 'Cannot unset properties on ILO_URL_Metric.', 'performance-lab' ) );
+	}
+
+	/**
+	 * Gets the JSON representation of the object.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize(): array {
+		return $this->data;
 	}
 }

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -60,8 +60,7 @@ final class ILO_URL_Metric implements JsonSerializable {
 				'timestamp' => array(
 					'description' => __( 'Timestamp at which the URL metric was captured.', 'performance-lab' ),
 					'type'        => 'number',
-					'readonly'    => true, // Use the server-provided timestamp.
-					'default'     => microtime( true ),
+					'required'    => true,
 					'minimum'     => 0,
 				),
 				'elements'  => array(

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Image Loading Optimization: ILO_URL_Metric class
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+/**
+ * Representation of the measurements taken from a single client's visit to a specific URL.
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+final class ILO_URL_Metric {
+
+	/**
+	 * Gets JSON schema for URL Metric.
+	 *
+	 * @return array
+	 */
+	public static function get_json_schema(): array {
+		$dom_rect_schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'width'  => array(
+					'type'    => 'number',
+					'minimum' => 0,
+				),
+				'height' => array(
+					'type'    => 'number',
+					'minimum' => 0,
+				),
+				// TODO: There are other properties to define if we need them: x, y, top, right, bottom, left.
+			),
+		);
+
+		return array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'ilo-url-metric',
+			'type'       => 'object',
+			'properties' => array(
+				'viewport' => array(
+					'description' => __( 'Viewport dimensions', 'performance-lab' ),
+					'type'        => 'object',
+					'required'    => true,
+					'properties'  => array(
+						'width'  => array(
+							'type'     => 'integer',
+							'required' => true,
+							'minimum'  => 0,
+						),
+						'height' => array(
+							'type'     => 'integer',
+							'required' => true,
+							'minimum'  => 0,
+						),
+					),
+				),
+				'elements' => array(
+					'description' => __( 'Element metrics', 'performance-lab' ),
+					'type'        => 'array',
+					'required'    => true,
+					'items'       => array(
+						// See the ElementMetrics in detect.js.
+						'type'       => 'object',
+						'properties' => array(
+							'isLCP'              => array(
+								'type'     => 'boolean',
+								'required' => true,
+							),
+							'isLCPCandidate'     => array(
+								'type' => 'boolean',
+							),
+							'xpath'              => array(
+								'type'     => 'string',
+								'required' => true,
+								'pattern'  => ILO_HTML_Tag_Processor::XPATH_PATTERN,
+							),
+							'intersectionRatio'  => array(
+								'type'     => 'number',
+								'required' => true,
+								'minimum'  => 0.0,
+								'maximum'  => 1.0,
+							),
+							'intersectionRect'   => $dom_rect_schema,
+							'boundingClientRect' => $dom_rect_schema,
+						),
+					),
+				),
+			),
+		);
+	}
+}

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -95,6 +95,8 @@ final class ILO_URL_Metric implements JsonSerializable {
 					'description' => __( 'Timestamp at which the URL metric was captured.', 'performance-lab' ),
 					'type'        => 'number',
 					'required'    => true,
+					'readonly'    => true, // Omit from REST API.
+					'default'     => microtime( true ), // Value provided when instantiating ILO_URL_Metric in REST API.
 					'minimum'     => 0,
 				),
 				'elements'  => array(

--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -140,10 +140,10 @@ final class ILO_URL_Metric implements JsonSerializable {
 	/**
 	 * Gets viewport width.
 	 *
-	 * @return int
+	 * @return array{ width: int, height: int }
 	 */
-	public function get_viewport_width(): int {
-		return $this->data['viewport']['width'];
+	public function get_viewport(): array {
+		return $this->data['viewport'];
 	}
 
 	/**

--- a/modules/images/image-loading-optimization/load.php
+++ b/modules/images/image-loading-optimization/load.php
@@ -18,6 +18,7 @@ define( 'IMAGE_LOADING_OPTIMIZATION_VERSION', 'Performance Lab ' . PERFLAB_VERSI
 require_once __DIR__ . '/hooks.php';
 
 // Storage logic.
+require_once __DIR__ . '/class-ilo-url-metric.php';
 require_once __DIR__ . '/storage/lock.php';
 require_once __DIR__ . '/storage/post-type.php';
 require_once __DIR__ . '/storage/data.php';

--- a/modules/images/image-loading-optimization/load.php
+++ b/modules/images/image-loading-optimization/load.php
@@ -18,6 +18,7 @@ define( 'IMAGE_LOADING_OPTIMIZATION_VERSION', 'Performance Lab ' . PERFLAB_VERSI
 require_once __DIR__ . '/hooks.php';
 
 // Storage logic.
+require_once __DIR__ . '/class-ilo-data-validation-exception.php';
 require_once __DIR__ . '/class-ilo-url-metric.php';
 require_once __DIR__ . '/storage/lock.php';
 require_once __DIR__ . '/storage/post-type.php';

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -122,7 +122,7 @@ function ilo_verify_url_metrics_storage_nonce( string $nonce, string $slug ): bo
  * @access private
  *
  * @param ILO_URL_Metric[] $url_metrics    Existing URL metrics. Each URL metric is expected to have a timestamp key.
- * @param ILO_URL_Metric   $new_url_metric Validated URL metric. See JSON Schema defined in ilo_register_endpoint().
+ * @param ILO_URL_Metric   $new_url_metric New URL metric.
  * @param int[]            $breakpoints    Breakpoint max widths.
  * @param int              $sample_size    Sample size for URL metrics at a given breakpoint.
  *

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -253,7 +253,7 @@ function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpo
 	foreach ( $url_metrics as $url_metric ) {
 		$current_minimum_viewport = 0;
 		foreach ( $minimum_viewport_widths as $viewport_minimum_width ) {
-			if ( $url_metric->get_viewport_width() > $viewport_minimum_width ) {
+			if ( $url_metric->get_viewport()['width'] > $viewport_minimum_width ) {
 				$current_minimum_viewport = $viewport_minimum_width;
 			} else {
 				break;

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -141,7 +141,7 @@ function ilo_unshift_url_metrics( array $url_metrics, ILO_URL_Metric $new_url_me
 				usort(
 					$breakpoint_url_metrics,
 					static function ( ILO_URL_Metric $a, ILO_URL_Metric $b ) {
-						return $b['timestamp'] <=> $a['timestamp'];
+						return $b->get_timestamp() <=> $a->get_timestamp();
 					}
 				);
 
@@ -233,10 +233,10 @@ function ilo_get_url_metrics_breakpoint_sample_size(): int {
  *
  * @param ILO_URL_Metric[] $url_metrics URL metrics.
  * @param int[]            $breakpoints Viewport breakpoint max widths, sorted in ascending order.
- * @return array URL metrics grouped by breakpoint. The array keys are the minimum widths for a viewport to lie within
- *               the breakpoint. The returned array is always one larger than the provided array of breakpoints, since
- *               the breakpoints reflect the max inclusive boundaries whereas the return value is the groups of page
- *               metrics with viewports on either side of the breakpoint boundaries.
+ * @return array<int, ILO_URL_Metric[]> URL metrics grouped by breakpoint. The array keys are the minimum widths for a viewport to lie within
+ *                                      the breakpoint. The returned array is always one larger than the provided array of breakpoints, since
+ *                                      the breakpoints reflect the max inclusive boundaries whereas the return value is the groups of page
+ *                                      metrics with viewports on either side of the breakpoint boundaries.
  */
 function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpoints ): array {
 
@@ -253,7 +253,7 @@ function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpo
 	foreach ( $url_metrics as $url_metric ) {
 		$current_minimum_viewport = 0;
 		foreach ( $minimum_viewport_widths as $viewport_minimum_width ) {
-			if ( $url_metric['viewport']['width'] > $viewport_minimum_width ) {
+			if ( $url_metric->get_viewport_width() > $viewport_minimum_width ) {
 				$current_minimum_viewport = $viewport_minimum_width;
 			} else {
 				break;
@@ -277,7 +277,7 @@ function ilo_group_url_metrics_by_breakpoint( array $url_metrics, array $breakpo
  * @since n.e.x.t
  * @access private
  *
- * @param array $grouped_url_metrics URL metrics grouped by breakpoint. See `ilo_group_url_metrics_by_breakpoint()`.
+ * @param array<int, ILO_URL_Metric[]> $grouped_url_metrics URL metrics grouped by breakpoint. See `ilo_group_url_metrics_by_breakpoint()`.
  * @return array LCP elements keyed by its minimum viewport width. If there is no supported LCP element at a breakpoint, then `false` is used.
  */
 function ilo_get_lcp_elements_by_minimum_viewport_widths( array $grouped_url_metrics ): array {
@@ -291,7 +291,7 @@ function ilo_get_lcp_elements_by_minimum_viewport_widths( array $grouped_url_met
 		$breadcrumb_element = array();
 
 		foreach ( $breakpoint_url_metrics as $breakpoint_url_metric ) {
-			foreach ( $breakpoint_url_metric['elements'] as $element ) {
+			foreach ( $breakpoint_url_metric->get_elements() as $element ) {
 				if ( ! $element['isLCP'] ) {
 					continue;
 				}
@@ -353,11 +353,11 @@ function ilo_get_lcp_elements_by_minimum_viewport_widths( array $grouped_url_met
  * @since n.e.x.t
  * @access private
  *
- * @param array $url_metrics            URL metrics.
- * @param float $current_time           Current time as returned by `microtime(true)`.
- * @param int[] $breakpoint_max_widths  Breakpoint max widths.
- * @param int   $sample_size            Sample size for viewports in a breakpoint.
- * @param int   $freshness_ttl          Freshness TTL for a URL metric.
+ * @param ILO_URL_Metric[] $url_metrics URL metrics.
+ * @param float            $current_time           Current time as returned by `microtime(true)`.
+ * @param int[]            $breakpoint_max_widths  Breakpoint max widths.
+ * @param int              $sample_size            Sample size for viewports in a breakpoint.
+ * @param int              $freshness_ttl          Freshness TTL for a URL metric.
  * @return array<int, array{int, bool}> Array of tuples mapping minimum viewport width to whether URL metric(s) are needed.
  */
 function ilo_get_needed_minimum_viewport_widths( array $url_metrics, float $current_time, array $breakpoint_max_widths, int $sample_size, int $freshness_ttl ): array {
@@ -369,7 +369,7 @@ function ilo_get_needed_minimum_viewport_widths( array $url_metrics, float $curr
 			$needs_url_metrics = true;
 		} else {
 			foreach ( $viewport_url_metrics as $url_metric ) {
-				if ( isset( $url_metric['timestamp'] ) && $url_metric['timestamp'] + $freshness_ttl < $current_time ) {
+				if ( $url_metric->get_timestamp() + $freshness_ttl < $current_time ) {
 					$needs_url_metrics = true;
 					break;
 				}

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -140,7 +140,7 @@ function ilo_unshift_url_metrics( array $url_metrics, ILO_URL_Metric $new_url_me
 				// Sort URL metrics in descending order by timestamp.
 				usort(
 					$breakpoint_url_metrics,
-					static function ( ILO_URL_Metric $a, ILO_URL_Metric $b ) {
+					static function ( ILO_URL_Metric $a, ILO_URL_Metric $b ): int {
 						return $b->get_timestamp() <=> $a->get_timestamp();
 					}
 				);

--- a/modules/images/image-loading-optimization/storage/post-type.php
+++ b/modules/images/image-loading-optimization/storage/post-type.php
@@ -93,9 +93,10 @@ function ilo_parse_stored_url_metrics( WP_Post $post ): array {
 	if ( json_last_error() ) {
 		$trigger_error(
 			sprintf(
-				/* translators: 1: Post type slug, 2: JSON error message */
-				__( 'Contents of %1$s post type not valid JSON: %2$s', 'performance-lab' ),
+				/* translators: 1: Post type slug, 2: Post ID, 3: JSON error message */
+				__( 'Contents of %1$s post type (ID: %2$s) not valid JSON: %3$s', 'performance-lab' ),
 				ILO_URL_METRICS_POST_TYPE,
+				$post->ID,
 				json_last_error_msg()
 			)
 		);
@@ -125,9 +126,10 @@ function ilo_parse_stored_url_metrics( WP_Post $post ): array {
 					} catch ( Exception $e ) {
 						$trigger_error(
 							sprintf(
-								/* translators: %s is post type slug */
-								__( 'Unexpected shape to JSON array in post_content of %s post type.', 'performance-lab' ),
-								ILO_URL_METRICS_POST_TYPE
+								/* translators: 1: Post type slug. 2: Exception message. */
+								__( 'Unexpected shape to JSON array in post_content of %1$s post type: %2$s', 'performance-lab' ),
+								ILO_URL_METRICS_POST_TYPE,
+								$e->getMessage()
 							)
 						);
 						return null;

--- a/modules/images/image-loading-optimization/storage/post-type.php
+++ b/modules/images/image-loading-optimization/storage/post-type.php
@@ -121,9 +121,8 @@ function ilo_parse_stored_url_metrics( WP_Post $post ): array {
 					}
 
 					try {
-						// TODO: This is re-validating the data which has been stored in the post type. This ensures it remains valid, but is it overkill?
 						return new ILO_URL_Metric( $url_metric_data );
-					} catch ( Exception $e ) {
+					} catch ( ILO_Data_Validation_Exception $e ) {
 						$trigger_error(
 							sprintf(
 								/* translators: 1: Post type slug. 2: Exception message. */

--- a/modules/images/image-loading-optimization/storage/post-type.php
+++ b/modules/images/image-loading-optimization/storage/post-type.php
@@ -120,6 +120,7 @@ function ilo_parse_stored_url_metrics( WP_Post $post ): array {
 					}
 
 					try {
+						// TODO: This is re-validating the data which has been stored in the post type. This ensures it remains valid, but is it overkill?
 						return new ILO_URL_Metric( $url_metric_data );
 					} catch ( Exception $e ) {
 						$trigger_error(

--- a/modules/images/image-loading-optimization/storage/post-type.php
+++ b/modules/images/image-loading-optimization/storage/post-type.php
@@ -115,6 +115,10 @@ function ilo_parse_stored_url_metrics( WP_Post $post ): array {
 		array_filter(
 			array_map(
 				static function ( $url_metric_data ) use ( $trigger_error ) {
+					if ( ! is_array( $url_metric_data ) ) {
+						return null;
+					}
+
 					try {
 						return new ILO_URL_Metric( $url_metric_data );
 					} catch ( Exception $e ) {

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -142,7 +142,24 @@ function ilo_handle_rest_request( WP_REST_Request $request ) {
 	}
 
 	ilo_set_url_metric_storage_lock();
-	$new_url_metric = wp_array_slice_assoc( $request->get_params(), array( 'viewport', 'elements' ) );
+
+	try {
+		$data           = array_merge(
+			wp_array_slice_assoc( $request->get_params(), array( 'viewport', 'elements' ) ),
+			array(
+				'timestamp' => microtime( true ),
+			)
+		);
+		$new_url_metric = new ILO_URL_Metric(
+			$data,
+			true // Already validated via REST API.
+		);
+	} catch ( Exception $e ) {
+		return new WP_Error(
+			'url_metric_exception',
+			__( 'Exception occurred while creating URL metric.', 'performance-lab' )
+		);
+	}
 
 	$result = ilo_store_url_metric(
 		$request->get_param( 'url' ),

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -86,6 +86,7 @@ function ilo_register_endpoint() {
 		ILO_URL_METRICS_ROUTE,
 		array(
 			'methods'             => 'POST',
+			'args'                => $args,
 			'callback'            => static function ( WP_REST_Request $request ) {
 				return ilo_handle_rest_request( $request );
 			},
@@ -100,7 +101,6 @@ function ilo_register_endpoint() {
 				}
 				return true;
 			},
-			'args'                => $args,
 		)
 	);
 }
@@ -148,17 +148,16 @@ function ilo_handle_rest_request( WP_REST_Request $request ) {
 	ilo_set_url_metric_storage_lock();
 
 	try {
-		$data           = array_merge(
-			wp_array_slice_assoc(
-				$request->get_params(),
-				array_keys( ILO_URL_Metric::get_json_schema()['properties'] )
-			),
-			array(
-				'timestamp' => microtime( true ),
-			)
-		);
 		$new_url_metric = new ILO_URL_Metric(
-			$data,
+			array_merge(
+				wp_array_slice_assoc(
+					$request->get_params(),
+					array_keys( ILO_URL_Metric::get_json_schema()['properties'] )
+				),
+				array(
+					'timestamp' => microtime( true ),
+				)
+			),
 			true // Already validated via REST API.
 		);
 	} catch ( Exception $e ) {

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -145,7 +145,10 @@ function ilo_handle_rest_request( WP_REST_Request $request ) {
 
 	try {
 		$data           = array_merge(
-			wp_array_slice_assoc( $request->get_params(), array( 'viewport', 'elements' ) ),
+			wp_array_slice_assoc(
+				$request->get_params(),
+				array_keys( ILO_URL_Metric::get_json_schema()['properties'] )
+			),
 			array(
 				'timestamp' => microtime( true ),
 			)

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -163,7 +163,11 @@ function ilo_handle_rest_request( WP_REST_Request $request ) {
 	} catch ( Exception $e ) {
 		return new WP_Error(
 			'url_metric_exception',
-			__( 'Exception occurred while creating URL metric.', 'performance-lab' )
+			sprintf(
+				/* translators: %s is exception name */
+				__( 'Failed to validate URL metric: %s', 'performance-lab' ),
+				$e->getMessage()
+			)
 		);
 	}
 

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -157,10 +157,9 @@ function ilo_handle_rest_request( WP_REST_Request $request ) {
 				array(
 					'timestamp' => microtime( true ),
 				)
-			),
-			true // Already validated via REST API.
+			)
 		);
-	} catch ( Exception $e ) {
+	} catch ( ILO_Data_Validation_Exception $e ) {
 		return new WP_Error(
 			'url_metric_exception',
 			sprintf(

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -75,6 +75,10 @@ function ilo_register_endpoint() {
 
 	$schema = ILO_URL_Metric::get_json_schema();
 
+	// Make timestamp not required since it is forcibly-provided in ilo_handle_rest_request().
+	$schema['properties']['timestamp']['required'] = false;
+	$schema['properties']['timestamp']['readonly'] = true;
+
 	$args = array_merge( $args, $schema['properties'] );
 
 	register_rest_route(

--- a/modules/images/image-loading-optimization/storage/rest-api.php
+++ b/modules/images/image-loading-optimization/storage/rest-api.php
@@ -73,16 +73,15 @@ function ilo_register_endpoint() {
 		),
 	);
 
-	$schema = ILO_URL_Metric::get_json_schema();
-
-	$args = array_merge( $args, rest_get_endpoint_args_for_schema( $schema ) );
-
 	register_rest_route(
 		ILO_REST_API_NAMESPACE,
 		ILO_URL_METRICS_ROUTE,
 		array(
 			'methods'             => 'POST',
-			'args'                => $args,
+			'args'                => array_merge(
+				$args,
+				rest_get_endpoint_args_for_schema( ILO_URL_Metric::get_json_schema() )
+			),
 			'callback'            => static function ( WP_REST_Request $request ) {
 				return ilo_handle_rest_request( $request );
 			},

--- a/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
@@ -6,6 +6,15 @@
  * @group   image-loading-optimization
  *
  * @coversDefaultClass ILO_HTML_Tag_Processor
+ *
+ * @noinspection HtmlUnknownTarget
+ * @noinspection HtmlRequiredTitleElement
+ * @noinspection HtmlRequiredAltAttribute
+ * @noinspection HtmlRequiredLangAttribute
+ * @noinspection HtmlDeprecatedTag
+ * @noinspection HtmlDeprecatedAttribute
+ * @noinspection HtmlExtraClosingTag
+ * @todo What are the other inspection IDs which can turn off inspections for the other irrelevant warnings? Remaining is "The tag is marked as deprecated."
  */
 class ILO_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 
@@ -26,7 +35,7 @@ class ILO_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 							<p>
 								Foo!
 								<br>
-								<img src="/foo.jpg" width="1000" height="600" alt="Foo">
+								<img src="https://example.com/foo.jpg" width="1000" height="600" alt="Foo">
 							</p>
 							<form><textarea>Write here!</textarea></form>
 							<footer>The end!</footer>
@@ -124,14 +133,14 @@ class ILO_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 							<embed>
 							<frame>
 							<hr>
-							<img>
+							<img src="">
 							<input>
 							<keygen>
 							<link>
 							<meta>
-							<param>
+							<param name="foo" value="bar">
 							<source>
-							<track>
+							<track src="https://example.com/track">
 							<wbr>
 
 							<!-- The following are not void -->

--- a/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-html-tag-processor-tests.php
@@ -7,7 +7,6 @@
  *
  * @coversDefaultClass ILO_HTML_Tag_Processor
  *
- * @noinspection HtmlUnknownTarget
  * @noinspection HtmlRequiredTitleElement
  * @noinspection HtmlRequiredAltAttribute
  * @noinspection HtmlRequiredLangAttribute

--- a/tests/modules/images/image-loading-optimization/class-ilo-url-metric-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-url-metric-tests.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for image-loading-optimization class ILO_URL_Metric.
+ *
+ * @package performance-lab
+ * @group   image-loading-optimization
+ *
+ * @coversDefaultClass ILO_URL_Metric
+ */
+class ILO_URL_Metric_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array
+	 */
+	public function data_provider(): array {
+		$viewport = array(
+			'width'  => 640,
+			'height' => 480,
+		);
+
+		return array(
+			'valid_minimal'          => array(
+				'data' => array(
+					'viewport'  => $viewport,
+					'timestamp' => microtime( true ),
+					'elements'  => array(),
+				),
+			),
+			'valid_with_element'     => array(
+				'data' => array(
+					'viewport'  => $viewport,
+					'timestamp' => microtime( true ),
+					'elements'  => array(
+						array(
+							'isLCP'             => true,
+							'isLCPCandidate'    => true,
+							'xpath'             => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+							'intersectionRatio' => 1.0,
+						),
+					),
+				),
+			),
+			'missing_viewport'       => array(
+				'data'  => array(
+					'timestamp' => microtime( true ),
+					'elements'  => array(),
+				),
+				'error' => 'viewport is a required property of ILO_URL_Metric.',
+			),
+			'missing_viewport_width' => array(
+				'data'  => array(
+					'viewport'  => array( 'height' => 640 ),
+					'timestamp' => microtime( true ),
+					'elements'  => array(),
+				),
+				'error' => 'width is a required property of ILO_URL_Metric[viewport].',
+			),
+			'bad_viewport'           => array(
+				'data'  => array(
+					'viewport'  => array(
+						'height' => 'tall',
+						'width'  => 'wide',
+					),
+					'timestamp' => microtime( true ),
+					'elements'  => array(),
+				),
+				'error' => 'ILO_URL_Metric[viewport][height] is not of type integer.',
+			),
+			'missing_timestamp'      => array(
+				'data'  => array(
+					'viewport' => $viewport,
+					'elements' => array(),
+				),
+				'error' => 'timestamp is a required property of ILO_URL_Metric.',
+			),
+			'missing_elements'       => array(
+				'data'  => array(
+					'viewport'  => $viewport,
+					'timestamp' => microtime( true ),
+				),
+				'error' => 'elements is a required property of ILO_URL_Metric.',
+			),
+			'bad_elements'           => array(
+				'data'  => array(
+					'viewport'  => $viewport,
+					'timestamp' => microtime( true ),
+					'elements'  => array(
+						array(
+							'isElSeePee' => true,
+						),
+					),
+				),
+				'error' => 'isLCP is a required property of ILO_URL_Metric[elements][0].',
+			),
+		);
+	}
+
+	/**
+	 * Tests construction.
+	 *
+	 * @covers ::get_viewport
+	 * @covers ::get_timestamp
+	 * @covers ::get_elements
+	 * @covers ::jsonSerialize
+	 *
+	 * @dataProvider data_provider
+	 */
+	public function test_constructor( array $data, string $error = '' ) {
+		if ( $error ) {
+			$this->expectException( Exception::class );
+			$this->expectExceptionMessage( $error );
+		}
+		$url_metric = new ILO_URL_Metric( $data );
+		$this->assertSame( $data['viewport'], $url_metric->get_viewport() );
+		$this->assertSame( $data['timestamp'], $url_metric->get_timestamp() );
+		$this->assertSame( $data['elements'], $url_metric->get_elements() );
+		$this->assertEquals( $data, $url_metric->jsonSerialize() );
+	}
+
+	/**
+	 * Tests get_json_schema().
+	 *
+	 * @covers ::get_json_schema
+	 */
+	public function test_get_json_schema() {
+		$schema = ILO_URL_Metric::get_json_schema();
+		$this->assertArrayHasKey( 'properties', $schema );
+	}
+}

--- a/tests/modules/images/image-loading-optimization/class-ilo-url-metric-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-url-metric-tests.php
@@ -109,7 +109,7 @@ class ILO_URL_Metric_Tests extends WP_UnitTestCase {
 	 */
 	public function test_constructor( array $data, string $error = '' ) {
 		if ( $error ) {
-			$this->expectException( Exception::class );
+			$this->expectException( ILO_Data_Validation_Exception::class );
 			$this->expectExceptionMessage( $error );
 		}
 		$url_metric = new ILO_URL_Metric( $data );

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -4,12 +4,20 @@
  *
  * @package performance-lab
  * @group   image-loading-optimization
+ *
+ * @noinspection HtmlUnknownTarget
  */
 
 class ILO_Optimization_Tests extends WP_UnitTestCase {
 
+	/**
+	 * @var string
+	 */
 	private $original_request_uri;
 
+	/**
+	 * @var string
+	 */
 	private $original_request_method;
 
 	public function set_up() {
@@ -76,7 +84,6 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 				'set_up'   => function () {
 					$this->go_to( home_url( '/' ) );
 					global $wp_customize;
-					/** @noinspection PhpIncludeInspection */
 					require_once ABSPATH . 'wp-includes/class-wp-customize-manager.php';
 					$wp_customize = new WP_Customize_Manager();
 					$wp_customize->start_previewing_theme();
@@ -341,7 +348,7 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 							<title>...</title>
 						</head>
 						<body>
-							<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==">
+							<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==" alt="">
 						</body>
 					</html>
 				',
@@ -354,7 +361,7 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
-							<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==">
+							<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==" alt="">
 						</body>
 					</html>
 				',
@@ -369,8 +376,8 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 							<title>...</title>
 						</head>
 						<body>
-							<img id="no-src">
-							<img id="empty-src" src="">
+							<img id="no-src" alt="">
+							<img id="empty-src" src="" alt="">
 						</body>
 					</html>
 				',
@@ -382,8 +389,8 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
-							<img id="no-src">
-							<img id="empty-src" src="">
+							<img id="no-src" alt="">
+							<img id="empty-src" src="" alt="">
 						</body>
 					</html>
 				',
@@ -1011,6 +1018,7 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 	 *
 	 * @param int $viewport_width Viewport width for the URL metric.
 	 * @return ILO_URL_Metric URL metric.
+	 * @throws Exception From ILO_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width, array $elements = array() ): ILO_URL_Metric {
 		$data = array(

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -5,7 +5,6 @@
  * @package performance-lab
  * @group   image-loading-optimization
  *
- * @noinspection HtmlUnknownTarget
  * @todo There are "Cannot resolve ..." errors and "Element img doesn't have a required attribute src" warnings that should be excluded from inspection.
  */
 
@@ -156,47 +155,47 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 				'lcp_elements_by_minimum_viewport_widths' => array(
 					0 => array(
 						'img_attributes' => array(
-							'src'         => 'elva-fairy-800w.jpg',
-							'srcset'      => 'elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w',
+							'src'         => 'https://example.com/elva-fairy-800w.jpg',
+							'srcset'      => 'https://example.com/elva-fairy-480w.jpg 480w, https://example.com/elva-fairy-800w.jpg 800w',
 							'sizes'       => '(max-width: 600px) 480px, 800px',
 							'crossorigin' => 'anonymous',
 						),
 					),
 				),
 				'expected'                                => '
-					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="elva-fairy-800w.jpg" imagesrcset="elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen">
+					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/elva-fairy-800w.jpg" imagesrcset="https://example.com/elva-fairy-480w.jpg 480w, https://example.com/elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen">
 				',
 			),
 			'two-breakpoint-responsive-lcp-images'      => array(
 				'lcp_elements_by_minimum_viewport_widths' => array(
 					0   => array(
 						'img_attributes' => array(
-							'src'         => 'elva-fairy-800w.jpg',
-							'srcset'      => 'elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w',
+							'src'         => 'https://example.com/elva-fairy-800w.jpg',
+							'srcset'      => 'https://example.com/elva-fairy-480w.jpg 480w, https://example.com/elva-fairy-800w.jpg 800w',
 							'sizes'       => '(max-width: 600px) 480px, 800px',
 							'crossorigin' => 'anonymous',
 						),
 					),
 					601 => array(
 						'img_attributes' => array(
-							'src'         => 'alt-elva-fairy-800w.jpg',
-							'srcset'      => 'alt-elva-fairy-480w.jpg 480w, alt-elva-fairy-800w.jpg 800w',
+							'src'         => 'https://example.com/alt-elva-fairy-800w.jpg',
+							'srcset'      => 'https://example.com/alt-elva-fairy-480w.jpg 480w, https://example.com/alt-elva-fairy-800w.jpg 800w',
 							'sizes'       => '(max-width: 600px) 480px, 800px',
 							'crossorigin' => 'anonymous',
 						),
 					),
 				),
 				'expected'                                => '
-					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="elva-fairy-800w.jpg" imagesrcset="elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (max-width: 600px)">
-					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="alt-elva-fairy-800w.jpg" imagesrcset="alt-elva-fairy-480w.jpg 480w, alt-elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (min-width: 601px)">
+					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/elva-fairy-800w.jpg" imagesrcset="https://example.com/elva-fairy-480w.jpg 480w, https://example.com/elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (max-width: 600px)">
+					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/alt-elva-fairy-800w.jpg" imagesrcset="https://example.com/alt-elva-fairy-480w.jpg 480w, https://example.com/alt-elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (min-width: 601px)">
 				',
 			),
 			'two-non-consecutive-responsive-lcp-images' => array(
 				'lcp_elements_by_minimum_viewport_widths' => array(
 					0   => array(
 						'img_attributes' => array(
-							'src'         => 'elva-fairy-800w.jpg',
-							'srcset'      => 'elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w',
+							'src'         => 'https://example.com/elva-fairy-800w.jpg',
+							'srcset'      => 'https://example.com/elva-fairy-480w.jpg 480w, https://example.com/elva-fairy-800w.jpg 800w',
 							'sizes'       => '(max-width: 600px) 480px, 800px',
 							'crossorigin' => 'anonymous',
 						),
@@ -204,16 +203,16 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 					481 => false,
 					601 => array(
 						'img_attributes' => array(
-							'src'         => 'alt-elva-fairy-800w.jpg',
-							'srcset'      => 'alt-elva-fairy-480w.jpg 480w, alt-elva-fairy-800w.jpg 800w',
+							'src'         => 'https://example.com/alt-elva-fairy-800w.jpg',
+							'srcset'      => 'https://example.com/alt-elva-fairy-480w.jpg 480w, https://example.com/alt-elva-fairy-800w.jpg 800w',
 							'sizes'       => '(max-width: 600px) 480px, 800px',
 							'crossorigin' => 'anonymous',
 						),
 					),
 				),
 				'expected'                                => '
-					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="elva-fairy-800w.jpg" imagesrcset="elva-fairy-480w.jpg 480w, elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (max-width: 480px)">
-					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="alt-elva-fairy-800w.jpg" imagesrcset="alt-elva-fairy-480w.jpg 480w, alt-elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (min-width: 601px)">
+					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/elva-fairy-800w.jpg" imagesrcset="https://example.com/elva-fairy-480w.jpg 480w, https://example.com/elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (max-width: 480px)">
+					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/alt-elva-fairy-800w.jpg" imagesrcset="https://example.com/alt-elva-fairy-480w.jpg 480w, https://example.com/alt-elva-fairy-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (min-width: 601px)">
 				',
 			),
 			'one-background-lcp-image'                  => array(
@@ -244,8 +243,8 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 				'lcp_elements_by_minimum_viewport_widths' => array(
 					0   => array(
 						'img_attributes' => array(
-							'src'         => 'mobile-800w.jpg',
-							'srcset'      => 'mobile-480w.jpg 480w, mobile-800w.jpg 800w',
+							'src'         => 'https://example.com/mobile-800w.jpg',
+							'srcset'      => 'https://example.com/mobile-480w.jpg 480w, https://example.com/mobile-800w.jpg 800w',
 							'sizes'       => '(max-width: 600px) 480px, 800px',
 							'crossorigin' => 'anonymous',
 						),
@@ -255,7 +254,7 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 					),
 				),
 				'expected'                                => '
-					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="mobile-800w.jpg" imagesrcset="mobile-480w.jpg 480w, mobile-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (max-width: 480px)">
+					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-800w.jpg" imagesrcset="https://example.com/mobile-480w.jpg 480w, https://example.com/mobile-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous" media="screen and (max-width: 480px)">
 					<link data-ilo-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop.jpg" media="screen and (min-width: 481px)">
 				',
 			),

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -6,6 +6,7 @@
  * @group   image-loading-optimization
  *
  * @noinspection HtmlUnknownTarget
+ * @todo There are "Cannot resolve ..." errors and "Element img doesn't have a required attribute src" warnings that should be excluded from inspection.
  */
 
 class ILO_Optimization_Tests extends WP_UnitTestCase {

--- a/tests/modules/images/image-loading-optimization/optimization-tests.php
+++ b/tests/modules/images/image-loading-optimization/optimization-tests.php
@@ -1010,15 +1010,16 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 	 * Gets a validated URL metric.
 	 *
 	 * @param int $viewport_width Viewport width for the URL metric.
-	 * @return array URL metric.
+	 * @return ILO_URL_Metric URL metric.
 	 */
-	private function get_validated_url_metric( int $viewport_width, array $elements = array() ): array {
-		return array(
-			'viewport' => array(
+	private function get_validated_url_metric( int $viewport_width, array $elements = array() ): ILO_URL_Metric {
+		$data = array(
+			'viewport'  => array(
 				'width'  => $viewport_width,
 				'height' => 800,
 			),
-			'elements' => array_map(
+			'timestamp' => microtime( true ),
+			'elements'  => array_map(
 				static function ( array $element ): array {
 					return array_merge(
 						array(
@@ -1031,6 +1032,7 @@ class ILO_Optimization_Tests extends WP_UnitTestCase {
 				$elements
 			),
 		);
+		return new ILO_URL_Metric( $data );
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/storage/data-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/data-tests.php
@@ -346,9 +346,9 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 
 			$this->assertIsArray( $grouped_url_metrics[ $minimum_viewport_width ] );
 			foreach ( $grouped_url_metrics[ $minimum_viewport_width ] as $url_metric ) {
-				$this->assertGreaterThanOrEqual( $minimum_viewport_width, $url_metric->get_viewport_width() );
+				$this->assertGreaterThanOrEqual( $minimum_viewport_width, $url_metric->get_viewport()['width'] );
 				if ( isset( $maximum_viewport_width ) ) {
-					$this->assertLessThanOrEqual( $maximum_viewport_width, $url_metric->get_viewport_width() );
+					$this->assertLessThanOrEqual( $maximum_viewport_width, $url_metric->get_viewport()['width'] );
 				}
 			}
 		}

--- a/tests/modules/images/image-loading-optimization/storage/data-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/data-tests.php
@@ -4,10 +4,15 @@
  *
  * @package performance-lab
  * @group   image-loading-optimization
+ *
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 
+	/**
+	 * @var string
+	 */
 	private $original_request_uri;
 
 	public function set_up() {
@@ -344,7 +349,6 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 				$this->assertLessThan( $maximum_viewport_width, $minimum_viewport_width );
 			}
 
-			$this->assertIsArray( $grouped_url_metrics[ $minimum_viewport_width ] );
 			foreach ( $grouped_url_metrics[ $minimum_viewport_width ] as $url_metric ) {
 				$this->assertGreaterThanOrEqual( $minimum_viewport_width, $url_metric->get_viewport()['width'] );
 				if ( isset( $maximum_viewport_width ) ) {
@@ -553,7 +557,9 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 	 * @param int      $viewport_width Viewport width.
 	 * @param string[] $breadcrumbs    Breadcrumb tags.
 	 * @param bool     $is_lcp         Whether LCP.
+	 *
 	 * @return ILO_URL_Metric Validated URL metric.
+	 * @throws Exception From ILO_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width = 480, array $breadcrumbs = array( 'HTML', 'BODY', 'IMG' ), bool $is_lcp = true ): ILO_URL_Metric {
 		$data = array(

--- a/tests/modules/images/image-loading-optimization/storage/data-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/data-tests.php
@@ -215,10 +215,15 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 
 		// Make sure that ilo_unshift_url_metrics() added a timestamp and then force them to all be old.
 		$all_url_metrics = array_map(
-			function ( $url_metric ) use ( $old_timestamp ) {
-				$this->assertArrayHasKey( 'timestamp', $url_metric, 'Expected a timestamp to have been added to a URL metric.' );
-				$url_metric['timestamp'] = $old_timestamp;
-				return $url_metric;
+			static function ( $url_metric ) use ( $old_timestamp ): ILO_URL_Metric {
+				return new ILO_URL_Metric(
+					array_merge(
+						$url_metric->jsonSerialize(),
+						array(
+							'timestamp' => $old_timestamp,
+						)
+					)
+				);
 			},
 			$all_url_metrics
 		);
@@ -239,7 +244,7 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 		);
 		$new_count = 0;
 		foreach ( $all_url_metrics as $url_metric ) {
-			if ( $url_metric['timestamp'] > $old_timestamp ) {
+			if ( $url_metric->get_timestamp() > $old_timestamp ) {
 				++$new_count;
 			}
 		}
@@ -341,9 +346,9 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 
 			$this->assertIsArray( $grouped_url_metrics[ $minimum_viewport_width ] );
 			foreach ( $grouped_url_metrics[ $minimum_viewport_width ] as $url_metric ) {
-				$this->assertGreaterThanOrEqual( $minimum_viewport_width, $url_metric['viewport']['width'] );
+				$this->assertGreaterThanOrEqual( $minimum_viewport_width, $url_metric->get_viewport_width() );
 				if ( isset( $maximum_viewport_width ) ) {
-					$this->assertLessThanOrEqual( $maximum_viewport_width, $url_metric['viewport']['width'] );
+					$this->assertLessThanOrEqual( $maximum_viewport_width, $url_metric->get_viewport_width() );
 				}
 			}
 		}
@@ -462,12 +467,22 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 					array_fill(
 						0,
 						3,
-						array_merge( $this->get_validated_url_metric( 400 ), array( 'timestamp' => $current_time ) )
+						new ILO_URL_Metric(
+							array_merge(
+								$this->get_validated_url_metric( 400 )->jsonSerialize(),
+								array( 'timestamp' => $current_time )
+							)
+						)
 					),
 					array_fill(
 						0,
 						3,
-						array_merge( $this->get_validated_url_metric( 600 ), array( 'timestamp' => $current_time ) )
+						new ILO_URL_Metric(
+							array_merge(
+								$this->get_validated_url_metric( 600 )->jsonSerialize(),
+								array( 'timestamp' => $current_time )
+							)
+						)
 					)
 				);
 			} )(),
@@ -503,7 +518,9 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 
 			'url-metric-too-old'     => array_merge(
 				( static function ( $data ): array {
-					$data['url_metrics'][0]['timestamp'] -= $data['freshness_ttl'] + 1;
+					$url_metrics_data = $data['url_metrics'][0]->jsonSerialize();
+					$url_metrics_data['timestamp'] -= $data['freshness_ttl'] + 1;
+					$data['url_metrics'][0] = new ILO_URL_Metric( $url_metrics_data );
 					return $data;
 				} )( $none_needed_data ),
 				array(
@@ -536,15 +553,16 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 	 * @param int      $viewport_width Viewport width.
 	 * @param string[] $breadcrumbs    Breadcrumb tags.
 	 * @param bool     $is_lcp         Whether LCP.
-	 * @return array Validated URL metric.
+	 * @return ILO_URL_Metric Validated URL metric.
 	 */
-	private function get_validated_url_metric( int $viewport_width = 480, array $breadcrumbs = array( 'HTML', 'BODY', 'IMG' ), bool $is_lcp = true ): array {
-		return array(
-			'viewport' => array(
+	private function get_validated_url_metric( int $viewport_width = 480, array $breadcrumbs = array( 'HTML', 'BODY', 'IMG' ), bool $is_lcp = true ): ILO_URL_Metric {
+		$data = array(
+			'viewport'  => array(
 				'width'  => $viewport_width,
 				'height' => 640,
 			),
-			'elements' => array(
+			'timestamp' => microtime( true ),
+			'elements'  => array(
 				array(
 					'isLCP'             => $is_lcp,
 					'isLCPCandidate'    => $is_lcp,
@@ -553,6 +571,7 @@ class ILO_Storage_Data_Tests extends WP_UnitTestCase {
 				),
 			),
 		);
+		return new ILO_URL_Metric( $data );
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
@@ -62,7 +62,7 @@ class ILO_Storage_Post_Type_Tests extends WP_UnitTestCase {
 					'width'  => 640,
 					'height' => 480,
 				),
-				'timestamp' => microtime( true ),
+				'timestamp' => (int) microtime( true ), // Integer to facilitate equality tests.
 				'elements'  => array(),
 			),
 		);

--- a/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
@@ -101,7 +101,13 @@ class ILO_Storage_Post_Type_Tests extends WP_UnitTestCase {
 			)
 		);
 
-		$url_metrics = ilo_parse_stored_url_metrics( $post );
+		$url_metrics = array_map(
+			static function ( ILO_URL_Metric $url_metric ): array {
+				return $url_metric->jsonSerialize();
+			},
+			ilo_parse_stored_url_metrics( $post )
+		);
+
 		$this->assertSame( $expected_value, $url_metrics );
 	}
 
@@ -114,19 +120,22 @@ class ILO_Storage_Post_Type_Tests extends WP_UnitTestCase {
 		$url  = home_url( '/' );
 		$slug = ilo_get_url_metrics_slug( array( 'p' => 1 ) );
 
-		$validated_url_metric = array(
-			'viewport' => array(
-				'width'  => 480,
-				'height' => 640,
-			),
-			'elements' => array(
-				array(
-					'isLCP'             => true,
-					'isLCPCandidate'    => true,
-					'xpath'             => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
-					'intersectionRatio' => 1,
+		$validated_url_metric = new ILO_URL_Metric(
+			array(
+				'viewport'  => array(
+					'width'  => 480,
+					'height' => 640,
 				),
-			),
+				'timestamp' => microtime( true ),
+				'elements'  => array(
+					array(
+						'isLCP'             => true,
+						'isLCPCandidate'    => true,
+						'xpath'             => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
+						'intersectionRatio' => 1,
+					),
+				),
+			)
 		);
 
 		$post_id = ilo_store_url_metric( $url, $slug, $validated_url_metric );
@@ -138,22 +147,11 @@ class ILO_Storage_Post_Type_Tests extends WP_UnitTestCase {
 
 		$url_metrics = ilo_parse_stored_url_metrics( $post );
 		$this->assertCount( 1, $url_metrics );
-		$this->assertArrayHasKey( 'timestamp', $url_metrics[0] );
-		$this->assertIsFloat( $url_metrics[0]['timestamp'] );
-		$this->assertLessThanOrEqual( microtime( true ), $url_metrics[0]['timestamp'] );
 
 		$again_post_id = ilo_store_url_metric( $url, $slug, $validated_url_metric );
 		$post          = get_post( $again_post_id );
 		$this->assertSame( $post_id, $again_post_id );
 		$url_metrics = ilo_parse_stored_url_metrics( $post );
 		$this->assertCount( 2, $url_metrics );
-
-		foreach ( $url_metrics as $url_metric ) {
-			$this->assertArrayHasKey( 'timestamp', $url_metric );
-			$this->assertIsFloat( $url_metric['timestamp'] );
-			$this->assertLessThanOrEqual( microtime( true ), $url_metric['timestamp'] );
-			unset( $url_metric['timestamp'] );
-			$this->assertSame( $validated_url_metric, $url_metric );
-		}
 	}
 }

--- a/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
@@ -4,6 +4,8 @@
  *
  * @package performance-lab
  * @group   image-loading-optimization
+ *
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 class ILO_Storage_Post_Type_Tests extends WP_UnitTestCase {

--- a/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/post-type-tests.php
@@ -58,11 +58,12 @@ class ILO_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	public function data_provider_test_ilo_parse_stored_url_metrics(): array {
 		$valid_content = array(
 			array(
-				'viewport' => array(
+				'viewport'  => array(
 					'width'  => 640,
 					'height' => 480,
 				),
-				'elements' => array(),
+				'timestamp' => microtime( true ),
+				'elements'  => array(),
 			),
 		);
 

--- a/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
@@ -44,7 +44,7 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 		$this->assertInstanceOf( WP_Post::class, $post );
 
 		$url_metrics = ilo_parse_stored_url_metrics( $post );
-		$this->assertCount( 1, $url_metrics );
+		$this->assertCount( 1, $url_metrics, 'Expected number of URL metrics stored.' );
 		foreach ( array( 'viewport', 'elements' ) as $key ) {
 			$this->assertSame( $valid_params[ $key ], $url_metrics[0][ $key ] );
 		}
@@ -139,8 +139,8 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
 		$request->set_body_params( $params );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 400, $response->get_status() );
-		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] );
+		$this->assertSame( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'], 'Response: ' . wp_json_encode( $response ) );
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
@@ -34,7 +34,7 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 		$this->assertCount( 0, get_posts( array( 'post_type' => ILO_URL_METRICS_POST_TYPE ) ) );
 		$request->set_body_params( $valid_params );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 200, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
 
 		$data = $response->get_data();
 		$this->assertTrue( $data['success'] );
@@ -222,7 +222,7 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 */
 	private function get_valid_params(): array {
 		$slug = ilo_get_url_metrics_slug( array() );
-		return array_merge(
+		$data = array_merge(
 			array(
 				'url'   => home_url( '/' ),
 				'slug'  => $slug,
@@ -230,6 +230,8 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 			),
 			$this->get_sample_validated_url_metric()
 		);
+		unset( $data['timestamp'] ); // Since provided by request handler.
+		return $data;
 	}
 
 	/**
@@ -239,11 +241,12 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 */
 	private function get_sample_validated_url_metric(): array {
 		return array(
-			'viewport' => array(
+			'viewport'  => array(
 				'width'  => 480,
 				'height' => 640,
 			),
-			'elements' => array(
+			'timestamp' => microtime( true ),
+			'elements'  => array(
 				array(
 					'isLCP'             => true,
 					'isLCPCandidate'    => true,

--- a/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
@@ -46,7 +46,7 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 		$url_metrics = ilo_parse_stored_url_metrics( $post );
 		$this->assertCount( 1, $url_metrics, 'Expected number of URL metrics stored.' );
 		$this->assertSame( $valid_params['elements'], $url_metrics[0]->get_elements() );
-		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport_width() );
+		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport()['width'] );
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
@@ -45,10 +45,8 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 
 		$url_metrics = ilo_parse_stored_url_metrics( $post );
 		$this->assertCount( 1, $url_metrics, 'Expected number of URL metrics stored.' );
-		foreach ( array( 'viewport', 'elements' ) as $key ) {
-			$this->assertSame( $valid_params[ $key ], $url_metrics[0][ $key ] );
-		}
-		$this->assertArrayHasKey( 'timestamp', $url_metrics[0] );
+		$this->assertSame( $valid_params['elements'], $url_metrics[0]->get_elements() );
+		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport_width() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This implements these aspects of #933:

> Introduce class to represent a single URL metric (e.g. `ILO_URL_Metric`).
> * This would mostly be a value object with properties like `url`, `slug`, `viewport`, `elements`.
> * The class could potentially have private logic to take care of validation.
> * The `elements` entry may deserve some further thought, particularly around how it could work considering additional use-cases than LCP elements in the future.

> * Functions that today return an array of URL metric associative arrays should going forward return an array of URL metric class instances (e.g. `ilo_parse_stored_url_metrics()`).

Subsequent points will be addressed in follow-up PRs.

## Relevant technical choices

* A new class called `ILO_URL_Metric` is used instead of passing around an array of the same data.
* The `ILO_URL_Metric` class contains the validation logic to ensure that the data is as expected.
* The REST API route re-uses the JSON schema defined in the `ILO_URL_Metric` class to validate requests.
* The `ILO_URL_Metric` class now requires that a `timestamp` be provided at construction time, which removes this concern from `ilo_unshift_url_metrics()`.
* Validation logic is applied to the URL metrics pulled from the `ilo_url_metrics` post type. This ensures that if the data format changes, any prior entries will just be omitted.
* Static analysis is further improved with typing and addressing various inspection issues flagged by PhpStorm.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
