### PR TITLE
Facilitate embedding Speculative Loading in other plugins/themes

### DIFF
--- a/bin/phpstan/constants.php
+++ b/bin/phpstan/constants.php
@@ -5,5 +5,5 @@
  * @package speculation-rules
  */
 
-define( 'SPECULATION_RULES_VERSION', '1.2.1' );
+define( 'SPECULATION_RULES_VERSION', '0.0.0' );
 define( 'SPECULATION_RULES_MAIN_FILE', 'plugins/speculation-rules/load.php' );

--- a/bin/phpstan/constants.php
+++ b/bin/phpstan/constants.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Constants for PHPStan static analysis.
+ *
+ * @package speculation-rules
+ */
+
+define( 'SPECULATION_RULES_VERSION', '1.2.1' );
+define( 'SPECULATION_RULES_MAIN_FILE', 'plugins/speculation-rules/load.php' );

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,7 +8,7 @@ parameters:
 		- plugins/
 		- tests/
 	bootstrapFiles:
-		- plugins/speculation-rules/load.php
+		- bin/phpstan/constants.php
 	scanDirectories:
 		- vendor/wp-phpunit/wp-phpunit/
 	dynamicConstantNames:

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -32,13 +32,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		if ( ! isset( $GLOBALS[ $global_var_name ] ) ) {
 			$bootstrap = static function () use ( $global_var_name ) {
 				if (
-					isset( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] )
+					isset( $GLOBALS[ $global_var_name ]['load'] )
 					&&
 					$GLOBALS[ $global_var_name ]['load'] instanceof Closure
-					&&
-					is_string( $GLOBALS[ $global_var_name ]['version'] )
 				) {
-					call_user_func( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] );
+					call_user_func( $GLOBALS[ $global_var_name ]['load'] );
 					unset( $GLOBALS[ $global_var_name ] );
 				}
 			};
