### PR TITLE
Remove plugins.json from PL plugin build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /tests export-ignore
 /plugin-tests export-ignore
 /plugins export-ignore
+/plugins.json export-ignore
 
 /*.DS_store export-ignore
 /.DS_store? export-ignore


### PR DESCRIPTION
I discovered that `plugins.json` was unexpectedly being distributed with the plugin build on WordPress.org: https://plugins.trac.wordpress.org/browser/performance-lab/tags/3.0.0/plugins.json

It is not used by production code, so it should be omitted from the build.