### PR TITLE
Ensure only HTML responses are optimized

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -33,17 +33,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 function od_buffer_output( string $passthrough ): string {
 	ob_start(
 		static function ( string $output ): string {
-			$is_html_content_type = false;
-			foreach ( headers_list() as $header ) {
-				$header_parts = preg_split( '/\s*[:;]\s*/', strtolower( $header ) );
-				if ( count( $header_parts ) >= 2 && 'content-type' === $header_parts[0] ) {
-					$is_html_content_type = in_array( $header_parts[1], array( 'text/html', 'application/xhtml+xml' ), true );
-				}
-			}
-			if ( ! $is_html_content_type ) {
-				return $output;
-			}
-
 			/**
 			 * Filters the template output buffer prior to sending to the client.
 			 *
@@ -184,6 +173,31 @@ function od_construct_preload_links( array $lcp_elements_by_minimum_viewport_wid
 }
 
 /**
+ * Determines whether the response has an HTML Content-Type.
+ *
+ * @since n.e.x.t
+ * @private
+ *
+ * @return bool Whether Content-Type is HTML.
+ */
+function od_is_response_html_content_type(): bool {
+	$is_html_content_type = false;
+
+	$headers_list = array_merge(
+		array( 'Content-Type: ' . ini_get( 'default_mimetype' ) ),
+		headers_list()
+	);
+	foreach ( $headers_list as $header ) {
+		$header_parts = preg_split( '/\s*[:;]\s*/', strtolower( $header ) );
+		if ( count( $header_parts ) >= 2 && 'content-type' === $header_parts[0] ) {
+			$is_html_content_type = in_array( $header_parts[1], array( 'text/html', 'application/xhtml+xml' ), true );
+		}
+	}
+
+	return $is_html_content_type;
+}
+
+/**
  * Optimizes template output buffer.
  *
  * @since 0.1.0
@@ -193,6 +207,10 @@ function od_construct_preload_links( array $lcp_elements_by_minimum_viewport_wid
  * @return string Filtered template output buffer.
  */
 function od_optimize_template_output_buffer( string $buffer ): string {
+	if ( ! od_is_response_html_content_type() ) {
+		return $buffer;
+	}
+
 	$slug = od_get_url_metrics_slug( od_get_normalized_query_vars() );
 	$post = OD_URL_Metrics_Post_Type::get_post( $slug );
 

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -33,6 +33,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 function od_buffer_output( string $passthrough ): string {
 	ob_start(
 		static function ( string $output ): string {
+			$is_html_content_type = false;
+			foreach ( headers_list() as $header ) {
+				$header_parts = preg_split( '/\s*[:;]\s*/', strtolower( $header ) );
+				if ( count( $header_parts ) >= 2 && 'content-type' === $header_parts[0] ) {
+					$is_html_content_type = in_array( $header_parts[1], array( 'text/html', 'application/xhtml+xml' ), true );
+				}
+			}
+			if ( ! $is_html_content_type ) {
+				return $output;
+			}
+
 			/**
 			 * Filters the template output buffer prior to sending to the client.
 			 *

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -19,15 +19,22 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 */
 	private $original_request_method;
 
+	/**
+	 * @var string
+	 */
+	private $default_mimetype;
+
 	public function set_up() {
 		$this->original_request_uri    = $_SERVER['REQUEST_URI'];
 		$this->original_request_method = $_SERVER['REQUEST_METHOD'];
+		$this->default_mimetype        = ini_get( 'default_mimetype' );
 		parent::set_up();
 	}
 
 	public function tear_down() {
 		$_SERVER['REQUEST_URI']    = $this->original_request_uri;
 		$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
+		ini_set( 'default_mimetype', $this->default_mimetype ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		unset( $GLOBALS['wp_customize'] );
 		parent::tear_down();
 	}
@@ -341,7 +348,9 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 			),
 
 			'no-url-metrics-with-data-url-background-image' => array(
-				'set_up'   => static function () {},
+				'set_up'   => static function () {
+					ini_set( 'default_mimetype', 'text/html; charset=utf-8' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+				},
 				// Smallest PNG courtesy of <https://evanhahn.com/worlds-smallest-png/>.
 				'buffer'   => '
 					<html lang="en">
@@ -1008,6 +1017,69 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 					</html>
 				',
 			),
+
+			'rss-response'                                => array(
+				'set_up'   => static function () {
+					ini_set( 'default_mimetype', 'application/rss+xml' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+				},
+				'buffer'   => '<?xml version="1.0" encoding="UTF-8"?>
+					<rss version="2.0">
+						<channel>
+							<title>Example Blog</title>
+							<link>https://www.example.com</link>
+							<description>
+								<img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" />
+								A blog about technology, design, and culture.
+							</description>
+							<language>en-us</language>
+						</channel>
+					</rss>
+				',
+				'expected' => '<?xml version="1.0" encoding="UTF-8"?>
+					<rss version="2.0">
+						<channel>
+							<title>Example Blog</title>
+							<link>https://www.example.com</link>
+							<description>
+								<img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" />
+								A blog about technology, design, and culture.
+							</description>
+							<language>en-us</language>
+						</channel>
+					</rss>
+				',
+			),
+
+			'xhtml-response'                              => array(
+				'set_up'   => static function () {
+					ini_set( 'default_mimetype', 'application/xhtml+xml; charset=utf-8' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+				},
+				'buffer'   => '<?xml version="1.0" encoding="UTF-8"?>
+					<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+					<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+						<head>
+						  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
+						  <title>XHTML 1.0 Strict Example</title>
+						</head>
+						<body>
+							<p><img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" /></p>
+						</body>
+					</html>
+				',
+				'expected' => '<?xml version="1.0" encoding="UTF-8"?>
+					<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+					<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+						<head>
+						  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
+						  <title>XHTML 1.0 Strict Example</title>
+						</head>
+						<body>
+							<p><img data-od-xpath="/*[0][self::HTML]/*[1][self::BODY]/*[0][self::P]/*[0][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" /></p>
+							<script type="module">/* import detect ... */</script>
+						</body>
+					</html>
+				',
+			),
 		);
 	}
 
@@ -1015,6 +1087,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 * Test od_optimize_template_output_buffer().
 	 *
 	 * @covers ::od_optimize_template_output_buffer
+	 * @covers ::od_is_response_html_content_type
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 */


### PR DESCRIPTION
I realized in https://github.com/WordPress/gutenberg/pull/61212 that Optimization Detective is currently attempting to optimize all frontend responses, including those which may not be HTML. (This does not apply to feeds or robots.txt, as it only is relevant when `template-loader.php` gets to filtering `template_include`.) For example, a plugin may decide to render an XML response instead for a template. These should be ignored from optimization.