### PR TITLE
Add crate-ci/typos config file with false positives.

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-words]
+# Don't correct the abbreviated "duration"
+dur = "dur"


### PR DESCRIPTION
## Summary

It looks like our Spell Check underlying repository was updated and now complains about the word "dur", which however is intentional, as it abbreviates "duration" and is in fact a syntax requirement for the Server-Timing API. See failure here for reference: https://github.com/WordPress/performance/actions/runs/8513515250/job/23317345691?pr=1105

This fix is based on the documentation in https://github.com/crate-ci/typos?tab=readme-ov-file#false-positives