### PR TITLE
Add support for AVIF image in site health

### DIFF
--- a/includes/site-health/avif-support/helper.php
+++ b/includes/site-health/avif-support/helper.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Helper functions used for AVIF Support.
+ *
+ * @package performance-lab
+ * @since 3.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Callback for avif_enabled test.
+ *
+ * @since 1.0.0
+ *
+ * @return array
+ */
+function avif_uploads_check_avif_supported_test() {
+	$result = array(
+		'label'       => __( 'Your site supports AVIF', 'performance-lab' ),
+		'status'      => 'good',
+		'badge'       => array(
+			'label' => __( 'Performance', 'performance-lab' ),
+			'color' => 'blue',
+		),
+		'description' => sprintf(
+			'<p>%s</p>',
+			__( 'The AVIF image format generally has better compression than WebP, JPEG, PNG and GIF and is designed to supersede them, which can reduce page load time and consume less bandwidth.', 'performance-lab' )
+		),
+		'actions'     => '',
+		'test'        => 'is_avif_uploads_enabled',
+	);
+
+	$avif_supported = wp_image_editor_supports( array( 'mime_type' => 'image/avif' ) );
+
+	if ( ! $avif_supported ) {
+		$result['status']  = 'recommended';
+		$result['label']   = __( 'Your site does not support AVIF', 'performance-lab' );
+		$result['actions'] = sprintf(
+			'<p>%s</p>',
+			/* translators: Accessibility text. */
+			__( 'AVIF support can only be enabled by your hosting provider, so contact them for more information.', 'performance-lab' )
+		);
+	}
+
+	return $result;
+}

--- a/includes/site-health/avif-support/helper.php
+++ b/includes/site-health/avif-support/helper.php
@@ -3,7 +3,7 @@
  * Helper functions used for AVIF Support.
  *
  * @package performance-lab
- * @since 3.0.0
+ * @since n.e.x.t
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Callback for avif_enabled test.
  *
- * @since 1.0.0
+ * @since n.e.x.t
  *
  * @return array
  */

--- a/includes/site-health/avif-support/hooks.php
+++ b/includes/site-health/avif-support/hooks.php
@@ -3,7 +3,7 @@
  * Hook callbacks used for AVIF Support.
  *
  * @package performance-lab
- * @since 3.0.0
+ * @since n.e.x.t
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds tests to site health.
  *
- * @since 1.0.0
+ * @since n.e.x.t
  *
  * @param array $tests Site Health Tests.
  * @return array

--- a/includes/site-health/avif-support/hooks.php
+++ b/includes/site-health/avif-support/hooks.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Hook callbacks used for AVIF Support.
+ *
+ * @package performance-lab
+ * @since 3.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Adds tests to site health.
+ *
+ * @since 1.0.0
+ *
+ * @param array $tests Site Health Tests.
+ * @return array
+ */
+function avif_uploads_add_is_avif_supported_test( $tests ) {
+	$tests['direct']['avif_supported'] = array(
+		'label' => __( 'AVIF Support', 'performance-lab' ),
+		'test'  => 'avif_uploads_check_avif_supported_test',
+	);
+	return $tests;
+}
+add_filter( 'site_status_tests', 'avif_uploads_add_is_avif_supported_test' );

--- a/includes/site-health/load.php
+++ b/includes/site-health/load.php
@@ -21,3 +21,7 @@ require_once __DIR__ . '/audit-enqueued-assets/hooks.php';
 // WebP Support site health check.
 require_once __DIR__ . '/webp-support/helper.php';
 require_once __DIR__ . '/webp-support/hooks.php';
+
+// AVIF Support site health check.
+require_once __DIR__ . '/avif-support/helper.php';
+require_once __DIR__ . '/avif-support/hooks.php';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1152 

## Relevant technical choices

Adds a module in site health to check for AVIF image format is support and shows a warning if support is not present.
If server has AVIF support, the AVIF support warning is not shown.

## Screenshot
<img width="799" alt="Screenshot 2024-04-24 at 8 57 38 PM" src="https://github.com/WordPress/performance/assets/13062380/45affeb5-8bd3-4f65-9633-cbb1089a2c6a">

