### PR TITLE
Prepend Settings link in webp-uploads

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -169,19 +169,25 @@ function perflab_render_pointer( $pointer_id = 'perflab-admin-pointer', $args = 
  *
  * @see perflab_add_features_page()
  *
- * @param array $links List of plugin action links HTML.
- * @return array Modified list of plugin action links HTML.
+ * @param string[]|mixed $links List of plugin action links HTML.
+ * @return string[]|mixed Modified list of plugin action links HTML.
  */
 function perflab_plugin_action_links_add_settings( $links ) {
+	if ( ! is_array( $links ) ) {
+		return $links;
+	}
+
 	// Add link as the first plugin action link.
 	$settings_link = sprintf(
 		'<a href="%s">%s</a>',
 		esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) ),
 		esc_html__( 'Settings', 'performance-lab' )
 	);
-	array_unshift( $links, $settings_link );
 
-	return $links;
+	return array_merge(
+		array( 'settings' => $settings_link ),
+		$links
+	);
 }
 
 /**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,6 +9,7 @@ parameters:
 		- tests/
 	bootstrapFiles:
 		- plugins/speculation-rules/load.php
+		- plugins/webp-uploads/load.php
 	scanDirectories:
 		- vendor/wp-phpunit/wp-phpunit/
 	dynamicConstantNames:

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -774,29 +774,3 @@ function webp_uploads_render_generator() {
 	echo '<meta name="generator" content="webp-uploads ' . esc_attr( WEBP_UPLOADS_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'webp_uploads_render_generator' );
-
-/**
- * Adds a settings link to the plugin's action links.
- *
- * @since 1.1.0
- *
- * @param string[]|mixed $links An array of plugin action links.
- * @return string[]|mixed The modified list of actions.
- */
-function webp_uploads_settings_link( $links ) {
-	if ( ! is_array( $links ) ) {
-		return $links;
-	}
-
-	return array_merge(
-		array(
-			'settings' => sprintf(
-				'<a href="%1$s">%2$s</a>',
-				esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ),
-				esc_html__( 'Settings', 'webp-uploads' )
-			),
-		),
-		$links
-	);
-}
-add_filter( 'plugin_action_links_' . WEBP_UPLOADS_MAIN_FILE, 'webp_uploads_settings_link' );

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -780,18 +780,23 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
  *
  * @since 1.1.0
  *
- * @param array $links An array of plugin action links.
- * @return array The modified list of actions.
+ * @param string[]|mixed $links An array of plugin action links.
+ * @return string[]|mixed The modified list of actions.
  */
 function webp_uploads_settings_link( $links ) {
 	if ( ! is_array( $links ) ) {
 		return $links;
 	}
-	$links[] = sprintf(
-		'<a href="%1$s">%2$s</a>',
-		esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ),
-		esc_html__( 'Settings', 'webp-uploads' )
+
+	return array_merge(
+		array(
+			'settings' => sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ),
+				esc_html__( 'Settings', 'webp-uploads' )
+			),
+		),
+		$links
 	);
-	return $links;
 }
 add_filter( 'plugin_action_links_' . WEBP_UPLOADS_MAIN_FILE, 'webp_uploads_settings_link' );

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -87,3 +87,30 @@ function webp_uploads_media_setting_style() {
 	<?php
 }
 add_action( 'admin_head-options-media.php', 'webp_uploads_media_setting_style' );
+
+/**
+ * Adds a settings link to the plugin's action links.
+ *
+ * @since 1.1.0
+ * @since n.e.x.t Renamed from webp_uploads_settings_link() to webp_uploads_add_settings_action_link()
+ *
+ * @param string[]|mixed $links An array of plugin action links.
+ * @return string[]|mixed The modified list of actions.
+ */
+function webp_uploads_add_settings_action_link( $links ) {
+	if ( ! is_array( $links ) ) {
+		return $links;
+	}
+
+	return array_merge(
+		array(
+			'settings' => sprintf(
+				'<a href="%1$s">%2$s</a>',
+				esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ),
+				esc_html__( 'Settings', 'webp-uploads' )
+			),
+		),
+		$links
+	);
+}
+add_filter( 'plugin_action_links_' . WEBP_UPLOADS_MAIN_FILE, 'webp_uploads_add_settings_action_link' );

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -102,14 +102,14 @@ function webp_uploads_add_settings_action_link( $links ) {
 		return $links;
 	}
 
+	$settings_link = sprintf(
+		'<a href="%1$s">%2$s</a>',
+		esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ),
+		esc_html__( 'Settings', 'webp-uploads' )
+	);
+
 	return array_merge(
-		array(
-			'settings' => sprintf(
-				'<a href="%1$s">%2$s</a>',
-				esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ),
-				esc_html__( 'Settings', 'webp-uploads' )
-			),
-		),
+		array( 'settings' => $settings_link ),
 		$links
 	);
 }

