### PR TITLE
Bump minimum required WordPress version to 6.4

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -45,7 +45,7 @@ jobs:
         wp: [ 'latest' ]
         include:
           - php: '7.4'
-            wp: '6.3'
+            wp: '6.4'
           - php: '8.3'
             wp: 'trunk'
     env:

--- a/.github/workflows/php-test-standalone-plugins.yml
+++ b/.github/workflows/php-test-standalone-plugins.yml
@@ -51,7 +51,7 @@ jobs:
         wp: [ 'latest' ]
         include:
         - php: '7.4'
-          wp: '6.3'
+          wp: '6.4'
         - php: '8.3'
           wp: 'trunk'
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Performance Lab plugin! Compl
 
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the Performance Lab plugin must follow these requirements:
 
-- **WordPress**: As of Performance Lab v2.7.0, released October 16, 2023, the plugin's minimum WordPress version requirement is 6.3.
+- **WordPress**: As of Performance Lab v3.0.0, released April 15, 2024, the plugin's minimum WordPress version requirement is 6.4.
 - **PHP**: Always match the latest WordPress version. The minimum required version right now is 7.0.
 
 

--- a/load.php
+++ b/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Performance Lab
  * Plugin URI: https://github.com/WordPress/performance
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance modules.
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.0
  * Version: 2.9.0
  * Author: WordPress Performance Team

--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Auto-sizes for Lazy-loaded Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
  * Description: This plugin implements the HTML spec for adding `sizes="auto"` to lazy-loaded images.
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.0
  * Version: 1.0.1
  * Author: WordPress Performance Team

--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -5,7 +5,7 @@
  * Description: This plugin implements the HTML spec for adding `sizes="auto"` to lazy-loaded images.
  * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,6 +25,6 @@ if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.0.1' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.0.2' );
 
 require_once __DIR__ . '/hooks.php';

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.0.1
+Stable tag:        1.0.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, auto-sizes
@@ -47,6 +47,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.0.2 =
+
+* Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 
 = 1.0.1 =
 

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Dominant Color Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
  * Description: Adds support to store the dominant color of newly uploaded images and create a placeholder background of that color.
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.0
  * Version: 1.0.2
  * Author: WordPress Performance Team

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -5,7 +5,7 @@
  * Description: Adds support to store the dominant color of newly uploaded images and create a placeholder background of that color.
  * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'DOMINANT_COLOR_IMAGES_VERSION' ) ) {
 	return;
 }
 
-define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.0.2' );
+define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.0.3' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.0.2
+Stable tag:        1.0.3
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, dominant color
@@ -46,6 +46,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.0.3 =
+
+* Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 
 = 1.0.2 =
 

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -1,7 +1,7 @@
 === Dominant Color Images ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.3
+Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
 Stable tag:        1.0.2

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -27,7 +27,6 @@ function plsr_print_speculation_rules() {
 	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/60320>.
 	$needs_html5_workaround = (
 		! current_theme_supports( 'html5', 'script' ) &&
-		version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.4', '>=' ) &&
 		version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.5', '<' )
 	);
 	if ( $needs_html5_workaround ) {

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -27,6 +27,7 @@ function plsr_print_speculation_rules() {
 	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/60320>.
 	$needs_html5_workaround = (
 		! current_theme_supports( 'html5', 'script' ) &&
+		version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.4', '>=' ) &&
 		version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.5', '<' )
 	);
 	if ( $needs_html5_workaround ) {

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Uses the Speculation Rules API to prerender linked URLs upon hover by default.
  * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
 	return;
 }
 
-define( 'SPECULATION_RULES_VERSION', '1.1.0' );
+define( 'SPECULATION_RULES_VERSION', '1.1.1' );
 
 require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';
 require_once __DIR__ . '/helper.php';

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Speculation Rules
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/speculation-rules
  * Description: Uses the Speculation Rules API to prerender linked URLs upon hover by default.
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.0
  * Version: 1.1.0
  * Author: WordPress Performance Team

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.1.0
+Stable tag:        1.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, javascript, speculation rules, prerender, prefetch
@@ -99,6 +99,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.1.1 =
+
+* Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 
 = 1.1.0 =
 

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -1,7 +1,7 @@
 === Speculation Rules ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.3
+Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
 Stable tag:        1.1.0

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Creates WebP versions for new JPEG image uploads if supported by the server.
  * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 1.0.6
+ * Version: 1.0.7
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '1.0.6' );
+define( 'WEBP_UPLOADS_VERSION', '1.0.7' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: WebP Uploads
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
  * Description: Creates WebP versions for new JPEG image uploads if supported by the server.
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.0
  * Version: 1.0.6
  * Author: WordPress Performance Team

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -1,7 +1,7 @@
 === WebP Uploads ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.3
+Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
 Stable tag:        1.0.6

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.0.6
+Stable tag:        1.0.7
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, webp
@@ -57,6 +57,10 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the WebP Uploads plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 1.0.7 =
+
+* Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 
 = 1.0.6 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Performance Lab ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.3
+Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
 Stable tag:        2.9.0

--- a/tests/plugins/speculation-rules/speculation-rules-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-test.php
@@ -50,7 +50,7 @@ class Speculation_Rules_Tests extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'prerender', $rules );
 
 		// Make sure that theme support was restored. This is only relevant to WordPres 6.4 per https://core.trac.wordpress.org/ticket/60320.
-		if ( $html5_support || version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.4', '<' ) ) {
+		if ( $html5_support ) {
 			$this->assertStringNotContainsString( '/* <![CDATA[ */', wp_get_inline_script_tag( '/*...*/' ) );
 		} else {
 			$this->assertStringContainsString( '/* <![CDATA[ */', wp_get_inline_script_tag( '/*...*/' ) );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1056

<!--
For maintainers only, please make sure:

- PR has either `[Focus]` or `Infrastructure` label.
- PR has a `[Type]` label.
- PR has a milestone or the `no milestone` label.
-->
