### PR TITLE
Avoid _doing_it_wrong() for Server-Timing in Optimization Detective when output buffering is not enabled

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -58,7 +58,13 @@ function od_maybe_add_template_output_buffer_filter(): void {
 		return;
 	}
 	$callback = 'od_optimize_template_output_buffer';
-	if ( function_exists( 'perflab_wrap_server_timing' ) ) {
+	if (
+		function_exists( 'perflab_wrap_server_timing' )
+		&&
+		function_exists( 'perflab_server_timing_use_output_buffer' )
+		&&
+		perflab_server_timing_use_output_buffer()
+	) {
 		$callback = perflab_wrap_server_timing( $callback, 'optimization-detective', 'exist' );
 	}
 	add_filter( 'od_template_output_buffer', $callback );


### PR DESCRIPTION
When Optimization Detective active, I noticed a `_doing_it_wrong()` warning in Query Monitor:

> ![Screenshot 2024-04-30 17 12 00](https://github.com/WordPress/performance/assets/134745/10ef06fc-0751-46ac-96ab-36c24812f837)

In the Server-Timing admin page, output buffering is not enabled:

> ![image](https://github.com/WordPress/performance/assets/134745/4eac372b-2eb3-41c5-bb19-72ec3c051ede)

The issue is that Performance Lab's Server-Timing functionality is not aware that Optimization Detective is doing output buffering of the template (although it used to be in #875, but it was backed out in #1082). So the PL functionality is sending the `Server-Timing` header after Optimization Detective starts buffering the output, but then when the buffer closes and the server timing wrapper attempts to then process the timing, it fails because the header has already been sent. So we need to add an additional check for whether the output buffering checkbox has been checked (via the `perflab_server_timing_use_output_buffer()` function).

(If Performance Lab had been aware of the Optimization Detective output buffer, then it wouldn't need the checkbox at all since the `Server-Timing` header could be sent after the output buffer is closed.)