### PR TITLE
Avoid passing incomplete data to perflab_render_plugin_card() and show error when plugin directory API query fails

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -260,14 +260,14 @@ function perflab_install_activate_plugin_callback() {
 		$api = perflab_query_plugin_info( $plugin_slug );
 
 		// Return early if plugin API returns an error.
-		if ( ! $api ) {
+		if ( $api instanceof WP_Error ) {
 			wp_die(
 				wp_kses(
 					sprintf(
 						/* translators: %s: Support forums URL. */
 						__( 'An unexpected error occurred. Something may be wrong with WordPress.org or this server&#8217;s configuration. If you continue to have problems, please try the <a href="%s">support forums</a>.', 'default' ),
 						__( 'https://wordpress.org/support/forums/', 'default' )
-					),
+					) . ' ' . $api->get_error_message(),
 					array( 'a' => array( 'href' => true ) )
 				)
 			);

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -304,7 +304,7 @@ function perflab_install_activate_plugin_callback() {
 
 	$result = activate_plugin( $plugin_basename );
 	if ( is_wp_error( $result ) ) {
-		wp_die( esc_html( $result->get_error_message() ) );
+		wp_die( wp_kses_post( $result->get_error_message() ) );
 	}
 
 	$url = add_query_arg(

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.8.0
  *
  * @param string $plugin_slug The string identifier for the plugin in questions slug.
- * @return array|WP_Error Array of plugin data or WP_Error if failed.
+ * @return array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: string[], download_link: string}|WP_Error Array of plugin data or WP_Error if failed.
  */
 function perflab_query_plugin_info( string $plugin_slug ) {
 	$plugin = get_transient( 'perflab_plugin_info_' . $plugin_slug );
@@ -29,8 +29,13 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		array(
 			'slug'   => $plugin_slug,
 			'fields' => array(
+				'name'              => true,
+				'slug'              => true,
 				'short_description' => true,
-				'icons'             => true,
+				'requires'          => true,
+				'requires_php'      => true,
+				'requires_plugins'  => true,
+				'download_link'     => true,
 			),
 		)
 	);
@@ -146,18 +151,15 @@ function perflab_render_plugins_ui() {
  * @see WP_Plugin_Install_List_Table::display_rows()
  * @link https://github.com/WordPress/wordpress-develop/blob/0b8ca16ea3bd9722bd1a38f8ab68901506b1a0e7/src/wp-admin/includes/class-wp-plugin-install-list-table.php#L467-L830
  *
- * @param array{name: string, slug: string, short_description: string, requires_php: string|false, requires: string|false, requires_plugins: string[], version: string, experimental: bool} $plugin_data Plugin data augmenting data from the WordPress.org API.
+ * @param array{name: string, slug: string, short_description: string, requires_php: string|false, requires: string|false, requires_plugins: string[], experimental: bool} $plugin_data Plugin data augmenting data from the WordPress.org API.
  */
 function perflab_render_plugin_card( array $plugin_data ) {
 
-	// Remove any HTML from the description.
+	$name        = wp_strip_all_tags( $plugin_data['name'] );
 	$description = wp_strip_all_tags( $plugin_data['short_description'] );
-	$title       = $plugin_data['name'];
 
 	/** This filter is documented in wp-admin/includes/class-wp-plugin-install-list-table.php */
 	$description = apply_filters( 'plugin_install_description', $description, $plugin_data );
-	$version     = $plugin_data['version'];
-	$name        = wp_strip_all_tags( $title . ' ' . $version );
 
 	$requires_php = isset( $plugin_data['requires_php'] ) ? $plugin_data['requires_php'] : null;
 	$requires_wp  = isset( $plugin_data['requires'] ) ? $plugin_data['requires'] : null;
@@ -314,7 +316,7 @@ function perflab_render_plugin_card( array $plugin_data ) {
 			<div class="name column-name">
 				<h3>
 					<a href="<?php echo esc_url( $details_link ); ?>"<?php echo $title_link_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-						<?php echo wp_kses_post( $title ); ?>
+						<?php echo wp_kses_post( $name ); ?>
 					</a>
 					<?php if ( $plugin_data['experimental'] ) : ?>
 						<em class="perflab-plugin-experimental">

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.8.0
  *
  * @param string $plugin_slug The string identifier for the plugin in questions slug.
- * @return array Array of plugin data, or empty if none/error.
+ * @return array|WP_Error Array of plugin data or WP_Error if failed.
  */
 function perflab_query_plugin_info( string $plugin_slug ) {
 	$plugin = get_transient( 'perflab_plugin_info_' . $plugin_slug );
@@ -36,7 +36,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	);
 
 	if ( is_wp_error( $plugin ) ) {
-		return array();
+		return $plugin;
 	}
 
 	if ( is_object( $plugin ) ) {
@@ -77,7 +77,18 @@ function perflab_render_plugins_ui() {
 		$api_data = perflab_query_plugin_info( $plugin_slug ); // Data from wordpress.org.
 
 		// Skip if the plugin is not on WordPress.org or there was a network error.
-		if ( ! $api_data ) {
+		if ( $api_data instanceof WP_Error ) {
+			wp_admin_notice(
+				esc_html(
+					sprintf(
+						/* translators: %s is the plugin slug */
+						__( 'Failed to query WordPress.org Plugin Directory for plugin "%s".', 'performance-lab' ) . ' %s',
+						$plugin_slug,
+						$api_data->get_error_message()
+					)
+				),
+				array( 'type' => 'error' )
+			);
 			continue;
 		}
 

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -305,23 +305,19 @@ function perflab_render_plugin_card( array $plugin_data ) {
 					<a href="<?php echo esc_url( $details_link ); ?>"<?php echo $title_link_attr; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 						<?php echo wp_kses_post( $title ); ?>
 					</a>
-					<?php
-					if ( isset( $plugin_data['experimental'] ) && $plugin_data['experimental'] ) {
-						?>
+					<?php if ( $plugin_data['experimental'] ) : ?>
 						<em class="perflab-plugin-experimental">
 							<?php echo esc_html( _x( '(experimental)', 'plugin suffix', 'performance-lab' ) ); ?>
 						</em>
-						<?php
-					}
-					?>
+					<?php endif; ?>
 				</h3>
 			</div>
 			<div class="action-links">
-				<?php
-				if ( ! empty( $action_links ) ) {
-					echo wp_kses_post( '<ul class="plugin-action-buttons"><li>' . implode( '</li><li>', $action_links ) . '</li></ul>' );
-				}
-				?>
+				<ul class="plugin-action-buttons">
+					<?php foreach ( $action_links as $action_link ) : ?>
+						<li><?php echo wp_kses_post( $action_link ); ?></li>
+					<?php endforeach; ?>
+				</ul>
 			</div>
 			<div class="desc column-description">
 				<p><?php echo wp_kses_post( $description ); ?></p>

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -108,7 +108,7 @@ function perflab_render_plugins_ui() {
 		}
 	}
 
-	if ( empty( $plugins ) ) {
+	if ( ! $plugins && ! $experimental_plugins ) {
 		return;
 	}
 	?>

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -95,8 +95,8 @@ function perflab_render_plugins_ui() {
 			wp_admin_notice(
 				esc_html(
 					sprintf(
-						/* translators: %s is the plugin slug */
-						__( 'Failed to query WordPress.org Plugin Directory for plugin "%s".', 'performance-lab' ) . ' %s',
+						/* translators: 1: plugin slug. 2: error message. */
+						__( 'Failed to query WordPress.org Plugin Directory for plugin "%1$s". %2$s', 'performance-lab' ),
 						$plugin_slug,
 						$api_data->get_error_message()
 					)

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -146,7 +146,7 @@ function perflab_render_plugins_ui() {
  * @see WP_Plugin_Install_List_Table::display_rows()
  * @link https://github.com/WordPress/wordpress-develop/blob/0b8ca16ea3bd9722bd1a38f8ab68901506b1a0e7/src/wp-admin/includes/class-wp-plugin-install-list-table.php#L467-L830
  *
- * @param array{name: string, slug: string, short_description: string, requires_php: ?string, requires: ?string, version: string, experimental: bool} $plugin_data Plugin data augmenting data from the WordPress.org API.
+ * @param array{name: string, slug: string, short_description: string, requires_php: string|false, requires: string|false, requires_plugins: string[], version: string, experimental: bool} $plugin_data Plugin data augmenting data from the WordPress.org API.
  */
 function perflab_render_plugin_card( array $plugin_data ) {
 


### PR DESCRIPTION
## Summary

When working on Image Prioritizer (#1172), I added the plugin to the `perflab_get_standalone_plugin_data()` but then I started getting PHPUnit test failures. I also got a bunch of warnings on the Performance screen:

> ![image](https://github.com/WordPress/performance/assets/134745/3fea5fcb-f46e-44af-9af0-76549b4555ad)

The issue here is that Image Prioritizer is not on WordPress.org yet, so the call to `perflab_query_plugin_info()` is returning an empty array. Nevertheless, this logic in `perflab_render_plugin_card()` is not working as expected:

https://github.com/WordPress/performance/blob/cb5a37e8871e06564ac23e793b2121d6181dc0b8/includes/admin/plugins.php#L130-L134

This is because we are merging the response from WordPress.org with our own data from `perflab_get_standalone_plugin_data()` meaning `$plugin_data` will _never_ be empty:

https://github.com/WordPress/performance/blob/cb5a37e8871e06564ac23e793b2121d6181dc0b8/includes/admin/plugins.php#L76-L88

This scenario could happen not only if the plugin is not on WordPress.org but also if the query fails due to WordPress.org being down. So with this PR an error is now shown when an error occurs:

![image](https://github.com/WordPress/performance/assets/134745/0b877862-7a8b-4646-8cc1-50503fdf3f8a)

This PR also removes the standalone plugin version from being referenced on the Performance screen. It was only referenced in `aria-label` and `data-title` attributes.

Lastly, when a WordPress.org Plugins API query fails during installation, an error message is now displayed rather than just a generic error.

Related: #1170