### PR TITLE
Remove PHPUnit and PHPCS config file path from composer scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ vendor/
 .DS_store?
 
 ############
-## CS and tools
+## CS tools
 ############
 phpcs.xml
 phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ vendor/
 .DS_store?
 
 ############
+## CS and tools
+############
+phpcs.xml
+phpunit.xml
+phpstan.neon
+
+############
 ## Misc
 ############
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,7 @@ vendor/
 .DS_store?
 
 ############
-## CS tools
+## Config overrides for CS tools
 ############
 phpcs.xml
 phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "post-install-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs install --no-interaction; else echo 'Skipping composer install for build-cs since not on PHP 8.1+. You are running: '; php -v;  fi",
     "post-update-cmd": "if php -r 'exit( version_compare( phpversion(), \"8.1\", \">=\" ) ? 0 : 1 );'; then composer --working-dir=build-cs update --no-interaction; else echo 'Skipping composer update for build-cs since not on PHP 8.1+. You are running: '; php -v; fi",
     "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M",
-    "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
-    "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",
+    "format": "build-cs/vendor/bin/phpcbf --report-summary --report-source",
+    "lint": "build-cs/vendor/bin/phpcs",
     "test": "phpunit --verbose",
     "test-multisite": "phpunit -c tests/multisite.xml --verbose"
   },

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "phpstan": "build-cs/vendor/bin/phpstan analyse --memory-limit=2048M",
     "format": "build-cs/vendor/bin/phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
     "lint": "build-cs/vendor/bin/phpcs --standard=phpcs.xml.dist",
-    "test": "phpunit -c phpunit.xml.dist --verbose",
+    "test": "phpunit --verbose",
     "test-multisite": "phpunit -c tests/multisite.xml --verbose"
   },
   "config": {


### PR DESCRIPTION
## Summary

Previously: https://github.com/WordPress/performance/pull/989

Remove hard-coded config file paths to let the tools decide which config to load on the user machine. With this, the following tools will be able to:
- PHPCS will be able to prioritize `phpcs.xml` over `phpcs.xml.dist` if present locally.
- PHPUnit will be able to prioritize `phpunit.xml` over `phpunit.xml.dist` if present locally.

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
