### PR TITLE
Refine logic in perflab_install_activate_plugin_callback() to rely only on validated slug

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -243,9 +243,8 @@ function perflab_install_activate_plugin_callback() {
 		wp_die( esc_html__( 'Missing required parameter.', 'performance-lab' ) );
 	}
 
-	$all_plugin_slugs = array_keys( perflab_get_standalone_plugin_data() );
-	$plugin_slug      = sanitize_text_field( wp_unslash( $_GET['slug'] ) );
-	if ( ! in_array( $plugin_slug, $all_plugin_slugs, true ) ) {
+	$plugin_slug = sanitize_text_field( wp_unslash( $_GET['slug'] ) );
+	if ( ! in_array( $plugin_slug, perflab_get_standalone_plugins(), true ) ) {
 		wp_die( esc_html__( 'Invalid plugin.', 'performance-lab' ) );
 	}
 

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -250,11 +250,11 @@ function perflab_install_activate_plugin_callback() {
 
 	// Check if installed and determine the plugin basename.
 	$is_plugin_installed = false;
-	$plugin_basename     = null;
-	foreach ( array_keys( get_plugins() ) as $plugin_file ) {
-		if ( strtok( $plugin_file, '/' ) === $plugin_slug ) {
+	$plugin_file         = null;
+	foreach ( array_keys( get_plugins() ) as $installed_plugin_file ) {
+		if ( strtok( $installed_plugin_file, '/' ) === $plugin_slug ) {
 			$is_plugin_installed = true;
-			$plugin_basename     = $plugin_file; // TODO: The variable name "$plugin_basename" seems misleading. To follow core convention, it should be "$plugin_file", right?
+			$plugin_file         = $installed_plugin_file;
 			break;
 		}
 	}
@@ -302,14 +302,14 @@ function perflab_install_activate_plugin_callback() {
 		}
 
 		$plugin_file_names = array_keys( $plugins );
-		$plugin_basename   = $plugin_slug . '/' . $plugin_file_names[0];
+		$plugin_file       = $plugin_slug . '/' . $plugin_file_names[0];
 	}
 
-	if ( ! current_user_can( 'activate_plugin', $plugin_basename ) ) {
+	if ( ! current_user_can( 'activate_plugin', $plugin_file ) ) {
 		wp_die( esc_html__( 'Sorry, you are not allowed to activate this plugin.', 'default' ) );
 	}
 
-	$result = activate_plugin( $plugin_basename );
+	$result = activate_plugin( $plugin_file );
 	if ( is_wp_error( $result ) ) {
 		wp_die( esc_html( $result->get_error_message() ) );
 	}

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -242,7 +242,8 @@ function perflab_install_activate_plugin_callback() {
 	if ( ! isset( $_GET['slug'] ) ) {
 		wp_die( esc_html__( 'Missing required parameter.', 'performance-lab' ) );
 	}
-	$all_plugin_slugs = json_decode( file_get_contents( PERFLAB_PLUGIN_DIR_PATH . 'plugins.json' ), true )['plugins']; // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+	$all_plugin_slugs = array_keys( perflab_get_standalone_plugin_data() );
 	$plugin_slug      = sanitize_text_field( wp_unslash( $_GET['slug'] ) );
 	if ( ! in_array( $plugin_slug, $all_plugin_slugs, true ) ) {
 		wp_die( esc_html__( 'Invalid plugin.', 'performance-lab' ) );

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -248,19 +248,18 @@ function perflab_install_activate_plugin_callback() {
 		wp_die( esc_html__( 'Invalid plugin.', 'performance-lab' ) );
 	}
 
-	// Check if installed and determine the plugin basename.
-	$is_plugin_installed = false;
-	$plugin_file         = null;
+	// Check if plugin (by slug) is installed by obtaining the plugin file.
+	// Remember a plugin file typically looks like "{slug}/load.php" or "{slug}/{slug}.php".
+	$plugin_file = null;
 	foreach ( array_keys( get_plugins() ) as $installed_plugin_file ) {
 		if ( strtok( $installed_plugin_file, '/' ) === $plugin_slug ) {
-			$is_plugin_installed = true;
-			$plugin_file         = $installed_plugin_file;
+			$plugin_file = $installed_plugin_file;
 			break;
 		}
 	}
 
-	// Install the plugin if it is not installed yet.
-	if ( ! $is_plugin_installed ) {
+	// Install the plugin if it is not installed yet (in which case the plugin file could not be discovered above).
+	if ( ! isset( $plugin_file ) ) {
 		// Check if the user have plugin installation capability.
 		if ( ! current_user_can( 'install_plugins' ) ) {
 			wp_die( esc_html__( 'Sorry, you are not allowed to install plugins on this site.', 'default' ) );

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -53,9 +53,9 @@ function perflab_query_plugin_info( string $plugin_slug ) {
  *
  * @since 2.8.0
  *
- * @return array List of WPP standalone plugins as slugs.
+ * @return string[] List of WPP standalone plugins as slugs.
  */
-function perflab_get_standalone_plugins() {
+function perflab_get_standalone_plugins(): array {
 	return array_keys(
 		perflab_get_standalone_plugin_data()
 	);

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -174,7 +174,6 @@ function perflab_render_plugin_card( array $plugin_data ) {
 					'action'   => 'perflab_install_activate_plugin',
 					'_wpnonce' => wp_create_nonce( 'perflab_install_activate_plugin' ),
 					'slug'     => $plugin_data['slug'],
-					'file'     => $status['file'],
 				),
 				admin_url( 'options-general.php' )
 			)

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,7 @@ parameters:
 		- plugins/
 		- tests/
 	bootstrapFiles:
+		- load.php
 		- plugins/speculation-rules/load.php
 		- plugins/webp-uploads/load.php
 	scanDirectories:


### PR DESCRIPTION
This first came up in https://github.com/WordPress/performance/pull/1168#discussion_r1575163896. 

I felt it was strange that `perflab_install_activate_plugin_callback()` was relying on both a `slug` and a `file` query var to be passed, with when the latter is absent then the plugin is installed. It assumes that if `file` is absent, then the plugin is not installed. But it could be that someone installed the plugin in another session while that screen is open, meaning that the `file` query var check would result in a plugin attempting to be installed when it is actually already installed.

So this PR gets rid of the `file` query var in favor of exclusively sending the `slug` query var. Then in the `perflab_install_activate_plugin_callback()` function it takes the plugin slug and checks among all the installed plugins whether one of them (via the plugin file) to see if it is installed. If not, then it goes ahead and installs it.

This also improves the variable terminology to use `$plugin_file` rather than `$plugin_basename` which seems misleading as it could refer to just the file in the plugin's directory, when in fact it should be something like `$slug/load.php`.

Lastly, the submitted slug is better validated by checking if it is among any of the actual PL plugin slugs.