### PR TITLE
Add optimization_detective_disabled query var to disable behavior

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -54,7 +54,7 @@ function od_buffer_output( string $passthrough ): string {
  * @access private
  */
 function od_maybe_add_template_output_buffer_filter(): void {
-	if ( ! od_can_optimize_response() ) {
+	if ( ! od_can_optimize_response() || isset( $_GET['optimization_detective_disabled'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		return;
 	}
 	$callback = 'od_optimize_template_output_buffer';

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -83,6 +83,20 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 		od_maybe_add_template_output_buffer_filter();
 		$this->assertTrue( has_filter( 'od_template_output_buffer' ) );
 	}
+	/**
+	 * Test od_maybe_add_template_output_buffer_filter().
+	 *
+	 * @covers ::od_maybe_add_template_output_buffer_filter
+	 */
+	public function test_od_maybe_add_template_output_buffer_filter_with_query_var_to_disable() {
+		$this->assertFalse( has_filter( 'od_template_output_buffer' ) );
+
+		add_filter( 'od_can_optimize_response', '__return_true' );
+		$this->go_to( home_url( '/?optimization_detective_disabled=1' ) );
+		$this->assertTrue( od_can_optimize_response() );
+		od_maybe_add_template_output_buffer_filter();
+		$this->assertFalse( has_filter( 'od_template_output_buffer' ) );
+	}
 
 	/**
 	 * Data provider.


### PR DESCRIPTION
<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1069

This will allow us to add `?optimization_detective_disabled` to any URL running with Optimization Detective in order to generate the page without the optimizations. This will be useful for us to observe in the wild the performance gains by comparing a page with the non-optimized version.