### PR TITLE
Add CODEOWNERS for AVIF Support site health check

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 /bin                                        @mukeshpanchal27 @felixarntz
 /.github                                    @mukeshpanchal27 @felixarntz @thelovekesh
 
+# Site Health: AVIF Support Health Check
+/includes/site-health/avif-support                                          @adamsilverstein
+
 # Site Health: WebP Support Health Check
 /includes/site-health/webp-support                                          @adamsilverstein
 


### PR DESCRIPTION
Follow-up #1177

The #1177 PR just committed and we need codeowners for Site health check so i'm going to open the PR and add @adamsilverstein for now.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
