### PR TITLE
Update PHPStan to 1.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require-dev": {
     "phpcompatibility/php-compatibility": "^9.3",
     "phpstan/extension-installer": "^1.3",
-    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan": "^1.11",
     "phpstan/phpstan-deprecation-rules": "^1.1",
     "phpstan/phpstan-phpunit": "^1.3",
     "slevomat/coding-standard": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d924800b9c7a182fa46bd0ef6c685361",
+    "content-hash": "7591e86048aac3251cc36e10f53ccd0e",
     "packages": [],
     "packages-dev": [
         {
@@ -732,16 +732,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.67",
+            "version": "1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493"
+                "reference": "666cb1703742cea9cc80fee631f0940e1592fa6e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/16ddbe776f10da6a95ebd25de7c1dbed397dc493",
-                "reference": "16ddbe776f10da6a95ebd25de7c1dbed397dc493",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/666cb1703742cea9cc80fee631f0940e1592fa6e",
+                "reference": "666cb1703742cea9cc80fee631f0940e1592fa6e",
                 "shasum": ""
             },
             "require": {
@@ -786,7 +786,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-16T07:22:02+00:00"
+            "time": "2024-05-13T06:02:22+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/composer.lock
+++ b/composer.lock
@@ -732,16 +732,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.0",
+            "version": "1.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "666cb1703742cea9cc80fee631f0940e1592fa6e"
+                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/666cb1703742cea9cc80fee631f0940e1592fa6e",
-                "reference": "666cb1703742cea9cc80fee631f0940e1592fa6e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e524358f930e41a2b4cca1320e3b04fc26b39e0b",
+                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b",
                 "shasum": ""
             },
             "require": {
@@ -786,29 +786,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-05-13T06:02:22+00:00"
+            "time": "2024-05-15T08:00:59+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "1.1.4",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "089d8a8258ed0aeefdc7b68b6c3d25572ebfdbaa"
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/089d8a8258ed0aeefdc7b68b6c3d25572ebfdbaa",
-                "reference": "089d8a8258ed0aeefdc7b68b6c3d25572ebfdbaa",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.10.3"
+                "phpstan/phpstan": "^1.11"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-php-parser": "^1.1",
                 "phpstan/phpstan-phpunit": "^1.0",
                 "phpunit/phpunit": "^9.5"
             },
@@ -832,27 +831,27 @@
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.1.4"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.0"
             },
-            "time": "2023-08-05T09:02:04+00:00"
+            "time": "2024-04-20T06:39:48+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",
-            "version": "1.3.16",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-phpunit.git",
-                "reference": "d5242a59d035e46774f2e634b374bc39ff62cb95"
+                "reference": "f3ea021866f4263f07ca3636bf22c64be9610c11"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/d5242a59d035e46774f2e634b374bc39ff62cb95",
-                "reference": "d5242a59d035e46774f2e634b374bc39ff62cb95",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/f3ea021866f4263f07ca3636bf22c64be9610c11",
+                "reference": "f3ea021866f4263f07ca3636bf22c64be9610c11",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.10"
+                "phpstan/phpstan": "^1.11"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.0"
@@ -884,9 +883,9 @@
             "description": "PHPUnit extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
-                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.3.16"
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.4.0"
             },
-            "time": "2024-02-23T09:51:20+00:00"
+            "time": "2024-04-20T06:39:00+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -277,7 +277,6 @@ add_action( 'admin_action_perflab_install_activate_plugin', 'perflab_install_act
  * Callback function to handle admin inline style.
  *
  * @since 3.0.0
