### PR TITLE
Update `since` command for standalone plugin usage

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -5,6 +5,11 @@
  */
 const program = require( 'commander' );
 
+/**
+ * Internal dependencies
+ */
+const { formats } = require( './lib/logger' );
+
 const withOptions = ( command, options ) => {
 	options.forEach( ( { description, argname, defaults } ) => {
 		command = command.option( argname, description, defaults );
@@ -17,7 +22,7 @@ const catchException = ( handler ) => {
 		try {
 			await handler( ...args );
 		} catch ( error ) {
-			console.error( error ); // eslint-disable-line no-console
+			console.error( formats.error( error.message ) ); // eslint-disable-line no-console
 			process.exitCode = 1;
 		}
 	};

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -20,7 +20,7 @@ const { plugins } = require( '../../../plugins.json' );
 exports.options = [
 	{
 		argname: '-p, --plugin <plugin>',
-		description: 'Plugin name',
+		description: 'Plugin slug',
 		defaults: 'performance-lab',
 	},
 	{

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -18,6 +18,10 @@ const { log, formats } = require( '../lib/logger' );
 
 exports.options = [
 	{
+		argname: '-p, --plugin <plugin>',
+		description: 'Plugin name',
+	},
+	{
 		argname: '-r, --release <release>',
 		description: 'Release version number',
 	},
@@ -38,13 +42,23 @@ exports.handler = async ( opt ) => {
 		return;
 	}
 
-	const patterns = [
-		path.resolve( __dirname, '../../../**/*.php' ),
-		path.resolve( __dirname, '../../../**/*.js' ),
-	];
+	const patterns = [];
+	const pluginRoot = path.resolve( __dirname, '../../../' );
+	const ignore = [ '**/node_modules', '**/vendor', '**/bin', '**/build' ];
+
+	if ( opt.plugin ) {
+		const pluginPath = path.resolve( pluginRoot, 'plugins', opt.plugin );
+
+		patterns.push( `${ pluginPath }/**/*.php` );
+		patterns.push( `${ pluginPath }/**/*.js` );
+	} else {
+		ignore.push( '**/plugins' );
+		patterns.push( `${ pluginRoot }/**/*.php` );
+		patterns.push( `${ pluginRoot }/**/*.js` );
+	}
 
 	const files = await glob( patterns, {
-		ignore: [ __filename, '**/node_modules', '**/vendor' ],
+		ignore,
 	} );
 
 	const regexp = new RegExp( '@since(\\s+)n.e.x.t', 'g' );

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -21,6 +21,7 @@ exports.options = [
 	{
 		argname: '-p, --plugin <plugin>',
 		description: 'Plugin name',
+		defaults: 'performance-lab',
 	},
 	{
 		argname: '-r, --release <release>',
@@ -43,7 +44,7 @@ exports.handler = async ( opt ) => {
 		return;
 	}
 
-	if ( opt.plugin && ! plugins.includes( opt.plugin ) ) {
+	if ( opt.plugin !== 'performance-lab' && ! plugins.includes( opt.plugin ) ) {
 		log(
 			formats.error(
 				`The plugin "${ opt.plugin }" is not found in the plugins.json file.`
@@ -56,7 +57,7 @@ exports.handler = async ( opt ) => {
 	const pluginRoot = path.resolve( __dirname, '../../../' );
 	const ignore = [ '**/node_modules', '**/vendor', '**/bin', '**/build' ];
 
-	if ( opt.plugin ) {
+	if ( opt.plugin !== 'performance-lab' ) {
 		const pluginPath = path.resolve( pluginRoot, 'plugins', opt.plugin );
 
 		patterns.push( `${ pluginPath }/**/*.php` );

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -14,7 +14,8 @@ const { plugins } = require( '../../../plugins.json' );
 /**
  * @typedef WPSinceCommandOptions
  *
- * @property {string} version Version number.
+ * @property {string} plugin  Plugin slug.
+ * @property {string} release Release version number.
  */
 
 exports.options = [

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -47,7 +47,7 @@ exports.handler = async ( opt ) => {
 	if ( opt.plugin !== 'performance-lab' && ! plugins.includes( opt.plugin ) ) {
 		log(
 			formats.error(
-				`The plugin "${ opt.plugin }" is not found in the plugins.json file.`
+				`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`
 			)
 		);
 		return;

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -9,6 +9,7 @@ const fs = require( 'fs' );
  * Internal dependencies
  */
 const { log, formats } = require( '../lib/logger' );
+const { plugins } = require( '../../../plugins.json' );
 
 /**
  * @typedef WPSinceCommandOptions
@@ -37,6 +38,15 @@ exports.handler = async ( opt ) => {
 		log(
 			formats.error(
 				'The release version must be provided via the --release (-r) argument.'
+			)
+		);
+		return;
+	}
+
+	if ( opt.plugin && ! plugins.includes( opt.plugin ) ) {
+		log(
+			formats.error(
+				`The plugin "${ opt.plugin }" is not found in the plugins.json file.`
 			)
 		);
 		return;

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -8,7 +8,6 @@ const glob = require( 'fast-glob' );
 /**
  * Internal dependencies
  */
-const { log, formats } = require( '../lib/logger' );
 const { plugins } = require( '../../../plugins.json' );
 
 /**
@@ -37,26 +36,18 @@ exports.options = [
  */
 exports.handler = async ( opt ) => {
 	if ( ! opt.release ) {
-		log(
-			formats.error(
-				'The release version must be provided via the --release (-r) argument.'
-			)
+		throw new Error(
+			'The release version must be provided via the --release (-r) argument.'
 		);
-
-		process.exit( 1 );
 	}
 
 	if (
 		opt.plugin !== 'performance-lab' &&
 		! plugins.includes( opt.plugin )
 	) {
-		log(
-			formats.error(
-				`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`
-			)
+		throw new Error(
+			`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`
 		);
-
-		process.exit( 1 );
 	}
 
 	const patterns = [];

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+const fs = require( 'fs' );
 const path = require( 'path' );
 const glob = require( 'fast-glob' );
-const fs = require( 'fs' );
 
 /**
  * Internal dependencies
@@ -42,7 +42,8 @@ exports.handler = async ( opt ) => {
 				'The release version must be provided via the --release (-r) argument.'
 			)
 		);
-		return;
+
+		process.exit( 1 );
 	}
 
 	if (
@@ -54,7 +55,8 @@ exports.handler = async ( opt ) => {
 				`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`
 			)
 		);
-		return;
+
+		process.exit( 1 );
 	}
 
 	const patterns = [];

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -45,7 +45,10 @@ exports.handler = async ( opt ) => {
 		return;
 	}
 
-	if ( opt.plugin !== 'performance-lab' && ! plugins.includes( opt.plugin ) ) {
+	if (
+		opt.plugin !== 'performance-lab' &&
+		! plugins.includes( opt.plugin )
+	) {
 		log(
 			formats.error(
 				`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -61,6 +61,10 @@ exports.handler = async ( opt ) => {
 	const pluginRoot = path.resolve( __dirname, '../../../' );
 	const ignore = [ '**/node_modules', '**/vendor', '**/bin', '**/build' ];
 
+	/*
+	 * For a standalone plugin, use the specific plugin directory.
+	 * For Performance Lab, use the root directory and ignore the standalone plugin directories.
+	 */
 	if ( opt.plugin !== 'performance-lab' ) {
 		const pluginPath = path.resolve( pluginRoot, 'plugins', opt.plugin );
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1118

## Relevant technical choices

- Add `--plugin` flag to pass the specific plugin name.
- If no `--plugin` flag is passed, it will run on PL plugin.
- Return with error if `--plugin` is passed with wrong plugin name.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
