### PR TITLE
Fix checking if plugin status is not install

### DIFF
--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -164,7 +164,7 @@ function perflab_render_plugin_card( array $plugin_data ) {
 			current_user_can( 'activate_plugins' )
 		) &&
 		(
-			'install' !== $status ||
+			'install' !== $status['status'] ||
 			current_user_can( 'install_plugins' )
 		)
 	) {
@@ -186,7 +186,7 @@ function perflab_render_plugin_card( array $plugin_data ) {
 			esc_html__( 'Activate', 'default' )
 		);
 	} else {
-		$explanation    = 'install' !== $status || current_user_can( 'install_plugins' ) ? _x( 'Cannot Activate', 'plugin', 'default' ) : _x( 'Cannot Install', 'plugin', 'default' );
+		$explanation    = 'install' !== $status['status'] || current_user_can( 'install_plugins' ) ? _x( 'Cannot Activate', 'plugin', 'default' ) : _x( 'Cannot Install', 'plugin', 'default' );
 		$action_links[] = sprintf(
 			'<button type="button" class="button button-disabled" disabled="disabled">%s</button>',
 			esc_html( $explanation )


### PR DESCRIPTION
This is a sub-PR of #1126 which is also about fixing issues that PHPStan's static analysis uncovered. In PHPStan [level 4](https://phpstan.org/user-guide/rule-levels#:~:text=basic%20dead%20code%20checking%20%2D%20always%20false%20instanceof%20and%20other%20type%20checks%2C%20dead%20else%20branches%2C%20unreachable%20code%20after%20return%3B%20etc.):

> basic dead code checking - always false instanceof and other type checks, dead else branches, unreachable code after return; etc.

The following issues were reported in `includes/admin/plugins.php`:

```
  167    Result of || is always true.                                                                                                                       
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.         
  167    Strict comparison using !== between 'install' and array{status: string, url: string, version: string, file: string} will always evaluate to true.  
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.         
  189    Result of || is always true.                                                                                                                       
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.         
  189    Strict comparison using !== between 'install' and array{status: string, url: string, version: string, file: string} will always evaluate to true. 
```

The `$status` variable is populated with the return value of [`install_plugin_install_status()`](https://developer.wordpress.org/reference/functions/install_plugin_install_status/) which is always an array with these keys:

> ![image](https://github.com/WordPress/performance/assets/134745/36df3b5a-7170-4e3b-829f-72a7817f30a6)

Therefore, the current checks for `'install' !== $status` will always evaluate to `false` because `$status` is always an array and never a string.

This was introduced in #1091. We need to make sure that fixing this static analysis bug doesn't cause a regression in the expected behavior.

Again, to prevent this from happening in the future, we need to increase the PHPStan level from 0 (#775).