### PR TITLE
Update PHPStan level to 5

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,7 @@ includes:
 parameters:
 	level: 5
 	treatPhpDocTypesAsCertain: false
+	rememberPossiblyImpureFunctionValues: false
 	paths:
 		- load.php
 		- includes/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
-	level: 4
+	level: 5
 	treatPhpDocTypesAsCertain: false
 	paths:
 		- load.php

--- a/tests/includes/server-timing/perflab-server-timing-tests.php
+++ b/tests/includes/server-timing/perflab-server-timing-tests.php
@@ -108,6 +108,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-measure-callback',
+			// @phpstan-ignore-next-line
 			array( 'access_cap' => 'exist' )
 		);
 
@@ -119,6 +120,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-access-cap',
+			// @phpstan-ignore-next-line
 			array( 'measure_callback' => '__return_null' )
 		);
 

--- a/tests/includes/server-timing/perflab-server-timing-tests.php
+++ b/tests/includes/server-timing/perflab-server-timing-tests.php
@@ -108,7 +108,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-measure-callback',
-			// @phpstan-ignore-next-line
+			// @phpstan-ignore-next-line -- Ignored to test incorrect usage.
 			array( 'access_cap' => 'exist' )
 		);
 
@@ -120,7 +120,7 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-access-cap',
-			// @phpstan-ignore-next-line
+			// @phpstan-ignore-next-line -- Ignored to test incorrect usage.
 			array( 'measure_callback' => '__return_null' )
 		);
 

--- a/tests/includes/site-health/audit-autoloaded-options/audit-autoloaded-options-test.php
+++ b/tests/includes/site-health/audit-autoloaded-options/audit-autoloaded-options-test.php
@@ -18,13 +18,18 @@ class Audit_Autoloaded_Options_Tests extends WP_UnitTestCase {
 			'test'  => 'perflab_aao_autoloaded_options_test',
 		);
 
+		$initial_test = array(
+			'label' => 'Label',
+			'test'  => 'initial_test',
+		);
 		$this->assertEquals(
 			array(
 				'direct' => array(
+					'initial'            => $initial_test,
 					'autoloaded_options' => $expected_test,
 				),
 			),
-			perflab_aao_add_autoloaded_options_test( array() )
+			perflab_aao_add_autoloaded_options_test( array( 'direct' => array( 'initial' => $initial_test ) ) )
 		);
 	}
 

