### PR TITLE
Prefix standalone plugins with 'PL' in list table and add plugin row meta link to Performance Lab settings screen

### DIFF
--- a/admin/load.php
+++ b/admin/load.php
@@ -912,3 +912,38 @@ function perflab_print_modules_page_style() {
 </style>
 	<?php
 }
+
+/**
+ * Filters all plugins to prefix Performance Lab standalone plugins with "PL".
+ *
+ * @since n.e.x.t
+ *
+ * @param array<string, array{ Name: string }> $plugins Plugins.
+ * @return array<string, array{ Name: string }> Filtered plugins.
+ */
+function perflab_filter_plugins_list( array $plugins ): array {
+	$standalone_plugins = perflab_get_standalone_plugins();
+
+	$did_prefix  = false;
+	$name_prefix = __( 'PL', 'performance-lab' ) . ' ';
+	foreach ( array_keys( $plugins ) as $plugin_basename ) {
+		if ( in_array( strtok( $plugin_basename, '/' ), $standalone_plugins, true ) ) {
+			$plugins[ $plugin_basename ]['Name'] = $name_prefix . $plugins[ $plugin_basename ]['Name'];
+
+			$did_prefix = true;
+		}
+	}
+
+	// Re-sort by name if prefixed.
+	if ( $did_prefix ) {
+		uasort(
+			$plugins,
+			static function ( array $a, array $b ) {
+				return strnatcasecmp( $a['Name'], $b['Name'] );
+			}
+		);
+	}
+
+	return $plugins;
+}
+add_filter( 'all_plugins', 'perflab_filter_plugins_list' );

--- a/admin/load.php
+++ b/admin/load.php
@@ -914,14 +914,14 @@ function perflab_print_modules_page_style() {
 }
 
 /**
- * Filters all plugins to prefix Performance Lab standalone plugins with "PL".
+ * Adds "PL" prefix to the names of all Performance Lab standalone plugins.
  *
  * @since n.e.x.t
  *
  * @param array<string, array{ Name: string }> $plugins Plugins.
  * @return array<string, array{ Name: string }> Filtered plugins.
  */
-function perflab_filter_plugins_list( array $plugins ): array {
+function perflab_add_pl_prefix_to_standalone_plugins( array $plugins ): array {
 	$standalone_plugins = perflab_get_standalone_plugins();
 
 	$did_prefix  = false;
@@ -946,4 +946,26 @@ function perflab_filter_plugins_list( array $plugins ): array {
 
 	return $plugins;
 }
-add_filter( 'all_plugins', 'perflab_filter_plugins_list' );
+add_filter( 'all_plugins', 'perflab_add_pl_prefix_to_standalone_plugins' );
+
+/**
+ * Filters plugin row meta to add a Performance Lab link to its settings screen.
+ *
+ * @since n.e.x.t
+ *
+ * @param string[] $plugin_meta  An array of the plugin's metadata, including
+ *                               the version, author, author URI, and plugin URI.
+ * @param string   $plugin_file  Path to the plugin file relative to the plugins directory.
+ * @return string[] Plugin meta.
+ */
+function perflab_filter_plugin_row_meta( array $plugin_meta, string $plugin_file ): array {
+	if ( in_array( strtok( $plugin_file, '/' ), perflab_get_standalone_plugins(), true ) ) {
+		$plugin_meta[] = sprintf(
+			'<a href="%1$s">%2$s</a>',
+			esc_url( add_query_arg( 'page', PERFLAB_MODULES_SCREEN, admin_url( 'options-general.php' ) ) ),
+			esc_html__( 'Performance Lab', 'performance-lab' )
+		);
+	}
+	return $plugin_meta;
+}
+add_filter( 'plugin_row_meta', 'perflab_filter_plugin_row_meta', 10, 2 );


### PR DESCRIPTION
## Summary

See #1046. When the PL plugin is active, this prefixes all installed standalone plugins with PL so that they appear grouped together. A "Performance Lab" plugin row meta link is also added which points to the settings screen.

Performance Lab Deactivated | Performance Lab Activated
--|--
![localhost_8888_wp-admin_plugins php_plugin_status=all paged=1 s](https://github.com/WordPress/performance/assets/134745/8fbb1a47-8829-46da-90ac-39a3b1a0e230) | ![localhost_8888_wp-admin_plugins php](https://github.com/WordPress/performance/assets/134745/0062985c-d693-4f01-af81-3648f32b5a99)

## Relevant technical choices

The `all_plugins` filter is employed to loop overall installed plugins, and if any one matches one of the standalone plugin slugs, it prefixes the Name with "PL". After this, the plugins are re-sorted so that the PL plugins appear together.

Also, the plugin row meta is filtered for the standalone plugins so that a "Performance Lab" link is added for the plugin's settings screen.

<!--
For maintainers only, please make sure:

- PR has either `[Focus]` or `Infrastructure` label.
- PR has a `[Type]` label.
- PR has a milestone or the `no milestone` label.
-->
