### PR TITLE
Add Speculative Loading generator tag

### DIFF
--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -178,11 +178,6 @@ add_filter( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
  * @since 1.0.0
  */
 function dominant_color_render_generator() {
-	if (
-		defined( 'DOMINANT_COLOR_IMAGES_VERSION' ) &&
-		! str_starts_with( DOMINANT_COLOR_IMAGES_VERSION, 'Performance Lab ' )
-	) {
-		echo '<meta name="generator" content="Dominant Color Images ' . esc_attr( DOMINANT_COLOR_IMAGES_VERSION ) . '">' . "\n";
-	}
+	echo '<meta name="generator" content="Dominant Color Images ' . esc_attr( DOMINANT_COLOR_IMAGES_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'dominant_color_render_generator' );

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -162,10 +162,6 @@ function embed_optimizer_trigger_error( string $function_name, string $message, 
  * @since 0.1.0
  */
 function embed_optimizer_render_generator() {
-	if (
-		defined( 'EMBED_OPTIMIZER_VERSION' )
-	) {
-		echo '<meta name="generator" content="Embed Optimizer ' . esc_attr( EMBED_OPTIMIZER_VERSION ) . '">' . "\n";
-	}
+	echo '<meta name="generator" content="Embed Optimizer ' . esc_attr( EMBED_OPTIMIZER_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'embed_optimizer_render_generator' );

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -45,3 +45,15 @@ function plsr_print_speculation_rules() {
 	}
 }
 add_action( 'wp_footer', 'plsr_print_speculation_rules' );
+
+/**
+ * Displays the HTML generator meta tag for the Speculative Loading plugin.
+ *
+ * See {@see 'wp_head'}.
+ *
+ * @since 1.1.0
+ */
+function plsr_render_generator_meta_tag() {
+	echo '<meta name="generator" content="Speculative Loading ' . esc_attr( SPECULATION_RULES_VERSION ) . '">' . "\n";
+}
+add_action( 'wp_head', 'plsr_render_generator_meta_tag' );

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -103,6 +103,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 = 1.1.0 =
 
 * Allow excluding URL patterns from prerendering or prefetching specifically. ([1025](https://github.com/WordPress/performance/pull/1025))
+* Add Speculative Loading generator tag. ([1102](https://github.com/WordPress/performance/pull/1102))
 * Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 * Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -770,11 +770,7 @@ add_filter( 'wp_editor_set_quality', 'webp_uploads_modify_webp_quality', 10, 2 )
  * @since 1.0.0
  */
 function webp_uploads_render_generator() {
-	if (
-		defined( 'WEBP_UPLOADS_VERSION' )
-	) {
-		echo '<meta name="generator" content="WebP Uploads ' . esc_attr( WEBP_UPLOADS_VERSION ) . '">' . "\n";
-	}
+	echo '<meta name="generator" content="WebP Uploads ' . esc_attr( WEBP_UPLOADS_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'webp_uploads_render_generator' );
 


### PR DESCRIPTION
## Summary

Adds a generator tag to the Speculative Loading plugin, similar to how the other standalone plugins include one.

## Relevant technical choices

* Uses the new plugin name per #1046 / #1101
