### PR TITLE
Bump plugin versions and add versions command to verify version consistency in plugins

### DIFF
--- a/.github/workflows/deploy-standalone-plugins.yml
+++ b/.github/workflows/deploy-standalone-plugins.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Check plugin versions
+        run: npm run versions -- --plugin=${{ matrix.plugin }}
+
       - name: Build plugin
         run: npm run build:plugin:${{ matrix.plugin }}
 

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -43,6 +43,10 @@ const {
 	handler: sinceHandler,
 	options: sinceOptions,
 } = require( './commands/since' );
+const {
+	handler: versionsHandler,
+	options: versionsOptions,
+} = require( './commands/versions' );
 
 withOptions( program.command( 'release-plugin-changelog' ), changelogOptions )
 	.alias( 'changelog' )
@@ -58,5 +62,10 @@ withOptions( program.command( 'plugin-readme' ), readmeOptions )
 	.alias( 'readme' )
 	.description( 'Updates the readme.txt file' )
 	.action( catchException( readmeHandler ) );
+
+withOptions( program.command( 'verify-version-consistency' ), versionsOptions )
+	.alias( 'versions' )
+	.description( 'Verifies consistency of versions in plugins' )
+	.action( catchException( versionsHandler ) );
 
 program.parse( process.argv );

--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -1,0 +1,157 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const glob = require( 'fast-glob' );
+const { log, formats } = require( '../lib/logger' );
+
+/**
+ * Internal dependencies
+ */
+const { plugins } = require( '../../../plugins.json' );
+
+/**
+ * @typedef WPVersionsCommandOptions
+ *
+ * @property {?string} plugin Plugin slug.
+ */
+
+exports.options = [
+	{
+		argname: '-p, --plugin <plugin>',
+		description: 'Plugin slug',
+		defaults: null,
+	},
+];
+
+/**
+ * Checks a plugin directory for the required versions.
+ *
+ * @throws Error When there are inconsistent versions.
+ *
+ * @param {string} pluginDirectory
+ * @return {Promise<string>} Consistent version.
+ */
+async function checkPluginDirectory( pluginDirectory ) {
+	const readmeContents = fs.readFileSync(
+		path.resolve( pluginDirectory, 'readme.txt' ),
+		'utf-8'
+	);
+
+	const stableTagVersionMatches = readmeContents.match(
+		/^Stable tag:\s*(\d+\.\d+\.\d+)$/m
+	);
+	if ( ! stableTagVersionMatches ) {
+		throw new Error( 'Unable to locate stable tag in readme.txt' );
+	}
+	const stableTagVersion = stableTagVersionMatches[ 1 ];
+
+	const latestChangelogMatches = readmeContents.match(
+		/^== Changelog ==\n+= (\d+\.\d+\.\d+) =$/m
+	);
+	if ( ! latestChangelogMatches ) {
+		throw new Error(
+			'Unable to latest version entry in readme changelog.'
+		);
+	}
+	const latestChangelogVersion = latestChangelogMatches[ 1 ];
+
+	// Find the bootstrap file.
+	let phpBootstrapFileContents = null;
+	for ( const phpFile of await glob(
+		path.resolve( pluginDirectory, '*.php' )
+	) ) {
+		const phpFileContents = fs.readFileSync( phpFile, 'utf-8' );
+		if ( /^<\?php\n\/\*\*\n \* Plugin Name:/.test( phpFileContents ) ) {
+			phpBootstrapFileContents = phpFileContents;
+			break;
+		}
+	}
+	if ( ! phpBootstrapFileContents ) {
+		throw new Error( 'Unable to locate the PHP bootstrap file.' );
+	}
+
+	const headerVersionMatches = phpBootstrapFileContents.match(
+		/^ \* Version:\s+(\d+\.\d+\.\d+)$/m
+	);
+	if ( ! headerVersionMatches ) {
+		throw new Error(
+			'Unable to locate version in plugin PHP bootstrap file header.'
+		);
+	}
+	const headerVersion = headerVersionMatches[ 1 ];
+
+	const phpLiteralVersionMatches =
+		phpBootstrapFileContents.match( /'(\d+\.\d+\.\d+?)'/ );
+	if ( ! phpLiteralVersionMatches ) {
+		throw new Error( 'Unable to locate the PHP literal version.' );
+	}
+	const phpLiteralVersion = phpLiteralVersionMatches[ 1 ];
+
+	const allVersions = [
+		stableTagVersion,
+		latestChangelogVersion,
+		headerVersion,
+		phpLiteralVersion,
+	];
+
+	if ( ! allVersions.every( ( version ) => version === stableTagVersion ) ) {
+		throw new Error(
+			`Version mismatch: ${ JSON.stringify( {
+				latestChangelogVersion,
+				headerVersion,
+				stableTagVersion,
+				phpLiteralVersion,
+			} ) }`
+		);
+	}
+
+	return stableTagVersion;
+}
+
+/**
+ * Checks that the versions are consistent across all plugins, including in:
+ *
+ * - Plugin bootstrap header metadata comment.
+ * - Plugin bootstrap PHP literal (e.g. constant).
+ * - The 'Stable tag' in readme.txt.
+ * - The most recent changelog entry in readme.txt.
+ *
+ * @param {WPVersionsCommandOptions} opt Command options.
+ */
+exports.handler = async ( opt ) => {
+	const pluginRoot = path.resolve( __dirname, '../../../' );
+
+	const pluginDirectories = [];
+
+	if ( ! opt.plugin || 'performance-lab' === opt.plugin ) {
+		pluginDirectories.push( pluginRoot ); // TODO: Remove this after <https://github.com/WordPress/performance/pull/1182>.
+	}
+
+	for ( const pluginSlug of plugins ) {
+		if ( ! opt.plugin || pluginSlug === opt.plugin ) {
+			pluginDirectories.push(
+				path.resolve( pluginRoot, 'plugins', pluginSlug )
+			);
+		}
+	}
+
+	let errorCount = 0;
+	for ( const pluginDirectory of pluginDirectories ) {
+		const slug = path.basename( pluginDirectory );
+		try {
+			const version = await checkPluginDirectory( pluginDirectory );
+			log( formats.success( `✅ ${ slug }: ${ version } ` ) );
+		} catch ( error ) {
+			errorCount++;
+			log( formats.error( `❌ ${ slug }: ${ error.message }` ) );
+		}
+	}
+
+	if ( errorCount > 0 ) {
+		throw new Error(
+			`There are ${ errorCount } plugin(s) with inconsistent versions.`
+		);
+	}
+};

