### PR TITLE
Prepare 3.0.0 release

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -39,7 +39,7 @@ add_action( 'admin_menu', 'perflab_add_features_page' );
  *
  * @since 1.0.0
  * @since 3.0.0 Renamed to perflab_load_features_page(), and the
- *                $module and $hook_suffix parameters were removed.
+ *              $module and $hook_suffix parameters were removed.
  */
 function perflab_load_features_page() {
 	// Handle script enqueuing for settings page.

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Adds the features page to the Settings menu.
  *
  * @since 1.0.0
- * @since n.e.x.t Renamed to perflab_add_features_page().
+ * @since 3.0.0 Renamed to perflab_add_features_page().
  */
 function perflab_add_features_page() {
 	$hook_suffix = add_options_page(
@@ -38,7 +38,7 @@ add_action( 'admin_menu', 'perflab_add_features_page' );
  * Initializes functionality for the features page.
  *
  * @since 1.0.0
- * @since n.e.x.t Renamed to perflab_load_features_page(), and the
+ * @since 3.0.0 Renamed to perflab_load_features_page(), and the
  *                $module and $hook_suffix parameters were removed.
  */
 function perflab_load_features_page() {
@@ -56,7 +56,7 @@ function perflab_load_features_page() {
  * Renders the plugin page.
  *
  * @since 1.0.0
- * @since n.e.x.t Renamed to perflab_render_settings_page().
+ * @since 3.0.0 Renamed to perflab_render_settings_page().
  */
 function perflab_render_settings_page() {
 	?>
@@ -205,7 +205,7 @@ add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 
  * Callback function to handle admin scripts.
  *
  * @since 2.8.0
- * @since n.e.x.t Renamed to perflab_enqueue_features_page_scripts().
+ * @since 3.0.0 Renamed to perflab_enqueue_features_page_scripts().
  */
 function perflab_enqueue_features_page_scripts() {
 	// These assets are needed for the "Learn more" popover.
@@ -217,7 +217,7 @@ function perflab_enqueue_features_page_scripts() {
 /**
  * Callback for handling installation/activation of plugin.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  */
 function perflab_install_activate_plugin_callback() {
 	check_admin_referer( 'perflab_install_activate_plugin' );
@@ -312,7 +312,7 @@ add_action( 'admin_action_perflab_install_activate_plugin', 'perflab_install_act
 /**
  * Callback function to handle admin inline style.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  */
 function perflab_print_features_page_style() {
 	?>

--- a/includes/site-health/audit-autoloaded-options/helper.php
+++ b/includes/site-health/audit-autoloaded-options/helper.php
@@ -195,7 +195,7 @@ function perflab_aao_get_autoloaded_options_table() {
 /**
  * Gets disabled autoload options table.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
@@ -252,7 +252,7 @@ function perflab_aao_get_disabled_autoloaded_options_table() {
 /**
  * Gets the autoload values in the database that should trigger their option to be autoloaded.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  *
  * @return array List of autoload values.
  */

--- a/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/includes/site-health/audit-autoloaded-options/hooks.php
@@ -30,7 +30,7 @@ add_filter( 'site_status_tests', 'perflab_aao_add_autoloaded_options_test' );
 /**
  * Register admin actions for handling autoload enable/disable.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  */
 function perflab_aao_register_admin_actions() {
 	add_action( 'admin_action_perflab_aao_update_autoload', 'perflab_aao_handle_update_autoload' );
@@ -40,7 +40,7 @@ add_action( 'admin_init', 'perflab_aao_register_admin_actions' );
 /**
  * Callback for handling disable autoload action.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  */
 function perflab_aao_handle_update_autoload() {
 	check_admin_referer( 'perflab_aao_update_autoload' );
@@ -92,7 +92,7 @@ function perflab_aao_handle_update_autoload() {
 /**
  * Callback function hooked to admin_notices to render admin notices on the site health screen.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  *
  * @global string $pagenow The filename of the current screen.
  */

--- a/includes/site-health/load.php
+++ b/includes/site-health/load.php
@@ -3,7 +3,7 @@
  * Site Health checks loader.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/load.php
+++ b/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 2.9.0
+ * Version: 3.0.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '2.9.0' );
+define( 'PERFLAB_VERSION', '3.0.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/load.php
+++ b/load.php
@@ -46,7 +46,7 @@ require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/site-health/load.php';
  *
  * @since 1.1.0
  * @since 2.9.0 The generator tag now includes the active standalone plugin slugs.
- * @since n.e.x.t The generator tag no longer includes module slugs.
+ * @since 3.0.0 The generator tag no longer includes module slugs.
  */
 function perflab_get_generator_content() {
 	$active_plugins = array();
@@ -81,7 +81,7 @@ add_action( 'wp_head', 'perflab_render_generator' );
 /**
  * Gets the standalone plugins and their data.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  *
  * @return array<string, array{'constant': string, 'experimental'?: bool}> Associative array of $plugin_slug => $plugin_data pairs.
  */
@@ -121,7 +121,7 @@ function perflab_get_standalone_plugin_data() {
  * Gets the standalone plugin constants used for each available standalone plugin.
  *
  * @since 2.9.0
- * @since n.e.x.t The $source parameter was removed.
+ * @since 3.0.0 The $source parameter was removed.
  *
  * @return array<string, string> Map of plugin slug and the version constant used.
  */
@@ -173,7 +173,7 @@ function perflab_maybe_set_object_cache_dropin() {
 	 *
 	 * This filter should not be used outside of tests.
 	 *
-	 * @since n.e.x.t
+	 * @since 3.0.0
 	 * @internal
 	 *
 	 * @param int|bool $current_dropin_version The drop-in version as defined by the
@@ -294,7 +294,7 @@ register_deactivation_hook( __FILE__, 'perflab_maybe_remove_object_cache_dropin'
 /**
  * Redirects legacy module page to the performance feature page.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  *
  * @global $plugin_page
  */
@@ -317,7 +317,7 @@ add_action( 'admin_page_access_denied', 'perflab_no_access_redirect_module_to_pe
 /**
  * Cleanup function to delete legacy 'perflab_modules_settings' option if present.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  */
 function perflab_cleanup_option() {
 	if ( current_user_can( 'manage_options' ) ) {

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -91,7 +91,7 @@ function od_get_normalized_query_vars(): array {
  * This is essentially the REQUEST_URI prefixed by the scheme and host for the home URL.
  * This is needed in particular due to subdirectory installs.
  *
- * @since 3.0.0
+ * @since 0.1.1
  * @access private
  *
  * @return string Current URL.

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -91,7 +91,7 @@ function od_get_normalized_query_vars(): array {
  * This is essentially the REQUEST_URI prefixed by the scheme and host for the home URL.
  * This is needed in particular due to subdirectory installs.
  *
- * @since n.e.x.t
+ * @since 3.0.0
  * @access private
  *
  * @return string Current URL.

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Requires PHP:      7.0
 Stable tag:        3.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, javascript, site health, measurement, object caching
+Tags:              performance, site health, measurement, object caching
 
 Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
 

--- a/readme.txt
+++ b/readme.txt
@@ -60,6 +60,24 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 == Changelog ==
 
+= 3.0.0 =
+
+**Enhancements**
+
+* Add caching to the wordpress.org query to get plugin information. ([1022](https://github.com/WordPress/performance/pull/1022))
+* Add support for autoloading enhancements in WordPress 6.6 trunk to autoloaded options Site Health check. ([1112](https://github.com/WordPress/performance/pull/1112))
+* Bump minimum required WordPress version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
+* Enhance `object-cache.php` drop-in placement logic to support updating to a newer version of the file. ([1047](https://github.com/WordPress/performance/pull/1047))
+* Implement support for annotating certain plugins as experimental. ([1111](https://github.com/WordPress/performance/pull/1111))
+* Migrate Site Health checks from being modules to becoming part of the plugin core. ([1042](https://github.com/WordPress/performance/pull/1042))
+* Remove modules infrastructure and UI from the plugin. ([1060](https://github.com/WordPress/performance/pull/1060))
+* Support changing autoload value for largest autoloaded options in Site Health check. ([1048](https://github.com/WordPress/performance/pull/1048))
+* Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
+
+**Documentation**
+
+* Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
+
 = 2.9.0 =
 
 **Features**
@@ -449,21 +467,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.0.0 =
 
-**Enhancements**
-
-* Add caching to the wordpress.org query to get plugin information. ([1022](https://github.com/WordPress/performance/pull/1022))
-* Add support for autoloading enhancements in WordPress 6.6 trunk to autoloaded options Site Health check. ([1112](https://github.com/WordPress/performance/pull/1112))
-* Bump minimum required WordPress version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
-* Enhance `object-cache.php` drop-in placement logic to support updating to a newer version of the file. ([1047](https://github.com/WordPress/performance/pull/1047))
-* Implement support for annotating certain plugins as experimental. ([1111](https://github.com/WordPress/performance/pull/1111))
-* Migrate Site Health checks from being modules to becoming part of the plugin core. ([1042](https://github.com/WordPress/performance/pull/1042))
-* Remove modules infrastructure and UI from the plugin. ([1060](https://github.com/WordPress/performance/pull/1060))
-* Support changing autoload value for largest autoloaded options in Site Health check. ([1048](https://github.com/WordPress/performance/pull/1048))
-* Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
-
-**Documentation**
-
-* Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
+Starting with this release, modules such as Image Placeholders and Modern Image Formats are only available as standalone plugins as opposed to bundled modules. After updating, you will be able to easily migrate to this new structure.
 
 = 2.5.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -449,7 +449,21 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.0.0 =
 
-Starting with this release, modules such as Image Placeholders and Modern Image Formats are only available as standalone plugins as opposed to bundled modules. After updating, you will be able to easily migrate to this new structure.
+**Enhancements**
+
+* Add caching to the wordpress.org query to get plugin information. ([1022](https://github.com/WordPress/performance/pull/1022))
+* Add support for autoloading enhancements in WordPress 6.6 trunk to autoloaded options Site Health check. ([1112](https://github.com/WordPress/performance/pull/1112))
+* Bump minimum required WordPress version to 6.4. ([1062](https://github.com/WordPress/performance/pull/1062))
+* Enhance `object-cache.php` drop-in placement logic to support updating to a newer version of the file. ([1047](https://github.com/WordPress/performance/pull/1047))
+* Implement support for annotating certain plugins as experimental. ([1111](https://github.com/WordPress/performance/pull/1111))
+* Migrate Site Health checks from being modules to becoming part of the plugin core. ([1042](https://github.com/WordPress/performance/pull/1042))
+* Remove modules infrastructure and UI from the plugin. ([1060](https://github.com/WordPress/performance/pull/1060))
+* Support changing autoload value for largest autoloaded options in Site Health check. ([1048](https://github.com/WordPress/performance/pull/1048))
+* Use plugin slug for generator tag. ([1103](https://github.com/WordPress/performance/pull/1103))
+
+**Documentation**
+
+* Update tested WordPress version to 6.5. ([1027](https://github.com/WordPress/performance/pull/1027))
 
 = 2.5.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Requires PHP:      7.0
 Stable tag:        3.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, site health, measurement, object caching
+Tags:              performance, site health, measurement
 
 Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Requires PHP:      7.0
 Stable tag:        3.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, site health, measurement
+Tags:              performance, site health, measurement, optimization, diagnostics
 
 Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        2.9.0
+Stable tag:        3.0.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, javascript, site health, measurement, object caching


### PR DESCRIPTION
Previously: https://github.com/WordPress/performance/pull/992

- [x] Bump stable tag in `readme.txt`
- [x] Bump versions in `load.php`
- [x] Run `npm run since -- -r 3.0.0`
- [x] Update changelog