### PR TITLE
Add missing uninstall.php to remove plugin's database option

### DIFF
--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Enables browsers to speculatively prerender or prefetch pages when hovering over links.
  * Requires at least: 6.4
  * Requires PHP: 7.0
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
 	return;
 }
 
-define( 'SPECULATION_RULES_VERSION', '1.1.0' );
+define( 'SPECULATION_RULES_VERSION', '1.2.0' );
 
 require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';
 require_once __DIR__ . '/helper.php';

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -104,8 +104,6 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.2.0 =
 
-**Enhancements**
-
 * Add missing uninstall.php to remove plugin's database option. ([1128](https://github.com/WordPress/performance/pull/1128))
 
 = 1.1.0 =

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.0
-Stable tag:        1.1.0
+Stable tag:        1.2.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, javascript, speculation rules, prerender, prefetch

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -102,6 +102,12 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 == Changelog ==
 
+= 1.2.0 =
+
+**Enhancements**
+
+* Add missing uninstall.php to remove plugin's database option. ([1128](https://github.com/WordPress/performance/pull/1128))
+
 = 1.1.0 =
 
 * Allow excluding URL patterns from prerendering or prefetching specifically. ([1025](https://github.com/WordPress/performance/pull/1025))

--- a/plugins/speculation-rules/uninstall.php
+++ b/plugins/speculation-rules/uninstall.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin uninstaller logic.
+ *
+ * @package speculation-rules
+ * @since 1.1.0
+ */
+
+// If uninstall.php is not called by WordPress, bail.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+// For a multisite, delete the option for all sites (however limited to 100 sites to avoid memory limit or timeout problems in large scale networks).
+if ( is_multisite() ) {
+	$site_ids = get_sites(
+		array(
+			'fields'                 => 'ids',
+			'number'                 => 100,
+			'update_site_cache'      => false,
+			'update_site_meta_cache' => false,
+		)
+	);
+
+	foreach ( $site_ids as $site_id ) {
+		switch_to_blog( $site_id );
+		speculation_rules_delete_plugin_option();
+		restore_current_blog();
+	}
+}
+
+speculation_rules_delete_plugin_option();
+
+/**
+ * Delete the current site's option.
+ *
+ * @since 1.1.0
+ */
+function speculation_rules_delete_plugin_option() {
+	delete_option( 'plsr_speculation_rules' );
+}

--- a/plugins/speculation-rules/uninstall.php
+++ b/plugins/speculation-rules/uninstall.php
@@ -24,18 +24,18 @@ if ( is_multisite() ) {
 
 	foreach ( $site_ids as $site_id ) {
 		switch_to_blog( $site_id );
-		speculation_rules_delete_plugin_option();
+		plsr_delete_plugin_option();
 		restore_current_blog();
 	}
 }
 
-speculation_rules_delete_plugin_option();
+plsr_delete_plugin_option();
 
 /**
  * Delete the current site's option.
  *
  * @since 1.2.0
  */
-function speculation_rules_delete_plugin_option() {
+function plsr_delete_plugin_option() {
 	delete_option( 'plsr_speculation_rules' );
 }

--- a/plugins/speculation-rules/uninstall.php
+++ b/plugins/speculation-rules/uninstall.php
@@ -3,7 +3,7 @@
  * Plugin uninstaller logic.
  *
  * @package speculation-rules
- * @since 1.1.0
+ * @since 1.2.0
  */
 
 // If uninstall.php is not called by WordPress, bail.
@@ -34,7 +34,7 @@ speculation_rules_delete_plugin_option();
 /**
  * Delete the current site's option.
  *
- * @since 1.1.0
+ * @since 1.2.0
  */
 function speculation_rules_delete_plugin_option() {
 	delete_option( 'plsr_speculation_rules' );

--- a/tests/plugins/speculation-rules/speculation-rules-uninstall-tests.php
+++ b/tests/plugins/speculation-rules/speculation-rules-uninstall-tests.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tests for speculation-rules plugin uninstall.php.
+ *
+ * @runInSeparateProcess
+ * @package speculation-rules
+ */
+
+class Speculation_Rules_Uninstall_Tests extends WP_UnitTestCase {
+
+	/**
+	 * Runs the routine before setting up all tests.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		// Mock uninstall const.
+		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+			define( 'WP_UNINSTALL_PLUGIN', 'Yes' );
+		}
+	}
+
+	/**
+	 * Load uninstall.php.
+	 */
+	private function require_uninstall() {
+		require __DIR__ . '/../../../plugins/speculation-rules/uninstall.php';
+	}
+
+	/**
+	 * Test option deletion.
+	 *
+	 * @covers ::plsr_delete_plugin_option
+	 */
+	public function test_delete_plugin_option() {
+		unregister_setting( 'reading', 'plsr_speculation_rules' );
+		$test_blogname = 'Hello World';
+		update_option( 'blogname', $test_blogname );
+		update_option( 'plsr_speculation_rules', plsr_get_setting_default() );
+
+		$this->assertEquals( $test_blogname, $test_blogname );
+		$this->assertEquals( plsr_get_setting_default(), get_option( 'plsr_speculation_rules' ) );
+
+		$this->require_uninstall();
+
+		$this->assertEquals( $test_blogname, get_option( 'blogname' ) );
+		$this->assertFalse( get_option( 'plsr_speculation_rules' ) );
+	}
+}


### PR DESCRIPTION
In preparing for the PL 3.0.0 release, I was looking at the `build` directory after running `npm run build-plugins`. I noticed that while `webp-uploads` has an `uninstall.php` now (#1116), and an `uninstall.php` is also present for `optimization-detective`, there is none for Speculative Loading. This adds the missing `uninstall.php`, adapted from the one from `webp-uploads`.

This also bumps the plugin version to 1.2.0 and updates the changelog.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
