### PR TITLE
Fix PHPStan issues in Optimization Detective

### DIFF
--- a/bin/phpstan/constants.php
+++ b/bin/phpstan/constants.php
@@ -7,3 +7,6 @@
 
 define( 'SPECULATION_RULES_VERSION', '0.0.0' );
 define( 'SPECULATION_RULES_MAIN_FILE', 'plugins/speculation-rules/load.php' );
+
+define( 'OPTIMIZATION_DETECTIVE_VERSION', '0.0.0' );
+define( 'OPTIMIZATION_DETECTIVE_MAIN_FILE', 'plugins/optimization-detective/load.php' );

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *                           }
  * @phpstan-type Data        array{
  *                               url: string,
- *                               timestamp: int,
+ *                               timestamp: float,
  *                               viewport: RectData,
  *                               elements: ElementData[]
  *                           }

--- a/tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php
+++ b/tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php
@@ -16,6 +16,11 @@
  */
 class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, mixed> Data.
+	 */
 	public function data_provider_sample_documents(): array {
 		return array(
 			'well-formed-html'   => array(
@@ -301,8 +306,12 @@ class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 	 * @covers ::get_xpath
 	 *
 	 * @dataProvider data_provider_sample_documents
+	 *
+	 * @param string   $document Document.
+	 * @param string[] $open_tags Open tags.
+	 * @param string[] $xpaths XPaths.
 	 */
-	public function test_open_tags_and_get_xpath( string $document, array $open_tags, array $xpaths ) {
+	public function test_open_tags_and_get_xpath( string $document, array $open_tags, array $xpaths ): void {
 		$p = new OD_HTML_Tag_Walker( $document );
 		$this->assertSame( '', $p->get_xpath(), 'Expected empty XPath since iteration has not started.' );
 		$actual_open_tags = array();
@@ -322,7 +331,7 @@ class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 	 * @covers ::append_head_html
 	 * @covers OD_HTML_Tag_Processor::append_html
 	 */
-	public function test_append_head_html() {
+	public function test_append_head_html(): void {
 		$html     = '
 			<html>
 				<head>
@@ -370,7 +379,7 @@ class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 	 * @covers ::append_body_html
 	 * @covers OD_HTML_Tag_Processor::append_html
 	 */
-	public function test_append_head_and_body_html() {
+	public function test_append_head_and_body_html(): void {
 		$html          = '
 			<html>
 				<head>
@@ -430,7 +439,7 @@ class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 	 * @covers ::remove_attribute
 	 * @covers ::get_updated_html
 	 */
-	public function test_html_tag_processor_wrapper_methods() {
+	public function test_html_tag_processor_wrapper_methods(): void {
 		$processor = new OD_HTML_Tag_Walker( '<html lang="en" xml:lang="en"></html>' );
 		foreach ( $processor->open_tags() as $open_tag ) {
 			if ( 'HTML' === $open_tag ) {
@@ -444,6 +453,10 @@ class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 
 	/**
 	 * Export an array as a PHP literal to use as a snapshot.
+	 *
+	 * @param array<int|string, mixed> $data Data.
+	 * @param bool                     $one_line One line.
+	 * @return string Snapshot.
 	 */
 	private function export_array_snapshot( array $data, bool $one_line = false ): string {
 		$php = preg_replace( '/^\s*\d+\s*=>\s*/m', '', var_export( $data, true ) );

--- a/tests/plugins/optimization-detective/class-od-url-metric-tests.php
+++ b/tests/plugins/optimization-detective/class-od-url-metric-tests.php
@@ -11,7 +11,7 @@ class OD_URL_Metric_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider(): array {
 		$viewport = array(
@@ -122,8 +122,11 @@ class OD_URL_Metric_Tests extends WP_UnitTestCase {
 	 * @covers ::jsonSerialize
 	 *
 	 * @dataProvider data_provider
+	 *
+	 * @param array<string, mixed> $data Data.
+	 * @param string               $error Error.
 	 */
-	public function test_constructor( array $data, string $error = '' ) {
+	public function test_constructor( array $data, string $error = '' ): void {
 		if ( $error ) {
 			$this->expectException( OD_Data_Validation_Exception::class );
 			$this->expectExceptionMessage( $error );
@@ -141,7 +144,7 @@ class OD_URL_Metric_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_json_schema
 	 */
-	public function test_get_json_schema() {
+	public function test_get_json_schema(): void {
 		$schema = OD_URL_Metric::get_json_schema();
 		$this->assertArrayHasKey( 'properties', $schema );
 	}

--- a/tests/plugins/optimization-detective/class-od-url-metrics-group-collection-tests.php
+++ b/tests/plugins/optimization-detective/class-od-url-metrics-group-collection-tests.php
@@ -573,6 +573,14 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 					'isLCPCandidate'    => true,
 					'xpath'             => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]',
 					'intersectionRatio' => 1,
+					'intersectionRect'  => array(
+						'width'  => 100,
+						'height' => 100,
+					),
+					'boundingClientRect'  => array(
+						'width'  => 100,
+						'height' => 100,
+					),
 				),
 			),
 		);

--- a/tests/plugins/optimization-detective/class-od-url-metrics-group-collection-tests.php
+++ b/tests/plugins/optimization-detective/class-od-url-metrics-group-collection-tests.php
@@ -14,7 +14,8 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_construction(): array {
 		return array(
@@ -91,8 +92,12 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 * @covers ::__construct
 	 *
 	 * @dataProvider data_provider_test_construction
+	 *
+	 * @param OD_URL_Metric[] $url_metrics URL Metrics.
+	 * @param int[]           $breakpoints Breakpoints.
+	 * @param int             $sample_size Sample size.
 	 */
-	public function test_construction( array $url_metrics, array $breakpoints, int $sample_size, int $freshness_ttl, string $exception ) {
+	public function test_construction( array $url_metrics, array $breakpoints, int $sample_size, int $freshness_ttl, string $exception ): void {
 		if ( $exception ) {
 			$this->expectException( $exception );
 		}
@@ -103,7 +108,7 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_sample_size_and_breakpoints(): array {
 		return array(
@@ -169,14 +174,14 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 * @covers ::add_url_metric
 	 *
 	 * @param int             $sample_size     Sample size.
-	 * @param array           $breakpoints     Breakpoints.
+	 * @param int[]           $breakpoints     Breakpoints.
 	 * @param array<int, int> $viewport_widths Viewport widths mapped to the number of URL metrics to instantiate.
 	 * @param array<int, int> $expected_counts Minimum viewport widths mapped to the expected counts in each group.
 	 *
 	 * @dataProvider data_provider_sample_size_and_breakpoints
 	 * @throws OD_Data_Validation_Exception When failing to instantiate a URL metric.
 	 */
-	public function test_add_url_metric( int $sample_size, array $breakpoints, array $viewport_widths, array $expected_counts ) {
+	public function test_add_url_metric( int $sample_size, array $breakpoints, array $viewport_widths, array $expected_counts ): void {
 		$group_collection = new OD_URL_Metrics_Group_Collection( array(), $breakpoints, $sample_size, HOUR_IN_SECONDS );
 
 		// Over-populate the sample size for the breakpoints by a dozen.
@@ -206,7 +211,7 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 *
 	 * @throws OD_Data_Validation_Exception When failing to instantiate a URL metric.
 	 */
-	public function test_adding_pushes_out_old_metrics() {
+	public function test_adding_pushes_out_old_metrics(): void {
 		$sample_size      = 3;
 		$breakpoints      = array( 400, 600 );
 		$group_collection = new OD_URL_Metrics_Group_Collection( array(), $breakpoints, $sample_size, HOUR_IN_SECONDS );
@@ -254,7 +259,7 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_get_iterator(): array {
 		return array(
@@ -304,8 +309,13 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 * @covers ::getIterator
 	 *
 	 * @dataProvider data_provider_test_get_iterator
+	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
+	 *
+	 * @param int[]             $breakpoints Breakpoints.
+	 * @param int[]             $viewport_widths Viewport widths.
+	 * @param array<int, mixed> $expected_groups Expected groups.
 	 */
-	public function test_get_iterator( array $breakpoints, array $viewport_widths, array $expected_groups ) {
+	public function test_get_iterator( array $breakpoints, array $viewport_widths, array $expected_groups ): void {
 		$url_metrics = array_map(
 			function ( $viewport_width ) {
 				return $this->get_validated_url_metric( $viewport_width );
@@ -341,7 +351,7 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_get_group_for_viewport_width(): array {
 		$current_time = microtime( true );
@@ -463,13 +473,21 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 * @covers OD_URL_Metrics_Group::get_minimum_viewport_width
 	 *
 	 * @dataProvider data_provider_test_get_group_for_viewport_width
+	 *
+	 * @param OD_URL_Metric[]   $url_metrics URL Metrics.
+	 * @param float             $current_time Current time.
+	 * @param int[]             $breakpoints Breakpoints.
+	 * @param int               $sample_size Sample size.
+	 * @param int               $freshness_ttl Freshness TTL.
+	 * @param array<int, mixed> $expected_return Expected return.
+	 * @param array<int, bool>  $expected_is_group_complete Expected is group complete.
 	 */
-	public function test_get_group_for_viewport_width( array $url_metrics, float $current_time, array $breakpoints, int $sample_size, int $freshness_ttl, array $expected_return, array $expected_is_group_complete ) {
+	public function test_get_group_for_viewport_width( array $url_metrics, float $current_time, array $breakpoints, int $sample_size, int $freshness_ttl, array $expected_return, array $expected_is_group_complete ): void {
 		$group_collection = new OD_URL_Metrics_Group_Collection( $url_metrics, $breakpoints, $sample_size, $freshness_ttl );
 		$this->assertSame(
 			$expected_return,
 			array_map(
-				static function ( OD_URL_Metrics_Group $group ) {
+				static function ( OD_URL_Metrics_Group $group ): array {
 					return array(
 						'minimumViewportWidth' => $group->get_minimum_viewport_width(),
 						'complete'             => $group->is_complete(),
@@ -489,12 +507,12 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test is_every_group_populated() and is_every_group_complete()..
+	 * Test is_every_group_populated() and is_every_group_complete().
 	 *
 	 * @covers ::is_every_group_populated
 	 * @covers ::is_every_group_complete
 	 */
-	public function test_is_every_group_populated() {
+	public function test_is_every_group_populated(): void {
 		$breakpoints      = array( 480, 800 );
 		$sample_size      = 3;
 		$group_collection = new OD_URL_Metrics_Group_Collection(
@@ -529,7 +547,7 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_flattened_url_metrics
 	 */
-	public function test_get_flattened_url_metrics() {
+	public function test_get_flattened_url_metrics(): void {
 		$url_metrics = array(
 			$this->get_validated_url_metric( 400 ),
 			$this->get_validated_url_metric( 600 ),
@@ -569,15 +587,15 @@ class OD_URL_Metrics_Group_Collection_Tests extends WP_UnitTestCase {
 			'timestamp' => microtime( true ),
 			'elements'  => array(
 				array(
-					'isLCP'             => true,
-					'isLCPCandidate'    => true,
-					'xpath'             => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]',
-					'intersectionRatio' => 1,
-					'intersectionRect'  => array(
+					'isLCP'              => true,
+					'isLCPCandidate'     => true,
+					'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]',
+					'intersectionRatio'  => 1,
+					'intersectionRect'   => array(
 						'width'  => 100,
 						'height' => 100,
 					),
-					'boundingClientRect'  => array(
+					'boundingClientRect' => array(
 						'width'  => 100,
 						'height' => 100,
 					),

--- a/tests/plugins/optimization-detective/class-od-url-metrics-group-tests.php
+++ b/tests/plugins/optimization-detective/class-od-url-metrics-group-tests.php
@@ -15,7 +15,7 @@ class OD_URL_Metrics_Group_Tests extends WP_UnitTestCase {
 	 * Data provider.
 	 *
 	 * @throws OD_Data_Validation_Exception If bad arguments are provided to OD_URL_Metric.
-	 * @return array
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_construction(): array {
 		return array(
@@ -98,8 +98,15 @@ class OD_URL_Metrics_Group_Tests extends WP_UnitTestCase {
 	 * @covers ::count
 	 *
 	 * @dataProvider data_provider_test_construction
+	 *
+	 * @param OD_URL_Metric[] $url_metrics URL Metrics.
+	 * @param int             $minimum_viewport_width Minimum viewport width.
+	 * @param int             $maximum_viewport_width Maximum viewport width.
+	 * @param int             $sample_size Sample size.
+	 * @param int             $freshness_ttl Freshness TTL.
+	 * @param string          $exception Expected exception.
 	 */
-	public function test_construction( array $url_metrics, int $minimum_viewport_width, int $maximum_viewport_width, int $sample_size, int $freshness_ttl, string $exception ) {
+	public function test_construction( array $url_metrics, int $minimum_viewport_width, int $maximum_viewport_width, int $sample_size, int $freshness_ttl, string $exception ): void {
 		if ( $exception ) {
 			$this->expectException( $exception );
 		}
@@ -115,7 +122,7 @@ class OD_URL_Metrics_Group_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_is_viewport_width_in_range(): array {
 		return array(
@@ -151,8 +158,12 @@ class OD_URL_Metrics_Group_Tests extends WP_UnitTestCase {
 	 * @covers ::is_viewport_width_in_range
 	 *
 	 * @dataProvider data_provider_test_is_viewport_width_in_range
+	 *
+	 * @param int              $minimum_viewport_width Minimum viewport width.
+	 * @param int              $maximum_viewport_width Maximum viewport width.
+	 * @param array<int, bool> $viewport_widths_expected Viewport widths expected.
 	 */
-	public function test_is_viewport_width_in_range( int $minimum_viewport_width, int $maximum_viewport_width, array $viewport_widths_expected ) {
+	public function test_is_viewport_width_in_range( int $minimum_viewport_width, int $maximum_viewport_width, array $viewport_widths_expected ): void {
 		$group = new OD_URL_Metrics_Group( array(), $minimum_viewport_width, $maximum_viewport_width, 3, HOUR_IN_SECONDS );
 		foreach ( $viewport_widths_expected as $viewport_width => $expected ) {
 			$this->assertSame( $expected, $group->is_viewport_width_in_range( $viewport_width ), "Failed for viewport width of $viewport_width" );
@@ -162,7 +173,7 @@ class OD_URL_Metrics_Group_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_add_url_metric(): array {
 		return array(
@@ -183,7 +194,7 @@ class OD_URL_Metrics_Group_Tests extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_add_url_metric
 	 */
-	public function test_add_url_metric( int $viewport_width, string $exception ) {
+	public function test_add_url_metric( int $viewport_width, string $exception ): void {
 		if ( $exception ) {
 			$this->expectException( $exception );
 		}

--- a/tests/plugins/optimization-detective/detection-tests.php
+++ b/tests/plugins/optimization-detective/detection-tests.php
@@ -54,7 +54,7 @@ class OD_Detection_Tests extends WP_UnitTestCase {
 	 * @param Closure                                                                       $set_up           Set up callback.
 	 * @param array<string, array{set_up: Closure, expected_exports: array<string, mixed>}> $expected_exports Expected exports.
 	 */
-	public function test_od_get_detection_script_returns_script( Closure $set_up, array $expected_exports ) {
+	public function test_od_get_detection_script_returns_script( Closure $set_up, array $expected_exports ): void {
 		$set_up();
 		$slug = od_get_url_metrics_slug( array( 'p' => '1' ) );
 

--- a/tests/plugins/optimization-detective/helper-tests.php
+++ b/tests/plugins/optimization-detective/helper-tests.php
@@ -12,7 +12,7 @@ class OD_Helper_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_render_generator_meta_tag
 	 */
-	public function test_od_render_generator_meta_tag() {
+	public function test_od_render_generator_meta_tag(): void {
 		$tag = get_echo( 'od_render_generator_meta_tag' );
 		$this->assertStringStartsWith( '<meta', $tag );
 		$this->assertStringContainsString( 'generator', $tag );

--- a/tests/plugins/optimization-detective/hooks-tests.php
+++ b/tests/plugins/optimization-detective/hooks-tests.php
@@ -12,7 +12,7 @@ class OD_Hooks_Tests extends WP_UnitTestCase {
 	 *
 	 * @see OD_Storage_Post_Type_Tests::test_add_hooks()
 	 */
-	public function test_hooks_added() {
+	public function test_hooks_added(): void {
 		$this->assertEquals( PHP_INT_MAX, has_filter( 'template_include', 'od_buffer_output' ) );
 		$this->assertEquals( 10, has_filter( 'wp', 'od_maybe_add_template_output_buffer_filter' ) );
 		$this->assertSame(

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -1050,7 +1050,8 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	/**
 	 * Gets a validated URL metric.
 	 *
-	 * @param int $viewport_width Viewport width for the URL metric.
+	 * @param int                                      $viewport_width Viewport width for the URL metric.
+	 * @param array<array{xpath: string, isLCP: bool}> $elements       Elements.
 	 * @return OD_URL_Metric URL metric.
 	 * @throws Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
@@ -1061,13 +1062,21 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 				'width'  => $viewport_width,
 				'height' => 800,
 			),
-			'timestamp' => microtime( true ),
+			'timestamp' => (int) microtime( true ),
 			'elements'  => array_map(
 				static function ( array $element ): array {
 					return array_merge(
 						array(
-							'isLCPCandidate'    => true,
-							'intersectionRatio' => 1,
+							'isLCPCandidate'     => true,
+							'intersectionRatio'  => 1,
+							'intersectionRect'   => array(
+								'width'  => 100,
+								'height' => 100,
+							),
+							'boundingClientRect' => array(
+								'width'  => 100,
+								'height' => 100,
+							),
 						),
 						$element
 					);

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -1062,7 +1062,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 				'width'  => $viewport_width,
 				'height' => 800,
 			),
-			'timestamp' => (int) microtime( true ),
+			'timestamp' => microtime( true ),
 			'elements'  => array_map(
 				static function ( array $element ): array {
 					return array_merge(

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -37,7 +37,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_buffer_output
 	 */
-	public function test_od_buffer_output() {
+	public function test_od_buffer_output(): void {
 		$original = 'Hello World!';
 		$expected = '¡Hola Mundo!';
 
@@ -69,7 +69,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_maybe_add_template_output_buffer_filter
 	 */
-	public function test_od_maybe_add_template_output_buffer_filter() {
+	public function test_od_maybe_add_template_output_buffer_filter(): void {
 		$this->assertFalse( has_filter( 'od_template_output_buffer' ) );
 
 		add_filter( 'od_can_optimize_response', '__return_false', 1 );
@@ -87,7 +87,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_od_can_optimize_response(): array {
 		return array(
@@ -152,7 +152,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_od_can_optimize_response
 	 */
-	public function test_od_can_optimize_response( Closure $set_up, bool $expected ) {
+	public function test_od_can_optimize_response( Closure $set_up, bool $expected ): void {
 		$set_up();
 		$this->assertSame( $expected, od_can_optimize_response() );
 	}
@@ -160,7 +160,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_od_construct_preload_links(): array {
 		return array(
@@ -298,8 +298,11 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 * @covers ::od_construct_preload_links
 	 *
 	 * @dataProvider data_provider_test_od_construct_preload_links
+	 *
+	 * @param array<int, mixed> $lcp_elements_by_minimum_viewport_widths LCP elements by minimum viewport widths.
+	 * @param string            $expected Expected return value.
 	 */
-	public function test_od_construct_preload_links( array $lcp_elements_by_minimum_viewport_widths, string $expected ) {
+	public function test_od_construct_preload_links( array $lcp_elements_by_minimum_viewport_widths, string $expected ): void {
 		$this->assertSame(
 			$this->normalize_whitespace( $expected ),
 			$this->normalize_whitespace( od_construct_preload_links( $lcp_elements_by_minimum_viewport_widths ) )
@@ -309,7 +312,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array[]
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_od_optimize_template_output_buffer(): array {
 		return array(
@@ -1018,7 +1021,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 */
-	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ) {
+	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ): void {
 		$set_up();
 
 		$remove_initial_tabs = static function ( string $input ): string {

--- a/tests/plugins/optimization-detective/storage/class-od-storage-lock-tests.php
+++ b/tests/plugins/optimization-detective/storage/class-od-storage-lock-tests.php
@@ -63,7 +63,7 @@ class OD_Storage_Lock_Tests extends WP_UnitTestCase {
 	 * @param Closure $set_up   Set up.
 	 * @param int     $expected Expected value.
 	 */
-	public function test_get_ttl( Closure $set_up, int $expected ) {
+	public function test_get_ttl( Closure $set_up, int $expected ): void {
 		$set_up();
 		$this->assertSame( $expected, OD_Storage_Lock::get_ttl() );
 	}
@@ -73,7 +73,7 @@ class OD_Storage_Lock_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_transient_key
 	 */
-	public function test_get_transient_key() {
+	public function test_get_transient_key(): void {
 		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_FORWARDED_FOR'] );
 
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
@@ -95,7 +95,7 @@ class OD_Storage_Lock_Tests extends WP_UnitTestCase {
 	 * @covers ::get_transient_key
 	 * @covers ::get_ttl
 	 */
-	public function test_set_lock_and_is_locked() {
+	public function test_set_lock_and_is_locked(): void {
 		$key = OD_Storage_Lock::get_transient_key();
 		$ttl = OD_Storage_Lock::get_ttl();
 

--- a/tests/plugins/optimization-detective/storage/class-od-url-metrics-post-type-tests.php
+++ b/tests/plugins/optimization-detective/storage/class-od-url-metrics-post-type-tests.php
@@ -15,7 +15,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::add_hooks
 	 */
-	public function test_add_hooks() {
+	public function test_add_hooks(): void {
 		remove_all_actions( 'init' );
 		remove_all_actions( 'admin_init' );
 		remove_all_actions( OD_URL_Metrics_Post_Type::GC_CRON_EVENT_NAME );
@@ -41,7 +41,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::register_post_type
 	 */
-	public function test_register_post_type() {
+	public function test_register_post_type(): void {
 		unregister_post_type( OD_URL_Metrics_Post_Type::SLUG );
 		OD_URL_Metrics_Post_Type::register_post_type();
 		$post_type_object = get_post_type_object( OD_URL_Metrics_Post_Type::SLUG );
@@ -54,7 +54,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_post
 	 */
-	public function test_od_post_when_absent() {
+	public function test_od_post_when_absent(): void {
 		$slug = od_get_url_metrics_slug( array( 'p' => '1' ) );
 		$this->assertNull( OD_URL_Metrics_Post_Type::get_post( $slug ) );
 	}
@@ -64,7 +64,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_post
 	 */
-	public function test_od_post_when_present() {
+	public function test_od_post_when_present(): void {
 		$slug = od_get_url_metrics_slug( array( 'p' => '1' ) );
 
 		$post_id = self::factory()->post->create(
@@ -82,7 +82,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_get_url_metrics_from_post.
 	 *
-	 * @return array<string, array{post_content: string, expected_value: array}>
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_get_url_metrics_from_post(): array {
 		$valid_content = array(
@@ -123,8 +123,11 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 * @covers ::get_url_metrics_from_post
 	 *
 	 * @dataProvider data_provider_test_get_url_metrics_from_post
+	 *
+	 * @param string               $post_content Post content.
+	 * @param array<string, mixed> $expected_value Expected value.
 	 */
-	public function test_get_url_metrics_from_post( string $post_content, array $expected_value ) {
+	public function test_get_url_metrics_from_post( string $post_content, array $expected_value ): void {
 		$post = self::factory()->post->create_and_get(
 			array(
 				'post_type'    => OD_URL_Metrics_Post_Type::SLUG,
@@ -147,7 +150,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::store_url_metric
 	 */
-	public function test_store_url_metric() {
+	public function test_store_url_metric(): void {
 		$slug = od_get_url_metrics_slug( array( 'p' => 1 ) );
 
 		$validated_url_metric = $this->get_sample_url_metric( home_url( '/' ) );
@@ -174,7 +177,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::schedule_garbage_collection
 	 */
-	public function test_schedule_garbage_collection_logged_out() {
+	public function test_schedule_garbage_collection_logged_out(): void {
 		OD_URL_Metrics_Post_Type::schedule_garbage_collection();
 		$this->assertFalse( wp_get_scheduled_event( OD_URL_Metrics_Post_Type::GC_CRON_EVENT_NAME ), 'Expected scheduling to be skipped because user is not logged-in.' );
 	}
@@ -184,7 +187,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::schedule_garbage_collection
 	 */
-	public function test_schedule_garbage_collection_first_log_in() {
+	public function test_schedule_garbage_collection_first_log_in(): void {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		OD_URL_Metrics_Post_Type::schedule_garbage_collection();
 		$scheduled_event = wp_get_scheduled_event( OD_URL_Metrics_Post_Type::GC_CRON_EVENT_NAME );
@@ -197,7 +200,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::schedule_garbage_collection
 	 */
-	public function test_schedule_garbage_collection_reschedule() {
+	public function test_schedule_garbage_collection_reschedule(): void {
 		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 		wp_schedule_event( time(), 'hourly', OD_URL_Metrics_Post_Type::GC_CRON_EVENT_NAME );
 		OD_URL_Metrics_Post_Type::schedule_garbage_collection();
@@ -211,7 +214,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::delete_stale_posts
 	 */
-	public function test_delete_stale_posts() {
+	public function test_delete_stale_posts(): void {
 		global $wpdb;
 
 		$stale_timestamp_gmt = gmdate( 'Y-m-d H:i:s', strtotime( '-1 month' ) - HOUR_IN_SECONDS );
@@ -256,7 +259,7 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::delete_all_posts
 	 */
-	public function test_delete_all_posts() {
+	public function test_delete_all_posts(): void {
 		global $wpdb;
 
 		$other_post_meta_key       = 'foo';

--- a/tests/plugins/optimization-detective/storage/class-od-url-metrics-post-type-tests.php
+++ b/tests/plugins/optimization-detective/storage/class-od-url-metrics-post-type-tests.php
@@ -340,10 +340,18 @@ class OD_Storage_Post_Type_Tests extends WP_UnitTestCase {
 				'timestamp' => microtime( true ),
 				'elements'  => array(
 					array(
-						'isLCP'             => true,
-						'isLCPCandidate'    => true,
-						'xpath'             => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
-						'intersectionRatio' => 1,
+						'isLCP'              => true,
+						'isLCPCandidate'     => true,
+						'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
+						'intersectionRatio'  => 1,
+						'intersectionRect'   => array(
+							'width'  => 100,
+							'height' => 100,
+						),
+						'boundingClientRect' => array(
+							'width'  => 100,
+							'height' => 100,
+						),
 					),
 				),
 			)

--- a/tests/plugins/optimization-detective/storage/data-tests.php
+++ b/tests/plugins/optimization-detective/storage/data-tests.php
@@ -525,10 +525,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 		foreach ( $lcp_elements_by_minimum_viewport_widths as $minimum_viewport_width => $lcp_element ) {
 			$this->assertTrue( is_array( $lcp_element ) || false === $lcp_element );
 			if ( is_array( $lcp_element ) ) {
-				$this->assertTrue( $lcp_element['isLCP'] );
-				$this->assertTrue( $lcp_element['isLCPCandidate'] );
 				$this->assertIsString( $lcp_element['xpath'] );
-				$this->assertIsNumeric( $lcp_element['intersectionRatio'] );
 				$lcp_element_xpaths_by_minimum_viewport_widths[ $minimum_viewport_width ] = $lcp_element['xpath'];
 			} else {
 				$lcp_element_xpaths_by_minimum_viewport_widths[ $minimum_viewport_width ] = false;
@@ -558,10 +555,18 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 			'timestamp' => microtime( true ),
 			'elements'  => array(
 				array(
-					'isLCP'             => $is_lcp,
-					'isLCPCandidate'    => $is_lcp,
-					'xpath'             => $this->get_xpath( ...$breadcrumbs ),
-					'intersectionRatio' => 1,
+					'isLCP'              => $is_lcp,
+					'isLCPCandidate'     => $is_lcp,
+					'xpath'              => $this->get_xpath( ...$breadcrumbs ),
+					'intersectionRatio'  => 1,
+					'intersectionRect'   => array(
+						'width'  => 100,
+						'height' => 100,
+					),
+					'boundingClientRect' => array(
+						'width'  => 100,
+						'height' => 100,
+					),
 				),
 			),
 		);

--- a/tests/plugins/optimization-detective/storage/data-tests.php
+++ b/tests/plugins/optimization-detective/storage/data-tests.php
@@ -14,12 +14,12 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 */
 	private $original_request_uri;
 
-	public function set_up() {
+	public function set_up(): void {
 		$this->original_request_uri = $_SERVER['REQUEST_URI'];
 		parent::set_up();
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		$_SERVER['REQUEST_URI'] = $this->original_request_uri;
 		unset( $GLOBALS['wp_customize'] );
 		parent::tear_down();
@@ -30,7 +30,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_get_url_metric_freshness_ttl
 	 */
-	public function test_od_get_url_metric_freshness_ttl() {
+	public function test_od_get_url_metric_freshness_ttl(): void {
 		$this->assertSame( DAY_IN_SECONDS, od_get_url_metric_freshness_ttl() );
 
 		add_filter(
@@ -49,7 +49,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage od_get_url_metric_freshness_ttl
 	 * @covers ::od_get_url_metric_freshness_ttl
 	 */
-	public function test_bad_od_get_url_metric_freshness_ttl() {
+	public function test_bad_od_get_url_metric_freshness_ttl(): void {
 		add_filter(
 			'od_url_metric_freshness_ttl',
 			static function (): int {
@@ -63,7 +63,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_od_get_normalized_query_vars(): array {
 		return array(
@@ -103,14 +103,14 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 					);
 				},
 			),
-			'404'          => array(
-				'set_up' => function () {
+			'not-found'    => array(
+				'set_up' => function (): array {
 					$this->go_to( home_url( '/?p=1000000' ) );
 					return array( 'error' => 404 );
 				},
 			),
 			'logged-in'    => array(
-				'set_up' => function () {
+				'set_up' => function (): array {
 					wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
 					$this->go_to( home_url( '/' ) );
 					return array( 'user_logged_in' => true );
@@ -126,7 +126,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_od_get_normalized_query_vars
 	 */
-	public function test_od_get_normalized_query_vars( Closure $set_up ) {
+	public function test_od_get_normalized_query_vars( Closure $set_up ): void {
 		$expected = $set_up();
 		$this->assertSame( $expected, od_get_normalized_query_vars() );
 	}
@@ -134,11 +134,11 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	public function data_provider_test_get_current_url(): array {
 		$assertions = array(
-			'path'                        => function () {
+			'path'                        => function (): void {
 				$_SERVER['REQUEST_URI'] = wp_slash( '/foo/' );
 				$this->assertEquals(
 					home_url( '/foo/' ),
@@ -146,7 +146,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 				);
 			},
 
-			'query'                       => function () {
+			'query'                       => function (): void {
 				$_SERVER['REQUEST_URI'] = wp_slash( '/bar/?baz=1' );
 				$this->assertEquals(
 					home_url( '/bar/?baz=1' ),
@@ -154,25 +154,25 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 				);
 			},
 
-			'idn_domain'                  => function () {
+			'idn_domain'                  => function (): void {
 				$this->set_home_url_with_filter( 'https://⚡️.example.com' );
 				$this->go_to( '/?s=lightning' );
 				$this->assertEquals( 'https://⚡️.example.com/?s=lightning', od_get_current_url() );
 			},
 
-			'punycode_domain'             => function () {
+			'punycode_domain'             => function (): void {
 				$this->set_home_url_with_filter( 'https://xn--57h.example.com' );
 				$this->go_to( '/?s=thunder' );
 				$this->assertEquals( 'https://xn--57h.example.com/?s=thunder', od_get_current_url() );
 			},
 
-			'ip_host'                     => function () {
+			'ip_host'                     => function (): void {
 				$this->set_home_url_with_filter( 'http://127.0.0.1:1234' );
 				$this->go_to( '/' );
 				$this->assertEquals( 'http://127.0.0.1:1234/', od_get_current_url() );
 			},
 
-			'permalink'                   => function () {
+			'permalink'                   => function (): void {
 				global $wp_rewrite;
 				update_option( 'permalink_structure', '/%year%/%monthnum%/%day%/%postname%/' );
 				$wp_rewrite->use_trailing_slashes = true;
@@ -185,22 +185,22 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 				$this->assertEquals( $permalink, od_get_current_url() );
 			},
 
-			'unset_request_uri'           => function () {
+			'unset_request_uri'           => function (): void {
 				unset( $_SERVER['REQUEST_URI'] );
 				$this->assertEquals( home_url( '/' ), od_get_current_url() );
 			},
 
-			'empty_request_uri'           => function () {
+			'empty_request_uri'           => function (): void {
 				$_SERVER['REQUEST_URI'] = '';
 				$this->assertEquals( home_url( '/' ), od_get_current_url() );
 			},
 
-			'no_slash_prefix_request_uri' => function () {
+			'no_slash_prefix_request_uri' => function (): void {
 				$_SERVER['REQUEST_URI'] = 'foo/';
 				$this->assertEquals( home_url( '/foo/' ), od_get_current_url() );
 			},
 
-			'reconstructed_home_url'      => function () {
+			'reconstructed_home_url'      => function (): void {
 				$_SERVER['HTTPS']       = 'on';
 				$_SERVER['REQUEST_URI'] = '/about/';
 				$_SERVER['HTTP_HOST']   = 'foo.example.org';
@@ -211,7 +211,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 				);
 			},
 
-			'home_url_with_trimmings'     => function () {
+			'home_url_with_trimmings'     => function (): void {
 				$this->set_home_url_with_filter( 'https://example.museum:8080' );
 				$_SERVER['REQUEST_URI'] = '/about/';
 				$this->assertEquals(
@@ -220,7 +220,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 				);
 			},
 
-			'complete_parse_fail'         => function () {
+			'complete_parse_fail'         => function (): void {
 				$_SERVER['HTTP_HOST'] = 'env.example.org';
 				unset( $_SERVER['REQUEST_URI'] );
 				$this->set_home_url_with_filter( ':' );
@@ -230,7 +230,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 				);
 			},
 
-			'default_to_localhost'        => function () {
+			'default_to_localhost'        => function (): void {
 				unset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] );
 				$this->set_home_url_with_filter( ':' );
 				$this->assertEquals(
@@ -240,7 +240,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 			},
 		);
 		return array_map(
-			static function ( $assertion ) {
+			static function ( Closure $assertion ): array {
 				return array( $assertion );
 			},
 			$assertions
@@ -252,7 +252,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @param string $home_url Home URL.
 	 */
-	private function set_home_url_with_filter( string $home_url ) {
+	private function set_home_url_with_filter( string $home_url ): void {
 		add_filter(
 			'home_url',
 			static function () use ( $home_url ): string {
@@ -268,7 +268,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_provider_test_get_current_url
 	 */
-	public function test_od_get_current_url( Closure $assert ) {
+	public function test_od_get_current_url( Closure $assert ): void {
 		call_user_func( $assert );
 	}
 
@@ -277,7 +277,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_get_url_metrics_slug
 	 */
-	public function test_od_get_url_metrics_slug() {
+	public function test_od_get_url_metrics_slug(): void {
 		$first  = od_get_url_metrics_slug( array() );
 		$second = od_get_url_metrics_slug( array( 'p' => 1 ) );
 		$this->assertNotEquals( $second, $first );
@@ -292,7 +292,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 * @covers ::od_get_url_metrics_storage_nonce
 	 * @covers ::od_verify_url_metrics_storage_nonce
 	 */
-	public function test_od_get_url_metrics_storage_nonce_and_od_verify_url_metrics_storage_nonce() {
+	public function test_od_get_url_metrics_storage_nonce_and_od_verify_url_metrics_storage_nonce(): void {
 		$user_id = self::factory()->user->create();
 
 		$nonce_life_actions = array();
@@ -337,7 +337,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_get_breakpoint_max_widths
 	 */
-	public function test_od_get_breakpoint_max_widths() {
+	public function test_od_get_breakpoint_max_widths(): void {
 		$this->assertSame(
 			array( 480, 600, 782 ),
 			od_get_breakpoint_max_widths()
@@ -347,7 +347,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 
 		add_filter(
 			'od_breakpoint_max_widths',
-			static function () use ( $filtered_breakpoints ) {
+			static function () use ( $filtered_breakpoints ): array {
 				return $filtered_breakpoints;
 			}
 		);
@@ -360,7 +360,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_bad_od_get_breakpoint_max_widths(): array {
 		return array(
@@ -390,11 +390,14 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @expectedIncorrectUsage od_get_breakpoint_max_widths
 	 * @dataProvider data_provider_test_bad_od_get_breakpoint_max_widths
+	 *
+	 * @param int[] $breakpoints Breakpoints.
+	 * @param int[] $expected Expected breakpoints.
 	 */
-	public function test_bad_od_get_breakpoint_max_widths( array $breakpoints, array $expected ) {
+	public function test_bad_od_get_breakpoint_max_widths( array $breakpoints, array $expected ): void {
 		add_filter(
 			'od_breakpoint_max_widths',
-			static function () use ( $breakpoints ) {
+			static function () use ( $breakpoints ): array {
 				return $breakpoints;
 			}
 		);
@@ -407,12 +410,12 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_get_url_metrics_breakpoint_sample_size
 	 */
-	public function test_od_get_url_metrics_breakpoint_sample_size() {
+	public function test_od_get_url_metrics_breakpoint_sample_size(): void {
 		$this->assertSame( 3, od_get_url_metrics_breakpoint_sample_size() );
 
 		add_filter(
 			'od_url_metrics_breakpoint_sample_size',
-			static function () {
+			static function (): string {
 				return '1';
 			}
 		);
@@ -426,7 +429,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 * @expectedIncorrectUsage od_get_url_metrics_breakpoint_sample_size
 	 * @covers ::od_get_url_metrics_breakpoint_sample_size
 	 */
-	public function test_bad_od_get_url_metrics_breakpoint_sample_size() {
+	public function test_bad_od_get_url_metrics_breakpoint_sample_size(): void {
 		add_filter(
 			'od_url_metrics_breakpoint_sample_size',
 			static function (): int {
@@ -441,7 +444,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 * Data provider.
 	 *
 	 * @throws OD_Data_Validation_Exception When failing to instantiate a URL metric.
-	 * @return array[]
+	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_get_lcp_elements_by_minimum_viewport_widths(): array {
 		return array(
@@ -515,8 +518,12 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_get_lcp_elements_by_minimum_viewport_widths
 	 * @dataProvider data_provider_test_get_lcp_elements_by_minimum_viewport_widths
+	 *
+	 * @param int[]              $breakpoints Breakpoints.
+	 * @param OD_URL_Metric[]    $url_metrics URL Metrics.
+	 * @param array<int, string> $expected_lcp_element_xpaths Expected XPaths.
 	 */
-	public function test_get_lcp_elements_by_minimum_viewport_widths( array $breakpoints, array $url_metrics, array $expected_lcp_element_xpaths ) {
+	public function test_get_lcp_elements_by_minimum_viewport_widths( array $breakpoints, array $url_metrics, array $expected_lcp_element_xpaths ): void {
 		$group_collection = new OD_URL_Metrics_Group_Collection( $url_metrics, $breakpoints, 10, HOUR_IN_SECONDS );
 
 		$lcp_elements_by_minimum_viewport_widths = od_get_lcp_elements_by_minimum_viewport_widths( $group_collection );
@@ -583,7 +590,7 @@ class OD_Storage_Data_Tests extends WP_UnitTestCase {
 		return implode(
 			'',
 			array_map(
-				static function ( $tag ) {
+				static function ( $tag ): string {
 					return sprintf( '/*[0][self::%s]', strtoupper( $tag ) );
 				},
 				$breadcrumbs

--- a/tests/plugins/optimization-detective/storage/rest-api-tests.php
+++ b/tests/plugins/optimization-detective/storage/rest-api-tests.php
@@ -17,7 +17,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_register_endpoint
 	 */
-	public function test_od_register_endpoint_hooked() {
+	public function test_od_register_endpoint_hooked(): void {
 		$this->assertSame( 10, has_action( 'rest_api_init', 'od_register_endpoint' ) );
 	}
 
@@ -27,7 +27,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_register_endpoint
 	 * @covers ::od_handle_rest_request
 	 */
-	public function test_rest_request_good_params() {
+	public function test_rest_request_good_params(): void {
 		$request      = new WP_REST_Request( 'POST', self::ROUTE );
 		$valid_params = $this->get_valid_params();
 		$this->assertCount( 0, get_posts( array( 'post_type' => OD_URL_Metrics_Post_Type::SLUG ) ) );
@@ -51,7 +51,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	/**
 	 * Data provider for test_rest_request_bad_params.
 	 *
-	 * @return array
+	 * @return array<string, mixed> Test data.
 	 */
 	public function data_provider_invalid_params(): array {
 		$valid_element = $this->get_valid_params()['elements'][0];
@@ -128,8 +128,10 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_handle_rest_request
 	 *
 	 * @dataProvider data_provider_invalid_params
+	 *
+	 * @param array<string, mixed> $params Params.
 	 */
-	public function test_rest_request_bad_params( array $params ) {
+	public function test_rest_request_bad_params( array $params ): void {
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
 		$request->set_body_params( $params );
 		$response = rest_get_server()->dispatch( $request );
@@ -145,7 +147,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_register_endpoint
 	 * @covers ::od_handle_rest_request
 	 */
-	public function test_rest_request_timestamp_ignored() {
+	public function test_rest_request_timestamp_ignored(): void {
 		$initial_microtime = microtime( true );
 
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
@@ -176,7 +178,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_register_endpoint
 	 * @covers ::od_handle_rest_request
 	 */
-	public function test_rest_request_locked() {
+	public function test_rest_request_locked(): void {
 		OD_Storage_Lock::set_lock();
 
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
@@ -193,7 +195,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_register_endpoint
 	 * @covers ::od_handle_rest_request
 	 */
-	public function test_rest_request_breakpoint_not_needed_for_any_breakpoint() {
+	public function test_rest_request_breakpoint_not_needed_for_any_breakpoint(): void {
 		add_filter( 'od_url_metric_storage_lock_ttl', '__return_zero' );
 
 		// First fully populate the sample for all breakpoints.
@@ -219,7 +221,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_register_endpoint
 	 * @covers ::od_handle_rest_request
 	 */
-	public function test_rest_request_breakpoint_not_needed_for_specific_breakpoint() {
+	public function test_rest_request_breakpoint_not_needed_for_specific_breakpoint(): void {
 		add_filter( 'od_url_metric_storage_lock_ttl', '__return_zero' );
 
 		$valid_params = $this->get_valid_params( array( 'viewport' => array( 'width' => 480 ) ) );
@@ -244,7 +246,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_register_endpoint
 	 * @covers ::od_handle_rest_request
 	 */
-	public function test_rest_request_over_populate_wider_viewport_group() {
+	public function test_rest_request_over_populate_wider_viewport_group(): void {
 		add_filter( 'od_url_metric_storage_lock_ttl', '__return_zero' );
 
 		// First establish a single breakpoint, so there are two groups of URL metrics
@@ -300,7 +302,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 * @covers ::od_register_endpoint
 	 * @covers ::od_handle_rest_request
 	 */
-	public function test_rest_request_over_populate_narrower_viewport_group() {
+	public function test_rest_request_over_populate_narrower_viewport_group(): void {
 		add_filter( 'od_url_metric_storage_lock_ttl', '__return_zero' );
 
 		// First establish a single breakpoint, so there are two groups of URL metrics
@@ -332,10 +334,10 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	/**
 	 * Populate URL metrics.
 	 *
-	 * @param int   $count  Count of URL metrics to populate.
-	 * @param array $params Params for URL metric.
+	 * @param int                  $count  Count of URL metrics to populate.
+	 * @param array<string, mixed> $params Params for URL metric.
 	 */
-	private function populate_url_metrics( int $count, array $params ) {
+	private function populate_url_metrics( int $count, array $params ): void {
 		for ( $i = 0; $i < $count; $i++ ) {
 			$request = new WP_REST_Request( 'POST', self::ROUTE );
 			$request->set_body_params( $params );
@@ -347,8 +349,8 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	/**
 	 * Gets valid params.
 	 *
-	 * @param array $extras Extra params which are recursively merged on top of the valid params.
-	 * @return array Params.
+	 * @param array<string, mixed> $extras Extra params which are recursively merged on top of the valid params.
+	 * @return array<string, mixed> Params.
 	 */
 	private function get_valid_params( array $extras = array() ): array {
 		$slug = od_get_url_metrics_slug( array() );
@@ -372,9 +374,9 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	 *
 	 * This is on contrast with `array_merge_recursive()` which creates arrays for colliding values.
 	 *
-	 * @param array $base_array   Base array.
-	 * @param array $sparse_array Sparse array.
-	 * @return array Merged array.
+	 * @param array<string, mixed> $base_array   Base array.
+	 * @param array<string, mixed> $sparse_array Sparse array.
+	 * @return array<string, mixed> Merged array.
 	 */
 	private function recursive_merge( array $base_array, array $sparse_array ): array {
 		foreach ( $sparse_array as $key => $value ) {
@@ -394,7 +396,7 @@ class OD_Storage_REST_API_Tests extends WP_UnitTestCase {
 	/**
 	 * Gets sample validated URL metric data.
 	 *
-	 * @return array
+	 * @return array<string, mixed>
 	 */
 	private function get_sample_validated_url_metric(): array {
 		return array(

--- a/tests/plugins/optimization-detective/uninstall-tests.php
+++ b/tests/plugins/optimization-detective/uninstall-tests.php
@@ -11,7 +11,7 @@ class OD_Uninstall_Tests extends WP_UnitTestCase {
 	/**
 	 * Runs the routine before setting up all tests.
 	 */
-	public static function set_up_before_class() {
+	public static function set_up_before_class(): void {
 		parent::set_up_before_class();
 
 		// Mock uninstall const.
@@ -23,14 +23,14 @@ class OD_Uninstall_Tests extends WP_UnitTestCase {
 	/**
 	 * Load uninstall.php.
 	 */
-	private function require_uninstall() {
+	private function require_uninstall(): void {
 		require __DIR__ . '/../../../plugins/optimization-detective/uninstall.php';
 	}
 
 	/**
 	 * Make sure post deletion is happening.
 	 */
-	public function test_post_deletion() {
+	public function test_post_deletion(): void {
 
 		$post_id             = self::factory()->post->create();
 		$url_metrics_post_id = self::factory()->post->create( array( 'post_type' => OD_URL_Metrics_Post_Type::SLUG ) );
@@ -45,7 +45,7 @@ class OD_Uninstall_Tests extends WP_UnitTestCase {
 	/**
 	 * Test scheduled event removal.
 	 */
-	public function test_event_removal() {
+	public function test_event_removal(): void {
 		$user = self::factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user );
 		OD_URL_Metrics_Post_Type::schedule_garbage_collection();


### PR DESCRIPTION
Part of #775.

Almost all of the changes here are trivial changes to test files.

The changes in this PR resolve the following PHPStan issues to bring the level to 6:

<details><summary>PHPStan Output</summary>

```
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php                                                                        
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------- 
  19     Method OD_HTML_Tag_Walker_Tests::data_provider_sample_documents() return type has no value type specified in iterable type array.              
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                      
  305    Method OD_HTML_Tag_Walker_Tests::test_open_tags_and_get_xpath() has no return type specified.                                                  
  305    Method OD_HTML_Tag_Walker_Tests::test_open_tags_and_get_xpath() has parameter $open_tags with no value type specified in iterable type array.  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                      
  305    Method OD_HTML_Tag_Walker_Tests::test_open_tags_and_get_xpath() has parameter $xpaths with no value type specified in iterable type array.     
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                      
  325    Method OD_HTML_Tag_Walker_Tests::test_append_head_html() has no return type specified.                                                         
  373    Method OD_HTML_Tag_Walker_Tests::test_append_head_and_body_html() has no return type specified.                                                
  433    Method OD_HTML_Tag_Walker_Tests::test_html_tag_processor_wrapper_methods() has no return type specified.                                       
  448    Method OD_HTML_Tag_Walker_Tests::export_array_snapshot() has parameter $data with no value type specified in iterable type array.              
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                      
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/class-od-url-metric-tests.php                                                       
 ------ ------------------------------------------------------------------------------------------------------------------------- 
  16     Method OD_URL_Metric_Tests::data_provider() return type has no value type specified in iterable type array.              
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                
  126    Method OD_URL_Metric_Tests::test_constructor() has no return type specified.                                             
  126    Method OD_URL_Metric_Tests::test_constructor() has parameter $data with no value type specified in iterable type array.  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                
  144    Method OD_URL_Metric_Tests::test_get_json_schema() has no return type specified.                                         
 ------ ------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/class-od-url-metrics-group-collection-tests.php                                                                                                     
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  19     Method OD_URL_Metrics_Group_Collection_Tests::data_provider_test_construction() return type has no value type specified in iterable type array.                                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  95     Method OD_URL_Metrics_Group_Collection_Tests::test_construction() has no return type specified.                                                                                          
  95     Method OD_URL_Metrics_Group_Collection_Tests::test_construction() has parameter $breakpoints with no value type specified in iterable type array.                                        
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  95     Method OD_URL_Metrics_Group_Collection_Tests::test_construction() has parameter $url_metrics with no value type specified in iterable type array.                                        
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  108    Method OD_URL_Metrics_Group_Collection_Tests::data_provider_sample_size_and_breakpoints() return type has no value type specified in iterable type array.                                
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  179    Method OD_URL_Metrics_Group_Collection_Tests::test_add_url_metric() has no return type specified.                                                                                        
  179    Method OD_URL_Metrics_Group_Collection_Tests::test_add_url_metric() has parameter $breakpoints with no value type specified in iterable type array.                                      
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  209    Method OD_URL_Metrics_Group_Collection_Tests::test_adding_pushes_out_old_metrics() has no return type specified.                                                                         
  222    Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,            
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:       
         string, timestamp: float, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool, isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect:  
         array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>} given.                                                                                             
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                                  
  259    Method OD_URL_Metrics_Group_Collection_Tests::data_provider_test_get_iterator() return type has no value type specified in iterable type array.                                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  308    Method OD_URL_Metrics_Group_Collection_Tests::test_get_iterator() has no return type specified.                                                                                          
  308    Method OD_URL_Metrics_Group_Collection_Tests::test_get_iterator() has parameter $breakpoints with no value type specified in iterable type array.                                        
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  308    Method OD_URL_Metrics_Group_Collection_Tests::test_get_iterator() has parameter $expected_groups with no value type specified in iterable type array.                                    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  308    Method OD_URL_Metrics_Group_Collection_Tests::test_get_iterator() has parameter $viewport_widths with no value type specified in iterable type array.                                    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  346    Method OD_URL_Metrics_Group_Collection_Tests::data_provider_test_get_group_for_viewport_width() return type has no value type specified in iterable type array.                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  356    Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,            
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:       
         string, timestamp: float, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool, isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect:  
         array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>} given.                                                                                             
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                                  
  366    Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,            
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:       
         string, timestamp: float, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool, isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect:  
         array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>} given.                                                                                             
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                                  
  467    Method OD_URL_Metrics_Group_Collection_Tests::test_get_group_for_viewport_width() has no return type specified.                                                                          
  467    Method OD_URL_Metrics_Group_Collection_Tests::test_get_group_for_viewport_width() has parameter $breakpoints with no value type specified in iterable type array.                        
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  467    Method OD_URL_Metrics_Group_Collection_Tests::test_get_group_for_viewport_width() has parameter $expected_is_group_complete with no value type specified in iterable type array.         
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  467    Method OD_URL_Metrics_Group_Collection_Tests::test_get_group_for_viewport_width() has parameter $expected_return with no value type specified in iterable type array.                    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  467    Method OD_URL_Metrics_Group_Collection_Tests::test_get_group_for_viewport_width() has parameter $url_metrics with no value type specified in iterable type array.                        
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                                
  497    Method OD_URL_Metrics_Group_Collection_Tests::test_is_every_group_populated() has no return type specified.                                                                              
  532    Method OD_URL_Metrics_Group_Collection_Tests::test_get_flattened_url_metrics() has no return type specified.                                                                             
  579    Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,            
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:       
         string, viewport: array{width: int, height: 640}, timestamp: float, elements: array{array{isLCP: true, isLCPCandidate: true, xpath: '/*[0][self::HTML]/*…', intersectionRatio: 1}}}      
         given.                                                                                                                                                                                   
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                                  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/plugins/optimization-detective/class-od-url-metrics-group-tests.php                                                                                                           
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  20     Method OD_URL_Metrics_Group_Tests::data_provider_test_construction() return type has no value type specified in iterable type array.                                                
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  73     Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,       
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:  
         string, viewport: array{width: 1, height: 2}, timestamp: float, elements: array{}} given.                                                                                           
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                             
  102    Method OD_URL_Metrics_Group_Tests::test_construction() has no return type specified.                                                                                                
  102    Method OD_URL_Metrics_Group_Tests::test_construction() has parameter $url_metrics with no value type specified in iterable type array.                                              
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  120    Method OD_URL_Metrics_Group_Tests::data_provider_test_is_viewport_width_in_range() return type has no value type specified in iterable type array.                                  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  155    Method OD_URL_Metrics_Group_Tests::test_is_viewport_width_in_range() has no return type specified.                                                                                  
  155    Method OD_URL_Metrics_Group_Tests::test_is_viewport_width_in_range() has parameter $viewport_widths_expected with no value type specified in iterable type array.                   
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  167    Method OD_URL_Metrics_Group_Tests::data_provider_test_add_url_metric() return type has no value type specified in iterable type array.                                              
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  186    Method OD_URL_Metrics_Group_Tests::test_add_url_metric() has no return type specified.                                                                                              
  195    Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,       
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:  
         string, viewport: array{width: int, height: 1000}, timestamp: float, elements: array{}} given.                                                                                      
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                             
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ -------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/detection-tests.php                                                
 ------ -------------------------------------------------------------------------------------------------------- 
  57     Method OD_Detection_Tests::test_od_get_detection_script_returns_script() has no return type specified.  
 ------ -------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/helper-tests.php                                      
 ------ ------------------------------------------------------------------------------------------- 
  15     Method OD_Helper_Tests::test_od_render_generator_meta_tag() has no return type specified.  
 ------ ------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/hooks-tests.php                     
 ------ ------------------------------------------------------------------------- 
  15     Method OD_Hooks_Tests::test_hooks_added() has no return type specified.  
 ------ ------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/plugins/optimization-detective/optimization-tests.php                                                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  40     Method OD_Optimization_Tests::test_od_buffer_output() has no return type specified.                                                                                                 
  72     Method OD_Optimization_Tests::test_od_maybe_add_template_output_buffer_filter() has no return type specified.                                                                       
  92     Method OD_Optimization_Tests::data_provider_test_od_can_optimize_response() return type has no value type specified in iterable type array.                                         
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  155    Method OD_Optimization_Tests::test_od_can_optimize_response() has no return type specified.                                                                                         
  165    Method OD_Optimization_Tests::data_provider_test_od_construct_preload_links() return type has no value type specified in iterable type array.                                       
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  302    Method OD_Optimization_Tests::test_od_construct_preload_links() has no return type specified.                                                                                       
  302    Method OD_Optimization_Tests::test_od_construct_preload_links() has parameter $lcp_elements_by_minimum_viewport_widths with no value type specified in iterable type array.         
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  314    Method OD_Optimization_Tests::data_provider_test_od_optimize_template_output_buffer() return type has no value type specified in iterable type array.                               
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  1021   Method OD_Optimization_Tests::test_od_optimize_template_output_buffer() has no return type specified.                                                                               
  1057   Method OD_Optimization_Tests::get_validated_url_metric() has parameter $elements with no value type specified in iterable type array.                                               
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  1078   Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,       
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:  
         string, viewport: array{width: int, height: 800}, timestamp: float, elements: array<non-empty-array>} given.                                                                        
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                             
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/storage/class-od-storage-lock-tests.php               
 ------ ------------------------------------------------------------------------------------------- 
  66     Method OD_Storage_Lock_Tests::test_get_ttl() has no return type specified.                 
  76     Method OD_Storage_Lock_Tests::test_get_transient_key() has no return type specified.       
  98     Method OD_Storage_Lock_Tests::test_set_lock_and_is_locked() has no return type specified.  
 ------ ------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/storage/class-od-url-metrics-post-type-tests.php                                                                                                
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  18     Method OD_Storage_Post_Type_Tests::test_add_hooks() has no return type specified.                                                                                                    
  44     Method OD_Storage_Post_Type_Tests::test_register_post_type() has no return type specified.                                                                                           
  57     Method OD_Storage_Post_Type_Tests::test_od_post_when_absent() has no return type specified.                                                                                          
  67     Method OD_Storage_Post_Type_Tests::test_od_post_when_present() has no return type specified.                                                                                         
  87     Method OD_Storage_Post_Type_Tests::data_provider_test_get_url_metrics_from_post() return type has no value type specified in iterable type array.                                    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                            
  127    Method OD_Storage_Post_Type_Tests::test_get_url_metrics_from_post() has no return type specified.                                                                                    
  127    Method OD_Storage_Post_Type_Tests::test_get_url_metrics_from_post() has parameter $expected_value with no value type specified in iterable type array.                               
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                            
  150    Method OD_Storage_Post_Type_Tests::test_store_url_metric() has no return type specified.                                                                                             
  177    Method OD_Storage_Post_Type_Tests::test_schedule_garbage_collection_logged_out() has no return type specified.                                                                       
  187    Method OD_Storage_Post_Type_Tests::test_schedule_garbage_collection_first_log_in() has no return type specified.                                                                     
  200    Method OD_Storage_Post_Type_Tests::test_schedule_garbage_collection_reschedule() has no return type specified.                                                                       
  214    Method OD_Storage_Post_Type_Tests::test_delete_stale_posts() has no return type specified.                                                                                           
  259    Method OD_Storage_Post_Type_Tests::test_delete_all_posts() has no return type specified.                                                                                             
  334    Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,        
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:   
         string, viewport: array{width: 480, height: 640}, timestamp: float, elements: array{array{isLCP: true, isLCPCandidate: true, xpath: '/*[0][self::HTML]/*…', intersectionRatio: 1}}}  
         given.                                                                                                                                                                               
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/plugins/optimization-detective/storage/data-tests.php                                                                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  33     Method OD_Storage_Data_Tests::test_od_get_url_metric_freshness_ttl() has no return type specified.                                                                                  
  52     Method OD_Storage_Data_Tests::test_bad_od_get_url_metric_freshness_ttl() has no return type specified.                                                                              
  68     Method OD_Storage_Data_Tests::data_provider_test_od_get_normalized_query_vars() return type has no value type specified in iterable type array.                                     
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  129    Method OD_Storage_Data_Tests::test_od_get_normalized_query_vars() has no return type specified.                                                                                     
  139    Method OD_Storage_Data_Tests::data_provider_test_get_current_url() return type has no value type specified in iterable type array.                                                  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  255    Method OD_Storage_Data_Tests::set_home_url_with_filter() has no return type specified.                                                                                              
  271    Method OD_Storage_Data_Tests::test_od_get_current_url() has no return type specified.                                                                                               
  280    Method OD_Storage_Data_Tests::test_od_get_url_metrics_slug() has no return type specified.                                                                                          
  295    Method OD_Storage_Data_Tests::test_od_get_url_metrics_storage_nonce_and_od_verify_url_metrics_storage_nonce() has no return type specified.                                         
  340    Method OD_Storage_Data_Tests::test_od_get_breakpoint_max_widths() has no return type specified.                                                                                     
  365    Method OD_Storage_Data_Tests::data_provider_test_bad_od_get_breakpoint_max_widths() return type has no value type specified in iterable type array.                                 
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  394    Method OD_Storage_Data_Tests::test_bad_od_get_breakpoint_max_widths() has no return type specified.                                                                                 
  394    Method OD_Storage_Data_Tests::test_bad_od_get_breakpoint_max_widths() has parameter $breakpoints with no value type specified in iterable type array.                               
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  394    Method OD_Storage_Data_Tests::test_bad_od_get_breakpoint_max_widths() has parameter $expected with no value type specified in iterable type array.                                  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  410    Method OD_Storage_Data_Tests::test_od_get_url_metrics_breakpoint_sample_size() has no return type specified.                                                                        
  429    Method OD_Storage_Data_Tests::test_bad_od_get_url_metrics_breakpoint_sample_size() has no return type specified.                                                                    
  446    Method OD_Storage_Data_Tests::data_provider_test_get_lcp_elements_by_minimum_viewport_widths() return type has no value type specified in iterable type array.                      
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  519    Method OD_Storage_Data_Tests::test_get_lcp_elements_by_minimum_viewport_widths() has no return type specified.                                                                      
  519    Method OD_Storage_Data_Tests::test_get_lcp_elements_by_minimum_viewport_widths() has parameter $breakpoints with no value type specified in iterable type array.                    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  519    Method OD_Storage_Data_Tests::test_get_lcp_elements_by_minimum_viewport_widths() has parameter $expected_lcp_element_xpaths with no value type specified in iterable type array.    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  519    Method OD_Storage_Data_Tests::test_get_lcp_elements_by_minimum_viewport_widths() has parameter $url_metrics with no value type specified in iterable type array.                    
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                                                           
  528    Offset 'isLCP' does not exist on array{xpath: string}.                                                                                                                              
  568    Parameter #1 $data of class OD_URL_Metric constructor expects array{url: string, timestamp: int, viewport: array{width: int, height: int}, elements: array<array{isLCP: bool,       
         isLCPCandidate: bool, xpath: string, intersectionRatio: float, intersectionRect: array{width: int, height: int}, boundingClientRect: array{width: int, height: int}}>}, array{url:  
         string, viewport: array{width: int, height: 640}, timestamp: float, elements: array{array{isLCP: bool, isLCPCandidate: bool, xpath: string, intersectionRatio: 1}}} given.          
         💡 Offset 'timestamp' (int) does not accept type float.                                                                                                                             
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/storage/rest-api-tests.php                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 
  20     Method OD_Storage_REST_API_Tests::test_od_register_endpoint_hooked() has no return type specified.                                           
  30     Method OD_Storage_REST_API_Tests::test_rest_request_good_params() has no return type specified.                                              
  56     Method OD_Storage_REST_API_Tests::data_provider_invalid_params() return type has no value type specified in iterable type array.             
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  132    Method OD_Storage_REST_API_Tests::test_rest_request_bad_params() has no return type specified.                                               
  132    Method OD_Storage_REST_API_Tests::test_rest_request_bad_params() has parameter $params with no value type specified in iterable type array.  
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  148    Method OD_Storage_REST_API_Tests::test_rest_request_timestamp_ignored() has no return type specified.                                        
  179    Method OD_Storage_REST_API_Tests::test_rest_request_locked() has no return type specified.                                                   
  196    Method OD_Storage_REST_API_Tests::test_rest_request_breakpoint_not_needed_for_any_breakpoint() has no return type specified.                 
  222    Method OD_Storage_REST_API_Tests::test_rest_request_breakpoint_not_needed_for_specific_breakpoint() has no return type specified.            
  247    Method OD_Storage_REST_API_Tests::test_rest_request_over_populate_wider_viewport_group() has no return type specified.                       
  303    Method OD_Storage_REST_API_Tests::test_rest_request_over_populate_narrower_viewport_group() has no return type specified.                    
  338    Method OD_Storage_REST_API_Tests::populate_url_metrics() has no return type specified.                                                       
  338    Method OD_Storage_REST_API_Tests::populate_url_metrics() has parameter $params with no value type specified in iterable type array.          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  353    Method OD_Storage_REST_API_Tests::get_valid_params() has parameter $extras with no value type specified in iterable type array.              
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  353    Method OD_Storage_REST_API_Tests::get_valid_params() return type has no value type specified in iterable type array.                         
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  379    Method OD_Storage_REST_API_Tests::recursive_merge() has parameter $base_array with no value type specified in iterable type array.           
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  379    Method OD_Storage_REST_API_Tests::recursive_merge() has parameter $sparse_array with no value type specified in iterable type array.         
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  379    Method OD_Storage_REST_API_Tests::recursive_merge() return type has no value type specified in iterable type array.                          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
  399    Method OD_Storage_REST_API_Tests::get_sample_validated_url_metric() return type has no value type specified in iterable type array.          
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type                                                    
 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/uninstall-tests.php                       
 ------ ------------------------------------------------------------------------------- 
  26     Method OD_Uninstall_Tests::require_uninstall() has no return type specified.   
  33     Method OD_Uninstall_Tests::test_post_deletion() has no return type specified.  
  48     Method OD_Uninstall_Tests::test_event_removal() has no return type specified.  
 ------ ------------------------------------------------------------------------------- 
```

</details> 

This is the config used:

<details><summary>PHPStan Config</summary>

```neon
includes:
	- phar://phpstan.phar/conf/bleedingEdge.neon
parameters:
	level: 6
	paths:
		- load.php
		- plugins/
		- includes/
		- tests/
	treatPhpDocTypesAsCertain: false
	checkGenericClassInNonGenericObjectType: false
	scanDirectories:
		- vendor/wp-phpunit/wp-phpunit/
	ignoreErrors:
		# These don't work in PhpStorm due to https://youtrack.jetbrains.com/issue/WI-63891
		# False positive as WordPress ships with a polyfill.
		-
			message: "#^Function str_starts_with not found\\.$#"
			paths:
				- load.php
				- plugins/optimization-detective/optimization.php
				- plugins/speculation-rules/class-plsr-url-pattern-prefixer.php
		-
			message: "#^Function str_contains not found\\.$#"
			paths:
				- plugins/auto-sizes/hooks.php
				- plugins/dominant-color-images/hooks.php

	dynamicConstantNames:
		- PERFLAB_OBJECT_CACHE_DROPIN_VERSION
		- WP_DEBUG_DISPLAY

	bootstrapFiles:
		- load.php
		- bin/phpstan/constants.php
		- plugins/webp-uploads/load.php
```

</details> 