### PR TITLE
Exclude rel=nofollow links from prefetch/prerender

### DIFF
--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -87,7 +87,7 @@ function plsr_get_speculation_rules() {
 							'href_matches' => $href_exclude_paths,
 						),
 					),
-					// Also exclude rel=nofollow links, as plugins like WooCommerce attribute their add-to-cart links (which should buttons).
+					// Also exclude rel=nofollow links, as plugins like WooCommerce attribute their add-to-cart links.
 					array(
 						'not' => array(
 							'selector_matches' => 'a[rel=nofollow]',

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -77,7 +77,7 @@ function plsr_get_speculation_rules() {
 			'source'    => 'document',
 			'where'     => array(
 				'and' => array(
-					// Prerender any URLs within the same site.
+					// Include any URLs within the same site.
 					array(
 						'href_matches' => $prefixer->prefix_path_pattern( '/*' ),
 					),
@@ -85,6 +85,12 @@ function plsr_get_speculation_rules() {
 					array(
 						'not' => array(
 							'href_matches' => $href_exclude_paths,
+						),
+					),
+					// Also exclude rel=nofollow links, as plugins like WooCommerce attribute their add-to-cart links (which should buttons).
+					array(
+						'not' => array(
+							'selector_matches' => 'a[rel=nofollow]',
 						),
 					),
 				),

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -87,7 +87,7 @@ function plsr_get_speculation_rules() {
 							'href_matches' => $href_exclude_paths,
 						),
 					),
-					// Also exclude rel=nofollow links, as plugins like WooCommerce attribute their add-to-cart links.
+					// Also exclude rel=nofollow links, as plugins like WooCommerce use that on their add-to-cart links.
 					array(
 						'not' => array(
 							'selector_matches' => 'a[rel=nofollow]',

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -100,7 +100,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		$rules = plsr_get_speculation_rules();
 
 		$this->assertArrayHasKey( 'prerender', $rules );
-		$this->assertCount( 3, $rules['prerender'][0]['where']['and'] );
+		$this->assertCount( 4, $rules['prerender'][0]['where']['and'] );
 	}
 
 	/**
@@ -112,7 +112,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		$rules = plsr_get_speculation_rules();
 
 		$this->assertArrayHasKey( 'prefetch', $rules );
-		$this->assertCount( 2, $rules['prefetch'][0]['where']['and'] );
+		$this->assertCount( 3, $rules['prefetch'][0]['where']['and'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

WooCommerce has `rel=nofollow` on its Add to Cart buttons (which are often links instead of `button` elements). These links are not idempotent and they must be excluded from prefech/prerender. 

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1140

Before | After
--|--
![image](https://github.com/WordPress/performance/assets/134745/1dc06574-814c-4ef9-a926-30d967a1fba2) | ![image](https://github.com/WordPress/performance/assets/134745/80f6b4a9-c9d9-45b8-ad3e-89df01235974)


## Relevant technical choices

Alternatively this could have excluded URLs that include the `add-to-cart` query parameter. However, this would seem to be overly-specific to WooCommerce. The issue https://github.com/WICG/nav-speculation/issues/309 was opened by @tunetheweb to consider whether `rel=nofollow` links should be excluded by default as well, so that is what this PR is going with now as well.

Eventually there may need to be a filter in addition to `plsr_speculation_rules_href_exclude_paths` which applies on the entire speculation rules array so that a plugin can add exclusions which are not URL-specific.

### Before

```json
{
  "prerender": [
    {
      "source": "document",
      "where": {
        "and": [
          {
            "href_matches": "/*"
          },
          {
            "not": {
              "href_matches": [
                "/wp-login.php",
                "/wp-admin/*"
              ]
            }
          },
          {
            "not": {
              "selector_matches": ".no-prerender"
            }
          }
        ]
      },
      "eagerness": "moderate"
    }
  ]
}
```

### After

```json
{
  "prerender": [
    {
      "source": "document",
      "where": {
        "and": [
          {
            "href_matches": "/*"
          },
          {
            "not": {
              "href_matches": [
                "/wp-login.php",
                "/wp-admin/*"
              ]
            }
          },
          {
            "not": {
              "selector_matches": "a[rel=nofollow]"
            }
          },
          {
            "not": {
              "selector_matches": ".no-prerender"
            }
          }
        ]
      },
      "eagerness": "moderate"
    }
  ]
}
```

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
