### PR TITLE
Fix composition of href exclude paths to account for JSON encoding and differing site/home URLs

### DIFF
--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -58,7 +58,7 @@ function plsr_get_speculation_rules() {
 	 *
 	 * @param string[] $href_exclude_paths Additional paths to disable speculative prerendering for. The base exclude paths,
 	 *                                     such as for wp-admin, cannot be removed.
-	 * @param string $mode                 Mode used to apply speculative prerendering. Either 'prefetch' or 'prerender'.
+	 * @param string   $mode               Mode used to apply speculative prerendering. Either 'prefetch' or 'prerender'.
 	 */
 	$href_exclude_paths = (array) apply_filters( 'plsr_speculation_rules_href_exclude_paths', array(), $mode );
 

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -42,7 +42,7 @@ function plsr_get_speculation_rules() {
 	$base_href_exclude_paths = array(
 		$prefixer->prefix_path_pattern( '/wp-login.php', 'site' ),
 		$prefixer->prefix_path_pattern( '/wp-admin/*', 'site' ),
-		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'site' ),
+		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'home' ),
 	);
 
 	/**

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -62,13 +62,18 @@ function plsr_get_speculation_rules() {
 	 */
 	$href_exclude_paths = (array) apply_filters( 'plsr_speculation_rules_href_exclude_paths', $href_exclude_paths, $mode );
 
