### PR TITLE
Bump minimum required WP version to 6.4

### DIFF
--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -3,9 +3,9 @@
  * Plugin Name: Embed Optimizer
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer
  * Description: Optimizes the performance of embeds by lazy-loading iframes and scripts.
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 0.1.0
+ * Version: 0.1.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'EMBED_OPTIMIZER_VERSION', '0.1.0' );
+define( 'EMBED_OPTIMIZER_VERSION', '0.1.1' );
 
 // Load in the Embed Optimizer module hooks.
 require_once __DIR__ . '/hooks.php';

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -1,10 +1,10 @@
 === Embed Optimizer ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.3
+Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        0.1.0
+Stable tag:        0.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, embeds
@@ -48,6 +48,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.1.1 =
+
+* Bump minimum required WP version to 6.4. ([1076](https://github.com/WordPress/performance/pull/1076))
 
 = 0.1.0 =
 


### PR DESCRIPTION
## Summary

Follow up to #1062 (Embed Optimizer was only merged into `trunk` after that PR).

See related #1074.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
