### PR TITLE
WPCS Improvement

### DIFF
--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -30,7 +30,7 @@ function auto_sizes_update_image_attributes( $attr ) {
 	}
 
 	// Don't add 'auto' to the sizes attribute if it already exists.
-	if ( false !== strpos( $attr['sizes'], 'auto,' ) ) {
+	if ( str_contains( $attr['sizes'], 'auto,' ) ) {
 		return $attr;
 	}
 

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -73,6 +73,10 @@ function od_maybe_add_template_output_buffer_filter() {
  * @return bool Whether response can be optimized.
  */
 function od_can_optimize_response(): bool {
+
+	// Retrieve the sanitized value of the 'REQUEST_METHOD' server variable.
+	$method = filter_input( INPUT_SERVER, 'REQUEST_METHOD', FILTER_SANITIZE_STRING );
+	
 	$able = ! (
 		// Since there is no predictability in whether posts in the loop will have featured images assigned or not. If a
 		// theme template for search results doesn't even show featured images, then this wouldn't be an issue.
@@ -80,7 +84,7 @@ function od_can_optimize_response(): bool {
 		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
 		is_customize_preview() ||
 		// Since the images detected in the response body of a POST request cannot, by definition, be cached.
-		'GET' !== $_SERVER['REQUEST_METHOD'] ||
+		( isset( $method ) && 'GET' !== $method ) ||
 		// The aim is to optimize pages for the majority of site visitors, not those who administer the site. For admin
 		// users, additional elements will be present like the script from wp_customize_support_script() which will
 		// interfere with the XPath indices. Note that od_get_normalized_query_vars() is varied by is_user_logged_in()

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -73,10 +73,6 @@ function od_maybe_add_template_output_buffer_filter() {
  * @return bool Whether response can be optimized.
  */
 function od_can_optimize_response(): bool {
-
-	// Retrieve the sanitized value of the 'REQUEST_METHOD' server variable.
-	$method = filter_input( INPUT_SERVER, 'REQUEST_METHOD', FILTER_SANITIZE_STRING );
-	
 	$able = ! (
 		// Since there is no predictability in whether posts in the loop will have featured images assigned or not. If a
 		// theme template for search results doesn't even show featured images, then this wouldn't be an issue.
@@ -84,7 +80,7 @@ function od_can_optimize_response(): bool {
 		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
 		is_customize_preview() ||
 		// Since the images detected in the response body of a POST request cannot, by definition, be cached.
-		( isset( $method ) && 'GET' !== $method ) ||
+		( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' !== $_SERVER['REQUEST_METHOD'] ) ||
 		// The aim is to optimize pages for the majority of site visitors, not those who administer the site. For admin
 		// users, additional elements will be present like the script from wp_customize_support_script() which will
 		// interfere with the XPath indices. Note that od_get_normalized_query_vars() is varied by is_user_logged_in()

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -93,7 +93,7 @@ function plsr_get_speculation_rules() {
 		),
 	);
 
-	// Allow adding a class on any links to prevent prerendering.
+	// Allow adding a class on any links to prevent pre-rendering.
 	if ( 'prerender' === $mode ) {
 		$rules[0]['where']['and'][] = array(
 			'not' => array(

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -93,7 +93,7 @@ function plsr_get_speculation_rules() {
 		),
 	);
 
-	// Allow adding a class on any links to prevent pre-rendering.
+	// Allow adding a class on any links to prevent prerendering.
 	if ( 'prerender' === $mode ) {
 		$rules[0]['where']['and'][] = array(
 			'not' => array(


### PR DESCRIPTION
## Summary

Fixes #

## Relevant technical choices

I've refactored the code to address PHPCS (PHP CodeSniffer) warnings and improve code readability and standards compliance.

- Used `isset()` to check if a variable is set before accessing it to avoid illegal string offset warnings.
- Replaced `strpos()` with `str_contains()` for more readable string containment checks.
- ~Utilized `filter_input()` with appropriate sanitization for better handling of input data from superglobals.~
- ~Ensured that all global variables like `$_SERVER` are properly validated before use to prevent potential security vulnerabilities.~

These changes aim to enhance the overall quality and maintainability of the codebase by adhering to best practices recommended by PHPCS.