### PR TITLE
Prevent speculatively loading links to the uploads, content, plugins, template, or stylesheet directories

### DIFF
--- a/plugins/speculation-rules/class-plsr-url-pattern-prefixer.php
+++ b/plugins/speculation-rules/class-plsr-url-pattern-prefixer.php
@@ -107,8 +107,9 @@ class PLSR_URL_Pattern_Prefixer {
 	 */
 	public static function get_default_contexts(): array {
 		return array(
-			'home' => self::escape_pattern_string( trailingslashit( wp_parse_url( home_url( '/' ), PHP_URL_PATH ) ) ),
-			'site' => self::escape_pattern_string( trailingslashit( wp_parse_url( site_url( '/' ), PHP_URL_PATH ) ) ),
+			'home'    => self::escape_pattern_string( trailingslashit( wp_parse_url( home_url( '/' ), PHP_URL_PATH ) ) ),
+			'site'    => self::escape_pattern_string( trailingslashit( wp_parse_url( site_url( '/' ), PHP_URL_PATH ) ) ),
+			'uploads' => self::escape_pattern_string( trailingslashit( wp_parse_url( wp_upload_dir( null, false )['baseurl'], PHP_URL_PATH ) ) ),
 		);
 	}
 

--- a/plugins/speculation-rules/class-plsr-url-pattern-prefixer.php
+++ b/plugins/speculation-rules/class-plsr-url-pattern-prefixer.php
@@ -107,9 +107,13 @@ class PLSR_URL_Pattern_Prefixer {
 	 */
 	public static function get_default_contexts(): array {
 		return array(
-			'home'    => self::escape_pattern_string( trailingslashit( wp_parse_url( home_url( '/' ), PHP_URL_PATH ) ) ),
-			'site'    => self::escape_pattern_string( trailingslashit( wp_parse_url( site_url( '/' ), PHP_URL_PATH ) ) ),
-			'uploads' => self::escape_pattern_string( trailingslashit( wp_parse_url( wp_upload_dir( null, false )['baseurl'], PHP_URL_PATH ) ) ),
+			'home'       => self::escape_pattern_string( trailingslashit( wp_parse_url( home_url( '/' ), PHP_URL_PATH ) ) ),
+			'site'       => self::escape_pattern_string( trailingslashit( wp_parse_url( site_url( '/' ), PHP_URL_PATH ) ) ),
+			'uploads'    => self::escape_pattern_string( trailingslashit( wp_parse_url( wp_upload_dir( null, false )['baseurl'], PHP_URL_PATH ) ) ),
+			'content'    => self::escape_pattern_string( trailingslashit( wp_parse_url( content_url(), PHP_URL_PATH ) ) ),
+			'plugins'    => self::escape_pattern_string( trailingslashit( wp_parse_url( plugins_url(), PHP_URL_PATH ) ) ),
+			'template'   => self::escape_pattern_string( trailingslashit( wp_parse_url( get_stylesheet_directory_uri(), PHP_URL_PATH ) ) ),
+			'stylesheet' => self::escape_pattern_string( trailingslashit( wp_parse_url( get_template_directory_uri(), PHP_URL_PATH ) ) ),
 		);
 	}
 

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -44,8 +44,8 @@ function plsr_get_speculation_rules() {
 		$prefixer->prefix_path_pattern( '/wp-admin/*', 'site' ),
 		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'home' ),
 		$prefixer->prefix_path_pattern( '/*', 'uploads' ),
-		trailingslashit( wp_parse_url( WP_CONTENT_URL, PHP_URL_PATH ) ) . '*',
-		trailingslashit( wp_parse_url( WP_PLUGIN_URL, PHP_URL_PATH ) ) . '*',
+		trailingslashit( wp_parse_url( content_url(), PHP_URL_PATH ) ) . '*',
+		trailingslashit( wp_parse_url( plugins_url(), PHP_URL_PATH ) ) . '*',
 		trailingslashit( wp_parse_url( get_stylesheet_directory_uri(), PHP_URL_PATH ) ) . '*',
 		trailingslashit( wp_parse_url( get_template_directory_uri(), PHP_URL_PATH ) ) . '*',
 	);

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -44,10 +44,10 @@ function plsr_get_speculation_rules() {
 		$prefixer->prefix_path_pattern( '/wp-admin/*', 'site' ),
 		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'home' ),
 		$prefixer->prefix_path_pattern( '/*', 'uploads' ),
-		trailingslashit( wp_parse_url( content_url(), PHP_URL_PATH ) ) . '*',
-		trailingslashit( wp_parse_url( plugins_url(), PHP_URL_PATH ) ) . '*',
-		trailingslashit( wp_parse_url( get_stylesheet_directory_uri(), PHP_URL_PATH ) ) . '*',
-		trailingslashit( wp_parse_url( get_template_directory_uri(), PHP_URL_PATH ) ) . '*',
+		$prefixer->prefix_path_pattern( '/*', 'content' ),
+		$prefixer->prefix_path_pattern( '/*', 'plugins' ),
+		$prefixer->prefix_path_pattern( '/*', 'template' ),
+		$prefixer->prefix_path_pattern( '/*', 'stylesheet' ),
 	);
 
 	/**

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -43,6 +43,7 @@ function plsr_get_speculation_rules() {
 		$prefixer->prefix_path_pattern( '/wp-login.php', 'site' ),
 		$prefixer->prefix_path_pattern( '/wp-admin/*', 'site' ),
 		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'home' ),
+		$prefixer->prefix_path_pattern( '/*', 'uploads' ),
 	);
 
 	/**

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -44,6 +44,10 @@ function plsr_get_speculation_rules() {
 		$prefixer->prefix_path_pattern( '/wp-admin/*', 'site' ),
 		$prefixer->prefix_path_pattern( '/*\\?*(^|&)_wpnonce=*', 'home' ),
 		$prefixer->prefix_path_pattern( '/*', 'uploads' ),
+		trailingslashit( wp_parse_url( WP_CONTENT_URL, PHP_URL_PATH ) ) . '*',
+		trailingslashit( wp_parse_url( WP_PLUGIN_URL, PHP_URL_PATH ) ) . '*',
+		trailingslashit( wp_parse_url( get_stylesheet_directory_uri(), PHP_URL_PATH ) ) . '*',
+		trailingslashit( wp_parse_url( get_template_directory_uri(), PHP_URL_PATH ) ) . '*',
 	);
 
 	/**

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -6,6 +6,27 @@
  */
 
 class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
