### PR TITLE
Fix `test-plugins` command

### DIFF
--- a/.github/workflows/php-test-standalone-plugins.yml
+++ b/.github/workflows/php-test-standalone-plugins.yml
@@ -8,6 +8,7 @@ on:
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test-standalone-plugins.yml'
+      - 'bin/plugin/commands/test-plugins.js'
       - 'plugin-tests/**'
       - '**.php'
       - '.wp-env.json'
@@ -24,6 +25,7 @@ on:
     # Only run if PHP-related files changed.
     paths:
       - '.github/workflows/php-test-standalone-plugins.yml'
+      - 'bin/plugin/commands/test-plugins.js'
       - 'plugin-tests/**'
       - '**.php'
       - '.wp-env.json'

--- a/bin/plugin/commands/test-plugins.js
+++ b/bin/plugin/commands/test-plugins.js
@@ -441,29 +441,27 @@ function doRunStandalonePluginTests( settings ) {
 				.filter( ( plugin ) => {
 					try {
 						fs.copySync(
-							`${ settings.pluginsDir }${ plugin.slug }/`,
-							`${ settings.builtPluginsDir }${ plugin.slug }/`,
+							`${ settings.pluginsDir }${ plugin }/`,
+							`${ settings.builtPluginsDir }${ plugin }/`,
 							{
 								overwrite: true,
 							}
 						);
 						log(
-							formats.success(
-								`Copied plugin "${ plugin.slug }".\n`
-							)
+							formats.success( `Copied plugin "${ plugin }".\n` )
 						);
 						return true;
 					} catch ( e ) {
 						// Handle the error appropriately
 						log(
 							formats.error(
-								`Error copying plugin "${ plugin.slug }": ${ e.message }`
+								`Error copying plugin "${ plugin }": ${ e.message }`
 							)
 						);
 						return false;
 					}
 				} )
-				.map( ( plugin ) => plugin.slug )
+				.map( ( plugin ) => plugin )
 		);
 	} catch ( error ) {
 		throw Error( `Error reading file at "${ pluginsFile }": ${ error }` );


### PR DESCRIPTION
## Summary

This PR resolves the issue with the `test-plugins` command. After transitioning the infrastructure from modules to plugins, it is now functioning correctly.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