--- a/load.php
+++ b/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 3.0.0
+ * Version: 3.1.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.0.0' );
+define( 'PERFLAB_VERSION', '3.1.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "changelog": "./bin/plugin/cli.js changelog",
     "since": "./bin/plugin/cli.js since",
     "readme": "./bin/plugin/cli.js readme",
+    "versions": "./bin/plugin/cli.js versions",
     "build": "wp-scripts build",
     "build-plugins": "npm-run-all 'build:plugin:!(performance-lab)'",
     "build:plugin:performance-lab": "rm -rf build/performance-lab && mkdir -p build/performance-lab && git archive HEAD | tar -x -C build/performance-lab",

--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -5,7 +5,7 @@
  * Description: Instructs browsers to automatically choose the right image size for lazy-loaded images.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,6 +25,6 @@ if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.0.1' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.0.2' );
 
 require_once __DIR__ . '/hooks.php';

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        1.0.1
+Stable tag:        1.0.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, auto-sizes
@@ -47,6 +47,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.0.2 =
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.0.1 =
 

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -5,7 +5,7 @@
  * Description: Displays placeholders based on an image's dominant color while the image is loading.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'DOMINANT_COLOR_IMAGES_VERSION' ) ) {
 	return;
 }
 
-define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.1.0' );
+define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.1.1' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        1.1.0
+Stable tag:        1.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, dominant color
@@ -48,6 +48,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.1.1 =
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.1.0 =
 

--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -5,7 +5,7 @@
  * Description: Optimizes the performance of embeds by lazy-loading iframes and scripts.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 0.1.1
