### PR TITLE
Add support for manually running the PHPUnit workflow.

### DIFF
--- a/.github/workflows/php-test.yml
+++ b/.github/workflows/php-test.yml
@@ -36,6 +36,7 @@ on:
       - opened
       - reopened
       - synchronize
+  workflow_dispatch:
 
 jobs:
   php-test:


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
This adds a `workflow_dispatch` trigger to the Unit Testing workflow.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
