### PR TITLE
Do not show admin pointer on the Performance screen and dismiss the pointer when visited

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -82,7 +82,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 		return;
 	}
 	$current_user = get_current_user_id();
-	$dismissed = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
+	$dismissed    = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
 
 	if ( in_array( 'perflab-admin-pointer', $dismissed, true ) ) {
 		return;
@@ -91,7 +91,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
 		// Do not show on the settings page and dismiss the pointer.
-		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ))) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
 		}

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -77,26 +77,25 @@ function perflab_render_settings_page() {
  * @param string $hook_suffix The current admin page.
  */
 function perflab_admin_pointer( $hook_suffix ) {
-	$current_user = get_current_user_id();
-	$dismissed    = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
-
-	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
-
-		// Do not show on the settings page and dismiss the pointer.
-		if ( isset( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$dismissed[] = 'perflab-admin-pointer';
-			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
-		}
-
-		return;
-	}
-
 	// Do not show admin pointer in multisite Network admin or User admin UI.
 	if ( is_network_admin() || is_user_admin() ) {
 		return;
 	}
+	$current_user = get_current_user_id();
+	$dismissed = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
 
 	if ( in_array( 'perflab-admin-pointer', $dismissed, true ) ) {
+		return;
+	}
+
+	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
+
+		// Do not show on the settings page and dismiss the pointer.
+		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ))) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$dismissed[] = 'perflab-admin-pointer';
+			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
+		}
+
 		return;
 	}
 

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -91,7 +91,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
 		// Do not show on the settings page and dismiss the pointer.
-		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
 		}

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -78,11 +78,12 @@ function perflab_render_settings_page() {
  */
 function perflab_admin_pointer( $hook_suffix ) {
 	$current_user = get_current_user_id();
+	$dismissed = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
 
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
-		// Dismiss the admin pointer once the user reaches the settings screen.
-		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// Do not show on the settings page and dismiss the pointer.
+		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ))) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
 		}
@@ -94,8 +95,6 @@ function perflab_admin_pointer( $hook_suffix ) {
 	if ( is_network_admin() || is_user_admin() ) {
 		return;
 	}
-
-	$dismissed = explode( ',', (string) get_user_meta( $current_user, 'dismissed_wp_pointers', true ) );
 
 	if ( in_array( 'perflab-admin-pointer', $dismissed, true ) ) {
 		return;

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -82,7 +82,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
 		// Do not show on the settings page and dismiss the pointer.
-		if ( !empty( $_GET['page'] ) && $_GET['page'] === PERFLAB_SCREEN ) {
+		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
 		}

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -81,7 +81,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
-		// Do not show on the settings page and dismiss the pointer
+		// Do not show on the settings page and dismiss the pointer.
 		if ( !empty( $_GET['page'] ) && $_GET['page'] === PERFLAB_SCREEN ) {
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -77,7 +77,16 @@ function perflab_render_settings_page() {
  * @param string $hook_suffix The current admin page.
  */
 function perflab_admin_pointer( $hook_suffix ) {
+	$current_user = get_current_user_id();
+
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
+
+		// Do not show on the settings page and dismiss the pointer
+		if ( !empty( $_GET['page'] ) && $_GET['page'] === PERFLAB_SCREEN ) {
+			$dismissed[] = 'perflab-admin-pointer';
+			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
+		}
+
 		return;
 	}
 
@@ -86,7 +95,6 @@ function perflab_admin_pointer( $hook_suffix ) {
 		return;
 	}
 
-	$current_user = get_current_user_id();
 	$dismissed    = explode( ',', (string) get_user_meta( $current_user, 'dismissed_wp_pointers', true ) );
 
 	if ( in_array( 'perflab-admin-pointer', $dismissed, true ) ) {

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -95,7 +95,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 		return;
 	}
 
-	$dismissed    = explode( ',', (string) get_user_meta( $current_user, 'dismissed_wp_pointers', true ) );
+	$dismissed = explode( ',', (string) get_user_meta( $current_user, 'dismissed_wp_pointers', true ) );
 
 	if ( in_array( 'perflab-admin-pointer', $dismissed, true ) ) {
 		return;

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -83,7 +83,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
 		// Do not show on the settings page and dismiss the pointer.
-		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
 		}

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -83,7 +83,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
 		// Do not show on the settings page and dismiss the pointer.
-		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ))) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
 		}

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -78,7 +78,7 @@ function perflab_render_settings_page() {
  */
 function perflab_admin_pointer( $hook_suffix ) {
 	$current_user = get_current_user_id();
-	$dismissed = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
+	$dismissed    = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
 
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -81,7 +81,7 @@ function perflab_admin_pointer( $hook_suffix ) {
 
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
-		// Do not show on the settings page and dismiss the pointer.
+		// Dismiss the admin pointer once the user reaches the settings screen.
 		if ( ! empty( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$dismissed[] = 'perflab-admin-pointer';
 			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );


### PR DESCRIPTION
## Summary

Fixes: #1135

## Relevant technical choices

I added the possibility to set the value of dismissed_wp_pointers at the beginning of the function if we are already in the plugin settings page.

I had to set $current_user at the beginning of the function


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
