### PR TITLE
Update PHPStan level to 9 (maybe)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -61,3 +61,12 @@ parameters:
 		-
 			message: '/Cannot cast .+ to string/'
 			path: tests/*
+		-
+			message: '/Cannot access offset .+ on mixed\./'
+			path: tests/*
+		-
+			message: '/Argument of an invalid type mixed supplied for foreach, only iterables are supported./'
+			path: tests/*
+		-
+			message: '/Property .+ does not accept mixed\./'
+			path: tests/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
-	level: 8
+	level: 9
 	treatPhpDocTypesAsCertain: false
 	paths:
 		- load.php

--- a/tests/plugins/webp-uploads/helper-tests.php
+++ b/tests/plugins/webp-uploads/helper-tests.php
@@ -509,7 +509,8 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 
 	public function test_webp_uploads_in_frontend_body_with_feed(): void {
 		$this->mock_empty_action( 'template_redirect' );
-		$GLOBALS['wp_query']->is_feed = true;
+		global $wp_query;
+		$wp_query->is_feed = true;
 
 		$this->assertFalse( webp_uploads_in_frontend_body() );
 	}


### PR DESCRIPTION
_This is a sub-PR of #1210. Review and merge it first._

See #775.

This addresses the following PHPStan issues:

<details><summary>[ERROR] Found 124 errors</summary>

```
------ -------------------------------------------------------------------------------- 
  Line   includes/admin/load.php                                                         
 ------ -------------------------------------------------------------------------------- 
  87     Cannot cast mixed to string.                                                    
  251    Parameter #1 $str of function sanitize_text_field expects string, mixed given.  
 ------ -------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   includes/admin/plugins.php                                                                                                                                                                                                                                                
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  25     Function perflab_query_plugin_info() should return array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: array<string>, download_link: string, version: string}|WP_Error but returns mixed.  
 ------ -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------- 
  Line   includes/admin/server-timing.php                                             
 ------ ----------------------------------------------------------------------------- 
  181    Parameter #2 $array of function implode expects array<string>, mixed given.  
  181    Parameter #2 $pieces of function implode expects array, mixed given.         
 ------ ----------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   includes/server-timing/defaults.php                                                    
 ------ --------------------------------------------------------------------------------------- 
  47     Cannot access property $queries on mixed.                                              
  55     Cannot access offset 1 on mixed.                                                       
  197    Cannot access property $queries on mixed.                                              
  204    Cannot access offset 1 on mixed.                                                       
  234    Argument of an invalid type mixed supplied for foreach, only iterables are supported.  
 ------ --------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   includes/server-timing/load.php                                                                                                                                  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  208    Parameter #1 $callback of function array_map expects (callable(mixed): mixed)|null, Closure(string): string given.                                               
         💡 Type #1 from the union: Type string of parameter #1 $hook_name of passed callable needs to be same or wider than parameter type mixed of accepting callable.  
 ------ ----------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------- 
  Line   includes/site-health/audit-autoloaded-options/helper.php                   
 ------ --------------------------------------------------------------------------- 
  217    Parameter #1 $var of function count expects array|Countable, mixed given.  
 ------ --------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------- 
  Line   includes/site-health/audit-autoloaded-options/hooks.php                                      
 ------ --------------------------------------------------------------------------------------------- 
  52     Parameter #1 $str of function sanitize_text_field expects string, mixed given.               
  53     Parameter #1 $value of function rest_sanitize_boolean expects bool|int|string, mixed given.  
  75     Parameter #2 $haystack of function array_search expects array, mixed given.                  
  77     Cannot access an offset on mixed.                                                            
  79     Cannot access offset int|string on mixed.                                                    
 ------ --------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------- 
  Line   includes/site-health/audit-enqueued-assets/helper.php                      
 ------ --------------------------------------------------------------------------- 
  253    Parameter #1 $var of function count expects array|Countable, mixed given.  
 ------ --------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------- 
  Line   load.php                                                                         
 ------ --------------------------------------------------------------------------------- 
  54     Parameter #1 $haystack of function str_starts_with expects string, mixed given.  
 ------ --------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   plugins/dominant-color-images/hooks.php                                                                                                                                                            
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  39     Function dominant_color_metadata() should return array{has_transparency?: bool, dominant_color?: string} but returns array.                                                                        
  59     Function dominant_color_update_attachment_image_attributes() should return array{data-has-transparency?: string, class?: string, data-dominant-color?: string, style?: string} but returns array.  
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------- 
  Line   plugins/optimization-detective/load.php                                          
 ------ --------------------------------------------------------------------------------- 
  35     Cannot access offset 'load' on mixed.                                            
  35     Cannot access offset 'version' on mixed.                                         
  54     Cannot access offset 'version' on mixed.                                         
  57     Parameter #2 $version2 of function version_compare expects string, mixed given.  
  62     Cannot access offset 'version' on mixed.                                         
  63     Cannot access offset 'load' on mixed.                                            
 ------ --------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------- 
  Line   plugins/optimization-detective/storage/class-od-storage-lock.php                                        
 ------ -------------------------------------------------------------------------------------------------------- 
  58     Parameter #1 $data of function wp_hash expects string, mixed given.                                     
  97     Parameter #1 $var of function floatval expects array|bool|float|int|resource|string|null, mixed given.  
 ------ -------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------ 
  Line   plugins/optimization-detective/storage/data.php                   
 ------ ------------------------------------------------------------------ 
  121    Parameter #1 $str of function ltrim expects string, mixed given.  
 ------ ------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------------------------------------------------------------------- 
  Line   plugins/optimization-detective/storage/rest-api.php                                                                               
 ------ ---------------------------------------------------------------------------------------------------------------------------------- 
  55     Parameter #2 $slug of function od_verify_url_metrics_storage_nonce expects string, mixed given.                                   
  55     Parameter #3 $url of function od_verify_url_metrics_storage_nonce expects string, mixed given.                                    
  103    Parameter #1 $slug of static method OD_URL_Metrics_Post_Type::get_post() expects string, mixed given.                             
  115    Cannot access offset 'width' on mixed.                                                                                            
  115    Parameter #1 $viewport_width of method OD_URL_Metrics_Group_Collection::get_group_for_viewport_width() expects int, mixed given.  
  137    Parameter #1 $input of function array_keys expects array, mixed given.                                                            
  142    Cannot access offset 'default' on mixed.                                                                                          
  142    Cannot access offset 'timestamp' on mixed.                                                                                        
  158    Parameter #1 $slug of static method OD_URL_Metrics_Post_Type::store_url_metric() expects string, mixed given.                     
 ------ ---------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------- 
  Line   plugins/speculation-rules/helper.php  
 ------ -------------------------------------- 
  37     Cannot cast mixed to string.          
 ------ -------------------------------------- 

 ------ --------------------------------------------------------------------------------- 
  Line   plugins/speculation-rules/load.php                                               
 ------ --------------------------------------------------------------------------------- 
  35     Cannot access offset 'load' on mixed.                                            
  35     Cannot access offset 'version' on mixed.                                         
  54     Cannot access offset 'version' on mixed.                                         
  57     Parameter #2 $version2 of function version_compare expects string, mixed given.  
  62     Cannot access offset 'version' on mixed.                                         
  63     Cannot access offset 'load' on mixed.                                            
 ------ --------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------------------- 
  Line   plugins/speculation-rules/settings.php                                                                  
 ------ -------------------------------------------------------------------------------------------------------- 
  96     Function plsr_sanitize_setting() should return array<string, string> but returns array<string, mixed>.  
  205    Cannot access offset non-falsy-string on mixed.                                                         
 ------ -------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   plugins/webp-uploads/helper.php                                                                                                                                                              
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  63     Function webp_uploads_get_upload_image_mime_transforms() should return array<string, array<string>> but returns array.                                                                       
  236    Parameter #3 $size_data of function webp_uploads_generate_additional_image_source expects array{width: int, height: int, crop: bool}, array{width: mixed, height: mixed, crop: bool} given.  
         💡 Offset 'width' (int) does not accept type mixed.                                                                                                                                          
         💡 Offset 'height' (int) does not accept type mixed.                                                                                                                                         
                                                                                                                                                                                                      
  266    Function webp_uploads_get_content_image_mimes() should return array<string> but returns array.                                                                                               
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   plugins/webp-uploads/hooks.php                                                                                                                              
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  274    Function webp_uploads_wp_get_missing_image_subsizes() should return array<string, array{width: int, height: int, crop: bool}> but returns non-empty-array.  
  329    Function webp_uploads_filter_image_editor_output_format() should return array<string, string> but returns array.                                            
  447    Cannot access offset 'sources' on mixed.                                                                                                                    
  451    Cannot access offset 'mime-type' on mixed.                                                                                                                  
  469    Parameter #2 $replace of function str_replace expects array|string, mixed given.                                                                            
  489    Argument of an invalid type mixed supplied for foreach, only iterables are supported.                                                                       
  494    Parameter #2 $replace of function str_replace expects array|string, mixed given.                                                                            
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  Line   plugins/webp-uploads/image-edit.php                                                                                                                                                                                                                                           
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
  154    Parameter #1 $key of function sanitize_key expects string, mixed given.                                                                                                                                                                                                       
  350    Parameter #1 $key of function sanitize_key expects string, mixed given.                                                                                                                                                                                                       
  503    Function webp_uploads_restore_image() should return array{width: int, height: int, file: string, sizes: array<string, array{file: string, width: int, height: int, mime-type: string}>, image_meta: array<string, mixed>, filesize: int, sources?: array<string, array{file:  
         string, filesize: int}>, original_image: string} but returns array{width: int, height: int, file: string, sizes: array<string, array{file: string, width: int, height: int, mime-type: string}>, image_meta: array<string, mixed>, filesize: int, original_image: string,     
         sources: array}.                                                                                                                                                                                                                                                              
         💡 Offset 'sources' (array<string, array{file: string, filesize: int}>) does not accept type array<mixed, mixed>.                                                                                                                                                             
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 

 ------ ---------------------------------------------------------------------------------- 
  Line   plugins/webp-uploads/rest-api.php                                                 
 ------ ---------------------------------------------------------------------------------- 
  25     Cannot access offset 'media_details' on mixed.                                    
  31     Cannot access offset 'sources' on mixed.                                          
  35     Cannot access offset 'source_url' on mixed.                                       
  35     Parameter #1 $path of function wp_basename expects string, mixed given.           
  37     Cannot access offset 'file' on mixed.                                             
  37     Cannot access offset 'source_url' on mixed.                                       
  37     Cannot access offset 'source_url' on mixed.                                       
  37     Parameter #2 $replace of function str_replace expects array|string, mixed given.  
  37     Parameter #3 $subject of function str_replace expects array|string, mixed given.  
  48     Cannot access offset 'sources' on mixed.                                          
  49     Cannot access offset 'media_details' on mixed.                                    
  49     Cannot access offset 'sources' on mixed.                                          
 ------ ---------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   tests/bootstrap.php                                                                    
 ------ --------------------------------------------------------------------------------------- 
  39     Argument of an invalid type mixed supplied for foreach, only iterables are supported.  
  42     Cannot access offset (float|int) on mixed.                                             
 ------ --------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------ 
  Line   tests/plugins/optimization-detective/optimization-tests.php                               
 ------ ------------------------------------------------------------------------------------------ 
  28     Property OD_Optimization_Tests::$original_request_uri (string) does not accept mixed.     
  29     Property OD_Optimization_Tests::$original_request_method (string) does not accept mixed.  
 ------ ------------------------------------------------------------------------------------------ 

 ------ --------------------------------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/storage/data-tests.php                            
 ------ --------------------------------------------------------------------------------------- 
  18     Property OD_Storage_Data_Tests::$original_request_uri (string) does not accept mixed.  
 ------ --------------------------------------------------------------------------------------- 

 ------ ----------------------------------------------------------------- 
  Line   tests/plugins/optimization-detective/storage/rest-api-tests.php  
 ------ ----------------------------------------------------------------- 
  39     Cannot access offset 'success' on mixed.                         
  48     Cannot access offset 'width' on mixed.                           
  57     Cannot access offset 0 on mixed.                                 
  139    Cannot access offset 'code' on mixed.                            
  189    Cannot access offset 'code' on mixed.                            
 ------ ----------------------------------------------------------------- 

 ------ ------------------------------------------------------------------- 
  Line   tests/plugins/speculation-rules/speculation-rules-helper-test.php  
 ------ ------------------------------------------------------------------- 
  51     Cannot access offset 'and' on mixed.                               
  51     Cannot access offset 'href_matches' on mixed.                      
  51     Cannot access offset 'not' on mixed.                               
  51     Cannot access offset 1 on mixed.                                   
  77     Cannot access offset 'and' on mixed.                               
  77     Cannot access offset 'href_matches' on mixed.                      
  77     Cannot access offset 'not' on mixed.                               
  77     Cannot access offset 1 on mixed.                                   
  115    Cannot access offset 'and' on mixed.                               
  115    Cannot access offset 'href_matches' on mixed.                      
  115    Cannot access offset 'not' on mixed.                               
  115    Cannot access offset 1 on mixed.                                   
  139    Cannot access offset 'and' on mixed.                               
  139    Cannot access offset 'href_matches' on mixed.                      
  139    Cannot access offset 'not' on mixed.                               
  139    Cannot access offset 1 on mixed.                                   
  177    Cannot access offset 'and' on mixed.                               
  177    Cannot access offset 'href_matches' on mixed.                      
  177    Cannot access offset 'not' on mixed.                               
  177    Cannot access offset 1 on mixed.                                   
  225    Cannot access offset 'and' on mixed.                               
  225    Cannot access offset 'href_matches' on mixed.                      
  225    Cannot access offset 'not' on mixed.                               
  225    Cannot access offset 1 on mixed.                                   
  250    Cannot access offset 'and' on mixed.                               
  262    Cannot access offset 'and' on mixed.                               
 ------ ------------------------------------------------------------------- 

 ------ ------------------------------------------------------------------------------------------------------------- 
  Line   tests/plugins/speculation-rules/speculation-rules-test.php                                                   
 ------ ------------------------------------------------------------------------------------------------------------- 
  15     Property Speculation_Rules_Tests::$original_wp_theme_features (array<string, mixed>) does not accept mixed.  
 ------ ------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------- 
  Line   tests/plugins/webp-uploads/helper-tests.php  
 ------ --------------------------------------------- 
  512    Cannot access property $is_feed on mixed.    
 ------ --------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   tests/plugins/webp-uploads/image-edit-tests.php                                        
 ------ --------------------------------------------------------------------------------------- 
  101    Argument of an invalid type mixed supplied for foreach, only iterables are supported.  
  116    Cannot access offset 'sources' on mixed.                                               
 ------ --------------------------------------------------------------------------------------- 

 ------ ------------------------------------------------------- 
  Line   tests/plugins/webp-uploads/load-tests.php              
 ------ ------------------------------------------------------- 
  426    Cannot access offset 'file' on mixed.                  
  426    Cannot access offset 'image/webp' on mixed.            
  427    Cannot access offset 'file' on mixed.                  
  427    Cannot access offset 'image/webp' on mixed.            
  427    Cannot access offset 'sources' on mixed.               
  934    Cannot access offset 'allowed_size_400x300' on mixed.  
  934    Cannot access offset 'provide_additional…' on mixed.   
 ------ ------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------- 
  Line   tests/plugins/webp-uploads/rest-api-tests.php                                          
 ------ --------------------------------------------------------------------------------------- 
  51     Argument of an invalid type mixed supplied for foreach, only iterables are supported.  
  51     Cannot access offset 'media_details' on mixed.                                         
  51     Cannot access offset 'sizes' on mixed.                                                 
  70     Cannot access offset 'media_details' on mixed.                                         
 ------ --------------------------------------------------------------------------------------- 


```

</details> 

Please review individual commits for changes.