- * @phpstan-ignore void.pure (PHPStan isn't apparently aware that this function is printing anything. See https://github.com/phpstan/phpstan/issues/11008)
  */
 function perflab_print_features_page_style(): void {
 	?>

--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -277,6 +277,7 @@ add_action( 'admin_action_perflab_install_activate_plugin', 'perflab_install_act
  * Callback function to handle admin inline style.
  *
  * @since 3.0.0
+ * @phpstan-ignore void.pure (PHPStan isn't apparently aware that this function is printing anything. See https://github.com/phpstan/phpstan/issues/11008)
  */
 function perflab_print_features_page_style(): void {
 	?>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,38 +26,35 @@ parameters:
 	ignoreErrors:
 		-
 			# Ignore error related to PHP 8 using a GdImage but PHP 7 using a resource.
-			message: '/^Parameter .+? of function .+? expects resource, GdImage\|resource given\.$/'
+			identifier: argument.type
 			path: plugins/dominant-color-images/*.php
 
 		# The following ignored errors are all for tests. They are likely excessively strict and do not warrant being fixed.
-		# TODO: Use error identifiers instead of messages once PHPStan 1.11 is out: <https://github.com/WordPress/performance/issues/1209>.
 		-
+			# TODO: For some reason, using `identifier: argument.type` here doesn't work.
 			message: '/Parameter #\d.+given./'
 			path: tests/*
 		-
-			message: '/Cannot use array destructuring/'
+			identifier: offsetAccess.nonArray
 			path: tests/*
 		-
-			message: '/Call to an undefined method/'
+			identifier: method.notFound
 			path: tests/*
 		-
-			message: '/Offset .+ might not exist on array/'
+			identifier: offsetAccess.notFound
 			path: tests/*
 		-
-			message: '/Part .+ of encapsed string cannot be cast to string/'
+			identifier: encapsedStringPart.nonString
 			path: tests/*
 		-
-			message: '/Possibly invalid array key type/'
+			identifier: offsetAccess.invalidOffset
 			path: tests/*
 		-
-			message: '/Static property .+ does not accept .+/'
+			identifier: assign.propertyType
 			path: tests/*
 		-
-			message: '/Cannot call method format\(\) on DateTimeImmutable\|false/'
+			identifier: method.nonObject
 			path: tests/*
 		-
-			message: '/Property .+ does not accept array.+/'
-			path: tests/*
-		-
-			message: '/Cannot cast .+ to string/'
+			identifier: cast.string
 			path: tests/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -26,13 +26,12 @@ parameters:
 	ignoreErrors:
 		-
 			# Ignore error related to PHP 8 using a GdImage but PHP 7 using a resource.
-			identifier: argument.type
+			message: '/^Parameter .+? of function .+? expects resource, GdImage\|resource given\.$/'
 			path: plugins/dominant-color-images/*.php
 
 		# The following ignored errors are all for tests. They are likely excessively strict and do not warrant being fixed.
 		-
-			# TODO: For some reason, using `identifier: argument.type` here doesn't work.
-			message: '/Parameter #\d.+given./'
+			identifier: argument.type
 			path: tests/*
 		-
 			identifier: offsetAccess.nonArray

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -154,7 +154,7 @@ class OD_URL_Metrics_Post_Type {
 						}
 
 						try {
-							// @phpstan-ignore-next-line -- Invalid data will be validated in the constructor.
+							// @phpstan-ignore-next-line argument.type (Invalid data will be validated in the constructor.)
 							return new OD_URL_Metric( $url_metric_data );
 						} catch ( OD_Data_Validation_Exception $e ) {
 							$trigger_warning(

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -130,7 +130,7 @@ function od_handle_rest_request( WP_REST_Request $request ) {
 	try {
 		$properties = OD_URL_Metric::get_json_schema()['properties'];
 		$url_metric = new OD_URL_Metric(
-			// @phpstan-ignore-next-line -- Array shape is validated by the constructor.
+			// @phpstan-ignore-next-line argument.type (Array shape is validated by the constructor.)
 			array_merge(
 				wp_array_slice_assoc(
 					$request->get_params(),

--- a/tests/includes/server-timing/perflab-server-timing-tests.php
+++ b/tests/includes/server-timing/perflab-server-timing-tests.php
@@ -114,7 +114,6 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-measure-callback',
-			// @phpstan-ignore-next-line -- Ignored to test incorrect usage.
 			array( 'access_cap' => 'exist' )
 		);
 
@@ -126,7 +125,6 @@ class Perflab_Server_Timing_Tests extends WP_UnitTestCase {
 
 		$this->server_timing->register_metric(
 			'metric-without-access-cap',
-			// @phpstan-ignore-next-line -- Ignored to test incorrect usage.
 			array( 'measure_callback' => '__return_null' )
 		);
 

--- a/tests/plugins/webp-uploads/helper-tests.php
+++ b/tests/plugins/webp-uploads/helper-tests.php
@@ -379,8 +379,7 @@ class WebP_Uploads_Helper_Tests extends ImagesTestCase {
 	 * @test
 	 */
 	public function it_should_return_default_transforms_when_filter_returns_non_array_type(): void {
-		/** @phpstan-ignore-next-line */
-		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_null' );
+		add_filter( 'webp_uploads_upload_image_mime_transforms', '__return_zero' );
 
 		$default_transforms = array(
 			'image/jpeg' => array( 'image/webp' ),

--- a/tests/plugins/webp-uploads/image-edit-tests.php
+++ b/tests/plugins/webp-uploads/image-edit-tests.php
@@ -399,7 +399,7 @@ class WebP_Uploads_Image_Edit_Tests extends ImagesTestCase {
 		$editor->rotate_right()->save();
 
 		$full_size_key = webp_uploads_get_next_full_size_key_from_backup( $attachment_id );
-		// @phpstan-ignore-next-line -- Work around PHPStan remembering the return value above being null but now being a string. This is instead of adding rememberPossiblyImpureFunctionValues:false to the config.
+		// @phpstan-ignore-next-line method.impossibleType (Work around PHPStan remembering the return value above being null but now being a string. This is instead of adding rememberPossiblyImpureFunctionValues:false to the config.)
 		$this->assertIsString( $full_size_key );
 		$this->assertSizeNameIsHashed( 'full', $full_size_key );
 	}


### PR DESCRIPTION
Fixes #1209 
See https://github.com/WordPress/performance/issues/775

* Leverage the new PHPStan error identifiers to ignore errors.
* Remove the need to ignore some errors.

<!-- Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