@@ -70,14 +68,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 )(
 	'plsr_pending_plugin_info',
 	'1.2.1',
-	static function ( string $version ) {
+	static function () {
 
 		// Define the constant.
 		if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
 			return;
 		}
 
-		define( 'SPECULATION_RULES_VERSION', $version );
+		define( 'SPECULATION_RULES_VERSION', '1.2.1' );
 		define( 'SPECULATION_RULES_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 		require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 (
 	/**
-	 * Register this copy of the plugin among other potential copies.
+	 * Register this copy of the plugin among other potential copies embedded in plugins or themes.
 	 *
 	 * @param string  $global_var_name Global variable name for storing the plugin pending loading.
 	 * @param string  $version         Version.
@@ -41,7 +41,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				}
 			};
 
-			// Wait until after the plugins have loaded and the theme has loaded.
+			// Wait until after the plugins have loaded and the theme has loaded. The after_setup_theme action is used
+			// because it is the first action that fires once the theme is loaded.
 			add_action( 'after_setup_theme', $bootstrap, 0 );
 		}
 

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -34,21 +34,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 				if (
 					isset( $GLOBALS[ $global_var_name ]['load'] )
 					&&
-					! isset( $GLOBALS[ $global_var_name ]['loaded'] )
-					&&
 					$GLOBALS[ $global_var_name ]['load'] instanceof Closure
 				) {
 					call_user_func( $GLOBALS[ $global_var_name ]['load'] );
-					$GLOBALS[ $global_var_name ]['loaded'] = true;
+					unset( $GLOBALS[ $global_var_name ] );
 				}
 			};
 
-			// Handle either where the plugin is installed as a regular plugin or is embedded in another plugin or in a theme.
-			if ( ! did_action( 'plugins_loaded' ) ) {
-				add_action( 'plugins_loaded', $bootstrap, 0 );
-			}
-
-			// Handle case where plugin is embedded in a theme.
+			// Wait until after the plugins have loaded and the theme has loaded.
 			add_action( 'after_setup_theme', $bootstrap, 0 );
 		}
 

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -34,10 +34,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 				if (
 					isset( $GLOBALS[ $global_var_name ]['load'] )
 					&&
+					! isset( $GLOBALS[ $global_var_name ]['loaded'] )
+					&&
 					$GLOBALS[ $global_var_name ]['load'] instanceof Closure
 				) {
 					call_user_func( $GLOBALS[ $global_var_name ]['load'] );
-					unset( $GLOBALS[ $global_var_name ] );
+					$GLOBALS[ $global_var_name ]['loaded'] = true;
 				}
 			};
 

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -43,7 +43,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			// Wait until after the plugins have loaded and the theme has loaded. The after_setup_theme action is used
 			// because it is the first action that fires once the theme is loaded.
-			add_action( 'after_setup_theme', $bootstrap, 0 );
+			add_action( 'after_setup_theme', $bootstrap, PHP_INT_MIN );
 		}
 
 		// Register this copy of the plugin.

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -20,15 +20,69 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Define the constant.
-if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
-	return;
-}
+(
+	/**
+	 * Register this copy of the plugin among other potential copies.
+	 *
+	 * @param string  $global_var_name Global variable name for storing the plugin pending loading.
+	 * @param string  $version         Version.
+	 * @param Closure $load            Callback that loads the plugin.
+	 */
+	static function ( string $global_var_name, string $version, Closure $load ) {
+		if ( ! isset( $GLOBALS[ $global_var_name ] ) ) {
+			$bootstrap = static function () use ( $global_var_name ) {
+				if (
+					isset( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] )
+					&&
+					$GLOBALS[ $global_var_name ]['load'] instanceof Closure
+					&&
+					is_string( $GLOBALS[ $global_var_name ]['version'] )
+				) {
+					call_user_func( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] );
+					unset( $GLOBALS[ $global_var_name ] );
+				}
+			};
 
-define( 'SPECULATION_RULES_VERSION', '1.2.1' );
-define( 'SPECULATION_RULES_MAIN_FILE', plugin_basename( __FILE__ ) );
+			// Handle either where the plugin is installed as a regular plugin or is embedded in another plugin or in a theme.
+			if ( ! did_action( 'plugins_loaded' ) ) {
+				add_action( 'plugins_loaded', $bootstrap, 0 );
+			}
 
-require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';
-require_once __DIR__ . '/helper.php';
-require_once __DIR__ . '/hooks.php';
-require_once __DIR__ . '/settings.php';
+			// Handle case where plugin is embedded in a theme.
+			add_action( 'after_setup_theme', $bootstrap, 0 );
+		}
+
+		// Register this copy of the plugin.
+		if (
+			// Register this copy if none has been registered yet.
+			! isset( $GLOBALS[ $global_var_name ]['version'] )
+			||
+			// Or register this copy if the version greater than what is currently registered.
+			version_compare( $version, $GLOBALS[ $global_var_name ]['version'], '>' )
+			||
+			// Otherwise, register this copy if it is actually the one installed in the directory for plugins.
+			rtrim( WP_PLUGIN_DIR, '/' ) === dirname( __DIR__ )
+		) {
+			$GLOBALS[ $global_var_name ]['version'] = $version;
+			$GLOBALS[ $global_var_name ]['load']    = $load;
+		}
+	}
+)(
+	'plsr_pending_plugin_info',
+	'1.2.1',
+	static function ( string $version ) {
+
+		// Define the constant.
+		if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
+			return;
+		}
+
+		define( 'SPECULATION_RULES_VERSION', $version );
+		define( 'SPECULATION_RULES_MAIN_FILE', plugin_basename( __FILE__ ) );
+
+		require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';
+		require_once __DIR__ . '/helper.php';
+		require_once __DIR__ . '/hooks.php';
+		require_once __DIR__ . '/settings.php';
+	}
+);

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -32,11 +32,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 		if ( ! isset( $GLOBALS[ $global_var_name ] ) ) {
 			$bootstrap = static function () use ( $global_var_name ) {
 				if (
-					isset( $GLOBALS[ $global_var_name ]['load'] )
+					isset( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] )
 					&&
 					$GLOBALS[ $global_var_name ]['load'] instanceof Closure
+					&&
+					is_string( $GLOBALS[ $global_var_name ]['version'] )
 				) {
-					call_user_func( $GLOBALS[ $global_var_name ]['load'] );
+					call_user_func( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] );
 					unset( $GLOBALS[ $global_var_name ] );
 				}
 			};
@@ -64,14 +66,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 )(
 	'plsr_pending_plugin_info',
 	'1.2.2',
-	static function () {
+	static function ( string $version ) {
 
 		// Define the constant.
 		if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
 			return;
 		}
 
-		define( 'SPECULATION_RULES_VERSION', '1.2.1' );
+		define( 'SPECULATION_RULES_VERSION', $version );
 		define( 'SPECULATION_RULES_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 		require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';


### PR DESCRIPTION
This ports over the demonstrated in the [plugin bootstrap file](https://github.com/woocommerce/action-scheduler/blob/3f8dd81ff69b0ed786079637f0b18b627f1935c1/action-scheduler.php#L32-L70) of the [woocommerce/action-scheduler](https://github.com/woocommerce/action-scheduler) plugin. It facilitates multiple copies of the plugin to be installed on a site:

* As a standalone plugin
* Embedded in another plugin
* Embedded in a theme

In each case, the logic in this PR ensures that only one copy is loaded. If it is embedded in multiple plugins, then the version of Speculation Rules which has the highest version is chosen. If it was not embedded in a plugin and isn't active as a standalone plugin but is embedded in a theme instead, then that is the copy which will load.

In contrast with the action scheduler plugin, I decided that if a copy of the plugin is installed in the plugins directory, then it should win out over other copies. This is because there is a Settings link in the plugin row actions, and when something is misbehaving with the plugin it would be confusing for them to report an issue for the plugin which is active but isn't actually loaded.

See #1081.