### PR TITLE
Use PHP 7.2 features in Optimization Detective

### DIFF
--- a/plugins/optimization-detective/class-od-html-tag-walker.php
+++ b/plugins/optimization-detective/class-od-html-tag-walker.php
@@ -287,7 +287,7 @@ final class OD_HTML_Tag_Walker {
 	 *
 	 * @param string $message Warning message.
 	 */
-	private function warn( string $message ) {
+	private function warn( string $message ): void {
 		wp_trigger_error(
 			__CLASS__ . '::open_tags',
 			esc_html( $message )

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -61,7 +61,7 @@ final class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Gets JSON schema for URL Metric.
 	 *
-	 * @return array Schema.
+	 * @return array<string, mixed> Schema.
 	 */
 	public static function get_json_schema(): array {
 		$dom_rect_schema = array(

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -46,6 +46,7 @@ final class OD_URL_Metric implements JsonSerializable {
 	 * Constructor.
 	 *
 	 * @param array $data URL metric data.
+	 * @phpstan-param Data $data URL metric data.
 	 *
 	 * @throws OD_Data_Validation_Exception When the input is invalid.
 	 */

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -45,8 +45,9 @@ final class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Constructor.
 	 *
-	 * @param array $data URL metric data.
 	 * @phpstan-param Data $data URL metric data.
+	 *
+	 * @param array $data URL metric data.
 	 *
 	 * @throws OD_Data_Validation_Exception When the input is invalid.
 	 */

--- a/plugins/optimization-detective/class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metrics-group-collection.php
@@ -155,7 +155,7 @@ final class OD_URL_Metrics_Group_Collection implements Countable, IteratorAggreg
 	 *
 	 * @param OD_URL_Metric $new_url_metric New URL metric.
 	 */
-	public function add_url_metric( OD_URL_Metric $new_url_metric ) {
+	public function add_url_metric( OD_URL_Metric $new_url_metric ): void {
 		foreach ( $this->groups as $group ) {
 			if ( $group->is_viewport_width_in_range( $new_url_metric->get_viewport_width() ) ) {
 				$group->add_url_metric( $new_url_metric );

--- a/plugins/optimization-detective/class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/class-od-url-metrics-group.php
@@ -157,7 +157,7 @@ final class OD_URL_Metrics_Group implements IteratorAggregate, Countable {
 	 *
 	 * @param OD_URL_Metric $url_metric URL metric.
 	 */
-	public function add_url_metric( OD_URL_Metric $url_metric ) {
+	public function add_url_metric( OD_URL_Metric $url_metric ): void {
 		if ( ! $this->is_viewport_width_in_range( $url_metric->get_viewport_width() ) ) {
 			throw new InvalidArgumentException(
 				esc_html__( 'URL metric is not in the viewport range for group.', 'optimization-detective' )

--- a/plugins/optimization-detective/helper.php
+++ b/plugins/optimization-detective/helper.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 0.1.0
  */
-function od_render_generator_meta_tag() {
+function od_render_generator_meta_tag(): void {
 	// Use the plugin slug as it is immutable.
 	echo '<meta name="generator" content="optimization-detective ' . esc_attr( OPTIMIZATION_DETECTIVE_VERSION ) . '">' . "\n";
 }

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @access private
  * @link https://core.trac.wordpress.org/ticket/43258
  *
- * @param string $passthrough Optional. Filter value. Default null.
+ * @param string $passthrough Optional. Filter value.
  * @return string Unmodified value of $passthrough.
  */
 function od_buffer_output( string $passthrough ): string {

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -53,7 +53,7 @@ function od_buffer_output( string $passthrough ): string {
  * @since 0.1.0
  * @access private
  */
-function od_maybe_add_template_output_buffer_filter() {
+function od_maybe_add_template_output_buffer_filter(): void {
 	if ( ! od_can_optimize_response() ) {
 		return;
 	}

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @access private
  * @link https://core.trac.wordpress.org/ticket/43258
  *
- * @param string $passthrough Optional. Filter value.
+ * @param string $passthrough Value for the template_include filter which is passed through.
  * @return string Unmodified value of $passthrough.
  */
 function od_buffer_output( string $passthrough ): string {

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -67,7 +67,7 @@ final class OD_Storage_Lock {
 	 * @since 0.1.0
 	 * @access private
 	 */
-	public static function set_lock() {
+	public static function set_lock(): void {
 		$ttl = self::get_ttl();
 		$key = self::get_transient_key();
 		if ( 0 === $ttl ) {

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -44,7 +44,7 @@ class OD_URL_Metrics_Post_Type {
 	 *
 	 * @since 0.1.0
 	 */
-	public static function add_hooks() {
+	public static function add_hooks(): void {
 		add_action( 'init', array( __CLASS__, 'register_post_type' ) );
 		add_action( 'admin_init', array( __CLASS__, 'schedule_garbage_collection' ) );
 		add_action( self::GC_CRON_EVENT_NAME, array( __CLASS__, 'delete_stale_posts' ) );
@@ -57,7 +57,7 @@ class OD_URL_Metrics_Post_Type {
 	 *
 	 * @since 0.1.0
 	 */
-	public static function register_post_type() {
+	public static function register_post_type(): void {
 		register_post_type(
 			self::SLUG,
 			array(
@@ -85,7 +85,7 @@ class OD_URL_Metrics_Post_Type {
 	 * @param string $slug URL metrics slug.
 	 * @return WP_Post|null Post object if exists.
 	 */
-	public static function get_post( string $slug ) {
+	public static function get_post( string $slug ): ?WP_Post {
 		$post_query = new WP_Query(
 			array(
 				'post_type'              => self::SLUG,
@@ -253,7 +253,7 @@ class OD_URL_Metrics_Post_Type {
 	 *
 	 * @since 0.1.0
 	 */
-	public static function schedule_garbage_collection() {
+	public static function schedule_garbage_collection(): void {
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
@@ -275,7 +275,7 @@ class OD_URL_Metrics_Post_Type {
 	 *
 	 * @since 0.1.0
 	 */
-	public static function delete_stale_posts() {
+	public static function delete_stale_posts(): void {
 		$one_month_ago = gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) );
 
 		$query = new WP_Query(
@@ -303,7 +303,7 @@ class OD_URL_Metrics_Post_Type {
 	 *
 	 * @since 0.1.0
 	 */
-	public static function delete_all_posts() {
+	public static function delete_all_posts(): void {
 		global $wpdb;
 
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -61,7 +61,7 @@ function od_get_url_metric_freshness_ttl(): int {
  * @since 0.1.0
  * @access private
  *
- * @return array Normalized query vars.
+ * @return array<string, mixed> Normalized query vars.
  */
 function od_get_normalized_query_vars(): array {
 	global $wp;
@@ -133,7 +133,7 @@ function od_get_current_url(): string {
  *
  * @see od_get_normalized_query_vars()
  *
- * @param array $query_vars Normalized query vars.
+ * @param array<string, mixed> $query_vars Normalized query vars.
  * @return string Slug.
  */
 function od_get_url_metrics_slug( array $query_vars ): string {

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -312,7 +312,10 @@ function od_get_url_metrics_breakpoint_sample_size(): int {
  * @access private
  *
  * @param OD_URL_Metrics_Group_Collection $group_collection URL metrics group collection.
- * @return array LCP elements keyed by its minimum viewport width. If there is no supported LCP element at a breakpoint, then `false` is used.
+ * @return array<int, array{xpath: string}|false> LCP elements keyed by its minimum viewport width. If there is no
+ *                                                supported LCP element at a breakpoint, then `false` is used. Note that
+ *                                                the array shape is actually an ElementData from OD_URL_Metric but
+ *                                                PHPStan does not support importing a type onto a function.
  */
 function od_get_lcp_elements_by_minimum_viewport_widths( OD_URL_Metrics_Group_Collection $group_collection ): array {
 	$lcp_element_by_viewport_minimum_width = array();

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -35,7 +35,7 @@ const OD_URL_METRICS_ROUTE = '/url-metrics:store';
  * @since 0.1.0
  * @access private
  */
-function od_register_endpoint() {
+function od_register_endpoint(): void {
 
 	$args = array(
 		'slug'  => array(


### PR DESCRIPTION
In #1130 the PHP version was bumped to 7.2. This allows us to make use of new PHP language features which further harden static analysis (related to #775). Changes in this PR include:

* Use the `void` return type
* Use the nullable type
* Add value types for arrays
* Add improved typing to prevent having to ignore the following errors in PHPStan level 6:
  * `#^(Function|Method) .+? return type has no value type specified in iterable type array#`
  * `#^(Function|Method) .+? has parameter .+? with no value type specified in iterable type array#`
  * `#^(Function|Method) .+? has no return type specified#`