### PR TITLE
Add settings link to Speculative Loading plugin action links

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,6 +7,8 @@ parameters:
 		- includes/
 		- plugins/
 		- tests/
+	bootstrapFiles:
+		- plugins/speculation-rules/load.php
 	scanDirectories:
 		- vendor/wp-phpunit/wp-phpunit/
 	dynamicConstantNames:

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -26,6 +26,7 @@ if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
 }
 
 define( 'SPECULATION_RULES_VERSION', '1.2.0' );
+define( 'SPECULATION_RULES_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';
 require_once __DIR__ . '/helper.php';

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -149,7 +149,11 @@ function plsr_add_setting_ui() {
 			</p>
 			<?php
 		},
-		'reading'
+		'reading',
+		array(
+			'before_section' => '<div id="speculative-loading">',
+			'after_section'  => '</div>',
+		)
 	);
 
 	$fields = array(
@@ -236,3 +240,24 @@ function plsr_render_settings_field( array $args ) {
 	</fieldset>
 	<?php
 }
+
+/**
+ * Adds a settings link to the plugin's action links.
+ *
+ * @since n.e.x.t
+ *
+ * @param string[]|mixed $links An array of plugin action links.
+ * @return string[]|mixed The modified list of actions.
+ */
+function plsr_add_settings_action_link( $links ) {
+	if ( ! is_array( $links ) ) {
+		return $links;
+	}
+	$links['settings'] = sprintf(
+		'<a href="%1$s">%2$s</a>',
+		esc_url( admin_url( 'options-reading.php#speculative-loading' ) ),
+		esc_html__( 'Settings', 'speculation-rules' )
+	);
+	return $links;
+}
+add_filter( 'plugin_action_links_' . SPECULATION_RULES_MAIN_FILE, 'plsr_add_settings_action_link' );

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -253,11 +253,16 @@ function plsr_add_settings_action_link( $links ) {
 	if ( ! is_array( $links ) ) {
 		return $links;
 	}
-	$links['settings'] = sprintf(
-		'<a href="%1$s">%2$s</a>',
-		esc_url( admin_url( 'options-reading.php#speculative-loading' ) ),
-		esc_html__( 'Settings', 'speculation-rules' )
+
+	return array_merge(
+		array(
+			'settings' => sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( admin_url( 'options-reading.php#speculative-loading' ) ),
+				esc_html__( 'Settings', 'speculation-rules' )
+			),
+		),
+		$links
 	);
-	return $links;
 }
 add_filter( 'plugin_action_links_' . SPECULATION_RULES_MAIN_FILE, 'plsr_add_settings_action_link' );

--- a/tests/plugins/speculation-rules/speculation-rules-settings-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-settings-test.php
@@ -23,6 +23,9 @@ class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
 	/**
 	 * @covers ::plsr_sanitize_setting
 	 * @dataProvider data_plsr_sanitize_setting
+	 *
+	 * @param mixed $input    Input.
+	 * @param array $expected Expected.
 	 */
 	public function test_plsr_sanitize_setting( $input, array $expected ) {
 		$this->assertSameSets(
@@ -31,7 +34,7 @@ class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
 		);
 	}
 
-	public function data_plsr_sanitize_setting() {
+	public function data_plsr_sanitize_setting(): array {
 		$default_value = array(
 			'mode'      => 'prerender',
 			'eagerness' => 'moderate',

--- a/tests/plugins/speculation-rules/speculation-rules-settings-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-settings-test.php
@@ -7,6 +7,9 @@
 
 class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
 
+	/**
+	 * @covers ::plsr_register_setting
+	 */
 	public function test_plsr_register_setting() {
 		unregister_setting( 'reading', 'plsr_speculation_rules' );
 		$settings = get_registered_settings();
@@ -18,6 +21,7 @@ class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::plsr_sanitize_setting
 	 * @dataProvider data_plsr_sanitize_setting
 	 */
 	public function test_plsr_sanitize_setting( $input, array $expected ) {
@@ -90,6 +94,28 @@ class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
 					'eagerness' => 'conservative',
 				),
 			),
+		);
+	}
+
+	/**
+	 * @covers ::plsr_add_settings_action_link
+	 */
+	public function test_plsr_add_settings_action_link() {
+		$this->assertSame( 10, has_filter( 'plugin_action_links_' . SPECULATION_RULES_MAIN_FILE, 'plsr_add_settings_action_link' ) );
+		$this->assertFalse( plsr_add_settings_action_link( false ) );
+
+		$default_action_links = array(
+			'deactivate' => '<a href="plugins.php?action=deactivate&amp;plugin=speculation-rules%2Fload.php&amp;plugin_status=all&amp;paged=1&amp;s&amp;_wpnonce=48f74bdd74" id="deactivate-speculation-rules" aria-label="Deactivate Speculative Loading">Deactivate</a>',
+		);
+
+		$this->assertSame(
+			array_merge(
+				$default_action_links,
+				array(
+					'settings' => '<a href="' . esc_url( admin_url( 'options-reading.php#speculative-loading' ) ) . '">Settings</a>',
+				)
+			),
+			plsr_add_settings_action_link( $default_action_links )
 		);
 	}
 }

--- a/tests/plugins/speculation-rules/speculation-rules-settings-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-settings-test.php
@@ -113,10 +113,10 @@ class Speculation_Rules_Settings_Tests extends WP_UnitTestCase {
 
 		$this->assertSame(
 			array_merge(
-				$default_action_links,
 				array(
 					'settings' => '<a href="' . esc_url( admin_url( 'options-reading.php#speculative-loading' ) ) . '">Settings</a>',
-				)
+				),
+				$default_action_links
 			),
 			plsr_add_settings_action_link( $default_action_links )
 		);


### PR DESCRIPTION
Fixes #1131

![image](https://github.com/WordPress/performance/assets/134745/342b587c-6325-49a3-875e-35b12285d8ac)