--- a/tests/includes/admin/load-tests.php
+++ b/tests/includes/admin/load-tests.php
@@ -51,10 +51,14 @@ class Admin_Load_Tests extends WP_UnitTestCase {
 	}
 
 	public function test_perflab_plugin_action_links_add_settings() {
-		$original_links = array( '<a href="https://wordpress.org">wordpress.org</a>' );
-		$expected_links = array(
-			'<a href="' . admin_url( '/' ) . 'options-general.php?page=' . PERFLAB_SCREEN . '">Settings</a>',
-			$original_links[0],
+		$original_links = array(
+			'deactivate' => '<a href="#">Deactivate</a>',
+		);
+		$expected_links = array_merge(
+			array(
+				'settings' => '<a href="' . admin_url( '/' ) . 'options-general.php?page=' . PERFLAB_SCREEN . '">Settings</a>',
+			),
+			$original_links
 		);
 
 		$actual_links = perflab_plugin_action_links_add_settings( $original_links );

--- a/tests/plugins/webp-uploads/settings-tests.php
+++ b/tests/plugins/webp-uploads/settings-tests.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Tests for webp-uploads plugin settings.php.
+ *
+ * @package webp-uploads
+ */
+
+class WebP_Uploads_Settings_Tests extends WP_UnitTestCase {
+
+	/**
+	 * @covers ::webp_uploads_add_settings_action_link
+	 */
+	public function test_webp_uploads_add_settings_action_link() {
+		$this->assertSame( 10, has_filter( 'plugin_action_links_' . WEBP_UPLOADS_MAIN_FILE, 'webp_uploads_add_settings_action_link' ) );
+		$this->assertFalse( webp_uploads_add_settings_action_link( false ) );
+
+		$default_action_links = array(
+			'deactivate' => '<a href="plugins.php?action=deactivate&amp;plugin=webp-uploads%2Fload.php&amp;plugin_status=all&amp;paged=1&amp;s&amp;_wpnonce=48f74bdd74" id="deactivate-speculation-rules" aria-label="Deactivate Speculative Loading">Deactivate</a>',
+		);
+
+		$this->assertSame(
+			array_merge(
+				array(
+					'settings' => '<a href="' . esc_url( admin_url( 'options-media.php#perflab_generate_webp_and_jpeg' ) ) . '">Settings</a>',
+				),
+				$default_action_links
+			),
+			webp_uploads_add_settings_action_link( $default_action_links )
+		);
+	}
+}

--- a/tests/plugins/webp-uploads/settings-tests.php
+++ b/tests/plugins/webp-uploads/settings-tests.php
@@ -15,7 +15,7 @@ class WebP_Uploads_Settings_Tests extends WP_UnitTestCase {
 		$this->assertFalse( webp_uploads_add_settings_action_link( false ) );
 
 		$default_action_links = array(
-			'deactivate' => '<a href="plugins.php?action=deactivate&amp;plugin=webp-uploads%2Fload.php&amp;plugin_status=all&amp;paged=1&amp;s&amp;_wpnonce=48f74bdd74" id="deactivate-speculation-rules" aria-label="Deactivate Speculative Loading">Deactivate</a>',
+			'deactivate' => '<a href="plugins.php?action=deactivate&amp;plugin=webp-uploads%2Fload.php&amp;plugin_status=all&amp;paged=1&amp;s&amp;_wpnonce=48f74bdd74" id="deactivate-webp-uploads" aria-label="Deactivate Modern Image Formats">Deactivate</a>',
 		);
 
 		$this->assertSame(


### PR DESCRIPTION
## Summary

_This is a sub-PR of #1145_

With this, all PL plugins' Settings links are prepended:

![image](https://github.com/WordPress/performance/assets/134745/e1a820bd-2ef4-432b-86e9-0a2f34386a11)


## Relevant technical choices

Additionally, the `settings` array key is used for the action link as otherwise `0` ends up getting rendered as the element's class name on the frontend. Having a `settings` key also makes it easier for other plugins to remove.

Before | After
--|--
![Screenshot 2024-04-15 17 33 24](https://github.com/WordPress/performance/assets/134745/431e0904-5952-4608-bde9-b998e64c9da7) | ![Screenshot 2024-04-15 17 33 45](https://github.com/WordPress/performance/assets/134745/444b062f-7e36-485e-b8ad-797f5661ab60)

This same change is done to the PL plugin's Settings link in 18c2b5d.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
