### PR TITLE
Add generator meta tag for Embed Optimizer

### DIFF
--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -155,7 +155,7 @@ function embed_optimizer_trigger_error( string $function_name, string $message, 
 }
 
 /**
- * Displays the HTML generator tag for the WebP Uploads plugin.
+ * Displays the HTML generator tag for the Embed Optimizer plugin.
  *
  * See {@see 'wp_head'}.
  *

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -153,3 +153,19 @@ function embed_optimizer_trigger_error( string $function_name, string $message, 
 	}
 	wp_trigger_error( $function_name, $message, $error_level );
 }
+
+/**
+ * Displays the HTML generator tag for the WebP Uploads plugin.
+ *
+ * See {@see 'wp_head'}.
+ *
+ * @since 0.1.0
+ */
+function embed_optimizer_render_generator() {
+	if (
+		defined( 'EMBED_OPTIMIZER_VERSION' )
+	) {
+		echo '<meta name="generator" content="Embed Optimizer ' . esc_attr( EMBED_OPTIMIZER_VERSION ) . '">' . "\n";
+	}
+}
+add_action( 'wp_head', 'embed_optimizer_render_generator' );

--- a/tests/plugins/embed-optimizer/embed-optimizer-test.php
+++ b/tests/plugins/embed-optimizer/embed-optimizer-test.php
@@ -156,4 +156,17 @@ class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 		$this->assertStringStartsWith( '<script type="module" nonce="abc123">', $script );
 		$this->assertStringEndsWith( '</script>', $script );
 	}
+
+	/**
+	 * Test printing the meta generator tag.
+	 *
+	 * @covers ::embed_optimizer_render_generator
+	 */
+	public function test_embed_optimizer_render_generator() {
+		$this->assertSame( 10, has_action( 'wp_head', 'embed_optimizer_render_generator' ) );
+		$tag = get_echo( 'embed_optimizer_render_generator' );
+		$this->assertStringStartsWith( '<meta', $tag );
+		$this->assertStringContainsString( 'generator', $tag );
+		$this->assertStringContainsString( EMBED_OPTIMIZER_VERSION, $tag );
+	}
 }


### PR DESCRIPTION
This matches the `meta[name=generator]` added by WebP Uploads and Dominant Color Images.