--- a/tests/includes/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
+++ b/tests/includes/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php
@@ -88,7 +88,7 @@ class Audit_Enqueued_Assets_Helper_Tests extends WP_UnitTestCase {
 	 * Tests perflab_aea_get_path_from_resource_url() functionality empty $url.
 	 */
 	public function test_perflab_aea_get_path_from_resource_url_empty_url() {
-		$test_url      = false;
+		$test_url      = '';
 		$expected_path = '';
 		$this->assertSame( $expected_path, perflab_aea_get_path_from_resource_url( $test_url ) );
 	}

--- a/tests/includes/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
+++ b/tests/includes/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php
@@ -164,9 +164,24 @@ class Audit_Enqueued_Assets_Tests extends WP_UnitTestCase {
 	 * Make sure perflab_aea_add_enqueued_assets_test adds the right information.
 	 */
 	public function test_perflab_aea_add_enqueued_assets_test() {
+		$initial_tests = array(
+			'direct' => array(
+				'initial' => array(
+					'label' => 'Label',
+					'test'  => 'test',
+				),
+			),
+		);
+
+		$expected           = $initial_tests;
+		$expected['direct'] = array_merge(
+			$expected['direct'],
+			Site_Health_Mock_Responses::return_added_test_info_site_health()['direct']
+		);
+
 		$this->assertEqualSets(
-			perflab_aea_add_enqueued_assets_test( array() ),
-			Site_Health_Mock_Responses::return_added_test_info_site_health()
+			$expected,
+			perflab_aea_add_enqueued_assets_test( $initial_tests )
 		);
 	}
 

--- a/tests/plugins/auto-sizes/auto-sizes-test.php
+++ b/tests/plugins/auto-sizes/auto-sizes-test.php
@@ -46,7 +46,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	public function test_image_with_lazy_loading_has_auto_sizes() {
 		$this->assertStringContainsString(
 			'sizes="auto, ',
-			wp_get_attachment_image( self::$image_id, 'large', null, array( 'loading' => 'lazy' ) )
+			wp_get_attachment_image( self::$image_id, 'large', false, array( 'loading' => 'lazy' ) )
 		);
 	}
 
@@ -58,7 +58,7 @@ class AutoSizesTests extends WP_UnitTestCase {
 	public function test_image_without_lazy_loading_does_not_have_auto_sizes() {
 		$this->assertStringContainsString(
 			'sizes="(max-width: 1024px) 100vw, 1024px"',
-			wp_get_attachment_image( self::$image_id, 'large', null, array( 'loading' => '' ) )
+			wp_get_attachment_image( self::$image_id, 'large', false, array( 'loading' => '' ) )
 		);
 	}
 

--- a/tests/plugins/dominant-color-images/dominant-color-test.php
+++ b/tests/plugins/dominant-color-images/dominant-color-test.php
@@ -234,7 +234,7 @@ class Dominant_Color_Test extends DominantColorTestCase {
 	public function test_dominant_color_update_attachment_image_attributes( $style_attr, $expected ) {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/plugins/dominant-color-images/data/images/red.jpg' );
 
-		$attachment_image = wp_get_attachment_image( $attachment_id, 'full', '', array( 'style' => $style_attr ) );
+		$attachment_image = wp_get_attachment_image( $attachment_id, 'full', false, array( 'style' => $style_attr ) );
 		$this->assertStringContainsString( $expected, $attachment_image );
 	}
 

--- a/tests/plugins/webp-uploads/load-tests.php
+++ b/tests/plugins/webp-uploads/load-tests.php
@@ -650,8 +650,8 @@ class WebP_Uploads_Load_Tests extends ImagesTestCase {
 			}
 
 			$this->assertIsString( $size['sources']['image/webp']['file'] );
-			$this->assertStringContainsString( $size['width'], $size['sources']['image/webp']['file'] );
-			$this->assertStringContainsString( $size['height'], $size['sources']['image/webp']['file'] );
+			$this->assertStringContainsString( (string) $size['width'], $size['sources']['image/webp']['file'] );
+			$this->assertStringContainsString( (string) $size['height'], $size['sources']['image/webp']['file'] );
 			$this->assertStringContainsString(
 				// Remove the extension from the file.
 				substr( $size['sources']['image/webp']['file'], 0, -13 ),


### PR DESCRIPTION
See #775.

This fixes the following PHPStan issues:

<details><summary>[ERROR] Found 11 errors</summary>

```
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/includes/server-timing/perflab-server-timing-tests.php                                                                                                                                   
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  111    Parameter #2 $args of method Perflab_Server_Timing::register_metric() expects array{measure_callback: callable(): mixed, access_cap: string}, array{access_cap: 'exist'} given.                
         💡 Array does not have offset 'measure_callback'.                                                                                                                                              
  122    Parameter #2 $args of method Perflab_Server_Timing::register_metric() expects array{measure_callback: callable(): mixed, access_cap: string}, array{measure_callback: '__return_null'} given.  
         💡 Array does not have offset 'access_cap'.                                                                                                                                                    
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   tests/includes/site-health/audit-autoloaded-options/audit-autoloaded-options-test.php                                                                             
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  27     Parameter #1 $tests of function perflab_aao_add_autoloaded_options_test expects array{direct: array<string, array{label: string, test: string}>}, array{} given.  
         💡 Array does not have offset 'direct'.                                                                                                                           
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------ 
  Line   tests/includes/site-health/audit-enqueued-assets/audit-enqueued-assets-helper-test.php                      
 ------ ------------------------------------------------------------------------------------------------------------ 
  93     Parameter #1 $resource_url of function perflab_aea_get_path_from_resource_url expects string, false given.  
 ------ ------------------------------------------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/includes/site-health/audit-enqueued-assets/audit-enqueued-assets-test.php                                                                                
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  168    Parameter #1 $tests of function perflab_aea_add_enqueued_assets_test expects array{direct: array<string, array{label: string, test: string}>}, array{} given.  
         💡 Array does not have offset 'direct'.                                                                                                                        
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------- 
  Line   tests/plugins/auto-sizes/auto-sizes-test.php                                      
 ------ ---------------------------------------------------------------------------------- 
  49     Parameter #3 $icon of function wp_get_attachment_image expects bool, null given.  
  61     Parameter #3 $icon of function wp_get_attachment_image expects bool, null given.  
 ------ ---------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------ 
  Line   tests/plugins/dominant-color-images/dominant-color-test.php                         
 ------ ------------------------------------------------------------------------------------ 
  237    Parameter #3 $icon of function wp_get_attachment_image expects bool, string given.  
 ------ ------------------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/webp-uploads/image-edit-tests.php                                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 
  400    Parameter #2 $hashed_size_name of method PerformanceLab\Tests\TestCase\ImagesTestCase::assertSizeNameIsHashed() expects string, null given.  
 ------ --------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------ 
  Line   tests/plugins/webp-uploads/load-tests.php                                                                         
 ------ ------------------------------------------------------------------------------------------------------------------ 
  653    Parameter #1 $needle of method PHPUnit\Framework\Assert::assertStringContainsString() expects string, int given.  
  654    Parameter #1 $needle of method PHPUnit\Framework\Assert::assertStringContainsString() expects string, int given.  
 ------ ------------------------------------------------------------------------------------------------------------------ 
```

</details> 

Please review individual commits for changes.