### PR TITLE
Automatically detect version when running since command and allow updating all plugins at once

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -55,7 +55,9 @@ withOptions( program.command( 'release-plugin-changelog' ), changelogOptions )
 
 withOptions( program.command( 'release-plugin-since' ), sinceOptions )
 	.alias( 'since' )
-	.description( 'Updates "n.e.x.t" tags with the current release version' )
+	.description(
+		'Updates "n.e.x.t" tags with the current release version in the "Stable tag" of readme.txt'
+	)
 	.action( catchException( sinceHandler ) );
 
 withOptions( program.command( 'plugin-readme' ), readmeOptions )

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -4,6 +4,7 @@
 const fs = require( 'fs' );
 const path = require( 'path' );
 const glob = require( 'fast-glob' );
+const { log, formats } = require( '../lib/logger' );
 
 /**
  * Internal dependencies
@@ -13,19 +14,13 @@ const { plugins } = require( '../../../plugins.json' );
 /**
  * @typedef WPSinceCommandOptions
  *
- * @property {string} plugin  Plugin slug.
- * @property {string} release Release version number.
+ * @property {string=} plugin Plugin slug.
  */
 
 exports.options = [
 	{
 		argname: '-p, --plugin <plugin>',
-		description: 'Plugin slug',
-		defaults: 'performance-lab',
-	},
-	{
-		argname: '-r, --release <release>',
-		description: 'Release version number',
+		description: 'Plugin slug. Defaults to update all.',
 	},
 ];
 
@@ -35,14 +30,11 @@ exports.options = [
  * @param {WPSinceCommandOptions} opt Command options.
  */
 exports.handler = async ( opt ) => {
-	if ( ! opt.release ) {
-		throw new Error(
-			'The release version must be provided via the --release (-r) argument.'
-		);
-	}
+	const isAllPlugins = ! opt.plugin;
 
 	if (
-		opt.plugin !== 'performance-lab' &&
+		! isAllPlugins &&
+		opt.plugin !== 'performance-lab' && // TODO: Remove this as of <https://github.com/WordPress/performance/pull/1182>.
 		! plugins.includes( opt.plugin )
 	) {
 		throw new Error(
@@ -50,38 +42,80 @@ exports.handler = async ( opt ) => {
 		);
 	}
 
-	const patterns = [];
 	const pluginRoot = path.resolve( __dirname, '../../../' );
-	const ignore = [ '**/node_modules', '**/vendor', '**/bin', '**/build' ];
 
-	/*
-	 * For a standalone plugin, use the specific plugin directory.
-	 * For Performance Lab, use the root directory and ignore the standalone plugin directories.
-	 */
-	if ( opt.plugin !== 'performance-lab' ) {
-		const pluginPath = path.resolve( pluginRoot, 'plugins', opt.plugin );
-
-		patterns.push( `${ pluginPath }/**/*.php` );
-		patterns.push( `${ pluginPath }/**/*.js` );
-	} else {
-		ignore.push( '**/plugins' );
-		patterns.push( `${ pluginRoot }/**/*.php` );
-		patterns.push( `${ pluginRoot }/**/*.js` );
+	const pluginDirectories = [];
+	if ( isAllPlugins || opt.plugin === 'performance-lab' ) {
+		pluginDirectories.push( pluginRoot ); // TODO: Remove this as of <https://github.com/WordPress/performance/pull/1182>.
 	}
-
-	const files = await glob( patterns, {
-		ignore,
-	} );
-
-	const regexp = new RegExp( '@since(\\s+)n.e.x.t', 'g' );
-
-	files.forEach( ( file ) => {
-		const content = fs.readFileSync( file, 'utf-8' );
-		if ( regexp.test( content ) ) {
-			fs.writeFileSync(
-				file,
-				content.replace( regexp, `@since$1${ opt.release }` )
+	if ( isAllPlugins ) {
+		for ( const pluginSlug of plugins ) {
+			pluginDirectories.push(
+				path.resolve( pluginRoot, 'plugins', pluginSlug )
 			);
 		}
-	} );
+	} else {
+		pluginDirectories.push(
+			path.resolve( pluginRoot, 'plugins', opt.plugin )
+		);
+	}
+
+	for ( const pluginDirectory of pluginDirectories ) {
+		const patterns = [];
+		const ignore = [ '**/node_modules', '**/vendor', '**/bin', '**/build' ];
+		const pluginSlug = path.basename( pluginDirectory );
+
+		const readmeFile = path.resolve( pluginDirectory, 'readme.txt' );
+		const readmeContent = fs.readFileSync( readmeFile, 'utf-8' );
+		const readmeContentMatches = readmeContent.match(
+			/^Stable tag:\s+(\d+\.\d+\.\d+)$/m
+		);
+		if ( ! readmeContentMatches ) {
+			throw new Error(
+				`Unable to parse out "Stable tag" from ${ readmeFile }.`
+			);
+		}
+		const version = readmeContentMatches[ 1 ];
+
+		if ( pluginDirectory === pluginRoot ) {
+			ignore.push( '**/plugins' ); // TODO: Remove this as of <https://github.com/WordPress/performance/pull/1182>.
+		}
+
+		patterns.push( `${ pluginDirectory }/**/*.php` );
+		patterns.push( `${ pluginDirectory }/**/*.js` );
+
+		const files = await glob( patterns, {
+			ignore,
+		} );
+
+		const regexp = /(@since\s+)n\.e\.x\.t/g;
+
+		let replacementCount = 0;
+		files.forEach( ( file ) => {
+			const content = fs.readFileSync( file, 'utf-8' );
+			if ( regexp.test( content ) ) {
+				fs.writeFileSync(
+					file,
+					content.replace( regexp, function ( matches, sinceTag ) {
+						replacementCount++;
+						return sinceTag + version;
+					} )
+				);
+			}
+		} );
+
+		const commonMessage = `Using version ${ version } for ${ pluginSlug }: `;
+		if ( replacementCount > 0 ) {
+			log(
+				formats.success(
+					commonMessage +
+						( replacementCount === 1
+							? '1 replacement'
+							: `${ replacementCount } replacements` )
+				)
+			);
+		} else {
+			log( commonMessage + 'No replacements' );
+		}
+	}
 };


### PR DESCRIPTION
The current instructions instructions for the Performance Lab plugin instruct:

> `npm run since -- -r $VERSION_NUMBER`

And for standalone plugins instruct:

> Make sure that any n.e.x.t version references have been updated via `npm run since -- --plugin $plugin_slug --release $plugin_version`.

This quickly gets tedious because you have to look up whatever the plugin version is and use it with each command. However, this is entirely unnecessary because the release instructions already instruct to update the `Stable tag` for each plugin first. Therefore, the `since` command can simply reuse the version in the `Stable tag` to use in the `n.e.x.t` version replacement. 

So this PR eliminates the `-r`/`--release` option, letting the version be automatically detected instead. It also removes `performance-lab` from being the default value for the `-p`/`--plugin` option, in which case all plugins get their `n.e.x.t` versions updated. For example:

![image](https://github.com/WordPress/performance/assets/134745/c8d37187-f227-4257-a186-e6ecd3657e24)

Where the output is 142c7813f31af3660f7c044c734f9a8753c9cceb.