### PR TITLE
Remove hard-coded PHPStan config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
   "scripts": {
     "post-install-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8.1+. You are running: '; php -v;  fi",
     "post-update-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8.1+. You are running: '; php -v; fi",
-    "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M -c phpstan.neon.dist",
+    "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M",
     "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
     "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",
     "test": "phpunit -c phpunit.xml.dist --verbose",


### PR DESCRIPTION
## Summary

Removing the hard-coded path to `phpstan.neon.dist` allows for PHPStan to pick the config file, allowing for local overrides. For example, I am using a stricter PHPStan config than is currently committed to the project. I have this config in `phpstan.neon` and [according to the PHPStan docs](https://phpstan.org/config-reference#:~:text=If%20you%20do%20not%20provide%20a%20config%20file%20explicitly), this should be chosen by PHPStan over the `phpstan.neon.dist`: 

<blockquote>
<p>If you do not provide a config file explicitly, PHPStan will look for files named <code>phpstan.neon</code>, <code>phpstan.neon.dist</code>, or <code>phpstan.dist.neon</code> in the current directory.</p>
<p>The resolution priority is as such:</p>
<ol> <li>If config file is provided as a command line option, it will be used.</li> <li>Otherwise, if <code>phpstan.neon</code> exists in the current working directory, it will be used.</li> <li>Otherwise, if <code>phpstan.neon.dist</code> exists in the current working directory, it will be used.</li> <li>Otherwise, if <code>phpstan.dist.neon</code> exists in the current working directory, it will be used.</li> <li>If none of the above is true, no config will be used.</li> </ol>
</blockquote>

This is not working at present, however, because the `phpstan.neon.dist` is the hard-coded config path.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
