### PR TITLE
Implement ILO_URL_Metrics_Group_Collection as iterator

### DIFF
--- a/modules/images/image-loading-optimization/class-ilo-url-metric.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metric.php
@@ -150,6 +150,15 @@ final class ILO_URL_Metric implements JsonSerializable {
 	}
 
 	/**
+	 * Gets viewport width.
+	 *
+	 * @return int Viewport width.
+	 */
+	public function get_viewport_width(): int {
+		return $this->data['viewport']['width'];
+	}
+
+	/**
 	 * Gets timestamp.
 	 *
 	 * @return float Timestamp.

--- a/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection.php
@@ -230,6 +230,9 @@ final class ILO_URL_Metrics_Group_Collection implements Countable, IteratorAggre
 	 * @return ILO_URL_Metric[] All URL metrics.
 	 */
 	public function get_flattened_url_metrics(): array {
+		// The duplication of iterator_to_array is not a mistake. This collection is an
+		// iterator and the collection contains iterator instances. So to flatten the
+		// two levels of iterators we need to nest calls to iterator_to_array().
 		return array_merge(
 			...array_map(
 				'iterator_to_array',

--- a/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection.php
@@ -152,7 +152,7 @@ final class ILO_URL_Metrics_Group_Collection implements Countable, IteratorAggre
 	 */
 	public function add_url_metric( ILO_URL_Metric $new_url_metric ) {
 		foreach ( $this->groups as $group ) {
-			if ( $group->is_viewport_width_in_range( $new_url_metric->get_viewport()['width'] ) ) {
+			if ( $group->is_viewport_width_in_range( $new_url_metric->get_viewport_width() ) ) {
 				$group->add_url_metric( $new_url_metric );
 				return;
 			}

--- a/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection.php
@@ -9,10 +9,12 @@
 /**
  * Collection of URL groups according to the breakpoints.
  *
+ * @implements IteratorAggregate<int, ILO_URL_Metrics_Group>
+ *
  * @since n.e.x.t
  * @access private
  */
-final class ILO_URL_Metrics_Group_Collection {
+final class ILO_URL_Metrics_Group_Collection implements Countable, IteratorAggregate {
 
 	/**
 	 * URL metrics groups.
@@ -161,15 +163,6 @@ final class ILO_URL_Metrics_Group_Collection {
 	}
 
 	/**
-	 * Gets grouped keyed by the minimum viewport width.
-	 *
-	 * @return ILO_URL_Metrics_Group[] Groups.
-	 */
-	public function get_groups(): array {
-		return $this->groups;
-	}
-
-	/**
 	 * Gets group for viewport width.
 	 *
 	 * @throws InvalidArgumentException When there is no group for the provided viewport width. This would only happen if a negative width is provided.
@@ -239,11 +232,27 @@ final class ILO_URL_Metrics_Group_Collection {
 	public function get_flattened_url_metrics(): array {
 		return array_merge(
 			...array_map(
-				static function ( ILO_URL_Metrics_Group $group ): array {
-					return iterator_to_array( $group );
-				},
-				$this->groups
+				'iterator_to_array',
+				iterator_to_array( $this )
 			)
 		);
+	}
+
+	/**
+	 * Returns an iterator for the groups of URL metrics.
+	 *
+	 * @return ArrayIterator<int, ILO_URL_Metrics_Group> Array iterator for ILO_URL_Metric_Group instances.
+	 */
+	public function getIterator(): ArrayIterator {
+		return new ArrayIterator( $this->groups );
+	}
+
+	/**
+	 * Counts the URL metrics groups in the collection.
+	 *
+	 * @return int Group count.
+	 */
+	public function count(): int {
+		return count( $this->groups );
 	}
 }

--- a/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
@@ -153,7 +153,7 @@ final class ILO_URL_Metrics_Group implements IteratorAggregate, Countable {
 	 * @param ILO_URL_Metric $url_metric URL metric.
 	 */
 	public function add_url_metric( ILO_URL_Metric $url_metric ) {
-		if ( ! $this->is_viewport_width_in_range( $url_metric->get_viewport()['width'] ) ) {
+		if ( ! $this->is_viewport_width_in_range( $url_metric->get_viewport_width() ) ) {
 			throw new InvalidArgumentException(
 				esc_html__( 'URL metric is not in the viewport range for group.', 'performance-lab' )
 			);

--- a/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
@@ -79,7 +79,7 @@ final class ILO_URL_Metrics_Group implements IteratorAggregate, Countable {
 		}
 		if ( $minimum_viewport_width >= $maximum_viewport_width ) {
 			throw new InvalidArgumentException(
-				esc_html__( 'The minimum viewport width must smaller larger than the maximum viewport width.', 'performance-lab' )
+				esc_html__( 'The minimum viewport width must be smaller than the maximum viewport width.', 'performance-lab' )
 			);
 		}
 		$this->minimum_viewport_width = $minimum_viewport_width;

--- a/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
@@ -199,7 +199,7 @@ final class ILO_URL_Metrics_Group implements IteratorAggregate, Countable {
 	}
 
 	/**
-	 * Gets the URL metrics in the group.
+	 * Returns an iterator for the URL metrics in the group.
 	 *
 	 * @return ArrayIterator<int, ILO_URL_Metric> ArrayIterator for ILO_URL_Metric instances.
 	 */
@@ -210,7 +210,7 @@ final class ILO_URL_Metrics_Group implements IteratorAggregate, Countable {
 	/**
 	 * Counts the URL metrics in the group.
 	 *
-	 * @return int Count of URL metrics in the group.
+	 * @return int URL metric count.
 	 */
 	public function count(): int {
 		return count( $this->url_metrics );

--- a/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
+++ b/modules/images/image-loading-optimization/class-ilo-url-metrics-group.php
@@ -79,7 +79,7 @@ final class ILO_URL_Metrics_Group implements IteratorAggregate, Countable {
 		}
 		if ( $minimum_viewport_width >= $maximum_viewport_width ) {
 			throw new InvalidArgumentException(
-				esc_html__( 'The minimum viewport width must be larger than the maximum viewport width.', 'performance-lab' )
+				esc_html__( 'The minimum viewport width must smaller larger than the maximum viewport width.', 'performance-lab' )
 			);
 		}
 		$this->minimum_viewport_width = $minimum_viewport_width;

--- a/modules/images/image-loading-optimization/detection.php
+++ b/modules/images/image-loading-optimization/detection.php
@@ -53,7 +53,7 @@ function ilo_get_detection_script( string $slug, ILO_URL_Metrics_Group_Collectio
 					'complete'             => $group->is_complete(),
 				);
 			},
-			$group_collection->get_groups()
+			iterator_to_array( $group_collection )
 		),
 		'storageLockTTL'          => ILO_Storage_Lock::get_ttl(),
 		'webVitalsLibrarySrc'     => $web_vitals_lib_src,

--- a/modules/images/image-loading-optimization/storage/data.php
+++ b/modules/images/image-loading-optimization/storage/data.php
@@ -272,7 +272,7 @@ function ilo_get_url_metrics_breakpoint_sample_size(): int {
  */
 function ilo_get_lcp_elements_by_minimum_viewport_widths( ILO_URL_Metrics_Group_Collection $group_collection ): array {
 	$lcp_element_by_viewport_minimum_width = array();
-	foreach ( $group_collection->get_groups() as $group ) {
+	foreach ( $group_collection as $group ) {
 
 		// The following arrays all share array indices.
 		$seen_breadcrumbs   = array();

--- a/modules/images/image-loading-optimization/storage/post-type.php
+++ b/modules/images/image-loading-optimization/storage/post-type.php
@@ -177,7 +177,7 @@ function ilo_store_url_metric( string $url, string $slug, ILO_URL_Metric $new_ur
 	);
 
 	try {
-		$group = $group_collection->get_group_for_viewport_width( $new_url_metric->get_viewport()['width'] );
+		$group = $group_collection->get_group_for_viewport_width( $new_url_metric->get_viewport_width() );
 		$group->add_url_metric( $new_url_metric );
 	} catch ( InvalidArgumentException $e ) {
 		return new WP_Error( 'invalid_url_metric', $e->getMessage() );

--- a/tests/modules/images/image-loading-optimization/class-ilo-url-metric-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-url-metric-tests.php
@@ -101,6 +101,7 @@ class ILO_URL_Metric_Tests extends WP_UnitTestCase {
 	 * Tests construction.
 	 *
 	 * @covers ::get_viewport
+	 * @covers ::get_viewport_width
 	 * @covers ::get_timestamp
 	 * @covers ::get_elements
 	 * @covers ::jsonSerialize
@@ -114,6 +115,7 @@ class ILO_URL_Metric_Tests extends WP_UnitTestCase {
 		}
 		$url_metric = new ILO_URL_Metric( $data );
 		$this->assertSame( $data['viewport'], $url_metric->get_viewport() );
+		$this->assertSame( $data['viewport']['width'], $url_metric->get_viewport_width() );
 		$this->assertSame( $data['timestamp'], $url_metric->get_timestamp() );
 		$this->assertSame( $data['elements'], $url_metric->get_elements() );
 		$this->assertEquals( $data, $url_metric->jsonSerialize() );

--- a/tests/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection-tests.php
@@ -98,7 +98,7 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 			$this->expectException( $exception );
 		}
 		$group_collection = new ILO_URL_Metrics_Group_Collection( $url_metrics, $breakpoints, $sample_size, $freshness_ttl );
-		$this->assertCount( count( $breakpoints ) + 1, $group_collection->get_groups() );
+		$this->assertCount( count( $breakpoints ) + 1, $group_collection );
 	}
 
 	/**
@@ -193,7 +193,7 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 			sprintf( 'Expected there to be at most sample size (%d) times the number of breakpoint groups (which is %d + 1)', $sample_size, count( $breakpoints ) )
 		);
 
-		$this->assertCount( count( $expected_counts ), $group_collection->get_groups() );
+		$this->assertCount( count( $expected_counts ), $group_collection );
 		foreach ( $expected_counts as $minimum_viewport_width => $count ) {
 			$group = $group_collection->get_group_for_viewport_width( $minimum_viewport_width );
 			$this->assertCount( $count, $group, "Expected equal count for $minimum_viewport_width minimum viewport width." );
@@ -257,7 +257,7 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 *
 	 * @return array[]
 	 */
-	public function data_provider_test_get_groups(): array {
+	public function data_provider_test_get_iterator(): array {
 		return array(
 			'2-breakpoints-and-3-viewport-widths' => array(
 				'breakpoints'     => array( 480, 640 ),
@@ -300,13 +300,13 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_groups().
+	 * Test getIterator().
 	 *
-	 * @covers ::get_groups
+	 * @covers ::getIterator
 	 *
-	 * @dataProvider data_provider_test_get_groups
+	 * @dataProvider data_provider_test_get_iterator
 	 */
-	public function test_get_groups( array $breakpoints, array $viewport_widths, array $expected_groups ) {
+	public function test_get_iterator( array $breakpoints, array $viewport_widths, array $expected_groups ) {
 		$url_metrics = array_map(
 			function ( $viewport_width ) {
 				return $this->get_validated_url_metric( $viewport_width );
@@ -318,12 +318,12 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 
 		$this->assertCount(
 			count( $breakpoints ) + 1,
-			$group_collection->get_groups(),
+			$group_collection,
 			'Expected number of breakpoint groups to always be one greater than the number of breakpoints.'
 		);
 
 		$actual_groups = array();
-		foreach ( $group_collection->get_groups() as $group ) {
+		foreach ( $group_collection as $group ) {
 			$actual_groups[] = array(
 				'minimum_viewport_width'     => $group->get_minimum_viewport_width(),
 				'maximum_viewport_width'     => $group->get_maximum_viewport_width(),
@@ -459,7 +459,7 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 * Test get_minimum_viewport_width().
 	 *
 	 * @covers ::get_group_for_viewport_width
-	 * @covers ::get_groups
+	 * @covers ::getIterator
 	 * @covers ILO_URL_Metrics_Group::is_complete
 	 * @covers ILO_URL_Metrics_Group::get_minimum_viewport_width
 	 *
@@ -476,7 +476,7 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 						'complete'             => $group->is_complete(),
 					);
 				},
-				$group_collection->get_groups()
+				iterator_to_array( $group_collection )
 			)
 		);
 
@@ -545,6 +545,11 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 		);
 
 		$this->assertEquals( $url_metrics, $group_collection->get_flattened_url_metrics() );
+
+		$this->assertEquals(
+			$url_metrics,
+			array_merge( ...array_map( 'iterator_to_array', iterator_to_array( $group_collection ) ) )
+		);
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection-tests.php
+++ b/tests/modules/images/image-loading-optimization/class-ilo-url-metrics-group-collection-tests.php
@@ -328,8 +328,8 @@ class ILO_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 				'minimum_viewport_width'     => $group->get_minimum_viewport_width(),
 				'maximum_viewport_width'     => $group->get_maximum_viewport_width(),
 				'url_metric_viewport_widths' => array_map(
-					static function ( ILO_URL_Metric $url_metric ) {
-						return $url_metric->get_viewport()['width'];
+					static function ( ILO_URL_Metric $url_metric ): int {
+						return $url_metric->get_viewport_width();
 					},
 					iterator_to_array( $group )
 				),

--- a/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
@@ -46,7 +46,7 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 		$url_metrics = ilo_parse_stored_url_metrics( $post );
 		$this->assertCount( 1, $url_metrics, 'Expected number of URL metrics stored.' );
 		$this->assertSame( $valid_params['elements'], $url_metrics[0]->get_elements() );
-		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport()['width'] );
+		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport_width() );
 	}
 
 	/**

--- a/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
+++ b/tests/modules/images/image-loading-optimization/storage/rest-api-tests.php
@@ -277,7 +277,7 @@ class ILO_Storage_REST_API_Tests extends WP_UnitTestCase {
 			ilo_get_url_metrics_breakpoint_sample_size(),
 			HOUR_IN_SECONDS
 		);
-		$url_metric_groups = $group_collection->get_groups();
+		$url_metric_groups = iterator_to_array( $group_collection );
 		$this->assertSame(
 			array( 0, $breakpoint_width + 1 ),
 			array_map(


### PR DESCRIPTION
## Summary

In follow-up to #1010 which implemented `ILO_URL_Metrics_Group` as an iterator, this PR does the same for `ILO_URL_Metrics_Group_Collection` for consistency.

It also fixes a typo discovered by @felixarntz in https://github.com/WordPress/performance/commit/34e3d062a2812458f4b1270a609d3238251dab84#r139510810.

Lastly, a `ILO_URL_Metric::get_viewport_width()` convenience getter method is added since we only are needing to get the width and not the height (so far).

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
