### PR TITLE
Add filter for whether speculation rules are printed and default to not when user is logged-in non-admin or PHP session is active

### DIFF
--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -24,6 +24,32 @@ function plsr_print_speculation_rules() {
 		return;
 	}
 
+	/**
+	 * Filters whether speculation rules are printed to the page.
+	 *
+	 * Speculative loading can add excessive server load on sites where many users are logged-in since page caching
+	 * is typically bypassed. So only enable if the user is not logged-in, except if the user is an administrator so
+	 * the can actually see the plugin working. Similarly, when PHP sessions are used, concurrent requests are not
+	 * possible. So if a page takes 2 seconds to generate, and two pages are requested at about the same time, the
+	 * first page's generation will block the generation of the second page, causing the second page to take 4 seconds
+	 * to generate. Therefore, speculation rules are disabled by default when a session is active.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param bool $can_print Whether to print speculation rules.
+	 */
+	$can_print = (bool) apply_filters(
+		'plsr_can_print_speculation_rules',
+		(
+			( ! is_user_logged_in() || current_user_can( 'activate_plugins' ) )
+			&&
+			session_status() !== PHP_SESSION_ACTIVE
+		)
+	);
+	if ( ! $can_print ) {
+		return;
+	}
+
 	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/60320>.
 	$needs_html5_workaround = (
 		! current_theme_supports( 'html5', 'script' ) &&


### PR DESCRIPTION
See these points raised by @AntonyXSI in #1157:

> 1\. Excluding logged in users. Prefetching really shines with page caching as the server is able to deliver the content almost instantly with near zero CPU usage without waiting for the page to be generated. Logged in visits are predominately dynamic non cacheable requests. Using prefetching/prerendering on dynamic pages specifically on shared hosting where it can often take 1s+ for a page to be generated, would result in higher CPU usage and resources more easily bottlenecking. This is from pages being requested that may not be visited, as well as the ease/rate for links to be requested by hovering over them rather than manually when navigating through the site, and fundamentally the dynamic requests taking a lot longer. This affects the ability of the server to handle the same amount of traffic, and traffic spikes.

> 4\. Prefetching has the potential to double response times when PHP sessions are used, as PHP requests will be queued. For instance if a page might take 3s to be generated, hovering over 1 link then clicking another would result in that second link responding in 6s rather then 3s since the server has to wait for the first request to be processed.

Note that a site can already disable speculative loading using the following plugin code with the existing codebase:

```php
add_action( 'init', static function () {
	if ( is_user_logged_in() ) {
		remove_action( 'wp_footer', 'plsr_print_speculation_rules' );
	}
} );
```

So adding a filter is not strictly required.

## To Do

- [ ] Add tests.
- [ ] Update README with docs on new filter and conditions for when speculation rules are not printed by default.
- [ ] Add note in Reading settings about when it is disabled by default. Should the off-by-default for logged-in user behavior be an option?
- [ ] Add Site Health test for PHP Sessions being used on the frontend?
- [ ] Consider adding a toggle to the settings section for whether speculative loading is enabled for logged-in users? Would this be an alternative to the filter?
- [ ] Could we hook into the page caching site health test to conditionally disable speculative loading for logged-in users when page caching is absent?