### PR TITLE
Delete option when uninstalling the Modern Image Formats plugin

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,6 @@ parameters:
 		- includes/
 		- plugins/
 		- tests/
-		- uninstall.php
 	scanDirectories:
 		- vendor/wp-phpunit/wp-phpunit/
 	dynamicConstantNames:

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -65,6 +65,7 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 * Add link to WebP settings to plugins table. ([1036](https://github.com/WordPress/performance/pull/1036))
 * Rename plugin to "Modern Image Formats". ([1101](https://github.com/WordPress/performance/pull/1101))
 * Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
+* Delete option when uninstalling the Modern Image Formats plugin. ([1116](https://github.com/WordPress/performance/pull/1116))
 * Bump minimum required WP version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
 * Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 

--- a/plugins/webp-uploads/uninstall.php
+++ b/plugins/webp-uploads/uninstall.php
@@ -2,8 +2,8 @@
 /**
  * Plugin uninstaller logic.
  *
- * @package performance-lab
- * @since 1.2.0
+ * @package webp-uploads
+ * @since n.e.x.t
  */
 
 // If uninstall.php is not called by WordPress, bail.
@@ -24,18 +24,18 @@ if ( is_multisite() ) {
 
 	foreach ( $site_ids as $site_id ) {
 		switch_to_blog( $site_id );
-		perflab_delete_plugin_option();
+		webp_uploads_delete_plugin_option();
 		restore_current_blog();
 	}
 }
 
-perflab_delete_plugin_option();
+webp_uploads_delete_plugin_option();
 
 /**
  * Delete the current site's option.
  *
- * @since 1.4.0
+ * @since n.e.x.t
  */
-function perflab_delete_plugin_option() {
+function webp_uploads_delete_plugin_option() {
 	delete_option( 'perflab_generate_webp_and_jpeg' );
 }

--- a/plugins/webp-uploads/uninstall.php
+++ b/plugins/webp-uploads/uninstall.php
@@ -3,7 +3,7 @@
  * Plugin uninstaller logic.
  *
  * @package webp-uploads
- * @since n.e.x.t
+ * @since 1.1.0
  */
 
 // If uninstall.php is not called by WordPress, bail.
@@ -34,7 +34,7 @@ webp_uploads_delete_plugin_option();
 /**
  * Delete the current site's option.
  *
- * @since n.e.x.t
+ * @since 1.1.0
  */
 function webp_uploads_delete_plugin_option() {
 	delete_option( 'perflab_generate_webp_and_jpeg' );


### PR DESCRIPTION
## Summary
We removed the module infrastructure in #1060 from the Performance Lab plugin. In #345, we introduced an uninstaller routine that removes options when the plugin is uninstalled from the site.

We should move the `uninstall.php` file to the WebP Uploads folder, as that plugin adds that option.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
