### PR TITLE
Minor fix for `perflab_print_plugin_progress_indicator_script()`

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -405,7 +405,7 @@ function perflab_plugin_admin_notices() {
  *
  * @since n.e.x.t
  */
-function perflab_print_plugin_progress_indicator_script() {
+function perflab_print_plugin_progress_indicator_script(): void {
 	$js_function = <<<JS
 		function addPluginProgressIndicator( message ) {
 			document.addEventListener( 'DOMContentLoaded', function () {
@@ -419,7 +419,7 @@ function perflab_print_plugin_progress_indicator_script() {
 						target.classList.add( 'updating-message' );
 						target.textContent = message;
 
-						wp.a11y.speak(message);
+						wp.a11y.speak( message );
 					}
 				} );
 			} );
@@ -430,7 +430,7 @@ JS;
 		sprintf(
 			'( %s )( %s );',
 			$js_function,
-			wp_json_encode( __( 'Activating…', 'default' ) )
+			wp_json_encode( __( 'Activating...', 'default' ) )
 		),
 		array( 'type' => 'module' )
 	);


### PR DESCRIPTION
## Summary

Follow-up: #1190


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
