### PR TITLE
Add link to WebP settings to plugins table

### DIFF
--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -790,10 +790,9 @@ function webp_uploads_settings_link( $links ) {
 	if ( ! is_array( $links ) ) {
 		return $links;
 	}
-	$url     = get_admin_url( null, 'options-media.php#perflab_generate_webp_and_jpeg' );
 	$links[] = sprintf(
-		'<a href="%s">%s</a>',
-		esc_url( $url ),
+		'<a href="%1$s">%2$s</a>',
+		esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ),
 		esc_html__( 'Settings', 'webp-uploads' )
 	);
 	return $links;

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -779,7 +779,7 @@ function webp_uploads_render_generator() {
 add_action( 'wp_head', 'webp_uploads_render_generator' );
 
 /**
- * Adds a settings link to the plugin page.
+ * Adds a settings link to the plugin's action links.
  *
  * @param array $links An array of plugin action links.
  * @return array Plugin action links.

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -781,6 +781,8 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
 /**
  * Adds a settings link to the plugin's action links.
  *
+ * @since 1.0.6
+ *
  * @param array $links An array of plugin action links.
  * @return array Plugin action links.
  */

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -782,7 +782,7 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
  * Adds a settings link to the plugin page.
  *
  * @param array $links An array of plugin action links.
- * @return mixed An array of plugin action links.
+ * @return array Plugin action links.
  */
 function webp_uploads_settings_link( $links ) {
 	if ( ! \is_array( $links ) ) {

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -784,11 +784,11 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
  * @param array $links An array of plugin action links.
  * @return mixed An array of plugin action links.
  */
-function webp_uploads_settings_link($links) {
+function webp_uploads_settings_link( $links ) {
 	if ( ! \is_array( $links ) ) {
 		return $links;
 	}
-	$url     = get_admin_url( null,'options-media.php#perflab_generate_webp_and_jpeg');
+	$url     = get_admin_url( null, 'options-media.php#perflab_generate_webp_and_jpeg' );
 	$links[] = sprintf(
 		'<a href="%s">%s</a>',
 		esc_url( $url ),
@@ -796,4 +796,4 @@ function webp_uploads_settings_link($links) {
 	);
 	return $links;
 }
-add_filter('plugin_action_links_' . WEBP_UPLOADS_MAIN_FILE, 'webp_uploads_settings_link');
+add_filter( 'plugin_action_links_' . WEBP_UPLOADS_MAIN_FILE, 'webp_uploads_settings_link' );

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -777,3 +777,23 @@ function webp_uploads_render_generator() {
 	}
 }
 add_action( 'wp_head', 'webp_uploads_render_generator' );
+
+/**
+ * Adds a settings link to the plugin page.
+ *
+ * @param array $links An array of plugin action links.
+ * @return mixed An array of plugin action links.
+ */
+function webp_uploads_settings_link($links) {
+	if ( ! \is_array( $links ) ) {
+		return $links;
+	}
+	$url     = get_admin_url( null,'options-media.php#perflab_generate_webp_and_jpeg');
+	$links[] = sprintf(
+		'<a href="%s">%s</a>',
+		esc_url( $url ),
+		esc_html__( 'Settings', 'webp-uploads' )
+	);
+	return $links;
+}
+add_filter('plugin_action_links_' . WEBP_UPLOADS_MAIN_FILE, 'webp_uploads_settings_link');

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -784,7 +784,7 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
  * @since 1.0.6
  *
  * @param array $links An array of plugin action links.
- * @return array Plugin action links.
+ * @return array The modified list of actions.
  */
 function webp_uploads_settings_link( $links ) {
 	if ( ! is_array( $links ) ) {

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -785,7 +785,7 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
  * @return array Plugin action links.
  */
 function webp_uploads_settings_link( $links ) {
-	if ( ! \is_array( $links ) ) {
+	if ( ! is_array( $links ) ) {
 		return $links;
 	}
 	$url     = get_admin_url( null, 'options-media.php#perflab_generate_webp_and_jpeg' );

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -26,6 +26,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 }
 
 define( 'WEBP_UPLOADS_VERSION', '1.0.6' );
+define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/rest-api.php';


### PR DESCRIPTION
Fixes #1016

## Relevant technical choices

I added a Settings link to the WebP Uploads plugin action links for better discoverability, using the plugin_action_links filter and directing users to the WebP settings in the Media section.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
