### PR TITLE
Update PHPStan level to 8

### DIFF
--- a/includes/server-timing/load.php
+++ b/includes/server-timing/load.php
@@ -212,7 +212,7 @@ function perflab_sanitize_server_timing_setting( $value ): array {
 							 * restricted to them, therefore the sanitization does not limit the characters
 							 * used.
 							 */
-							return preg_replace(
+							return (string) preg_replace(
 								'/\s/',
 								'',
 								sanitize_text_field( $hook_name )

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
-	level: 7
+	level: 8
 	treatPhpDocTypesAsCertain: false
 	paths:
 		- load.php

--- a/plugins/optimization-detective/class-od-html-tag-walker.php
+++ b/plugins/optimization-detective/class-od-html-tag-walker.php
@@ -212,6 +212,9 @@ final class OD_HTML_Tag_Walker {
 		$this->open_stack_indices = array();
 		while ( $p->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 			$tag_name = $p->get_tag();
+			if ( ! is_string( $tag_name ) ) {
+				continue;
+			}
 			if ( ! $p->is_tag_closer() ) {
 
 				// Close an open P tag when a P-closing tag is encountered.

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -742,7 +742,7 @@ function webp_uploads_wepb_fallback(): void {
 	$javascript = ob_get_clean();
 
 	wp_print_inline_script_tag(
-		preg_replace( '/\s+/', '', (string) $javascript ),
+		(string) preg_replace( '/\s+/', '', (string) $javascript ),
 		array(
 			'id'            => 'webpUploadsFallbackWebpImages',
 			'data-rest-api' => esc_url_raw( trailingslashit( get_rest_url() ) ),

--- a/plugins/webp-uploads/image-edit.php
+++ b/plugins/webp-uploads/image-edit.php
@@ -153,15 +153,19 @@ function webp_uploads_update_image_onchange( $override, string $file_path, WP_Im
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$target = isset( $_REQUEST['target'] ) ? sanitize_key( $_REQUEST['target'] ) : 'all';
 
-			foreach ( $old_metadata['sizes'] as $size_name => $size_details ) {
-				// If the target is 'nothumb', skip generating the 'thumbnail' size.
-				if ( webp_uploads_image_edit_thumbnails_separately() && 'nothumb' === $target && 'thumbnail' === $size_name ) {
-					continue;
-				}
+			if ( isset( $old_metadata['sizes'] ) ) {
+				foreach ( $old_metadata['sizes'] as $size_name => $size_details ) {
+					// If the target is 'nothumb', skip generating the 'thumbnail' size.
+					if ( webp_uploads_image_edit_thumbnails_separately() && 'nothumb' === $target && 'thumbnail' === $size_name ) {
+						continue;
+					}
 
-				if ( isset( $metadata['sizes'][ $size_name ] ) && ! empty( $metadata['sizes'][ $size_name ] ) &&
-					$metadata['sizes'][ $size_name ]['file'] !== $old_metadata['sizes'][ $size_name ]['file'] ) {
-					$resize_sizes[ $size_name ] = $metadata['sizes'][ $size_name ];
+					if (
+						isset( $metadata['sizes'][ $size_name ] ) && ! empty( $metadata['sizes'][ $size_name ] ) &&
+						$metadata['sizes'][ $size_name ]['file'] !== $old_metadata['sizes'][ $size_name ]['file']
+					) {
+						$resize_sizes[ $size_name ] = $metadata['sizes'][ $size_name ];
+					}
 				}
 			}
 

--- a/tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php
+++ b/tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php
@@ -459,7 +459,7 @@ class OD_HTML_Tag_Walker_Tests extends WP_UnitTestCase {
 	 * @return string Snapshot.
 	 */
 	private function export_array_snapshot( array $data, bool $one_line = false ): string {
-		$php = preg_replace( '/^\s*\d+\s*=>\s*/m', '', var_export( $data, true ) );
+		$php = (string) preg_replace( '/^\s*\d+\s*=>\s*/m', '', var_export( $data, true ) );
 		if ( $one_line ) {
 			$php = str_replace( "\n", ' ', $php );
 		}

--- a/tests/plugins/optimization-detective/optimization-tests.php
+++ b/tests/plugins/optimization-detective/optimization-tests.php
@@ -1112,7 +1112,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 		$set_up();
 
 		$remove_initial_tabs = static function ( string $input ): string {
-			return preg_replace( '/^\t+/m', '', $input );
+			return (string) preg_replace( '/^\t+/m', '', $input );
 		};
 
 		$expected = $remove_initial_tabs( $expected );
@@ -1134,7 +1134,7 @@ class OD_Optimization_Tests extends WP_UnitTestCase {
 	 * @return string Normalized string.
 	 */
 	private function normalize_whitespace( string $str ): string {
-		return preg_replace( '/\s+/', ' ', trim( $str ) );
+		return (string) preg_replace( '/\s+/', ' ', trim( $str ) );
 	}
 
 	/**


### PR DESCRIPTION
_This is a sub-PR of #1205. Review and merge it first._

See #775.

This fixes the following PHPStan issues (_only 8!_):

```
 ------ ------------------------------------------------------------------ 
  Line   includes/server-timing/load.php                                   
 ------ ------------------------------------------------------------------ 
  215    Anonymous function should return string but returns string|null.  
 ------ ------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------------------- 
  Line   plugins/optimization-detective/class-od-html-tag-walker.php                                        
 ------ --------------------------------------------------------------------------------------------------- 
  229    Property OD_HTML_Tag_Walker::$open_stack_tags (array<string>) does not accept array<string|null>.  
  239    Generator expects value type string, string|null given.                                            
 ------ --------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------- 
  Line   plugins/webp-uploads/hooks.php                                                                
 ------ ---------------------------------------------------------------------------------------------- 
  745    Parameter #1 $data of function wp_print_inline_script_tag expects string, string|null given.  
 ------ ---------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   plugins/webp-uploads/image-edit.php                                                                                                                                                                                                                                   
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  156    Offset 'sizes' might not exist on array{width: int, height: int, file: string, sizes: array<string, array{file: string, width: int, height: int, mime-type: string, sources?: array<string, array{file: string, filesize: int}>}>, image_meta: array<string, mixed>,  
         filesize: int, sources?: array<string, array{file: string, filesize: int}>, has_transparency?: bool, ...}|null.                                                                                                                                                       
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/class-od-html-tag-walker-tests.php                                 
 ------ -------------------------------------------------------------------------------------------------------- 
  466    Method OD_HTML_Tag_Walker_Tests::export_array_snapshot() should return string but returns string|null.  
 ------ -------------------------------------------------------------------------------------------------------- 

 ------ ---------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/optimization-tests.php                                         
 ------ ---------------------------------------------------------------------------------------------------- 
  1115   Anonymous function should return string but returns string|null.                                    
  1137   Method OD_Optimization_Tests::normalize_whitespace() should return string but returns string|null.  
 ------ ---------------------------------------------------------------------------------------------------- 
```

Please review individual commits for changes.