### PR TITLE
Reuse `WP_HTML_Processor::is_void()` now that WP 6.5 is minimum supported version

### DIFF
--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -22,36 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class OD_HTML_Tag_Processor {
 
 	/**
-	 * HTML void tags (i.e. those which are self-closing).
-	 *
-	 * @link https://html.spec.whatwg.org/multipage/syntax.html#void-elements
-	 * @see WP_HTML_Processor::is_void()
-	 * @todo Reuse `WP_HTML_Processor::is_void()` once WordPress 6.4 is the minimum-supported version.
-	 *
-	 * @var string[]
-	 */
-	const VOID_TAGS = array(
-		'AREA',
-		'BASE',
-		'BASEFONT', // Obsolete.
-		'BGSOUND', // Obsolete.
-		'BR',
-		'COL',
-		'EMBED',
-		'FRAME', // Deprecated.
-		'HR',
-		'IMG',
-		'INPUT',
-		'KEYGEN', // Obsolete.
-		'LINK',
-		'META',
-		'PARAM', // Deprecated.
-		'SOURCE',
-		'TRACK',
-		'WBR',
-	);
-
-	/**
 	 * Raw text tags.
 	 *
 	 * These are treated like void tags for the purposes of walking over the document since we do not process any text
@@ -225,7 +195,7 @@ final class OD_HTML_Tag_Processor {
 
 				// Immediately pop off self-closing and raw text tags.
 				if (
-					in_array( $tag_name, self::VOID_TAGS, true )
+					WP_HTML_Processor::is_void( $tag_name )
 					||
 					in_array( $tag_name, self::RAW_TEXT_TAGS, true )
 					||
@@ -236,7 +206,7 @@ final class OD_HTML_Tag_Processor {
 			} else {
 				// If the closing tag is for self-closing or raw text tag, we ignore it since it was already handled above.
 				if (
-					in_array( $tag_name, self::VOID_TAGS, true )
+					WP_HTML_Processor::is_void( $tag_name )
 					||
 					in_array( $tag_name, self::RAW_TEXT_TAGS, true )
 				) {

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -140,6 +140,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 = 0.1.1 =
 
 * Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
+* Reuse `WP_HTML_Processor::is_void()` now that WP 6.4 is minimum supported version. ([1115](https://github.com/WordPress/performance/pull/1115))
 
 = 0.1.0 =
 

--- a/tests/plugins/optimization-detective/class-od-html-tag-processor-tests.php
+++ b/tests/plugins/optimization-detective/class-od-html-tag-processor-tests.php
@@ -124,27 +124,19 @@ class OD_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 						<body>
 							<area>
 							<base>
-							<!-- TODO: Add these deprecated/non-standard tags to WP_HTML_Processor::is_void(). See <https://core.trac.wordpress.org/ticket/60961>.
 							<basefont>
 							<bgsound>
-							-->
 							<br>
 							<col>
 							<embed>
-							<!-- TODO: See above.
 							<frame>
-							-->
 							<hr>
 							<img src="">
 							<input>
-							<!-- TODO: See above.
 							<keygen>
-							-->
 							<link>
 							<meta>
-							<!-- TODO: See above.
 							<param name="foo" value="bar">
-							-->
 							<source>
 							<track src="https://example.com/track">
 							<wbr>
@@ -156,27 +148,32 @@ class OD_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 						</body>
 					</html>
 				',
-				'open_tags' => array( 'HTML', 'HEAD', 'BODY', 'AREA', 'BASE', 'BR', 'COL', 'EMBED', 'HR', 'IMG', 'INPUT', 'LINK', 'META', 'SOURCE', 'TRACK', 'WBR', 'DIV', 'SPAN', 'EM' ),
+				'open_tags' => array( 'HTML', 'HEAD', 'BODY', 'AREA', 'BASE', 'BASEFONT', 'BGSOUND', 'BR', 'COL', 'EMBED', 'FRAME', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR', 'DIV', 'SPAN', 'EM' ),
 				'xpaths'    => array(
 					'/*[0][self::HTML]',
 					'/*[0][self::HTML]/*[0][self::HEAD]',
 					'/*[0][self::HTML]/*[1][self::BODY]',
 					'/*[0][self::HTML]/*[1][self::BODY]/*[0][self::AREA]',
 					'/*[0][self::HTML]/*[1][self::BODY]/*[1][self::BASE]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[2][self::BR]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[3][self::COL]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[4][self::EMBED]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[5][self::HR]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[6][self::IMG]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[7][self::INPUT]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[8][self::LINK]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[9][self::META]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[10][self::SOURCE]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[11][self::TRACK]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[12][self::WBR]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::DIV]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::DIV]/*[0][self::SPAN]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::DIV]/*[0][self::SPAN]/*[0][self::EM]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[2][self::BASEFONT]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[3][self::BGSOUND]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[4][self::BR]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[5][self::COL]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[6][self::EMBED]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[7][self::FRAME]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[8][self::HR]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[9][self::IMG]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[10][self::INPUT]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[11][self::KEYGEN]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[12][self::LINK]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::META]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[14][self::PARAM]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[15][self::SOURCE]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[16][self::TRACK]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[17][self::WBR]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[18][self::DIV]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[18][self::DIV]/*[0][self::SPAN]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[18][self::DIV]/*[0][self::SPAN]/*[0][self::EM]',
 				),
 			),
 			'optional-closing-p' => array(

--- a/tests/plugins/optimization-detective/class-od-html-tag-processor-tests.php
+++ b/tests/plugins/optimization-detective/class-od-html-tag-processor-tests.php
@@ -124,19 +124,27 @@ class OD_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 						<body>
 							<area>
 							<base>
+							<!-- TODO: Add these deprecated/non-standard tags to WP_HTML_Processor::is_void(). See <https://core.trac.wordpress.org/ticket/60961>.
 							<basefont>
 							<bgsound>
+							-->
 							<br>
 							<col>
 							<embed>
+							<!-- TODO: See above.
 							<frame>
+							-->
 							<hr>
 							<img src="">
 							<input>
+							<!-- TODO: See above.
 							<keygen>
+							-->
 							<link>
 							<meta>
+							<!-- TODO: See above.
 							<param name="foo" value="bar">
+							-->
 							<source>
 							<track src="https://example.com/track">
 							<wbr>
@@ -148,32 +156,27 @@ class OD_HTML_Tag_Processor_Tests extends WP_UnitTestCase {
 						</body>
 					</html>
 				',
-				'open_tags' => array( 'HTML', 'HEAD', 'BODY', 'AREA', 'BASE', 'BASEFONT', 'BGSOUND', 'BR', 'COL', 'EMBED', 'FRAME', 'HR', 'IMG', 'INPUT', 'KEYGEN', 'LINK', 'META', 'PARAM', 'SOURCE', 'TRACK', 'WBR', 'DIV', 'SPAN', 'EM' ),
+				'open_tags' => array( 'HTML', 'HEAD', 'BODY', 'AREA', 'BASE', 'BR', 'COL', 'EMBED', 'HR', 'IMG', 'INPUT', 'LINK', 'META', 'SOURCE', 'TRACK', 'WBR', 'DIV', 'SPAN', 'EM' ),
 				'xpaths'    => array(
 					'/*[0][self::HTML]',
 					'/*[0][self::HTML]/*[0][self::HEAD]',
 					'/*[0][self::HTML]/*[1][self::BODY]',
 					'/*[0][self::HTML]/*[1][self::BODY]/*[0][self::AREA]',
 					'/*[0][self::HTML]/*[1][self::BODY]/*[1][self::BASE]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[2][self::BASEFONT]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[3][self::BGSOUND]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[4][self::BR]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[5][self::COL]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[6][self::EMBED]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[7][self::FRAME]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[8][self::HR]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[9][self::IMG]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[10][self::INPUT]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[11][self::KEYGEN]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[12][self::LINK]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::META]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[14][self::PARAM]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[15][self::SOURCE]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[16][self::TRACK]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[17][self::WBR]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[18][self::DIV]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[18][self::DIV]/*[0][self::SPAN]',
-					'/*[0][self::HTML]/*[1][self::BODY]/*[18][self::DIV]/*[0][self::SPAN]/*[0][self::EM]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[2][self::BR]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[3][self::COL]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[4][self::EMBED]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[5][self::HR]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[6][self::IMG]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[7][self::INPUT]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[8][self::LINK]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[9][self::META]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[10][self::SOURCE]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[11][self::TRACK]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[12][self::WBR]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::DIV]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::DIV]/*[0][self::SPAN]',
+					'/*[0][self::HTML]/*[1][self::BODY]/*[13][self::DIV]/*[0][self::SPAN]/*[0][self::EM]',
 				),
 			),
 			'optional-closing-p' => array(


### PR DESCRIPTION
This removes a TODO to reuse `WP_HTML_Processor::is_void()` instead of replicating that functionality which was not available until WP 6.4. Now that 6.4 is the minimum-supported version, that method can be reused.

This could have been done previously in #1068 when the minimum version was bumped. 