### PR TITLE
Exclude _wpnonce URLs in speculation rules

### DIFF
--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -42,6 +42,7 @@ function plsr_get_speculation_rules() {
 	$base_href_exclude_paths = array(
 		$prefixer->prefix_path_pattern( '/wp-login.php', 'site' ),
 		$prefixer->prefix_path_pattern( '/wp-admin/*', 'site' ),
+		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'site' ),
 	);
 	$href_exclude_paths      = $base_href_exclude_paths;
 

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -34,6 +34,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			array(
 				'/wp-login.php',
 				'/wp-admin/*',
+				'/*\\?*(^|&)_wpnonce=*',
 			),
 			$href_exclude_paths
 		);
@@ -54,6 +55,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			array(
 				'/wp-login.php',
 				'/wp-admin/*',
+				'/*\\?*(^|&)_wpnonce=*',
 				'/custom-file.php',
 			),
 			$href_exclude_paths


### PR DESCRIPTION
_This is a sub-PR of #1142._

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1141

Before | After
--|--
![Screenshot 2024-04-15 14 49 27](https://github.com/WordPress/performance/assets/134745/b3fe695b-f002-4b3b-a470-8a10179f90c3) | ![Screenshot 2024-04-15 14 49 33](https://github.com/WordPress/performance/assets/134745/cc0714c2-c8aa-4baa-a3f7-629190950c21)

<!-- Please describe your changes. -->

The URLPattern used to exclude URLs with `_wpnonce` is `/*\?*(^|&)_wpnonce=*`. Take special note that the second `*` wildcard only matches chars in the query segment. Additionally, the `^` anchors the match to the beginning of the `search` segment, and not to the beginning of the entire string. (Remember: `URLPattern` is not regex.) This means that only the `_wpnonce` query parameter will matched, whether it is the first query parameter or not. It also won't incorrectly match `other_wpnonce`.

The following URLs were tested to be properly included and excluded:

URL | Status | URLPattern Tester
--|--|--
`http://example.com/foo/?_wpnonce=1234` | Excluded | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tL2Zvby8/X3dwbm9uY2U9MTIzNCJ9)
`http://example.com/?_wpnonce=1234` | Excluded | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tLz9fd3Bub25jZT0xMjM0In0=)
`http://example.com/foo/?amp=1&_wpnonce=1234` | Excluded | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tL2Zvby8/YW1wPTEmX3dwbm9uY2U9MTIzNCJ9)
`http://example.com/?amp=1&_wpnonce=1234` | Excluded | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tLz9hbXA9MSZfd3Bub25jZT0xMjM0In0=)
`http://example.com/foo/?_wpnonce=1234&amp=1` | Excluded | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tL2Zvby8/X3dwbm9uY2U9MTIzNCZhbXA9MSJ9)
`http://example.com/?_wpnonce=1234&amp=1` | Excluded | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tLz9fd3Bub25jZT0xMjM0JmFtcD0xIn0=)
`http://example.com/?my_wpnonce=1234` | Not excluded (because not `_wpnonce`) | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tLz9teV93cG5vbmNlPTEyMzQifQ==)
`http://example.com/?p=1#?_wpnonce=1234` | Not excluded (because in URL fragment) | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tLz9wPTEjP193cG5vbmNlPTEyMzQifQ==)
`http://example.com/_wpnonce=1234/` | Not excluded (because in path) | [Test](https://urlpattern.com/#eyJ1cmxQYXR0ZXJuIjoiaHR0cDovL2V4YW1wbGUuY29tLypcXD8qKF58Jilfd3Bub25jZT0qIiwidXJsIjoiaHR0cDovL2V4YW1wbGUuY29tL193cG5vbmNlPTEyMzQvIn0=)

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
