### PR TITLE
Update tested WordPress version to 6.5

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -5,7 +5,7 @@
  * Description: This plugin implements the HTML spec for adding `sizes="auto"` to lazy-loaded images.
  * Requires at least: 6.3
  * Requires PHP: 7.0
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,6 +25,6 @@ if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.0.0' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.0.1' );
 
 require_once __DIR__ . '/hooks.php';

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -2,9 +2,9 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.4
-Tested up to:      6.4
+Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.0.0
+Stable tag:        1.0.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, auto-sizes
@@ -47,6 +47,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.0.1 =
+
+* Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 
 = 1.0.0 =
 

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -5,7 +5,7 @@
  * Description: Adds support to store the dominant color of newly uploaded images and create a placeholder background of that color.
  * Requires at least: 6.3
  * Requires PHP: 7.0
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'DOMINANT_COLOR_IMAGES_VERSION' ) ) {
 	return;
 }
 
-define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.0.1' );
+define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.0.2' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -2,9 +2,9 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.3
-Tested up to:      6.3
+Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.0.1
+Stable tag:        1.0.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, dominant color
@@ -46,6 +46,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.0.2 =
+
+* Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 
 = 1.0.1 =
 

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.3
-Tested up to:      6.4
+Tested up to:      6.5
 Requires PHP:      7.0
 Stable tag:        1.1.0
 License:           GPLv2 or later
@@ -103,6 +103,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 = 1.1.0 =
 
 * Allow excluding URL patterns from prerendering or prefetching specifically. ([1025](https://github.com/WordPress/performance/pull/1025))
+* Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 
 = 1.0.1 =
 

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Creates WebP versions for new JPEG image uploads if supported by the server.
  * Requires at least: 6.3
  * Requires PHP: 7.0
- * Version: 1.0.5
+ * Version: 1.0.6
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '1.0.5' );
+define( 'WEBP_UPLOADS_VERSION', '1.0.6' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/rest-api.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,9 +2,9 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.3
-Tested up to:      6.3
+Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.0.5
+Stable tag:        1.0.6
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, webp
@@ -57,6 +57,10 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the WebP Uploads plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 1.0.6 =
+
+* Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 
 = 1.0.5 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Requires at least: 6.3
-Tested up to:      6.4
+Tested up to:      6.5
 Requires PHP:      7.0
 Stable tag:        2.9.0
 License:           GPLv2 or later


### PR DESCRIPTION
## Summary

This PR updates Performance Lab and its standalone plugins' tested up to WordPress version to the upcoming 6.5. It also bumps the standalone plugin versions accordingly.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
