### PR TITLE
Added server timing to REST API response

### DIFF
--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -15,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds server timing to REST API response.
  *
+ * @since n.e.x.t
+ *
  * @param WP_REST_Response|WP_Error $response Result to send to the client. Usually a `WP_REST_Response`.
  * @return WP_REST_Response|WP_Error Filtered response.
  */

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -4,7 +4,7 @@
  *
  * @package performance-lab
  *
- * @since 1.0.0
+ * @since n.e.x.t
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -11,7 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-
 /**
  * Adds server timing to REST API response.
  *
@@ -20,18 +19,23 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param WP_REST_Response|WP_Error $response Result to send to the client. Usually a `WP_REST_Response`.
  * @return WP_REST_Response|WP_Error Filtered response.
  */
-function rest_post_dispatch_add_server_timing( $response ) {
-	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || ! function_exists( 'perflab_server_timing' ) || ! $response instanceof WP_REST_Response ) {
+function perflab_rest_post_dispatch_add_server_timing( $response ) {
+	// TODO: Change condition to use wp_is_rest_endpoint() once minimum-supported version is WordPress 6.5.
+	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || ! $response instanceof WP_REST_Response ) {
 		return $response;
 	}
 
 	$server_timing = perflab_server_timing();
 
 	/** This filter is documented in includes/server-timing/class-perflab-server-timing.php */
-	do_action( 'perflab_server_timing_send_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+	do_action( 'perflab_server_timing_send_header' );
 
-	$response->header( 'Server-Timing', $server_timing->get_header() );
+	$header_value = $server_timing->get_header();
+
+	if ( $header_value ) {
+		$response->header( 'Server-Timing', $header_value );
+	}
 
 	return $response;
 }
-add_filter( 'rest_post_dispatch', 'rest_post_dispatch_add_server_timing', PHP_INT_MAX );
+add_filter( 'rest_post_dispatch', 'perflab_rest_post_dispatch_add_server_timing', PHP_INT_MAX );

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -2,9 +2,9 @@
 /**
  * Hook callbacks used for Server Timing.
  *
- * @package dominant-color-images
+ * @package performance-lab
  *
- * @since 1.0.0
+ * @since n.e.x.t
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,20 +19,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return WP_REST_Response|WP_Error Filtered response.
  */
 function rest_post_dispatch_add_server_timing( $response ) {
-	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
-		return $response;
-	}
-
-	if ( ! function_exists( 'perflab_server_timing' ) || ! $response instanceof WP_REST_Response ) {
+	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || ! function_exists( 'perflab_server_timing' ) || ! $response instanceof WP_REST_Response ) {
 		return $response;
 	}
 
 	$server_timing = perflab_server_timing();
 
+	/** This filter is documented in includes/server-timing/class-perflab-server-timing.php */
 	do_action( 'perflab_server_timing_send_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 	$response->header( 'Server-Timing', $server_timing->get_header() );
 
 	return $response;
 }
-add_filter( 'rest_post_dispatch', 'rest_post_dispatch_add_server_timing' );
+add_filter( 'rest_post_dispatch', 'rest_post_dispatch_add_server_timing', PHP_INT_MAX );

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Hook callbacks used for Server Timing.
+ *
+ * @package dominant-color-images
+ *
+ * @since 1.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+
+/**
+ * Adds server timing to REST API response.
+ *
+ * @param WP_REST_Response|WP_Error $response Result to send to the client. Usually a `WP_REST_Response`.
+ * @return WP_REST_Response|WP_Error Filtered response.
+ */
+function rest_post_dispatch_add_server_timing( $response ) {
+	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		return $response;
+	}
+
+	if ( ! function_exists( 'perflab_server_timing' ) || ! $response instanceof WP_REST_Response ) {
+		return $response;
+	}
+
+	$server_timing = perflab_server_timing();
+
+	do_action( 'perflab_server_timing_send_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+	$response->header( 'Server-Timing', $server_timing->get_header() );
+
+	return $response;
+}
+add_filter( 'rest_post_dispatch', 'rest_post_dispatch_add_server_timing' );

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -33,7 +33,7 @@ function perflab_rest_post_dispatch_add_server_timing( $response ) {
 	$header_value = $server_timing->get_header();
 
 	if ( $header_value ) {
-		$response->header( 'Server-Timing', $header_value );
+		$response->header( 'Server-Timing', $header_value, false );
 	}
 
 	return $response;

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -26,7 +26,6 @@ function rest_post_dispatch_add_server_timing( $response ) {
 	$server_timing = perflab_server_timing();
 
 	/** This filter is documented in includes/server-timing/class-perflab-server-timing.php */
-	/** This filter is documented in includes/server-timing/class-perflab-server-timing.php */
 	do_action( 'perflab_server_timing_send_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 	$response->header( 'Server-Timing', $server_timing->get_header() );

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -26,6 +26,7 @@ function rest_post_dispatch_add_server_timing( $response ) {
 	$server_timing = perflab_server_timing();
 
 	/** This filter is documented in includes/server-timing/class-perflab-server-timing.php */
+	/** This filter is documented in includes/server-timing/class-perflab-server-timing.php */
 	do_action( 'perflab_server_timing_send_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 	$response->header( 'Server-Timing', $server_timing->get_header() );

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -2,7 +2,7 @@
 /**
  * Hook callbacks used for Server Timing.
  *
- * @package dominant-color-images
+ * @package performance-lab
  *
  * @since 1.0.0
  */

--- a/includes/server-timing/load.php
+++ b/includes/server-timing/load.php
@@ -18,6 +18,8 @@ if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING
 define( 'PERFLAB_SERVER_TIMING_SETTING', 'perflab_server_timing_settings' );
 define( 'PERFLAB_SERVER_TIMING_SCREEN', 'perflab-server-timing' );
 
+require_once __DIR__ . '/hooks.php';
+
 /**
  * Provides access the Server-Timing API.
  *
@@ -223,29 +225,3 @@ function perflab_sanitize_server_timing_setting( $value ): array {
 
 	return $value;
 }
-
-/**
- * Adds server timing to REST API response.
- *
- * @param WP_REST_Response|WP_Error $response Result to send to the client. Usually a `WP_REST_Response`.
- * @return WP_REST_Response|WP_Error Filtered response.
- */
-function rest_post_dispatch_add_server_timing( $response ) {
-	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
-		return $response;
-	}
-
-	if ( ! function_exists( 'perflab_server_timing' ) || ! $response instanceof WP_REST_Response ) {
-		return $response;
-	}
-
-	$server_timing = perflab_server_timing();
-
-	do_action( 'perflab_server_timing_send_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
-
-	$response->header( 'Server-Timing', $server_timing->get_header() );
-
-	return $response;
-}
-
-add_filter( 'rest_post_dispatch', 'rest_post_dispatch_add_server_timing' );

--- a/includes/server-timing/load.php
+++ b/includes/server-timing/load.php
@@ -223,3 +223,29 @@ function perflab_sanitize_server_timing_setting( $value ): array {
 
 	return $value;
 }
+
+/**
+ * Adds server timing to REST API response.
+ *
+ * @param WP_REST_Response|WP_Error $response Result to send to the client. Usually a `WP_REST_Response`.
+ * @return WP_REST_Response|WP_Error Filtered response.
+ */
+function rest_post_dispatch_add_server_timing( $response ) {
+	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST ) {
+		return $response;
+	}
+
+	if ( ! function_exists( 'perflab_server_timing' ) || ! $response instanceof WP_REST_Response ) {
+		return $response;
+	}
+
+	$server_timing = perflab_server_timing();
+
+	do_action( 'perflab_server_timing_send_header' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+
+	$response->header( 'Server-Timing', $server_timing->get_header() );
+
+	return $response;
+}
+
+add_filter( 'rest_post_dispatch', 'rest_post_dispatch_add_server_timing' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1149

## Relevant technical choices

<!-- Please describe your changes. -->
Updated the core plugin to add ServerTiming to WP REST API end-points as well

## How to test
1. On the site, visit the REST endpoint http://localhost:8888/wp-json/ with the Dev Tools open on the Network Tab
2. Record the data in the Timing tab as seen [here](https://make.wordpress.org/performance/files/2023/06/image.png) before and after the change.
4. The difference is documented as follows,
- Before the change is introduced,
![before-change-rest-api](https://github.com/WordPress/performance/assets/25629972/9c4d363f-7606-431e-9543-b74607c2a157)

- After the change,
![after-change-rest-api](https://github.com/WordPress/performance/assets/25629972/16d56834-7648-406b-90de-cb9ac9bcabb1)

props: @swissspidy for the code.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
