### PR TITLE
Use phpstan-assert to avoid ignoring errors

### DIFF
--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -45,18 +45,30 @@ final class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Constructor.
 	 *
-	 * @phpstan-param Data $data URL metric data.
+	 * @phpstan-param Data|array<string, mixed> $data Valid data or invalid data (in which case an exception is thrown).
 	 *
-	 * @param array $data URL metric data.
+	 * @param array<string, mixed> $data URL metric data.
 	 *
 	 * @throws OD_Data_Validation_Exception When the input is invalid.
 	 */
 	public function __construct( array $data ) {
+		$this->validate_data( $data );
+		$this->data = $data;
+	}
+
+	/**
+	 * Validate data.
+	 *
+	 * @phpstan-assert Data $data
+	 *
+	 * @param array<string, mixed> $data Data to validate.
+	 * @throws OD_Data_Validation_Exception When the input is invalid.
+	 */
+	private function validate_data( array $data ): void {
 		$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
 		if ( is_wp_error( $valid ) ) {
 			throw new OD_Data_Validation_Exception( esc_html( $valid->get_error_message() ) );
 		}
-		$this->data = $data;
 	}
 
 	/**

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -154,7 +154,6 @@ class OD_URL_Metrics_Post_Type {
 						}
 
 						try {
-							// @phpstan-ignore-next-line argument.type (Invalid data will be validated in the constructor.)
 							return new OD_URL_Metric( $url_metric_data );
 						} catch ( OD_Data_Validation_Exception $e ) {
 							$trigger_warning(

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -130,7 +130,6 @@ function od_handle_rest_request( WP_REST_Request $request ) {
 	try {
 		$properties = OD_URL_Metric::get_json_schema()['properties'];
 		$url_metric = new OD_URL_Metric(
-			// @phpstan-ignore-next-line argument.type (Array shape is validated by the constructor.)
 			array_merge(
 				wp_array_slice_assoc(
 					$request->get_params(),


### PR DESCRIPTION
Part of #775.

The current uses of `@phpstan-ignore-next-line argument.type` are eliminated in favor of using [`@phpstan-assert`](https://phpstan.org/writing-php-code/narrowing-types#custom-type-checking-functions-and-methods).