### PR TITLE
Fix unit test for Multisite

### DIFF
--- a/tests/multisite.xml
+++ b/tests/multisite.xml
@@ -10,9 +10,13 @@
 		<const name="WP_TESTS_MULTISITE" value="1" />
 	</php>
 	<testsuites>
-		<testsuite name="default">
+		<testsuite name="performance-lab">
 			<directory suffix=".php">./</directory>
-    		<exclude>./utils</exclude>
+			<exclude>./utils</exclude>
+			<exclude>./plugins</exclude>
+		</testsuite>
+		<testsuite name="auto-sizes">
+			<directory suffix=".php">./plugins/auto-sizes</directory>
 		</testsuite>
 	</testsuites>
 	<groups>


### PR DESCRIPTION
## Summary

In #956, we introduced a test suite for plugins, updating only the `phpunit.xml.dist` file. However, we missed updating the multisite config file `tests/multisite.xml`, causing it to show "No tests executed!" without an error. This PR adds the missing configuration for the multisite test suite. Thanks to @thelovekesh for spotting this oversight.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
