### PR TITLE
Add caching to the wordpress.org query to get plugin information.

### DIFF
--- a/admin/plugins.php
+++ b/admin/plugins.php
@@ -18,6 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array Array of plugin data, or empty if none/error.
  */
 function perflab_query_plugin_info( string $plugin_slug ) {
+	$plugin = get_transient( 'perflab_plugin_info_' . $plugin_slug );
+
+	if ( $plugin ) {
+		return $plugin;
+	}
+
 	$plugin = plugins_api(
 		'plugin_information',
 		array(
@@ -36,6 +42,8 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	if ( is_object( $plugin ) ) {
 		$plugin = (array) $plugin;
 	}
+
+	set_transient( 'perflab_plugin_info_' . $plugin_slug, $plugin, HOUR_IN_SECONDS );
 
 	return $plugin;
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes https://github.com/WordPress/performance/issues/1015

## Relevant technical choices

<!-- Please describe your changes. -->

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
