### PR TITLE
Update PHPStan level to 2

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
-	level: 1
+	level: 2
 	paths:
 		- load.php
 		- includes/

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -24,8 +24,8 @@ function dominant_color_set_image_editors( $editors ) {
 	}
 
 	$replaces = array(
-		'WP_Image_Editor_GD'      => 'Dominant_Color_Image_Editor_GD',
-		'WP_Image_Editor_Imagick' => 'Dominant_Color_Image_Editor_Imagick',
+		WP_Image_Editor_GD::class      => Dominant_Color_Image_Editor_GD::class,
+		WP_Image_Editor_Imagick::class => Dominant_Color_Image_Editor_Imagick::class,
 	);
 
 	foreach ( $replaces as $old => $new ) {
@@ -58,6 +58,13 @@ function dominant_color_get_dominant_color_data( $attachment_id ) {
 		$file = get_attached_file( $attachment_id );
 	}
 	add_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
+
+	/**
+	 * Editor.
+	 *
+	 * @see dominant_color_set_image_editors()
+	 * @var WP_Image_Editor|Dominant_Color_Image_Editor_GD|Dominant_Color_Image_Editor_Imagick|WP_Error $editor
+	 */
 	$editor = wp_get_image_editor(
 		$file,
 		array(
@@ -71,6 +78,10 @@ function dominant_color_get_dominant_color_data( $attachment_id ) {
 
 	if ( is_wp_error( $editor ) ) {
 		return $editor;
+	}
+
+	if ( ! ( $editor instanceof Dominant_Color_Image_Editor_GD || $editor instanceof Dominant_Color_Image_Editor_Imagick ) ) {
+		return new WP_Error( 'image_no_editor', __( 'No editor could be selected.', 'default' ) );
 	}
 
 	$has_transparency = $editor->has_transparency();

--- a/plugins/dominant-color-images/phpcs.xml.dist
+++ b/plugins/dominant-color-images/phpcs.xml.dist
@@ -4,7 +4,7 @@
 
 	<rule ref="../../bin/phpcs/phpcs.ruleset.xml"/>
 
-	<config name="text_domain" value="dominant-color-images"/>
+	<config name="text_domain" value="dominant-color-images,default"/>
 
 	<file>.</file>
 </ruleset>


### PR DESCRIPTION
See #775.

This fixes the following PHPStan issues:

```
 ------ -------------------------------------------------------------------- 
  Line   plugins/dominant-color-images/helper.php                            
 ------ -------------------------------------------------------------------- 
  76     Call to an undefined method WP_Image_Editor::has_transparency().    
  82     Call to an undefined method WP_Image_Editor::get_dominant_color().  
 ------ -------------------------------------------------------------------- 
```

Note that PHPStan is correctly identifying a bug here which could cause a fatal error in case another plugin is filtering `wp_image_editors` so that our specific subclasses are not used. 