### PR TITLE
Add shortcuts to simplify running PHPUnit tests for standalone plugins

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -72,7 +72,7 @@ jobs:
         # PHP that the composer.lock was created for.
       - name: Composer update
         run: npm run wp-env run tests-cli -- --env-cwd="wp-content/plugins/$(basename $(pwd))" composer update --no-interaction
-      - name: Running single site unit tests for Auto-sizes for Lazy-Loaded Images Plugin
-        run: npm run test-php -- -- -- --testsuite auto-sizes
-      - name: Running multisite unit tests for Auto-sizes for Lazy-Loaded Images Plugin
-        run: npm run test-php-multisite -- -- -- --testsuite auto-sizes
+      - name: Running single site unit tests for plugins
+        run: npm run test-php-plugins
+      - name: Running multisite unit tests for plugins
+        run: npm run test-php-multisite-plugins

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,23 @@
     "format": "build-cs/vendor/bin/phpcbf --report-summary --report-source",
     "lint": "build-cs/vendor/bin/phpcs",
     "test": "phpunit --verbose --testsuite performance-lab",
-    "test-multisite": "phpunit -c tests/multisite.xml --verbose --testsuite performance-lab"
+    "test-multisite": "phpunit -c tests/multisite.xml --verbose --testsuite performance-lab",
+    "test:all": [
+      "@test",
+      "@test:plugins"
+    ],
+    "test-multisite:all": [
+      "@test-multisite",
+      "@test-multisite:plugins"
+    ],
+    "test:plugins": [
+      "@test:auto-sizes"
+    ],
+    "test-multisite:plugins": [
+      "@test-multisite:auto-sizes"
+    ],
+    "test:auto-sizes": "phpunit --verbose --testsuite auto-sizes",
+    "test-multisite:auto-sizes": "phpunit -c tests/multisite.xml --verbose --testsuite auto-sizes"
   },
   "config": {
     "allow-plugins": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "lint-php": "composer lint",
     "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer test",
     "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer test-multisite",
+    "test-php-plugins": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer test:plugins",
+    "test-php-multisite-plugins": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/$(basename $(pwd)) composer test-multisite:plugins",
     "wp-env": "wp-env",
     "prepare": "husky install"
   },


### PR DESCRIPTION
## Summary

See https://github.com/WordPress/performance/pull/946#discussion_r1504874287: This PR adds shortcuts to simplify running PHPUnit tests for the new standalone plugins in a way that the new plugins only have to be added to `composer.json` and are then easy to test.

The way the shortcuts are defined is heavily inspired by #1002.

## Usage
* `composer test:auto-sizes`: Tests the Auto Sizes plugin on single site.
* `composer test-multisite:auto-sizes`: Tests the Auto Sizes plugin on multisite.
* `composer test:plugins`: Tests all standalone plugins on single site.
* `composer test-multisite:plugins`: Tests all standalone plugins on multisite.
* `composer test:all`: Tests all standalone plugins plus Performance Lab on single site.
* `composer test-multisite:all`: Tests all standalone plugins plus Performance Lab on multisite.

There's also an NPM shortcut specifically for the GitHub workflow to test all standalone plugins:
* `npm run test-php-plugins`: Wraps `composer test:plugins`.
* `npm run test-php-multisite-plugins`: Wraps `composer test-multisite:plugins`.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
