### PR TITLE
Remove checklist from pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,13 @@ Fixes #
 ## Relevant technical choices
 
 <!-- Please describe your changes. -->
+
+
+
+<!--
+For maintainers only, please make sure:
+
+- PR has either `[Focus]` or `Infrastructure` label.
+- PR has a `[Type]` label.
+- PR has a milestone or the `no milestone` label.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,3 @@ Fixes #
 ## Relevant technical choices
 
 <!-- Please describe your changes. -->
-
-## Checklist
-
-- [ ] PR has either `[Focus]` or `Infrastructure` label.
-- [ ] PR has a `[Type]` label.
-- [ ] PR has a milestone or the `no milestone` label.


### PR DESCRIPTION
## Summary

At WordCamp Asia Contributor Day, a contributor experienced friction when attempting to contribute because they were unable to action on the checklist in the pull request template. External contributors cannot set any labels, so they may feel blocked from contributing. I think the checklist should be removed for this reason, and also because the checklist is redundant with the [pr-validation](https://github.com/WordPress/performance/blob/trunk/.github/workflows/pr-validation.yml) workflow which will serve the same purpose as the checklist, but in terms of failing checks. Contributors who are part of the project know the labels they need to add (although we've also discussed adding these labels may not always be of much value anymore anyway). Also, the checklist adds additional overhead for contributors who regularly open PRs: they have to not only add the labels but also check the checkboxes. Removing the checklist will improve efficiency and reduce friction for new contributors.

## Checklist

- [x] PR has either `[Focus]` or `Infrastructure` label.
- [x] PR has a `[Type]` label.
- [x] PR has a milestone or the `no milestone` label.
