### PR TITLE
Fix passing error messages to wp_die() when plugin activation fails

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -292,7 +292,7 @@ function perflab_install_activate_plugin_callback() {
 
 	$result = activate_plugin( $plugin_basename );
 	if ( is_wp_error( $result ) ) {
-		wp_die( esc_html( implode( ' ', $result->get_error_messages() ) ) );
+		wp_die( esc_html( $result->get_error_message() ) );
 	}
 
 	$url = add_query_arg(

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -292,7 +292,7 @@ function perflab_install_activate_plugin_callback() {
 
 	$result = activate_plugin( $plugin_basename );
 	if ( is_wp_error( $result ) ) {
-		wp_die( esc_html( $result->get_error_messages() ) );
+		wp_die( esc_html( implode( ' ', $result->get_error_messages() ) ) );
 	}
 
 	$url = add_query_arg(


### PR DESCRIPTION
When working on preparing for the 3.0.0 release in #1125 I ran `npm run since -- -r 3.0.0` which touched `includes/admin/load.php`. When I went to commit, `lint-staged` failed the pre-commit check with the following error:

```
Script build-cs/vendor/bin/phpstan analyse --memory-limit=2048M handling the phpstan event returned with error code 1
 ------ ----------------------------------------------------------------------- 
  Line   includes/admin/load.php                                                
 ------ ----------------------------------------------------------------------- 
  295    Parameter #1 $text of function esc_html expects string, array<string>  
         given.                                                                 
 ------ ----------------------------------------------------------------------- 
```

In looking at the code in question, I see there was indeed an error as `$result->get_error_messages()` returns an array of strings, and this can't be passed to `esc_html()` without first imploding to a string. It's confusing from the codebase because further up there is this:

https://github.com/WordPress/performance/blob/2b7b8785770c70fde11313a4acc49f8539ed731e/includes/admin/load.php#L269-L275

Specifically note the last line `wp_die( esc_html( $skin->get_error_messages() ) )`. This is actually valid because `WP_Ajax_Upgrader_Skin::get_error_messages()` returns a `string` while the method of the same name on `WP_Error` returns `string[]`.

I discovered this issue because I have a local `phpstan.neon` which has a stricter [level](https://phpstan.org/user-guide/rule-levels)  (at level 6) than [`phpstan.neon.dist`](https://github.com/WordPress/performance/blob/c2bb4a71fbead8151bfc84a7d91f1da1a4b2e660/phpstan.neon.dist) (at level 0):

```neon
includes:
	- phar://phpstan.phar/conf/bleedingEdge.neon
	#- phpstan-baseline.neon
parameters:
	level: 6
	paths:
		- load.php
		- plugins/
		- includes/
		- tests/
		- uninstall.php
	scanDirectories:
		- vendor/wp-phpunit/wp-phpunit/
	ignoreErrors:
		- '#^(Function|Method) .+? return type has no value type specified in iterable type array#'
		- '#^(Function|Method) .+? has parameter .+? with no value type specified in iterable type array#'
		- '#^(Function|Method) .+? has no return type specified#'
		- '#^Function od_handle_rest_request\(\) has parameter \$request with generic class WP_REST_Request but does not specify its types: T#'
	dynamicConstantNames:
		- PERFLAB_OBJECT_CACHE_DROPIN_VERSION
```

The above issue was identified with level 5:

> checking types of arguments passed to methods and functions

Nevertheless, PhpStorm's static analysis also flagged this as an error:

![Screenshot 2024-04-11 16 11 10](https://github.com/WordPress/performance/assets/134745/1dd1bf1b-a4a7-4c36-b707-0f026a5a06fc)

Compare with PHPStan's error being surfaced in PhpStorm (which was returned above via `lint-staged`):

![Screenshot 2024-04-11 16 10 50](https://github.com/WordPress/performance/assets/134745/e5398325-e835-4295-97f7-02e499522a43)

Sure enough, when I simulate a failure in `activate_plugin()`, I did get a PHP warning:

![Screenshot 2024-04-11 16 15 25](https://github.com/WordPress/performance/assets/134745/09a11821-a0fe-465d-8716-85a6881aa311)

We really should prioritize increasing the PHPStan level (#775) so we can catch these issues earlier than a couple days before the release.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