+	/**
+	 * Runs the routine before each test is executed.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_filter(
+			'template_directory_uri',
+			static function () {
+				return trailingslashit( WP_CONTENT_URL ) . 'themes/template';
+			}
+		);
+
+		add_filter(
+			'stylesheet_directory_uri',
+			static function () {
+				return trailingslashit( WP_CONTENT_URL ) . 'themes/stylesheet';
+			}
+		);
+	}
+
 
 	/**
 	 * @covers ::plsr_get_speculation_rules
@@ -32,12 +53,17 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 
 		$this->assertSameSets(
 			array(
-				'/wp-login.php',
-				'/wp-admin/*',
-				'/*\\?*(^|&)_wpnonce=*',
-				'/wp-content/uploads/*',
+				0 => '/wp-login.php',
+				1 => '/wp-admin/*',
+				2 => '/*\\?*(^|&)_wpnonce=*',
+				3 => '/wp-content/uploads/*',
+				4 => '/wp-content/*',
+				5 => '/wp-content/plugins/*',
+				6 => '/wp-content/themes/stylesheet/*',
+				7 => '/wp-content/themes/template/*',
 			),
-			$href_exclude_paths
+			$href_exclude_paths,
+			'Snapshot: ' . var_export( $href_exclude_paths, true )
 		);
 
 		// Add filter that attempts to replace base exclude paths with a custom path to exclude.
@@ -54,13 +80,18 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 		// Ensure the base exclude paths are still present and that the custom path was formatted correctly.
 		$this->assertSameSets(
 			array(
-				'/wp-login.php',
-				'/wp-admin/*',
-				'/*\\?*(^|&)_wpnonce=*',
-				'/wp-content/uploads/*',
-				'/custom-file.php',
+				0 => '/wp-login.php',
+				1 => '/wp-admin/*',
+				2 => '/*\\?*(^|&)_wpnonce=*',
+				3 => '/wp-content/uploads/*',
+				4 => '/wp-content/*',
+				5 => '/wp-content/plugins/*',
+				6 => '/wp-content/themes/stylesheet/*',
+				7 => '/wp-content/themes/template/*',
+				8 => '/custom-file.php',
 			),
-			$href_exclude_paths
+			$href_exclude_paths,
+			'Snapshot: ' . var_export( $href_exclude_paths, true )
 		);
 	}
 
@@ -92,9 +123,14 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				1 => '/wp-admin/*',
 				2 => '/*\\?*(^|&)_wpnonce=*',
 				3 => '/wp-content/uploads/*',
-				4 => '/products/*',
+				4 => '/wp-content/*',
+				5 => '/wp-content/plugins/*',
+				6 => '/wp-content/themes/stylesheet/*',
+				7 => '/wp-content/themes/template/*',
+				8 => '/products/*',
 			),
-			$href_exclude_paths
+			$href_exclude_paths,
+			'Snapshot: ' . var_export( $href_exclude_paths, true )
 		);
 
 		// Update mode to be 'prefetch'.
@@ -110,8 +146,13 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				1 => '/wp-admin/*',
 				2 => '/*\\?*(^|&)_wpnonce=*',
 				3 => '/wp-content/uploads/*',
+				4 => '/wp-content/*',
+				5 => '/wp-content/plugins/*',
+				6 => '/wp-content/themes/stylesheet/*',
+				7 => '/wp-content/themes/template/*',
 			),
-			$href_exclude_paths
+			$href_exclude_paths,
+			'Snapshot: ' . var_export( $href_exclude_paths, true )
 		);
 	}
 
@@ -134,19 +175,25 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			}
 		);
 
+		$actual = plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches'];
 		$this->assertSame(
 			array(
 				0 => '/wp-login.php',
 				1 => '/wp-admin/*',
 				2 => '/*\\?*(^|&)_wpnonce=*',
 				3 => '/wp-content/uploads/*',
-				4 => '/unshifted/',
-				5 => '/next/',
-				6 => '/negative-one/',
-				7 => '/one-hundred/',
-				8 => '/letter-a/',
+				4 => '/wp-content/*',
+				5 => '/wp-content/plugins/*',
+				6 => '/wp-content/themes/stylesheet/*',
+				7 => '/wp-content/themes/template/*',
+				8 => '/unshifted/',
+				9 => '/next/',
+				10 => '/negative-one/',
+				11 => '/one-hundred/',
+				12 => '/letter-a/',
 			),
-			plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches']
+			$actual,
+			'Snapshot: ' . var_export( $actual, true )
 		);
 	}
 
@@ -176,15 +223,21 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 			}
 		);
 
+		$actual = plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches'];
 		$this->assertSame(
 			array(
 				0 => '/wp/wp-login.php',
 				1 => '/wp/wp-admin/*',
 				2 => '/blog/*\\?*(^|&)_wpnonce=*',
 				3 => '/wp-content/uploads/*',
-				4 => '/blog/store/*',
+				4 => '/wp-content/*',
+				5 => '/wp-content/plugins/*',
+				6 => '/wp-content/themes/stylesheet/*',
+				7 => '/wp-content/themes/template/*',
+				8 => '/blog/store/*',
 			),
-			plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches']
+			$actual,
+			'Snapshot: ' . var_export( $actual, true )
 		);
 	}
 

--- a/tests/plugins/speculation-rules/speculation-rules-helper-test.php
+++ b/tests/plugins/speculation-rules/speculation-rules-helper-test.php
@@ -35,6 +35,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				'/wp-login.php',
 				'/wp-admin/*',
 				'/*\\?*(^|&)_wpnonce=*',
+				'/wp-content/uploads/*',
 			),
 			$href_exclude_paths
 		);
@@ -56,6 +57,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				'/wp-login.php',
 				'/wp-admin/*',
 				'/*\\?*(^|&)_wpnonce=*',
+				'/wp-content/uploads/*',
 				'/custom-file.php',
 			),
 			$href_exclude_paths
@@ -89,7 +91,8 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				0 => '/wp-login.php',
 				1 => '/wp-admin/*',
 				2 => '/*\\?*(^|&)_wpnonce=*',
-				3 => '/products/*',
+				3 => '/wp-content/uploads/*',
+				4 => '/products/*',
 			),
 			$href_exclude_paths
 		);
@@ -106,6 +109,7 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				0 => '/wp-login.php',
 				1 => '/wp-admin/*',
 				2 => '/*\\?*(^|&)_wpnonce=*',
+				3 => '/wp-content/uploads/*',
 			),
 			$href_exclude_paths
 		);
@@ -135,11 +139,12 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				0 => '/wp-login.php',
 				1 => '/wp-admin/*',
 				2 => '/*\\?*(^|&)_wpnonce=*',
-				3 => '/unshifted/',
-				4 => '/next/',
-				5 => '/negative-one/',
-				6 => '/one-hundred/',
-				7 => '/letter-a/',
+				3 => '/wp-content/uploads/*',
+				4 => '/unshifted/',
+				5 => '/next/',
+				6 => '/negative-one/',
+				7 => '/one-hundred/',
+				8 => '/letter-a/',
 			),
 			plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches']
 		);
@@ -176,7 +181,8 @@ class Speculation_Rules_Helper_Tests extends WP_UnitTestCase {
 				0 => '/wp/wp-login.php',
 				1 => '/wp/wp-admin/*',
 				2 => '/blog/*\\?*(^|&)_wpnonce=*',
-				3 => '/blog/store/*',
+				3 => '/wp-content/uploads/*',
+				4 => '/blog/store/*',
 			),
 			plsr_get_speculation_rules()['prerender'][0]['where']['and'][1]['not']['href_matches']
 		);


### PR DESCRIPTION
This was brought up by @AntonyXSI in #1157:

> 3\. Excluding links that contain "." or file extensions i.e to prevent a user from downloading large PDFs or images potentially bottlenecking bandwidth. An example would be images being wrapped in a link to the original uncropped image. Hovering over images in a gallery for example could result in lots of large unoptimized images being downloaded unnecessarily in the background. As images will begin to render almost instantly prerendering images, pdfs etc may not be as beneficial as prerendering pages. I'm also not sure what happens if .exe,.pdf or other large files are prefetched that would normally be downloaded once clicked? Does Chrome drop the request or continue the download from the same prefetch request?

See Chrome's behavior for speculative loading of an image and a PDF: https://github.com/WordPress/performance/issues/1157#issuecomment-2065459362.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

In this PR, the uploads directory is excluded from speculative loading. The uploads directory path is added to the base href excludes.

Before | After
--|--
![image](https://github.com/WordPress/performance/assets/134745/c43eddd4-da8f-4a23-b747-aff93192f73a) | ![image](https://github.com/WordPress/performance/assets/134745/97251885-d0ae-46ad-aa95-83c6418cd7b2)

What if the uploads directory is pointing to a CDN instead? Well, it will be ignored anyway because the speculation rules are configured to only do same-origin speculative loads:

https://github.com/WordPress/performance/blob/cb5a37e8871e06564ac23e793b2121d6181dc0b8/plugins/speculation-rules/helper.php#L83-L91

So they will be excluded anyway. (The same goes for a site with a site customizing the `site_url` to point to another domain, cf. #1164). But what if someone _wants_ to do cross-origin speculative loads? That could be made possible with #1156 where the `href_matches` is changed from `/*` to instead be `*://*/*`. Nevertheless, it seems Chrome does not currently support this:

![image](https://github.com/WordPress/performance/assets/134745/b096b227-1359-4080-8405-2bf1d0724b78)

Nevertheless, the above was specifically for prerendering. If I try instead with the mode set to prefetch, I get different results:

![image](https://github.com/WordPress/performance/assets/134745/3f8dc699-d675-4a83-8a83-6fdaad13e540)

So it _can_ work with prefetch in some situations.

We should keep that in mind for the future.


