### PR TITLE
Fix `get-plugin-dir` command for plugins

### DIFF
--- a/bin/plugin/commands/get-plugin-dir.js
+++ b/bin/plugin/commands/get-plugin-dir.js
@@ -56,6 +56,7 @@ function doRunGetPluginDir( settings ) {
 				return;
 			}
 		}
+
 		for ( const plugin of Object.values( plugins ) ) {
 			if ( settings.slug === plugin ) {
 				log( 'plugins' );

--- a/bin/plugin/commands/get-plugin-dir.js
+++ b/bin/plugin/commands/get-plugin-dir.js
@@ -56,9 +56,8 @@ function doRunGetPluginDir( settings ) {
 				return;
 			}
 		}
-
 		for ( const plugin of Object.values( plugins ) ) {
-			if ( settings.slug === plugin.slug ) {
+			if ( settings.slug === plugin ) {
 				log( 'plugins' );
 				return;
 			}


### PR DESCRIPTION
## Summary

Follow-up #1000 

In the changes made in https://github.com/WordPress/performance/pull/1000/commits/15b1cc0404f04e5e491ec36f0f5c3e7b764f2a86, we simplified the commands `get-plugin-dir` and `get-plugin-version`. However, when we run `node ./bin/plugin/cli.js get-plugin-version --slug=auto-sizes` for the manual workflow, it shows an error: `Error: The "auto-sizes" module/plugin slug is missing in the file`.

This PR resolves that issue.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
