### PR TITLE
Fix auto sizes plugin description

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Auto-sizes for Lazy-loaded Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
- * Description: This plugin implements the HTML spec for adding `sizes="auto"` to lazy-loaded images.
+ * Description: This plugin implements the HTML spec for adding <code>sizes="auto"</code> to lazy-loaded images.
  * Requires at least: 6.4
  * Requires PHP: 7.0
  * Version: 1.0.1


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

Before:

<img width="964" alt="Screenshot 2024-03-28 at 10 26 40" src="https://github.com/WordPress/performance/assets/841956/72d365d7-10a0-42b0-8b64-bfba8f5b4f4c">

After:

<img width="951" alt="Screenshot 2024-03-28 at 10 26 44" src="https://github.com/WordPress/performance/assets/841956/cdafd44a-84d6-4208-bd48-886e16439fd2">


## Relevant technical choices

<!-- Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
