### PR TITLE
Allow excluding URL patterns from prerendering or prefetching specifically

### DIFF
--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -17,6 +17,21 @@
  * @return array Associative array of speculation rules by type.
  */
 function plsr_get_speculation_rules() {
+	$option = get_option( 'plsr_speculation_rules' );
+
+	/*
+	 * This logic is only relevant for edge-cases where the setting may not be registered,
+	 * a.k.a. defensive coding.
+	 */
+	if ( ! $option || ! is_array( $option ) ) {
+		$option = plsr_get_setting_default();
+	} else {
+		$option = array_merge( plsr_get_setting_default(), $option );
+	}
+
+	$mode      = $option['mode'];
+	$eagerness = $option['eagerness'];
+
 	$prefixer = new PLSR_URL_Pattern_Prefixer();
 
 	$base_href_exclude_paths = array(
@@ -34,10 +49,12 @@ function plsr_get_speculation_rules() {
 	 * If the WordPress site is in a subdirectory, the exclude paths will automatically be prefixed as necessary.
 	 *
 	 * @since 1.0.0
+	 * @since 1.1.0 The $mode parameter was added.
 	 *
-	 * @param array $href_exclude_paths Paths to disable speculative prerendering for.
+	 * @param array  $href_exclude_paths Paths to disable speculative prerendering for.
+	 * @param string $mode               Mode used to apply speculative prerendering. Either 'prefetch' or 'prerender'.
 	 */
-	$href_exclude_paths = (array) apply_filters( 'plsr_speculation_rules_href_exclude_paths', $href_exclude_paths );
+	$href_exclude_paths = (array) apply_filters( 'plsr_speculation_rules_href_exclude_paths', $href_exclude_paths, $mode );
 
 	// Ensure that there are no duplicates and that the base paths cannot be removed.
 	$href_exclude_paths = array_unique(
@@ -49,21 +66,6 @@ function plsr_get_speculation_rules() {
 			)
 		)
 	);
-
-	$option = get_option( 'plsr_speculation_rules' );
-
-	/*
-	 * This logic is only relevant for edge-cases where the setting may not be registered,
-	 * a.k.a. defensive coding.
-	 */
-	if ( ! $option || ! is_array( $option ) ) {
-		$option = plsr_get_setting_default();
-	} else {
-		$option = array_merge( plsr_get_setting_default(), $option );
-	}
-
-	$mode      = $option['mode'];
-	$eagerness = $option['eagerness'];
 
 	$rules = array(
 		array(

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Uses the Speculation Rules API to prerender linked URLs upon hover by default.
  * Requires at least: 6.3
  * Requires PHP: 7.0
- * Version: 1.0.1
+ * Version: 1.1.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -20,7 +20,7 @@ if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
 	return;
 }
 
-define( 'SPECULATION_RULES_VERSION', '1.0.1' );
+define( 'SPECULATION_RULES_VERSION', '1.1.0' );
 
 require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';
 require_once __DIR__ . '/helper.php';

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.3
 Tested up to:      6.4
 Requires PHP:      7.0
-Stable tag:        1.0.1
+Stable tag:        1.1.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, javascript, speculation rules, prerender, prefetch
@@ -63,6 +63,27 @@ add_filter(
 );
 `
 
+Keep in mind that sometimes it may be useful to exclude a URL from prerendering while still allowing it to be prefetched. For example, a page with client-side JavaScript to update user state should probably not be prerendered, but it would be reasonable to prefetch.
+
+For this purpose, the `plsr_speculation_rules_href_exclude_paths` filter receives the current mode (either "prefetch" or "prerender") to provide conditional exclusions.
+
+The following example would ensure that URLs like `https://example.com/products/...` cannot be prerendered, while still allowing them to be prefetched.
+`
+<?php
+
+add_filter(
+	'plsr_speculation_rules_href_exclude_paths',
+	function ( $exclude_paths, $mode ) {
+		if ( 'prerender' === $mode ) {
+			$exclude_paths[] = '/products/*';
+		}
+		return $exclude_paths;
+	},
+	10,
+	2
+);
+`
+
 = Where can I submit my plugin feedback? =
 
 Feedback is encouraged and much appreciated, especially since this plugin may contain future WordPress core features. If you have suggestions or requests for new features, you can [submit them as an issue in the WordPress Performance Team's GitHub repository](https://github.com/WordPress/performance/issues/new/choose). If you need help with troubleshooting or have a question about the plugin, please [create a new topic on our support forum](https://wordpress.org/support/plugin/speculation-rules/#new-topic-0).
@@ -78,6 +99,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.1.0 =
+
+* Allow excluding URL patterns from prerendering or prefetching specifically. ([1025](https://github.com/WordPress/performance/pull/1025))
 
 = 1.0.1 =
 

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -56,7 +56,7 @@ This example would ensure that URLs like `https://example.com/cart/` or `https:/
 
 add_filter(
 	'plsr_speculation_rules_href_exclude_paths',
-	function ( $exclude_paths ) {
+	function ( array $exclude_paths ): array {
 		$exclude_paths[] = '/cart/*';
 		return $exclude_paths;
 	}
@@ -73,7 +73,7 @@ The following example would ensure that URLs like `https://example.com/products/
 
 add_filter(
 	'plsr_speculation_rules_href_exclude_paths',
-	function ( $exclude_paths, $mode ) {
+	function ( array $exclude_paths, string $mode ): array {
 		if ( 'prerender' === $mode ) {
 			$exclude_paths[] = '/products/*';
 		}

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -7,6 +7,9 @@
 
 class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 
+	/**
+	 * @covers ::plsr_get_speculation_rules
+	 */
 	public function test_plsr_get_speculation_rules() {
 		$rules = plsr_get_speculation_rules();
 
@@ -20,6 +23,9 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * @covers ::plsr_get_speculation_rules
+	 */
 	public function test_plsr_get_speculation_rules_href_exclude_paths() {
 		$rules              = plsr_get_speculation_rules();
 		$href_exclude_paths = $rules['prerender'][0]['where']['and'][1]['not']['href_matches'];
@@ -54,6 +60,9 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * @covers ::plsr_get_speculation_rules
+	 */
 	public function test_plsr_get_speculation_rules_href_exclude_paths_with_mode() {
 		// Add filter that adds an exclusion only if the mode is 'prerender'.
 		add_filter(
@@ -84,6 +93,9 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		$this->assertNotContains( '/products/*', $href_exclude_paths );
 	}
 
+	/**
+	 * @covers ::plsr_get_speculation_rules
+	 */
 	public function test_plsr_get_speculation_rules_prerender() {
 		$rules = plsr_get_speculation_rules();
 
@@ -91,6 +103,9 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		$this->assertCount( 3, $rules['prerender'][0]['where']['and'] );
 	}
 
+	/**
+	 * @covers ::plsr_get_speculation_rules
+	 */
 	public function test_plsr_get_speculation_rules_prefetch() {
 		update_option( 'plsr_speculation_rules', array( 'mode' => 'prefetch' ) );
 
@@ -101,6 +116,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::plsr_get_speculation_rules
 	 * @dataProvider data_plsr_get_speculation_rules_with_eagerness
 	 */
 	public function test_plsr_get_speculation_rules_with_eagerness( string $eagerness ) {

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -54,6 +54,36 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_plsr_get_speculation_rules_href_exclude_paths_with_mode() {
+		// Add filter that adds an exclusion only if the mode is 'prerender'.
+		add_filter(
+			'plsr_speculation_rules_href_exclude_paths',
+			function ( $exclude_paths, $mode ) {
+				if ( 'prerender' === $mode ) {
+					$exclude_paths[] = '/products/*';
+				}
+				return $exclude_paths;
+			},
+			10,
+			2
+		);
+
+		$rules              = plsr_get_speculation_rules();
+		$href_exclude_paths = $rules['prerender'][0]['where']['and'][1]['not']['href_matches'];
+
+		// Ensure the additional exclusion is present because the mode is 'prerender'.
+		$this->assertContains( '/products/*', $href_exclude_paths );
+
+		// Update mode to be 'prefetch'.
+		update_option( 'plsr_speculation_rules', array( 'mode' => 'prefetch' ) );
+
+		$rules              = plsr_get_speculation_rules();
+		$href_exclude_paths = $rules['prefetch'][0]['where']['and'][1]['not']['href_matches'];
+
+		// Ensure the additional exclusion is not present because the mode is 'prefetch'.
+		$this->assertNotContains( '/products/*', $href_exclude_paths );
+	}
+
 	public function test_plsr_get_speculation_rules_prerender() {
 		$rules = plsr_get_speculation_rules();
 


### PR DESCRIPTION
## Summary

Fixes #907

## Relevant technical choices

* Add new `$mode` parameter as defined in the issue.
* Add documentation to readme FAQ.
* Add test coverage.
* Bump Speculation Rules plugin version to 1.1.0 to eventually release the enhancement.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
