### PR TITLE
Use plugin slug for generator tag

### DIFF
--- a/load.php
+++ b/load.php
@@ -57,7 +57,8 @@ function perflab_get_generator_content() {
 	}
 
 	return sprintf(
-		'Performance Lab %1$s; plugins: %2$s',
+		// Use the plugin slug as it is immutable.
+		'performance-lab %1$s; plugins: %2$s',
 		PERFLAB_VERSION,
 		implode( ', ', $active_plugins )
 	);

--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -178,6 +178,7 @@ add_filter( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
  * @since 1.0.0
  */
 function dominant_color_render_generator() {
-	echo '<meta name="generator" content="Image Placeholders ' . esc_attr( DOMINANT_COLOR_IMAGES_VERSION ) . '">' . "\n";
+	// Use the plugin slug as it is immutable.
+	echo '<meta name="generator" content="dominant-color-images ' . esc_attr( DOMINANT_COLOR_IMAGES_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'dominant_color_render_generator' );

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -52,6 +52,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 = 1.1.0 =
 
 * Rename plugin to "Image Placeholders". ([1101](https://github.com/WordPress/performance/pull/1101))
+* Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
 * Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 * Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -162,6 +162,7 @@ function embed_optimizer_trigger_error( string $function_name, string $message, 
  * @since 0.1.0
  */
 function embed_optimizer_render_generator() {
-	echo '<meta name="generator" content="Embed Optimizer ' . esc_attr( EMBED_OPTIMIZER_VERSION ) . '">' . "\n";
+	// Use the plugin slug as it is immutable.
+	echo '<meta name="generator" content="embed-optimizer ' . esc_attr( EMBED_OPTIMIZER_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'embed_optimizer_render_generator' );

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -51,6 +51,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.1.1 =
 
+* Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
 * Bump minimum required WP version to 6.4. ([1076](https://github.com/WordPress/performance/pull/1076))
 
 = 0.1.0 =

--- a/plugins/optimization-detective/helper.php
+++ b/plugins/optimization-detective/helper.php
@@ -18,5 +18,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.1.0
  */
 function od_render_generator_meta_tag() {
-	echo '<meta name="generator" content="Optimization Detective ' . esc_attr( OPTIMIZATION_DETECTIVE_VERSION ) . '">' . "\n";
+	// Use the plugin slug as it is immutable.
+	echo '<meta name="generator" content="optimization-detective ' . esc_attr( OPTIMIZATION_DETECTIVE_VERSION ) . '">' . "\n";
 }

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Uses real user metrics to improve heuristics WordPress applies on the frontend to improve image loading priority.
  * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 0.1.0
+ * Version: 0.1.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -43,7 +43,7 @@ if (
 	);
 }
 
-define( 'OPTIMIZATION_DETECTIVE_VERSION', '0.1.0' );
+define( 'OPTIMIZATION_DETECTIVE_VERSION', '0.1.1' );
 
 require_once __DIR__ . '/helper.php';
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        0.1.0
+Stable tag:        0.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images
@@ -136,6 +136,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.1.1 =
+
+* Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
 
 = 0.1.0 =
 

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -54,6 +54,7 @@ add_action( 'wp_footer', 'plsr_print_speculation_rules' );
  * @since 1.1.0
  */
 function plsr_render_generator_meta_tag() {
-	echo '<meta name="generator" content="Speculative Loading ' . esc_attr( SPECULATION_RULES_VERSION ) . '">' . "\n";
+	// Use the plugin slug as it is immutable.
+	echo '<meta name="generator" content="speculation-rules ' . esc_attr( SPECULATION_RULES_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'plsr_render_generator_meta_tag' );

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -770,7 +770,8 @@ add_filter( 'wp_editor_set_quality', 'webp_uploads_modify_webp_quality', 10, 2 )
  * @since 1.0.0
  */
 function webp_uploads_render_generator() {
-	echo '<meta name="generator" content="Modern Image Formats ' . esc_attr( WEBP_UPLOADS_VERSION ) . '">' . "\n";
+	// Use the plugin slug as it is immutable.
+	echo '<meta name="generator" content="webp-uploads ' . esc_attr( WEBP_UPLOADS_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'webp_uploads_render_generator' );
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -64,6 +64,7 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 * Add link to WebP settings to plugins table. ([1036](https://github.com/WordPress/performance/pull/1036))
 * Rename plugin to "Modern Image Formats". ([1101](https://github.com/WordPress/performance/pull/1101))
+* Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
 * Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 * Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 

--- a/tests/load-tests.php
+++ b/tests/load-tests.php
@@ -8,13 +8,13 @@
 class Load_Tests extends WP_UnitTestCase {
 
 	public function test_perflab_get_generator_content() {
-		$expected = 'Performance Lab ' . PERFLAB_VERSION . '; plugins: ';
+		$expected = 'performance-lab ' . PERFLAB_VERSION . '; plugins: ';
 		$content  = perflab_get_generator_content();
 		$this->assertSame( $expected, $content );
 	}
 
 	public function test_perflab_render_generator() {
-		$expected = '<meta name="generator" content="Performance Lab ' . PERFLAB_VERSION . '; plugins: ">' . "\n";
+		$expected = '<meta name="generator" content="performance-lab ' . PERFLAB_VERSION . '; plugins: ">' . "\n";
 		$output   = get_echo( 'perflab_render_generator' );
 		$this->assertSame( $expected, $output );
 

--- a/tests/plugins/dominant-color-images/dominant-color-test.php
+++ b/tests/plugins/dominant-color-images/dominant-color-test.php
@@ -371,4 +371,16 @@ class Dominant_Color_Test extends DominantColorTestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test printing the meta generator tag.
+	 *
+	 * @covers ::dominant_color_render_generator
+	 */
+	public function test_dominant_color_render_generator() {
+		$tag = get_echo( 'dominant_color_render_generator' );
+		$this->assertStringStartsWith( '<meta', $tag );
+		$this->assertStringContainsString( 'generator', $tag );
+		$this->assertStringContainsString( 'dominant-color-images ' . DOMINANT_COLOR_IMAGES_VERSION, $tag );
+	}
 }

--- a/tests/plugins/embed-optimizer/embed-optimizer-test.php
+++ b/tests/plugins/embed-optimizer/embed-optimizer-test.php
@@ -167,6 +167,6 @@ class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 		$tag = get_echo( 'embed_optimizer_render_generator' );
 		$this->assertStringStartsWith( '<meta', $tag );
 		$this->assertStringContainsString( 'generator', $tag );
-		$this->assertStringContainsString( EMBED_OPTIMIZER_VERSION, $tag );
+		$this->assertStringContainsString( 'embed-optimizer ' . EMBED_OPTIMIZER_VERSION, $tag );
 	}
 }

--- a/tests/plugins/embed-optimizer/embed-optimizer-test.php
+++ b/tests/plugins/embed-optimizer/embed-optimizer-test.php
@@ -7,6 +7,11 @@
 
 class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 
+	public function test_hooks() {
+		$this->assertSame( 10, has_filter( 'embed_oembed_html', 'embed_optimizer_filter_oembed_html' ) );
+		$this->assertSame( 10, has_action( 'wp_head', 'embed_optimizer_render_generator' ) );
+	}
+
 	/**
 	 * Test that the oEmbed HTML is filtered.
 	 *
@@ -163,7 +168,6 @@ class Embed_Optimizer_Helper_Tests extends WP_UnitTestCase {
 	 * @covers ::embed_optimizer_render_generator
 	 */
 	public function test_embed_optimizer_render_generator() {
-		$this->assertSame( 10, has_action( 'wp_head', 'embed_optimizer_render_generator' ) );
 		$tag = get_echo( 'embed_optimizer_render_generator' );
 		$this->assertStringStartsWith( '<meta', $tag );
 		$this->assertStringContainsString( 'generator', $tag );

--- a/tests/plugins/optimization-detective/helper-tests.php
+++ b/tests/plugins/optimization-detective/helper-tests.php
@@ -16,6 +16,6 @@ class OD_Helper_Tests extends WP_UnitTestCase {
 		$tag = get_echo( 'od_render_generator_meta_tag' );
 		$this->assertStringStartsWith( '<meta', $tag );
 		$this->assertStringContainsString( 'generator', $tag );
-		$this->assertStringContainsString( 'Optimization Detective ' . OPTIMIZATION_DETECTIVE_VERSION, $tag );
+		$this->assertStringContainsString( 'optimization-detective ' . OPTIMIZATION_DETECTIVE_VERSION, $tag );
 	}
 }

--- a/tests/plugins/speculation-rules/speculation-rules-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-test.php
@@ -19,6 +19,23 @@ class Speculation_Rules_Tests extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	public function test_hooks() {
+		$this->assertSame( 10, has_action( 'wp_footer', 'plsr_print_speculation_rules' ) );
+		$this->assertSame( 10, has_action( 'wp_head', 'plsr_render_generator_meta_tag' ) );
+	}
+
+	/**
+	 * Test printing the meta generator tag.
+	 *
+	 * @covers ::plsr_render_generator_meta_tag
+	 */
+	public function test_plsr_render_generator_meta_tag() {
+		$tag = get_echo( 'plsr_render_generator_meta_tag' );
+		$this->assertStringStartsWith( '<meta', $tag );
+		$this->assertStringContainsString( 'generator', $tag );
+		$this->assertStringContainsString( 'speculation-rules ' . SPECULATION_RULES_VERSION, $tag );
+	}
+
 	public function data_provider_to_test_print_speculation_rules(): array {
 		return array(
 			'xhtml' => array(
@@ -28,20 +45,6 @@ class Speculation_Rules_Tests extends WP_UnitTestCase {
 				'html5_support' => true,
 			),
 		);
-	}
-
-	/**
-	 * Test printing the meta generator tag.
-	 *
-	 * @covers ::plsr_render_generator_meta_tag
-	 */
-	public function test_plsr_render_generator_meta_tag() {
-		$this->assertSame( 10, has_action( 'wp_head', 'plsr_render_generator_meta_tag' ) );
-
-		$tag = get_echo( 'plsr_render_generator_meta_tag' );
-		$this->assertStringStartsWith( '<meta', $tag );
-		$this->assertStringContainsString( 'generator', $tag );
-		$this->assertStringContainsString( 'speculation-rules ' . SPECULATION_RULES_VERSION, $tag );
 	}
 
 	/**

--- a/tests/plugins/speculation-rules/speculation-rules-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-test.php
@@ -31,6 +31,20 @@ class Speculation_Rules_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test printing the meta generator tag.
+	 *
+	 * @covers ::plsr_render_generator_meta_tag
+	 */
+	public function test_plsr_render_generator_meta_tag() {
+		$this->assertSame( 10, has_action( 'wp_head', 'plsr_render_generator_meta_tag' ) );
+
+		$tag = get_echo( 'plsr_render_generator_meta_tag' );
+		$this->assertStringStartsWith( '<meta', $tag );
+		$this->assertStringContainsString( 'generator', $tag );
+		$this->assertStringContainsString( 'speculation-rules ' . SPECULATION_RULES_VERSION, $tag );
+	}
+
+	/**
 	 * @dataProvider data_provider_to_test_print_speculation_rules
 	 * @covers ::plsr_print_speculation_rules
 	 */

--- a/tests/plugins/speculation-rules/speculation-rules-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-test.php
@@ -24,18 +24,6 @@ class Speculation_Rules_Tests extends WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'wp_head', 'plsr_render_generator_meta_tag' ) );
 	}
 
-	/**
-	 * Test printing the meta generator tag.
-	 *
-	 * @covers ::plsr_render_generator_meta_tag
-	 */
-	public function test_plsr_render_generator_meta_tag() {
-		$tag = get_echo( 'plsr_render_generator_meta_tag' );
-		$this->assertStringStartsWith( '<meta', $tag );
-		$this->assertStringContainsString( 'generator', $tag );
-		$this->assertStringContainsString( 'speculation-rules ' . SPECULATION_RULES_VERSION, $tag );
-	}
-
 	public function data_provider_to_test_print_speculation_rules(): array {
 		return array(
 			'xhtml' => array(
@@ -72,5 +60,17 @@ class Speculation_Rules_Tests extends WP_UnitTestCase {
 		} else {
 			$this->assertStringContainsString( '/* <![CDATA[ */', wp_get_inline_script_tag( '/*...*/' ) );
 		}
+	}
+
+	/**
+	 * Test printing the meta generator tag.
+	 *
+	 * @covers ::plsr_render_generator_meta_tag
+	 */
+	public function test_plsr_render_generator_meta_tag() {
+		$tag = get_echo( 'plsr_render_generator_meta_tag' );
+		$this->assertStringStartsWith( '<meta', $tag );
+		$this->assertStringContainsString( 'generator', $tag );
+		$this->assertStringContainsString( 'speculation-rules ' . SPECULATION_RULES_VERSION, $tag );
 	}
 }

--- a/tests/plugins/webp-uploads/load-tests.php
+++ b/tests/plugins/webp-uploads/load-tests.php
@@ -985,6 +985,18 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 	}
 
 	/**
+	 * Test printing the meta generator tag.
+	 *
+	 * @covers ::webp_uploads_render_generator
+	 */
+	public function test_webp_uploads_render_generator() {
+		$tag = get_echo( 'webp_uploads_render_generator' );
+		$this->assertStringStartsWith( '<meta', $tag );
+		$this->assertStringContainsString( 'generator', $tag );
+		$this->assertStringContainsString( 'webp-uploads ' . WEBP_UPLOADS_VERSION, $tag );
+	}
+
+	/**
 	 * Runs (empty) hooks to satisfy webp_uploads_in_frontend_body() conditions.
 	 */
 	private function mock_frontend_body_hooks() {


### PR DESCRIPTION
## Summary

Based on the discussion in https://github.com/WordPress/performance/pull/1102#issuecomment-2026401373: Since plugin names can change over time, the original approach of using the plugin names for generator tags is not great. Therefore this PR proposes using the plugin slug, which is immutable. In the long run, this will be more maintainable as it won't result in tooling or queries requiring an update.

## Relevant technical choices

* Use the plugin slug instead of plugin name for all existing generator tags, including Performance Lab.
* Update existing tests, and add a missing test for the Speculation Rules plugin's generator tag.
* Add readme entries for the standalone plugins (for PL this will be auto-generated, while for the other standalone plugins we'll start with that after the next "set of releases").
* Bump Optimization Detective to 0.1.1 to include this change.
