### PR TITLE
Release Speculative Loading 1.2.2

### DIFF
--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Enables browsers to speculatively prerender or prefetch pages when hovering over links.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 1.2.1
+ * Version: 1.2.2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'SPECULATION_RULES_VERSION' ) ) {
 	return;
 }
 
-define( 'SPECULATION_RULES_VERSION', '1.2.1' );
+define( 'SPECULATION_RULES_VERSION', '1.2.2' );
 define( 'SPECULATION_RULES_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/class-plsr-url-pattern-prefixer.php';

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        1.2.1
+Stable tag:        1.2.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, javascript, speculation rules, prerender, prefetch

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -114,6 +114,16 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 == Changelog ==
 
+= 1.2.2 =
+
+**Bug Fixes**
+
+* Fix composition of href exclude paths to account for JSON encoding and differing site/home URLs. ([1164](https://github.com/WordPress/performance/pull/1164))
+
+**Documentation**
+
+* Update readme with browser support and FAQ section about analytics and personalization. ([1155](https://github.com/WordPress/performance/pull/1155))
+
 = 1.2.1 =
 
 **Enhancements**


### PR DESCRIPTION
See checklist: https://make.wordpress.org/performance/handbook/performance-lab/releasing-a-standalone-plugin/

Milestone: https://github.com/WordPress/performance/milestone/44?closed=1

- [x] Update versions in `readme.txt` and `load.php`
- [x] Run `npm run changelog` and add changelog to readme.
- [x] Run `npm run since` (no changes).