+ * Version: 0.1.2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'EMBED_OPTIMIZER_VERSION', '0.1.1' );
+define( 'EMBED_OPTIMIZER_VERSION', '0.1.2' );
 
 // Load in the Embed Optimizer plugin hooks.
 require_once __DIR__ . '/hooks.php';

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        0.1.1
+Stable tag:        0.1.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, embeds
@@ -48,6 +48,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.1.2 =
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 0.1.1 =
 

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Uses real user metrics to improve heuristics WordPress applies on the frontend to improve image loading priority.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 0.1.1
+ * Version: 0.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.1.1',
+	'0.2.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        0.1.1
+Stable tag:        0.2.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images
@@ -136,6 +136,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.2.0 =
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 0.1.1 =
 

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Enables browsers to speculatively prerender or prefetch pages when hovering over links.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 1.2.2
+ * Version: 1.3.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'plsr_pending_plugin_info',
-	'1.2.2',
+	'1.3.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        1.2.2
+Stable tag:        1.3.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, javascript, speculation rules, prerender, prefetch
@@ -113,6 +113,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.3.0 =
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.2.2 =
 

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '1.1.0' );
+define( 'WEBP_UPLOADS_VERSION', '1.1.1' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        1.1.0
+Stable tag:        1.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, webp
@@ -59,6 +59,10 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 1.1.1 =
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.1.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        3.0.0
+Stable tag:        3.1.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, site health, measurement, optimization, diagnostics
@@ -59,6 +59,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.1.0 =
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 3.0.0 =
 


### PR DESCRIPTION
This bumps the plugin versions in preparation for the 3.1.0 release. I've also manually added changelog entries for #775. The versions have been also updated in the [milestones](https://github.com/WordPress/performance/milestones) (except for auto-sizes which has no issues or PRs milestoned):

![image](https://github.com/WordPress/performance/assets/134745/02670ef1-d160-4b5c-b1cd-c0735303573b)

This is currently a tedious process which can be easy to mess up, as a version should appear in 4 places:

* `readme.txt` in the `Stable tag`
* `readme.txt` in the latest `Changelog` entry
* Bootstrap file in the plugin header
* Bootstrap file in the PHP string literal (e.g. constant)

To assist with this, this PR also adds an `npm run versions` command which automatically checks for version consistency in a plugin or all plugins. For example, if all is good:

```
$ npm run versions

✅ performance: 3.1.0 
✅ auto-sizes: 1.0.2 
✅ dominant-color-images: 1.1.1 
✅ embed-optimizer: 0.1.2 
✅ optimization-detective: 0.2.0 
✅ speculation-rules: 1.3.0 
✅ webp-uploads: 1.1.1 
```

But let's say that the `auto-sizes` plugin didn't update the `Stable tag`, the `optimization-detective` didn't add the changelog, and `webp-uploads` failed to update the version constant. Then the output is:

```
$ npm run versions

✅ performance: 3.1.0 
❌ auto-sizes: Version mismatch: {"latestChangelogVersion":"1.0.2","headerVersion":"1.0.2","stableTagVersion":"1.0.1","phpLiteralVersion":"1.0.2"}
✅ dominant-color-images: 1.1.1 
✅ embed-optimizer: 0.1.2 
❌ optimization-detective: Version mismatch: {"latestChangelogVersion":"0.1.1","headerVersion":"0.2.0","stableTagVersion":"0.2.0","phpLiteralVersion":"0.2.0"}
✅ speculation-rules: 1.3.0 
❌ webp-uploads: Version mismatch: {"latestChangelogVersion":"1.1.1","headerVersion":"1.1.1","stableTagVersion":"1.1.1","phpLiteralVersion":"1.1.0"}
There are 3 plugin(s) with inconsistent versions.
```

Additionally, you can just check one single plugin:

```
$ npm run versions -- --plugin=speculation-rules

✅ speculation-rules: 1.3.0 
```

When there is an error, an exit code of 1 is returned, allowing the command to be used in CI pipeline, which is what this PR also does: it integrates the command into the `deploy-standalone-plugins` GitHub workflow to check each standalone plugin before deployment. It does not do the same for the Performance Lab plugin because its workflow doesn't do `npm ci` currently, but this will be eliminated anyway as of https://github.com/WordPress/performance/pull/1182.