-	// Ensure that there are no duplicates and that the base paths cannot be removed.
-	$href_exclude_paths = array_unique(
-		array_map(
-			array( $prefixer, 'prefix_path_pattern' ),
-			array_merge(
-				$base_href_exclude_paths,
-				$href_exclude_paths
+	// Ensure that:
+	// 1. There are no duplicates.
+	// 2. The base paths cannot be removed.
+	// 3. The array has sequential keys (i.e. array_is_list()).
+	$href_exclude_paths = array_values(
+		array_unique(
+			array_map(
+				array( $prefixer, 'prefix_path_pattern' ),
+				array_merge(
+					$base_href_exclude_paths,
+					$href_exclude_paths
+				)
 			)
 		)
 	);

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -44,7 +44,6 @@ function plsr_get_speculation_rules() {
 		$prefixer->prefix_path_pattern( '/wp-admin/*', 'site' ),
 		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'site' ),
 	);
-	$href_exclude_paths      = $base_href_exclude_paths;
 
 	/**
 	 * Filters the paths for which speculative prerendering should be disabled.
@@ -57,10 +56,11 @@ function plsr_get_speculation_rules() {
 	 * @since 1.0.0
 	 * @since 1.1.0 The $mode parameter was added.
 	 *
-	 * @param array  $href_exclude_paths Paths to disable speculative prerendering for.
-	 * @param string $mode               Mode used to apply speculative prerendering. Either 'prefetch' or 'prerender'.
+	 * @param string[] $href_exclude_paths Additional paths to disable speculative prerendering for. The base exclude paths,
+	 *                                     such as for wp-admin, cannot be removed.
+	 * @param string $mode                 Mode used to apply speculative prerendering. Either 'prefetch' or 'prerender'.
 	 */
-	$href_exclude_paths = (array) apply_filters( 'plsr_speculation_rules_href_exclude_paths', $href_exclude_paths, $mode );
+	$href_exclude_paths = (array) apply_filters( 'plsr_speculation_rules_href_exclude_paths', array(), $mode );
 
 	// Ensure that:
 	// 1. There are no duplicates.

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -68,10 +68,12 @@ function plsr_get_speculation_rules() {
 	// 3. The array has sequential keys (i.e. array_is_list()).
 	$href_exclude_paths = array_values(
 		array_unique(
-			array_map(
-				array( $prefixer, 'prefix_path_pattern' ),
-				array_merge(
-					$base_href_exclude_paths,
+			array_merge(
+				$base_href_exclude_paths,
+				array_map(
+					static function ( string $href_exclude_path ) use ( $prefixer ): string {
+						return $prefixer->prefix_path_pattern( $href_exclude_path );
+					},
 					$href_exclude_paths
 				)
 			)

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -111,13 +111,13 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		);
 	}
 
-
 	/**
+	 * Tests filter that explicitly adds non-sequential keys.
+	 *
 	 * @covers ::plsr_get_speculation_rules
 	 */
 	public function test_plsr_get_speculation_rules_with_filtering_bad_keys() {
 
-		// Filter that explicitly adds bogus keys.
 		add_filter(
 			'plsr_speculation_rules_href_exclude_paths',
 			static function ( array $exclude_paths ): array {
@@ -130,7 +130,6 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			}
 		);
 
-		// Ensure the additional exclusion is not present because the mode is 'prefetch'.
 		$this->assertSame(
 			array(
 				0 => '/wp-login.php',
@@ -147,6 +146,8 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests scenario when the home_url and site_url have different paths.
+	 *
 	 * @covers ::plsr_get_speculation_rules
 	 */
 	public function test_plsr_get_speculation_rules_different_home_and_site_urls() {

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -149,6 +149,41 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 	/**
 	 * @covers ::plsr_get_speculation_rules
 	 */
+	public function test_plsr_get_speculation_rules_different_home_and_site_urls() {
+		add_filter(
+			'site_url',
+			static function (): string {
+				return 'https://example.com/wp/';
+			}
+		);
+		add_filter(
+			'home_url',
+			static function (): string {
+				return 'https://example.com/blog/';
+			}
+		);
+		add_filter(
+			'plsr_speculation_rules_href_exclude_paths',
+			static function ( array $exclude_paths ): array {
+				$exclude_paths[] = '/store/*';
+				return $exclude_paths;
+			}
+		);
+
+		$this->assertSame(
+			array(
+				0 => '/wp/wp-login.php',
+				1 => '/wp/wp-admin/*',
+				2 => '/wp/*\\?*(^|&)_wpnonce=*',
+				3 => '/blog/store/*',
+			),
+			plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches']
+		);
+	}
+
+	/**
+	 * @covers ::plsr_get_speculation_rules
+	 */
 	public function test_plsr_get_speculation_rules_prerender() {
 		$rules = plsr_get_speculation_rules();
 

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -174,7 +174,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			array(
 				0 => '/wp/wp-login.php',
 				1 => '/wp/wp-admin/*',
-				2 => '/wp/*\\?*(^|&)_wpnonce=*',
+				2 => '/blog/*\\?*(^|&)_wpnonce=*',
 				3 => '/blog/store/*',
 			),
 			plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches']

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -111,6 +111,41 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		);
 	}
 
+
+	/**
+	 * @covers ::plsr_get_speculation_rules
+	 */
+	public function test_plsr_get_speculation_rules_with_filtering_bad_keys() {
+
+		// Filter that explicitly adds bogus keys.
+		add_filter(
+			'plsr_speculation_rules_href_exclude_paths',
+			static function ( array $exclude_paths ): array {
+				$exclude_paths[] = '/next/';
+				array_unshift( $exclude_paths, '/unshifted/' );
+				$exclude_paths[-1]  = '/negative-one/';
+				$exclude_paths[100] = '/one-hundred/';
+				$exclude_paths['a'] = '/letter-a/';
+				return $exclude_paths;
+			}
+		);
+
+		// Ensure the additional exclusion is not present because the mode is 'prefetch'.
+		$this->assertSame(
+			array(
+				0 => '/wp-login.php',
+				1 => '/wp-admin/*',
+				2 => '/*\\?*(^|&)_wpnonce=*',
+				3 => '/unshifted/',
+				4 => '/next/',
+				5 => '/negative-one/',
+				6 => '/one-hundred/',
+				7 => '/letter-a/',
+			),
+			plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches']
+		);
+	}
+
 	/**
 	 * @covers ::plsr_get_speculation_rules
 	 */

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -83,7 +83,16 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		$href_exclude_paths = $rules['prerender'][0]['where']['and'][1]['not']['href_matches'];
 
 		// Ensure the additional exclusion is present because the mode is 'prerender'.
-		$this->assertContains( '/products/*', $href_exclude_paths );
+		// Also ensure keys are sequential starting from 0 (that is, that array_is_list()).
+		$this->assertSame(
+			array(
+				0 => '/wp-login.php',
+				1 => '/wp-admin/*',
+				2 => '/*\\?*(^|&)_wpnonce=*',
+				3 => '/products/*',
+			),
+			$href_exclude_paths
+		);
 
 		// Update mode to be 'prefetch'.
 		update_option( 'plsr_speculation_rules', array( 'mode' => 'prefetch' ) );
@@ -92,7 +101,14 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		$href_exclude_paths = $rules['prefetch'][0]['where']['and'][1]['not']['href_matches'];
 
 		// Ensure the additional exclusion is not present because the mode is 'prefetch'.
-		$this->assertNotContains( '/products/*', $href_exclude_paths );
+		$this->assertSame(
+			array(
+				0 => '/wp-login.php',
+				1 => '/wp-admin/*',
+				2 => '/*\\?*(^|&)_wpnonce=*',
+			),
+			$href_exclude_paths
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

When filtering `plsr_speculation_rules_href_exclude_paths` to add additional paths, make sure the resulting de-duplicated array has sequential keys starting from zero. If this is not the case, then `json_encode()` interprets the array as an object which causes a speculation rules failure in the browser.

Additionally, we found that the base exclude hrefs were getting prefixed with the site URL path and then prefixed again with the home URL path with the merge with the additional filtered exclude href exclude paths. On sites with different site URL and home URL (e.g. `/wp/` and `/blog/`) this can result in the base URLs getting double-prefixed in an erroneous prefix (e.g. `/blog/wp/`). This is fixed by avoiding the redundant prefixing, so that only the href exclude paths provided by the filter are prefixed with the home URL path. This PR also ensures that the nonce/`_wpnonce` action URLs (from #1143) are prefixed with the home URL path and not the site URL path.

Fixes #1163

## Relevant technical choices

The result of calling `array_unique()` is passed into `array_values()` to ensure that the keys are numerically sequential from zero. Tests are updated to ensure this is the case.

Additionally, the `$base_href_exclude_paths` are no longer provided as the initial value to pass into the `plsr_speculation_rules_href_exclude_paths` filter. The values in `$base_href_exclude_paths` get merged again with the result of the filter, meaning they will always be present regardless. It is misleading to pass them into the filter, as a developer may think they can remove a path by eliminating it from the array passed to the filter when they cannot. Eliminating this redundancy alone fixes the symptom of non-sequential array keys, but the changes in this PR go further to ensure there is no possibility of non-sequential array keys when the the base exclude paths are merged with the return value from the filter.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
