### PR TITLE
Prevent detection script injection from breaking import maps in classic themes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "issues": "https://github.com/WordPress/performance/issues"
   },
   "require-dev": {
+    "ext-libxml": "*",
     "wp-phpunit/wp-phpunit": "^5.8",
     "yoast/phpunit-polyfills": "^1.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "issues": "https://github.com/WordPress/performance/issues"
   },
   "require-dev": {
+    "ext-dom": "*",
     "ext-libxml": "*",
     "wp-phpunit/wp-phpunit": "^5.8",
     "yoast/phpunit-polyfills": "^1.0"
   },
   "require": {
     "composer/installers": "~1.0",
-    "ext-dom": "*",
     "ext-json": "*",
     "php": ">=7|^8"
   },

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,6 @@
     "issues": "https://github.com/WordPress/performance/issues"
   },
   "require-dev": {
-    "ext-dom": "*",
-    "ext-libxml": "*",
     "wp-phpunit/wp-phpunit": "^5.8",
     "yoast/phpunit-polyfills": "^1.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9508b469cacbd55eda5b14614e16c7ec",
+    "content-hash": "385dd53cf75b8b7388b8a30fe39b5e25",
     "packages": [
         {
             "name": "composer/installers",
@@ -2017,9 +2017,6 @@
         "ext-json": "*",
         "php": ">=7|^8"
     },
-    "platform-dev": {
-        "ext-dom": "*",
-        "ext-libxml": "*"
-    },
+    "platform-dev": [],
     "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9137ad9d733d989d724693a6ea3b40a0",
+    "content-hash": "9508b469cacbd55eda5b14614e16c7ec",
     "packages": [
         {
             "name": "composer/installers",
@@ -290,16 +290,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.0.1",
+            "version": "v5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69"
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2218c2252c874a4624ab2f613d86ac32d227bc69",
-                "reference": "2218c2252c874a4624ab2f613d86ac32d227bc69",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/139676794dc1e9231bf7bcd123cfc0c99182cb13",
+                "reference": "139676794dc1e9231bf7bcd123cfc0c99182cb13",
                 "shasum": ""
             },
             "require": {
@@ -342,26 +342,27 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.0.2"
             },
-            "time": "2024-02-21T19:24:10+00:00"
+            "time": "2024-03-05T20:51:40+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
                 "ext-xmlwriter": "*",
                 "phar-io/version": "^3.0.1",
@@ -402,9 +403,15 @@
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
             "support": {
                 "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
             },
-            "time": "2021-07-20T11:28:43+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
@@ -459,16 +466,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.30",
+            "version": "9.2.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089"
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/ca2bd87d2f9215904682a9cb9bb37dda98e76089",
-                "reference": "ca2bd87d2f9215904682a9cb9bb37dda98e76089",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/48c34b5d8d983006bd2adc2d0de92963b9155965",
+                "reference": "48c34b5d8d983006bd2adc2d0de92963b9155965",
                 "shasum": ""
             },
             "require": {
@@ -525,7 +532,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.30"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.31"
             },
             "funding": [
                 {
@@ -533,7 +540,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-22T06:47:57+00:00"
+            "time": "2024-03-02T06:37:42+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -778,16 +785,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.17",
+            "version": "9.6.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd"
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1a156980d78a6666721b7e8e8502fe210b587fcd",
-                "reference": "1a156980d78a6666721b7e8e8502fe210b587fcd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
+                "reference": "32c2c2d6580b1d8ab3c10b1e9e4dc263cc69bb04",
                 "shasum": ""
             },
             "require": {
@@ -861,7 +868,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.17"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.18"
             },
             "funding": [
                 {
@@ -877,20 +884,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-02-23T13:14:51+00:00"
+            "time": "2024-03-21T12:07:32+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
                 "shasum": ""
             },
             "require": {
@@ -925,7 +932,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
             },
             "funding": [
                 {
@@ -933,7 +940,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:08:49+00:00"
+            "time": "2024-03-02T06:27:43+00:00"
         },
         {
             "name": "sebastian/code-unit",
@@ -1179,16 +1186,16 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
                 "shasum": ""
             },
             "require": {
@@ -1233,7 +1240,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1241,7 +1248,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-05-07T05:35:17+00:00"
+            "time": "2024-03-02T06:30:58+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -1308,16 +1315,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/78c00df8f170e02473b682df15bfcdacc3d32d72",
+                "reference": "78c00df8f170e02473b682df15bfcdacc3d32d72",
                 "shasum": ""
             },
             "require": {
@@ -1373,7 +1380,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.6"
             },
             "funding": [
                 {
@@ -1381,20 +1388,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-09-14T06:03:37+00:00"
+            "time": "2024-03-02T06:33:00+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.6",
+            "version": "5.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
                 "shasum": ""
             },
             "require": {
@@ -1437,7 +1444,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
             },
             "funding": [
                 {
@@ -1445,7 +1452,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-02T09:26:13+00:00"
+            "time": "2024-03-02T06:35:11+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1681,16 +1688,16 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
                 "shasum": ""
             },
             "require": {
@@ -1702,7 +1709,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1723,8 +1730,7 @@
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
             "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
             },
             "funding": [
                 {
@@ -1732,7 +1738,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T06:45:17+00:00"
+            "time": "2024-03-14T16:00:52+00:00"
         },
         {
             "name": "sebastian/type",
@@ -1845,16 +1851,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.2",
+            "version": "1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
@@ -1883,7 +1889,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
             "funding": [
                 {
@@ -1891,11 +1897,11 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-11-20T00:12:19+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "5.9.8",
+            "version": "5.9.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
@@ -2008,10 +2014,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "ext-dom": "*",
         "ext-json": "*",
         "php": ">=7|^8"
     },
-    "platform-dev": [],
+    "platform-dev": {
+        "ext-dom": "*",
+        "ext-libxml": "*"
+    },
     "plugin-api-version": "2.2.0"
 }

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -194,12 +194,17 @@ final class OD_HTML_Tag_Processor {
 					return false;
 				}
 
+				// WordPress 6.5 changed the $end arg in the WP_HTML_Text_Replacement constructor to $length.
+				static $is_old_text_replacement_signature = null;
+				if ( null === $is_old_text_replacement_signature ) {
+					$is_old_text_replacement_signature = version_compare( get_bloginfo( 'version' ), '6.5', '<' );
+				}
+
 				$start = $this->bookmarks[ $bookmark ]->start;
 
 				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 					$start,
-					// In WordPress 6.5, the signature was changed from $end to $length.
-					version_compare( get_bloginfo( 'version' ), '6.5', '<' ) ? $start : 0,
+					$is_old_text_replacement_signature ? $start : 0,
 					$html
 				);
 				return true;

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -164,7 +164,12 @@ final class OD_HTML_Tag_Processor {
 	/**
 	 * Processor.
 	 *
-	 * @var WP_HTML_Tag_Processor
+	 * This contains an instance of an anonymous subclass of WP_HTML_Tag_Processor which adds an append_html method.
+	 * The use of the mixed type is due to the lack of typing being available for such an anonymous class. PHPCS
+	 * requires that there be a type provided, and yet if it is just WP_HTML_Tag_Processor then PHPStan complains about
+	 * the append_html method not being defined.
+	 *
+	 * @var WP_HTML_Tag_Processor|mixed
 	 */
 	private $processor;
 
@@ -422,7 +427,6 @@ final class OD_HTML_Tag_Processor {
 	 * @return bool Whether successful.
 	 */
 	public function append_head_html( string $html ): bool {
-		// @phpstan-ignore-next-line
 		$success = $this->processor->append_html( self::END_OF_HEAD_BOOKMARK, $html );
 		if ( ! $success ) {
 			$this->warn( __( 'Unable to append markup to the HEAD.', 'optimization-detective' ) );
@@ -437,7 +441,6 @@ final class OD_HTML_Tag_Processor {
 	 * @return bool Whether successful.
 	 */
 	public function append_body_html( string $html ): bool {
-		// @phpstan-ignore-next-line
 		$success = $this->processor->append_html( self::END_OF_BODY_BOOKMARK, $html );
 		if ( ! $success ) {
 			$this->warn( __( 'Unable to append markup to the BODY.', 'optimization-detective' ) );

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -194,9 +194,12 @@ final class OD_HTML_Tag_Processor {
 					return false;
 				}
 
+				$start = $this->bookmarks[ $bookmark ]->start;
+
 				$this->lexical_updates[] = new WP_HTML_Text_Replacement(
-					$this->bookmarks[ $bookmark ]->start,
-					0,
+					$start,
+					// In WordPress 6.5, the signature was changed from $end to $length.
+					version_compare( get_bloginfo( 'version' ), '6.5', '<' ) ? $start : 0,
 					$html
 				);
 				return true;

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Optimization Detective: OD_HTML_Tag_Processor class
+ *
+ * @package optimization-detective
+ * @since 0.1.1
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Extension to WP_HTML_Tag_Processor that supports injecting HTML.
+ *
+ * @since 0.1.1
+ * @access private
+ */
+final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
+
+	/**
+	 * Whether the old (pre-WP 6.5) signature for WP_HTML_Text_Replacement is needed.
+	 *
+	 * WordPress 6.5 changed the $end arg in the WP_HTML_Text_Replacement constructor to $length.
+	 *
+	 * @var bool
+	 */
+	private $old_text_replacement_signature_needed;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $html HTML to process.
+	 */
+	public function __construct( $html ) {
+		$this->old_text_replacement_signature_needed = version_compare( get_bloginfo( 'version' ), '6.5', '<' );
+		parent::__construct( $html );
+	}
+
+	/**
+	 * Appends HTML to the provided bookmark.
+	 *
+	 * @param string $bookmark Bookmark.
+	 * @param string $html     HTML to inject.
+	 * @return bool Whether the HTML was appended.
+	 */
+	public function append_html( string $bookmark, string $html ): bool {
+		if ( ! $this->has_bookmark( $bookmark ) ) {
+			return false;
+		}
+
+		$start = $this->bookmarks[ $bookmark ]->start;
+
+		$this->lexical_updates[] = new WP_HTML_Text_Replacement(
+			$start,
+			$this->old_text_replacement_signature_needed ? $start : 0,
+			$html
+		);
+		return true;
+	}
+}

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -180,7 +180,7 @@ final class OD_HTML_Tag_Processor {
 	 */
 	public function __construct( string $html ) {
 
-		$processor = new class( $html ) extends WP_HTML_Tag_Processor {
+		$this->processor = new class( $html ) extends WP_HTML_Tag_Processor {
 
 			/**
 			 * Appends HTML to the provided bookmark.
@@ -202,8 +202,6 @@ final class OD_HTML_Tag_Processor {
 				return true;
 			}
 		};
-
-		$this->processor = new $processor( $html );
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-html-tag-walker.php
+++ b/plugins/optimization-detective/class-od-html-tag-walker.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Optimization Detective: OD_HTML_Tag_Processor class
+ * Optimization Detective: OD_HTML_Tag_Walker class
  *
  * @package optimization-detective
- * @since 0.1.0
+ * @since 0.1.1
  */
 
 // Exit if accessed directly.
@@ -17,9 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Eventually this class should be made largely obsolete once `WP_HTML_Processor` is fully implemented to support all HTML tags.
  *
  * @since 0.1.0
+ * @since 0.1.1 Renamed from OD_HTML_Tag_Processor to OD_HTML_Tag_Walker
  * @access private
  */
-final class OD_HTML_Tag_Processor {
+final class OD_HTML_Tag_Walker {
 
 	/**
 	 * HTML void tags (i.e. those which are self-closing).

--- a/plugins/optimization-detective/class-od-html-tag-walker.php
+++ b/plugins/optimization-detective/class-od-html-tag-walker.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Processor leveraging WP_HTML_Tag_Processor which gathers breadcrumbs for computing XPaths while iterating the open_tags() generator.
+ * Walker leveraging WP_HTML_Tag_Processor which gathers breadcrumbs for computing XPaths while iterating the open_tags() generator.
  *
  * Eventually this class should be made largely obsolete once `WP_HTML_Processor` is fully implemented to support all HTML tags.
  *
@@ -380,7 +380,7 @@ final class OD_HTML_Tag_Walker {
 	/**
 	 * Returns the value of a requested attribute from a matched tag opener if that attribute exists.
 	 *
-	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * This is a wrapper around the underlying WP_HTML_Tag_Processor method of the same name since only a limited number of
 	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
 	 *
 	 * @since 0.1.0
@@ -396,7 +396,7 @@ final class OD_HTML_Tag_Walker {
 	/**
 	 * Updates or creates a new attribute on the currently matched tag with the passed value.
 	 *
-	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * This is a wrapper around the underlying WP_HTML_Tag_Processor method of the same name since only a limited number of
 	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
 	 *
 	 * @since 0.1.0
@@ -413,7 +413,7 @@ final class OD_HTML_Tag_Walker {
 	/**
 	 * Removes an attribute from the currently-matched tag.
 	 *
-	 * This is a wrapper around the underlying HTML_Tag_Processor method of the same name since only a limited number of
+	 * This is a wrapper around the underlying WP_HTML_Tag_Processor method of the same name since only a limited number of
 	 * methods can be exposed to prevent moving the pointer in such a way as the breadcrumb calculation is invalidated.
 	 *
 	 * @since 0.1.0

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -134,7 +134,7 @@ final class OD_URL_Metric implements JsonSerializable {
 							'xpath'              => array(
 								'type'     => 'string',
 								'required' => true,
-								'pattern'  => OD_HTML_Tag_Processor::XPATH_PATTERN,
+								'pattern'  => OD_HTML_Tag_Walker::XPATH_PATTERN,
 							),
 							'intersectionRatio'  => array(
 								'type'     => 'number',

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -36,7 +36,7 @@ function od_get_detection_script( string $slug, OD_URL_Metrics_Group_Collection 
 	$detection_time_window = apply_filters( 'od_detection_time_window', 5000 );
 
 	$web_vitals_lib_data = require __DIR__ . '/build/web-vitals.asset.php';
-	$web_vitals_lib_src  = add_query_arg( 'ver', $web_vitals_lib_data['version'], plugin_dir_url( __FILE__ ) . '/build/web-vitals.js' );
+	$web_vitals_lib_src  = add_query_arg( 'ver', $web_vitals_lib_data['version'], plugin_dir_url( __FILE__ ) . 'build/web-vitals.js' );
 
 	$current_url = od_get_current_url();
 	$detect_args = array(

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -49,6 +49,7 @@ require_once __DIR__ . '/helper.php';
 
 // Core infrastructure classes.
 require_once __DIR__ . '/class-od-data-validation-exception.php';
+require_once __DIR__ . '/class-od-html-tag-processor.php';
 require_once __DIR__ . '/class-od-url-metric.php';
 require_once __DIR__ . '/class-od-url-metrics-group.php';
 require_once __DIR__ . '/class-od-url-metrics-group-collection.php';

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -63,7 +63,7 @@ require_once __DIR__ . '/storage/rest-api.php';
 require_once __DIR__ . '/detection.php';
 
 // Optimization logic.
-require_once __DIR__ . '/class-od-html-tag-processor.php';
+require_once __DIR__ . '/class-od-html-tag-walker.php';
 require_once __DIR__ . '/optimization.php';
 
 // Add hooks for the above requires.

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -30,6 +30,18 @@ function od_get_detection_script_placeholder(): string {
 }
 
 /**
+ * Prints the detection script placeholder.
+ *
+ * @see wp_print_footer_scripts()
+ *
+ * @since 0.1.1
+ * @access private
+ */
+function od_print_detection_script_placeholder() {
+	echo esc_html( od_get_detection_script_placeholder() );
+}
+
+/**
  * Starts output buffering at the end of the 'template_include' filter.
  *
  * This is to implement #43258 in core.
@@ -82,18 +94,6 @@ function od_maybe_add_template_output_buffer_filter() {
 	}
 	add_filter( 'od_template_output_buffer', $callback );
 	add_action( 'wp_print_footer_scripts', 'od_print_detection_script_placeholder' );
-}
-
-/**
- * Prints the detection script placeholder.
- *
- * @see wp_print_footer_scripts()
- *
- * @since 0.1.1
- * @access private
- */
-function od_print_detection_script_placeholder() {
-	echo esc_html( od_get_detection_script_placeholder() );
 }
 
 /**

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -16,6 +16,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Once supported by the HTML API, the WP_HTML_Processor should be used to inject the script at the end of the BODY element.
  * It should also be used to inject the links in the HEAD.
  *
+ * @since  0.1.1
+ * @access private
+ *
  * @return string Placeholder.
  */
 function od_get_detection_script_placeholder(): string {

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -78,12 +78,19 @@ function od_maybe_add_template_output_buffer_filter() {
 		$callback = perflab_wrap_server_timing( $callback, 'optimization-detective', 'exist' );
 	}
 	add_filter( 'od_template_output_buffer', $callback );
-	add_action(
-		'wp_print_footer_scripts',
-		static function () {
-			echo esc_html( od_get_detection_script_placeholder() );
-		}
-	);
+	add_action( 'wp_print_footer_scripts', 'od_print_detection_script_placeholder' );
+}
+
+/**
+ * Prints the detection script placeholder.
+ *
+ * @see wp_print_footer_scripts()
+ *
+ * @since 0.1.1
+ * @access private
+ */
+function od_print_detection_script_placeholder() {
+	echo esc_html( od_get_detection_script_placeholder() );
 }
 
 /**
@@ -373,14 +380,10 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 
 	// Inject detection script.
 	// TODO: When optimizing above, if we find that there is a stored LCP element but it fails to match, it should perhaps set $needs_detection to true and send the request with an override nonce. However, this would require backtracking and adding the data-od-xpath attributes.
-	if ( $needs_detection ) {
-		// TODO: In the future, when it is supported, this injection should be done with the HTML Processor.
-		$buffer = str_replace(
-			esc_html( od_get_detection_script_placeholder() ),
-			od_get_detection_script( $slug, $group_collection ),
-			$buffer
-		);
-	}
-
-	return $buffer;
+	// TODO: In the future, when it is supported, this injection should be done with the HTML Processor.
+	return str_replace(
+		esc_html( od_get_detection_script_placeholder() ),
+		$needs_detection ? od_get_detection_script( $slug, $group_collection ) : '',
+		$buffer
+	);
 }

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-const OD_DETECTION_SCRIPT_PLACEHOLDER_COMMENT = '<!--OPTIMIZATION_DETECTIVE_DETECTION_SCRIPT-->';
+const OD_DETECTION_SCRIPT_PLACEHOLDER = '{{{OPTIMIZATION_DETECTIVE_DETECTION_SCRIPT}}}';
 
 /**
  * Starts output buffering at the end of the 'template_include' filter.
@@ -67,7 +67,7 @@ function od_maybe_add_template_output_buffer_filter() {
 	add_action(
 		'wp_print_footer_scripts',
 		static function () {
-			echo OD_DETECTION_SCRIPT_PLACEHOLDER_COMMENT; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo OD_DETECTION_SCRIPT_PLACEHOLDER; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	);
 }
@@ -361,7 +361,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	// TODO: When optimizing above, if we find that there is a stored LCP element but it fails to match, it should perhaps set $needs_detection to true and send the request with an override nonce. However, this would require backtracking and adding the data-od-xpath attributes.
 	if ( $needs_detection ) {
 		$buffer = str_replace(
-			OD_DETECTION_SCRIPT_PLACEHOLDER_COMMENT,
+			OD_DETECTION_SCRIPT_PLACEHOLDER,
 			od_get_detection_script( $slug, $group_collection ),
 			$buffer
 		);

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+const OD_DETECTION_SCRIPT_PLACEHOLDER_COMMENT = '<!--OPTIMIZATION_DETECTIVE_DETECTION_SCRIPT-->';
+
 /**
  * Starts output buffering at the end of the 'template_include' filter.
  *
@@ -62,6 +64,12 @@ function od_maybe_add_template_output_buffer_filter() {
 		$callback = perflab_wrap_server_timing( $callback, 'optimization-detective', 'exist' );
 	}
 	add_filter( 'od_template_output_buffer', $callback );
+	add_action(
+		'wp_print_footer_scripts',
+		static function () {
+			echo OD_DETECTION_SCRIPT_PLACEHOLDER_COMMENT; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+	);
 }
 
 /**
@@ -340,19 +348,22 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	// Inject any preload links at the end of the HEAD. In the future, WP_HTML_Processor could be used to do this injection.
 	// However, given the simple replacement here this is not essential.
 	$head_injection = od_construct_preload_links( $lcp_elements_by_minimum_viewport_widths );
-
-	// Inject detection script.
-	// TODO: When optimizing above, if we find that there is a stored LCP element but it fails to match, it should perhaps set $needs_detection to true and send the request with an override nonce. However, this would require backtracking and adding the data-od-xpath attributes.
-	if ( $needs_detection ) {
-		$head_injection .= od_get_detection_script( $slug, $group_collection );
-	}
-
 	if ( $head_injection ) {
 		$buffer = preg_replace(
 			'#(?=</HEAD>)#i',
 			$head_injection,
 			$buffer,
 			1
+		);
+	}
+
+	// Inject detection script.
+	// TODO: When optimizing above, if we find that there is a stored LCP element but it fails to match, it should perhaps set $needs_detection to true and send the request with an override nonce. However, this would require backtracking and adding the data-od-xpath attributes.
+	if ( $needs_detection ) {
+		$buffer = str_replace(
+			OD_DETECTION_SCRIPT_PLACEHOLDER_COMMENT,
+			od_get_detection_script( $slug, $group_collection ),
+			$buffer
 		);
 	}
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -140,6 +140,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 = 0.1.1 =
 
 * Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
+* Prevent detection script injection from breaking import maps in classic themes. ([1084](https://github.com/WordPress/performance/pull/1084))
 
 = 0.1.0 =
 

--- a/tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php
+++ b/tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Tests for optimization-detective class OD_HTML_Tag_Processor.
+ * Tests for optimization-detective class OD_HTML_Tag_Walker.
  *
  * @package optimization-detective
  *
- * @coversDefaultClass OD_HTML_Tag_Processor
+ * @coversDefaultClass OD_HTML_Tag_Walker
  *
  * @noinspection HtmlRequiredTitleElement
  * @noinspection HtmlRequiredAltAttribute
@@ -14,7 +14,7 @@
  * @noinspection HtmlExtraClosingTag
  * @todo What are the other inspection IDs which can turn off inspections for the other irrelevant warnings? Remaining is "The tag is marked as deprecated."
  */
-class OD_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
+class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 
 	public function data_provider_sample_documents(): array {
 		return array(
@@ -303,7 +303,7 @@ class OD_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 	 * @dataProvider data_provider_sample_documents
 	 */
 	public function test_open_tags_and_get_xpath( string $document, array $open_tags, array $xpaths ) {
-		$p = new OD_HTML_Tag_Processor( $document );
+		$p = new OD_HTML_Tag_Walker( $document );
 		$this->assertSame( '', $p->get_xpath(), 'Expected empty XPath since iteration has not started.' );
 		$actual_open_tags = array();
 		$actual_xpaths    = array();
@@ -325,7 +325,7 @@ class OD_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 	 * @covers ::get_updated_html
 	 */
 	public function test_html_tag_processor_wrapper_methods() {
-		$processor = new OD_HTML_Tag_Processor( '<html lang="en" xml:lang="en"></html>' );
+		$processor = new OD_HTML_Tag_Walker( '<html lang="en" xml:lang="en"></html>' );
 		foreach ( $processor->open_tags() as $open_tag ) {
 			if ( 'HTML' === $open_tag ) {
 				$this->assertSame( 'en', $processor->get_attribute( 'lang' ) );

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -1071,6 +1071,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 */
 	protected function parse_html_document( string $markup ): DOMDocument {
 		$dom = new DOMDocument();
+		libxml_use_internal_errors( true );
 		$dom->loadHTML( trim( $markup ) );
 
 		// Remove all whitespace nodes.

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -331,10 +331,10 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" loading="lazy">
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -360,10 +360,10 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<div style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==); width:100%; height: 200px;">This is so background!</div>
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -389,10 +389,10 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==" alt="">
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -417,11 +417,11 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<img id="no-src" alt="">
 							<img id="empty-src" src="" alt="">
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -721,10 +721,10 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 							<meta charset="utf-8">
 							<title>...</title>
 							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/foo.jpg" rel="preload" media="screen">
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800">
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -784,11 +784,11 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 							<title>...</title>
 							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (max-width: 782px)" rel="preload">
 							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/desktop-logo.png" media="screen and (min-width: 783px)" rel="preload">
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<img alt="Mobile Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
 							<img alt="Desktop Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -887,11 +887,11 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 							<title>...</title>
 							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (max-width: 480px)" rel="preload"/>
 							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/desktop-logo.png" media="screen and (min-width: 601px) and (max-width: 782px)" rel="preload"/>
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<img alt="Mobile Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
 							<img alt="Desktop Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -990,12 +990,12 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 							<meta charset="utf-8">
 							<title>...</title>
 							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (min-width: 481px) and (max-width: 600px)" rel="preload"/>
-							<script type="module">/* import detect ... */</script>
 						</head>
 						<body>
 							<img alt="Mobile Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
 							<p>New paragraph since URL Metrics were captured!</p>
 							<img alt="Desktop Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[2][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
 				',
@@ -1012,6 +1012,10 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ) {
 		$set_up();
+
+		// Simulate wp_print_footer_scripts().
+		$buffer = preg_replace( ':(?=</body>):', get_echo( 'od_print_detection_script_placeholder' ), $buffer );
+
 		$this->assertEquals(
 			$this->parse_html_document( $expected ),
 			$this->parse_html_document( od_optimize_template_output_buffer( $buffer ) )

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -33,6 +33,19 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests od_get_detection_script_placeholder() and od_print_detection_script_placeholder().
+	 *
+	 * @covers ::od_get_detection_script_placeholder
+	 * @covers ::od_print_detection_script_placeholder
+	 */
+	public function test_od_get_and_print_detection_script_placeholder() {
+		$placeholder = od_get_detection_script_placeholder();
+		$this->assertMatchesRegularExpression( '/^{{{OPTIMIZATION_DETECTIVE_DETECTION_SCRIPT-\d+}}}$/', $placeholder );
+		$this->assertSame( $placeholder, od_get_detection_script_placeholder() );
+		$this->assertSame( $placeholder, get_echo( 'od_print_detection_script_placeholder' ) );
+	}
+
+	/**
 	 * Make output is buffered and that it is also filtered.
 	 *
 	 * @covers ::od_buffer_output
@@ -76,12 +89,14 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 		od_maybe_add_template_output_buffer_filter();
 		$this->assertFalse( od_can_optimize_response() );
 		$this->assertFalse( has_filter( 'od_template_output_buffer' ) );
+		$this->assertFalse( has_action( 'wp_print_footer_scripts', 'od_print_detection_script_placeholder' ) );
 
 		add_filter( 'od_can_optimize_response', '__return_true', 2 );
 		$this->go_to( home_url( '/' ) );
 		$this->assertTrue( od_can_optimize_response() );
 		od_maybe_add_template_output_buffer_filter();
 		$this->assertTrue( has_filter( 'od_template_output_buffer' ) );
+		$this->assertSame( 10, has_action( 'wp_print_footer_scripts', 'od_print_detection_script_placeholder' ) );
 	}
 
 	/**

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -709,10 +709,14 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
+							<!--</head>-->
 						</head>
+						<!--</head>-->
 						<body>
 							<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800">
+							<!--</body>-->
 						</body>
+						<!--</body>-->
 					</html>
 				',
 				'expected' => '

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -33,19 +33,6 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests od_get_detection_script_placeholder() and od_print_detection_script_placeholder().
-	 *
-	 * @covers ::od_get_detection_script_placeholder
-	 * @covers ::od_print_detection_script_placeholder
-	 */
-	public function test_od_get_and_print_detection_script_placeholder() {
-		$placeholder = od_get_detection_script_placeholder();
-		$this->assertMatchesRegularExpression( '/^{{{OPTIMIZATION_DETECTIVE_DETECTION_SCRIPT-\d+}}}$/', $placeholder );
-		$this->assertSame( $placeholder, od_get_detection_script_placeholder() );
-		$this->assertSame( $placeholder, get_echo( 'od_print_detection_script_placeholder' ) );
-	}
-
-	/**
 	 * Make output is buffered and that it is also filtered.
 	 *
 	 * @covers ::od_buffer_output
@@ -89,14 +76,12 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 		od_maybe_add_template_output_buffer_filter();
 		$this->assertFalse( od_can_optimize_response() );
 		$this->assertFalse( has_filter( 'od_template_output_buffer' ) );
-		$this->assertFalse( has_action( 'wp_print_footer_scripts', 'od_print_detection_script_placeholder' ) );
 
 		add_filter( 'od_can_optimize_response', '__return_true', 2 );
 		$this->go_to( home_url( '/' ) );
 		$this->assertTrue( od_can_optimize_response() );
 		od_maybe_add_template_output_buffer_filter();
 		$this->assertTrue( has_filter( 'od_template_output_buffer' ) );
-		$this->assertSame( 10, has_action( 'wp_print_footer_scripts', 'od_print_detection_script_placeholder' ) );
 	}
 
 	/**
@@ -1027,10 +1012,6 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ) {
 		$set_up();
-
-		// Simulate wp_print_footer_scripts().
-		$buffer = preg_replace( ':(?=</body>):', get_echo( 'od_print_detection_script_placeholder' ), $buffer );
-
 		$this->assertEquals(
 			$this->parse_html_document( $expected ),
 			$this->parse_html_document( od_optimize_template_output_buffer( $buffer ) )

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -469,11 +469,11 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/foo.jpg" rel="preload" media="screen">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen">
 						</head>
 						<body>
-							<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" fetchpriority="high" data-od-added-fetchpriority data-od-removed-loading="lazy">
-							<img src="https://example.com/bar.jpg" alt="Bar" width="10" height="10" loading="lazy" data-od-removed-fetchpriority="high">
+							<img data-od-added-fetchpriority data-od-removed-loading="lazy" fetchpriority="high" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" >
+							<img data-od-removed-fetchpriority="high" src="https://example.com/bar.jpg" alt="Bar" width="10" height="10" loading="lazy" >
 						</body>
 					</html>
 				',
@@ -564,7 +564,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/foo-bg.jpg" rel="preload" media="screen">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo-bg.jpg" media="screen">
 						</head>
 						<body>
 							<div style="background-image:url(https://example.com/foo-bg.jpg); width:100%; height: 200px;">This is so background!</div>
@@ -630,9 +630,9 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 							<meta charset="utf-8">
 							<title>...</title>
 							<style>/* responsive styles to show only one div.header at a time... */</style>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/mobile-bg.jpg" media="screen and (max-width: 480px)" rel="preload">
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/tablet-bg.jpg" media="screen and (min-width: 481px) and (max-width: 600px)" rel="preload">
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/desktop-bg.jpg" media="screen and (min-width: 601px)" rel="preload">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-bg.jpg" media="screen and (max-width: 480px)">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/tablet-bg.jpg" media="screen and (min-width: 481px) and (max-width: 600px)">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop-bg.jpg" media="screen and (min-width: 601px)">
 						</head>
 						<body>
 							<div class="header desktop" style="background: red no-repeat center/80% url(\'https://example.com/desktop-bg.jpg\'); width:100%; height: 200px;">This is the desktop background!</div>
@@ -680,10 +680,10 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/foo.jpg" rel="preload" media="screen">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen">
 						</head>
 						<body>
-							<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" fetchpriority="high" data-od-fetchpriority-already-added>
+							<img data-od-fetchpriority-already-added src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" fetchpriority="high">
 						</body>
 					</html>
 				',
@@ -724,12 +724,16 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/foo.jpg" rel="preload" media="screen">
+							<!--</head>-->
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen">
 						</head>
+						<!--</head>-->
 						<body>
 							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800">
+							<!--</body>-->
 							<script type="module">/* import detect ... */</script>
 						</body>
+						<!--</body>-->
 					</html>
 				',
 			),
@@ -786,12 +790,12 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (max-width: 782px)" rel="preload">
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/desktop-logo.png" media="screen and (min-width: 783px)" rel="preload">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" media="screen and (max-width: 782px)">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop-logo.png" media="screen and (min-width: 783px)">
 						</head>
 						<body>
-							<img alt="Mobile Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
-							<img alt="Desktop Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" src="https://example.com/mobile-logo.png" alt="Mobile Logo" width="600" height="600">
+							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]" src="https://example.com/desktop-logo.png" alt="Desktop Logo" width="600" height="600">
 							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
@@ -889,12 +893,12 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (max-width: 480px)" rel="preload"/>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/desktop-logo.png" media="screen and (min-width: 601px) and (max-width: 782px)" rel="preload"/>
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" media="screen and (max-width: 480px)">
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop-logo.png" media="screen and (min-width: 601px) and (max-width: 782px)">
 						</head>
 						<body>
-							<img alt="Mobile Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
-							<img alt="Desktop Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" src="https://example.com/mobile-logo.png" alt="Mobile Logo" width="600" height="600">
+							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[1][self::IMG]" src="https://example.com/desktop-logo.png" alt="Desktop Logo" width="600" height="600">
 							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
@@ -993,12 +997,12 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 						<head>
 							<meta charset="utf-8">
 							<title>...</title>
-							<link as="image" data-od-added-tag="" fetchpriority="high" href="https://example.com/mobile-logo.png" media="screen and (min-width: 481px) and (max-width: 600px)" rel="preload"/>
+							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" media="screen and (min-width: 481px) and (max-width: 600px)">
 						</head>
 						<body>
-							<img alt="Mobile Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" height="600" src="https://example.com/mobile-logo.png" width="600"/>
+							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]" src="https://example.com/mobile-logo.png" alt="Mobile Logo" width="600" height="600">
 							<p>New paragraph since URL Metrics were captured!</p>
-							<img alt="Desktop Logo" data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[2][self::IMG]" height="600" src="https://example.com/desktop-logo.png" width="600"/>
+							<img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[2][self::IMG]" src="https://example.com/desktop-logo.png" alt="Desktop Logo" width="600" height="600">
 							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
@@ -1016,10 +1020,21 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ) {
 		$set_up();
-		$this->assertEquals(
-			$this->parse_html_document( $expected ),
-			$this->parse_html_document( od_optimize_template_output_buffer( $buffer ) )
+
+		$remove_initial_tabs = static function ( string $input ): string {
+			return preg_replace( '/^\t+/m', '', $input );
+		};
+
+		$expected = $remove_initial_tabs( $expected );
+		$buffer   = $remove_initial_tabs( $buffer );
+
+		$buffer = preg_replace(
+			':<script type="module">.+?</script>:s',
+			'<script type="module">/* import detect ... */</script>',
+			od_optimize_template_output_buffer( $buffer )
 		);
+
+		$this->assertEquals( $expected, $buffer );
 	}
 
 	/**
@@ -1061,39 +1076,5 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 			),
 		);
 		return new OD_URL_Metric( $data );
-	}
-
-	/**
-	 * Parse an HTML markup fragment and normalize for comparison.
-	 *
-	 * @param string $markup Markup.
-	 * @return DOMDocument Document containing the normalized markup fragment.
-	 */
-	protected function parse_html_document( string $markup ): DOMDocument {
-		$dom = new DOMDocument();
-		libxml_use_internal_errors( true );
-		$dom->loadHTML( trim( $markup ) );
-
-		// Remove all whitespace nodes.
-		$xpath = new DOMXPath( $dom );
-		foreach ( $xpath->query( '//text()' ) as $node ) {
-			/** @var DOMText $node */
-			if ( preg_match( '/^\s+$/', $node->nodeValue ) ) {
-				$node->nodeValue = '';
-			}
-		}
-
-		// Insert a newline before each node to make the diff easier to read.
-		foreach ( $xpath->query( '/html//*' ) as $node ) {
-			/** @var DOMElement $node */
-			$node->parentNode->insertBefore( $dom->createTextNode( "\n" ), $node );
-		}
-
-		// Normalize contents of module script output by od_get_detection_script().
-		foreach ( $xpath->query( '//script[ contains( text(), "import detect" ) ]' ) as $script ) {
-			$script->textContent = '/* import detect ... */';
-		}
-
-		return $dom;
 	}
 }


### PR DESCRIPTION
## Summary

Move detection script module from being injected at the end of `head` to instead happen at the end of `body`. This prevents the script module from breaking import maps, which are printed in the footer in classic themes rather than in the head (as done in block themes). The import map script must be printed before all script modules.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1083

## Relevant technical choices

<details><summary>Outdated technical choices</summary>

Previously the detection script module was injected just before the `</head>` closing tag. This broke import maps in classic themes, as an import map script must be added before any script modules, and classic themes output import map scripts in the footer. So instead of injecting the detection script at the end of the `head`, this PR changes it so that they get injected at the point where `wp_print_footer_scripts` happens. This injection happens by means of printing a placeholder string during template rendering and then this placeholder is replaced with the script module during output buffer processing. The placeholder is randomized to prevent accidental replacement of content. A placeholder is used instead of injecting before `</body>` since it may be that this exists inside of a comment, like `<!--</body>-->` in which case the replacement would be invalid.

Note that the injection of the preload links continues to happen just before `</head>`. The reason that a similar placeholder string is not used is that when a string appears in the `head`, the DOM specifies that this should cause the `head` to immediately close and implicitly open the `body`. In case there is any `DOMDocument` processing being done on the page in addition to our output buffer, the presence of a string placeholder would break the DOM. 

Additionally, a mustache-ish tag is used for the placeholder instead of an HTML comment because other plugins may try to optimize the page by removing all HTML comments to reduce page weight.

Ultimately, the injection of the preload links in the `head` and the detection script in the `body` should leverage the HTML API (via `WP_HTML_Processor`) once it is updated to support tag node insertions, which [it does not support yet](https://github.com/WordPress/wordpress-develop/blob/ea7888f114a9fe3c318716684d21703fe146ecbd/src/wp-includes/html-api/class-wp-html-processor.php#L28).

</details> 

Previously the detection script module was injected just before the `</head>` closing tag (using search/replace). This broke import maps in classic themes, as an import map script must be added before any script modules, and classic themes output import map scripts in the footer. Since it was using search/replace, it was also vulnerable to injecting the script in the wrong place, for example if the HTML contained `<!--</head>-->`. Now the HTML Tag Processor is extended (thanks to @dmsnell) to inject the script tag right before the `</body>` closing tag (and not confused by `<!--</body>-->`). The HTML Tag Processor is also used to inject any preload links at the end of the `</head>`. Note also that what was known as `OD_HTML_Tag_Processor` has been renamed to `OD_HTML_Tag_Walker`, and a new class `OD_HTML_Tag_Processor` is introduced which directly extends `WP_HTML_Tag_Processor`. The `OD_HTML_Tag_Walker` class (and the old `OD_HTML_Tag_Processor` class) did not extend `WP_HTML_Tag_Processor` but used it by composition. The new `OD_HTML_Tag_Processor` includes a method for injecting HTML in the `head` and `body`.

Finally, this PR removes the use of `ext-dom` to do equality assertions in PHPUnit. This was overkill and it made it difficult to debug when the assertions started failing.

----

This also fixes (46ca5f8) a trivial bug where an extra slash was present in the path to the web-vitals.js library (e.g. `optimization-detective//build/web-vitals.js`).

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
