### PR TITLE
Improve readme command

### DIFF
--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -62,7 +62,9 @@ withOptions( program.command( 'release-plugin-since' ), sinceOptions )
 
 withOptions( program.command( 'plugin-readme' ), readmeOptions )
 	.alias( 'readme' )
-	.description( 'Updates the readme.txt file' )
+	.description(
+		'Updates the changelog in the readme.txt file for the stable tag (requires milestones to be named "$plugin_slug $stable_tag")'
+	)
 	.action( catchException( readmeHandler ) );
 
 withOptions( program.command( 'verify-version-consistency' ), versionsOptions )

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -139,17 +139,10 @@ function getIssueType( issue ) {
  * @param {string}                          milestone    Milestone title.
  * @param {IssuesListForRepoResponseItem[]} pullRequests List of pull requests.
  *
- * @return {string} The formatted changelog string.
+ * @return {string} The formatted changelog string (without the heading).
  */
 function formatChangelog( milestone, pullRequests ) {
-	const version = milestone.match( /\d+\.\d+(\.\d+)?(-[A-Za-z0-9.]+)?$/ );
-	if ( ! version ) {
-		throw new Error(
-			`The ${ milestone } milestone does not end with a version number.`
-		);
-	}
-
-	let changelog = '= ' + version[ 0 ] + ' =\n\n';
+	let changelog = '';
 
 	// Group PRs by type.
 	const typeGroups = groupBy( pullRequests, getIssueType );

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -69,14 +69,13 @@ exports.handler = async ( opt ) => {
 };
 
 /**
- * Returns a promise resolving to an array of pull requests associated with the
+ * Returns a promise resolving to an array of merged pull requests associated with the
  * changelog settings object.
  *
  * @param {GitHub}              octokit  GitHub REST client.
  * @param {WPChangelogSettings} settings Changelog settings.
  *
- * @return {Promise<IssuesListForRepoResponseItem[]>} Promise resolving to array of
- *                                            pull requests.
+ * @return {Promise<IssuesListForRepoResponseItem[]>} Promise resolving to array of pull requests.
  */
 async function fetchAllPullRequests( octokit, settings ) {
 	const { owner, repo, milestone: milestoneTitle } = settings;
@@ -101,11 +100,9 @@ async function fetchAllPullRequests( octokit, settings ) {
 		'closed'
 	);
 
-	// Return all pull requests except those with the SKIP_CHANGELOG_LABEL.
+	// Return all merged pull requests.
 	return issues.filter(
-		( issue ) =>
-			issue.pull_request &&
-			! issue.labels.find( ( { name } ) => name === SKIP_CHANGELOG_LABEL )
+		( issue ) => issue.pull_request && issue.pull_request.merged_at
 	);
 }
 
@@ -216,11 +213,23 @@ async function getChangelog( settings ) {
 	const pullRequests = await fetchAllPullRequests( octokit, settings );
 	if ( ! pullRequests.length ) {
 		throw new Error(
-			'There are no (closed) pull requests associated with the milestone.'
+			`There are no merged pull requests associated with the milestone ${ settings.milestone }`
 		);
 	}
 
-	return formatChangelog( settings.milestone, pullRequests );
+	const nonSkippedPullRequests = pullRequests.filter(
+		( pullRequest ) =>
+			! pullRequest.labels.find(
+				( { name } ) => name === SKIP_CHANGELOG_LABEL
+			)
+	);
+	if ( ! nonSkippedPullRequests.length ) {
+		throw new Error(
+			`All of the merged pull requests in the ${ settings.milestone } milestone have the "${ SKIP_CHANGELOG_LABEL }" label.`
+		);
+	}
+
+	return formatChangelog( settings.milestone, nonSkippedPullRequests );
 }
 
 /**

--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -48,6 +48,7 @@ exports.handler = async ( opt ) => {
  *
  * @param {string} readmeFile Readme file path.
  * @param {string} changelog  Changelog in markdown.
+ * @return {string} Success status message.
  */
 function updateReadmeChangelog( readmeFile, changelog ) {
 	const fileContent = fs.readFileSync( readmeFile, 'utf-8' );

--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -10,34 +10,20 @@ const fs = require( 'fs' );
 const { log, formats } = require( '../lib/logger' );
 const config = require( '../config' );
 const { getChangelog } = require( './changelog' );
+const { plugins } = require( '../../../plugins.json' );
 
 /**
  * @typedef WPReadmeCommandOptions
  *
- * @property {string=} milestone Optional milestone title, to update the changelog in the readme.
- * @property {string=} path      Optional path to the readme.txt file to update. If omitted, it will be detected via --milestone.
- * @property {string=} token     Optional personal GitHub access token, only relevant for changelog updates.
- */
-
-/**
- * @typedef WPReadmeSettings
- *
- * @property {string}  owner     GitHub repository owner.
- * @property {string}  repo      GitHub repository name.
- * @property {string=} milestone Optional milestone title, to update the changelog in the readme.
- * @property {string=} path      Optional path to the readme.txt file to update.
- * @property {string=} token     Optional personal GitHub access token, only relevant for changelog updates.
+ * @property {string=} plugin Optional plugin slug to update one a single plugin's readme. If omitted, all plugins are updated.
+ * @property {string=} token  Optional personal GitHub access token.
  */
 
 exports.options = [
 	{
-		argname: '-m, --milestone <milestone>',
-		description: 'Milestone title, to update the changelog',
-	},
-	{
-		argname: '-p, --path <path>',
+		argname: '-p, --plugin <plugin>',
 		description:
-			'Path to the readme.txt file to update; if omitted, it will be detected via --milestone',
+			'The plugin slug to update; if omitted, all plugins are updated',
 	},
 	{
 		argname: '-t, --token <token>',
@@ -52,112 +38,135 @@ exports.options = [
  */
 exports.handler = async ( opt ) => {
 	await updateReadme( {
-		owner: config.githubRepositoryOwner,
-		repo: config.githubRepositoryName,
-		milestone: opt.milestone,
-		path: opt.path,
+		plugin: opt.plugin,
 		token: opt.token,
 	} );
 };
 
 /**
- * Detects the path to the readme.txt file to update based on the milestone title.
+ * Updates the `readme.txt` file with the given changelog.
  *
- * @param {string} milestone Milestone title.
- *
- * @return {string} Detected readme.txt path.
+ * @param {string} readmeFile Readme file path.
+ * @param {string} changelog  Changelog in markdown.
  */
-function detectReadmePath( milestone ) {
-	const slug = milestone.match( /^([a-z0-9-]+) / );
-	if ( ! slug ) {
-		throw new Error(
-			`The ${ milestone } milestone does not start with a valid plugin slug.`
-		);
+function updateReadmeChangelog( readmeFile, changelog ) {
+	const fileContent = fs.readFileSync( readmeFile, 'utf-8' );
+
+	const stableTagVersionMatches = fileContent.match(
+		/^Stable tag:\s*(\d+\.\d+\.\d+)$/m
+	);
+	if ( ! stableTagVersionMatches ) {
+		throw new Error( `Unable to locate stable tag in ${ readmeFile }` );
+	}
+	const stableTagVersion = stableTagVersionMatches[ 1 ];
+
+	const regex = new RegExp(
+		`(== Changelog ==\n+)(= ${ stableTagVersion } =\n+)([^=]+)`
+	);
+
+	const versionHeading = `= ${ stableTagVersion } =\n\n`;
+	const normalizedChangelog = changelog.trimEnd() + '\n';
+
+	let status = '';
+
+	// Try to merge the new changelog with the existing changelog.
+	let newContent = fileContent.replace(
+		regex,
+		( match, changelogHeading, _versionHeading, existingChangelog ) => {
+			status =
+				'Merged existing changelog with the new changelog in an Other section.';
+			return `${ changelogHeading }${ _versionHeading }${ normalizedChangelog }\n**Other**\n\n${ existingChangelog }`;
+		}
+	);
+
+	// No replacement was done, so we need to insert a new section.
+	if ( newContent === fileContent ) {
+		newContent = fileContent.replace( /(== Changelog ==\n+)/, ( match ) => {
+			status = 'Added new changelog section.';
+			return `${ match }${ versionHeading }${ normalizedChangelog }\n`;
+		} );
 	}
 
-	if ( 'performance-lab' === slug[ 1 ] ) {
-		return 'readme.txt';
+	if ( newContent === fileContent ) {
+		throw new Error( 'Failed to insert changelog into readme.' );
 	}
 
-	if ( ! fs.existsSync( path.join( '.', `plugins/${ slug[ 1 ] }` ) ) ) {
-		throw new Error( `Unknown plugin with slug '${ slug[ 1 ] }'` );
-	}
+	fs.writeFileSync( readmeFile, newContent );
 
-	return `plugins/${ slug[ 1 ] }/readme.txt`;
+	return status;
 }
 
 /**
- * Updates the `readme.txt` file with the given changelog.
+ * Gets the stable tag from a readme.
  *
- * @param {string}           changelog Changelog in markdown, with trailing newline.
- * @param {WPReadmeSettings} settings  Readme settings.
+ * @param {string} readmeFilePath Readme file path.
+ * @return {string} Stable tag.
  */
-function updateReadmeChangelog( changelog, settings ) {
-	// Detect the version number to replace it in readme changelog, if already present.
-	const version = settings.milestone.match(
-		/\d+\.\d+(\.\d+)?(-[A-Za-z0-9.]+)?$/
+function getStableTag( readmeFilePath ) {
+	const readmeContents = fs.readFileSync( readmeFilePath, 'utf-8' );
+
+	const stableTagVersionMatches = readmeContents.match(
+		/^Stable tag:\s*(\d+\.\d+\.\d+)$/m
 	);
-	if ( ! version ) {
-		throw new Error(
-			`The ${ settings.milestone } milestone does not end with a version number.`
-		);
+	if ( ! stableTagVersionMatches ) {
+		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );
 	}
-
-	const regex = new RegExp( `= ${ version[ 0 ] } =[^=]+` );
-
-	const readmeFile = path.join( '.', settings.path );
-	const fileContent = fs.readFileSync( readmeFile, 'utf8' );
-
-	let newContent;
-	if ( fileContent.match( regex ) ) {
-		newContent = fileContent
-			.replace( regex, changelog )
-			.trim()
-			.concat( '\n' );
-	} else {
-		newContent = fileContent.replace(
-			/(== Changelog ==\n\n)/,
-			( match ) => {
-				return `${ match }${ changelog }`;
-			}
-		);
-	}
-	fs.writeFileSync( readmeFile, newContent );
+	return stableTagVersionMatches[ 1 ];
 }
 
 /**
  * Updates the `readme.txt` file with a specific release changelog.
  *
- * @param {WPReadmeSettings} settings Readme settings.
+ * @param {WPReadmeCommandOptions} settings
  */
 async function updateReadme( settings ) {
-	if ( settings.milestone ) {
-		log(
-			formats.title(
-				`\n💃Updating readme.txt changelog for milestone "${ settings.milestone }"\n\n`
-			)
-		);
+	const pluginRoot = path.resolve( __dirname, '../../../' );
 
+	const allPluginSlugs = [
+		'performance-lab', // TODO: Remove as of <https://github.com/WordPress/performance/pull/1182>.
+		...plugins,
+	];
+	if ( settings.plugin && ! allPluginSlugs.includes( settings.plugin ) ) {
+		throw new Error( `Unrecognized plugin: ${ settings.plugin }` );
+	}
+
+	const pluginSlugs = [];
+	if ( settings.plugin ) {
+		pluginSlugs.push( settings.plugin );
+	} else {
+		pluginSlugs.push( ...allPluginSlugs );
+	}
+
+	for ( const pluginSlug of pluginSlugs ) {
 		try {
-			if ( ! settings.path ) {
-				settings.path = detectReadmePath( settings.milestone );
-			}
+			const pluginDirectory =
+				'performance-lab' === pluginSlug // TODO: Remove this condition as of <https://github.com/WordPress/performance/pull/1182>.
+					? pluginRoot
+					: path.resolve( pluginRoot, 'plugins', pluginSlug );
 
+			const readmeFilePath = path.resolve(
+				pluginDirectory,
+				'readme.txt'
+			);
+			const stableTag = getStableTag( readmeFilePath );
 			const changelog = await getChangelog( {
-				owner: settings.owner,
-				repo: settings.repo,
-				milestone: settings.milestone,
+				owner: config.githubRepositoryOwner,
+				repo: config.githubRepositoryName,
+				milestone: `${ pluginSlug } ${ stableTag }`,
 				token: settings.token,
 			} );
-			updateReadmeChangelog( changelog, settings );
+			const status = updateReadmeChangelog( readmeFilePath, changelog );
+			log(
+				formats.success(
+					`💃 ${ pluginSlug } successfully updated for version ${ stableTag }: ${ status }`
+				)
+			);
 		} catch ( error ) {
-			if ( error instanceof Error ) {
-				log( formats.error( error.stack ) );
-				return;
-			}
+			log(
+				formats.error(
+					`${ pluginSlug } failed to update: ${ error.message }`
+				)
+			);
 		}
-		log(
-			formats.success( `\n💃${ settings.path } successfully updated\n\n` )
-		);
 	}
 }

--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -34,16 +34,14 @@ exports.options = [
  * @return {Promise<string>} Consistent version.
  */
 async function checkPluginDirectory( pluginDirectory ) {
-	const readmeContents = fs.readFileSync(
-		path.resolve( pluginDirectory, 'readme.txt' ),
-		'utf-8'
-	);
+	const readmeFilePath = path.resolve( pluginDirectory, 'readme.txt' );
+	const readmeContents = fs.readFileSync( readmeFilePath, 'utf-8' );
 
 	const stableTagVersionMatches = readmeContents.match(
 		/^Stable tag:\s*(\d+\.\d+\.\d+)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
-		throw new Error( 'Unable to locate stable tag in readme.txt' );
+		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );
 	}
 	const stableTagVersion = stableTagVersionMatches[ 1 ];
 


### PR DESCRIPTION
_This is a sub-PR of #1223. Merge it before merging this one._

As part of the 3.1.0 release, the readme changelogs need to be updated for the plugins. For the Performance Lab plugin, the instructions are:

<blockquote>Run <code>npm run readme -- -m "performance-lab $VERSION_NUMBER"</code> to update the <code>readme.txt</code> file with the release changelog, where the quoted string is the name of the milestone. For example, if the milestone is <code>performance-lab 3.0.0</code>, the command needs to be <code>npm run readme -- -m "performance-lab 3.0.0"</code>.</blockquote>

And for standalone plugins:

<blockquote>Ensure the plugin’s <code>readme.txt</code> already contains the changelog section with all entries for the new version. You can use <code>npm run changelog -- --milestone="$plugin_slug $plugin_version"</code>.</blockquote>

This is tedious for couple reasons (similarly to #1223 for the `since` command):

1. You have to manually look up the current version for each plugin.
2. You have to constrict the milestone name by concatenating the plugin slug with the version.
3. You have to do this for each plugin separately.

This PR makes this process much easier by allowing you to just run `npm run readme` in one go to update all plugins in one go. The version is automatically pulled from the `Stable tag` in the `readme.txt`, and the list of all of the plugin slugs is pulled from `plugins.json`. If you want to just update a single plugin, you can do so with the `--plugin` argument.

Additionally, the behavior is improved in the following ways:

1. It does not get confused when there is an `Upgrade Notice` with a heading for the stable tag.
2. It merges any existing changelog content for the stable tag, putting it at the end in an **Other** group.
3. It only considers _merged_ pull requests as opposed to non-merged _closed_ pull requests which may still be in the milestone.
4. When all of the pull requests in a milestone have the `skip changelog` label, then this is now reflected separately in the output, as opposed to there being no merged pull requests at all.
5. Different success messages are shown based on whether the changelog was added as an entirely new section, or it was merged with an existing changelog section

![image](https://github.com/WordPress/performance/assets/134745/a06b3540-dde0-4835-a3f8-f304eeeeeaa0)

Example output: 4023559d