### PR TITLE
Publish 3.1.0 release

### DIFF
--- a/includes/admin/load.php
+++ b/includes/admin/load.php
@@ -398,7 +398,7 @@ function perflab_plugin_admin_notices(): void {
 /**
  * Callback function that print plugin progress indicator script.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  */
 function perflab_print_plugin_progress_indicator_script(): void {
 	$js_function = <<<JS
@@ -434,7 +434,7 @@ JS;
 /**
  * Gets the URL to the plugin settings screen if one exists.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  *
  * @param string $plugin_slug Plugin slug passed to generate the settings link.
  * @return string|null Either the plugin settings URL or null if not available.

--- a/includes/admin/plugins.php
+++ b/includes/admin/plugins.php
@@ -159,7 +159,7 @@ function perflab_render_plugins_ui(): void {
 /**
  * Checks if a given plugin is available.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  * @see perflab_install_and_activate_plugin()
  *
  * @param array{name: string, slug: string, short_description: string, requires_php: string|false, requires: string|false, requires_plugins: string[], version: string} $plugin_data                     Plugin data from the WordPress.org API.
@@ -226,7 +226,7 @@ function perflab_get_plugin_availability( array $plugin_data, array &$processed_
  *
  * Dependencies are recursively installed and activated as well.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  * @see perflab_get_plugin_availability()
  *
  * @param string   $plugin_slug       Plugin slug.

--- a/includes/server-timing/hooks.php
+++ b/includes/server-timing/hooks.php
@@ -4,7 +4,7 @@
  *
  * @package performance-lab
  *
- * @since n.e.x.t
+ * @since 3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds server timing to REST API response.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  *
  * @param WP_REST_Response|WP_Error $response Result to send to the client. Usually a `WP_REST_Response`.
  * @return WP_REST_Response|WP_Error Filtered response.

--- a/includes/server-timing/load.php
+++ b/includes/server-timing/load.php
@@ -54,7 +54,7 @@ function perflab_server_timing(): Perflab_Server_Timing {
 /**
  * Initializes the Server-Timing API.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  */
 function perflab_server_timing_init(): void {
 	perflab_server_timing();
@@ -148,7 +148,7 @@ function perflab_wrap_server_timing( callable $callback, string $metric_slug, st
 /**
  * Gets default value for server timing setting.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  *
  * @return array{benchmarking_actions: string[], benchmarking_filters: string[], output_buffering: bool} Default value.
  */

--- a/includes/site-health/avif-support/helper.php
+++ b/includes/site-health/avif-support/helper.php
@@ -3,7 +3,7 @@
  * Helper functions used for AVIF Support.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Callback for avif_enabled test.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  *
  * @return array{label: string, status: string, badge: array{label: string, color: string}, description: string, actions: string, test: string} Result.
  */

--- a/includes/site-health/avif-support/hooks.php
+++ b/includes/site-health/avif-support/hooks.php
@@ -3,7 +3,7 @@
  * Hook callbacks used for AVIF Support.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds tests to site health.
  *
- * @since n.e.x.t
+ * @since 3.1.0
  *
  * @param array{direct: array<string, array{label: string, test: string}>} $tests Site Health Tests.
  * @return array{direct: array<string, array{label: string, test: string}>} Amended tests.

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -51,6 +51,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 = 1.0.2 =
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 1.0.1 =
 

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -54,14 +54,11 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 **Enhancements**
 
 * Avoid needless array allocation in rgb to hex conversion. ([1104](https://github.com/WordPress/performance/pull/1104))
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 **Bug Fixes**
 
 * Fix Imagick detecting partial transparency. ([1215](https://github.com/WordPress/performance/pull/1215))
-
-**Other**
-
-* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.1.0 =
 

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -55,6 +55,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 * Avoid needless array allocation in rgb to hex conversion. ([1104](https://github.com/WordPress/performance/pull/1104))
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 **Bug Fixes**
 

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -51,6 +51,16 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.1.1 =
 
+**Enhancements**
+
+* Avoid needless array allocation in rgb to hex conversion. ([1104](https://github.com/WordPress/performance/pull/1104))
+
+**Bug Fixes**
+
+* Fix Imagick detecting partial transparency. ([1215](https://github.com/WordPress/performance/pull/1215))
+
+**Other**
+
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.1.0 =

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -54,6 +54,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 **Enhancements**
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 **Bug Fixes**
 

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -51,6 +51,12 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.1.2 =
 
+**Bug Fixes**
+
+* Hide post embed iframes with visibility:hidden instead of clipping. ([1192](https://github.com/WordPress/performance/pull/1192))
+
+**Other**
+
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 0.1.1 =

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -51,13 +51,13 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.1.2 =
 
+**Enhancements**
+
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+
 **Bug Fixes**
 
 * Hide post embed iframes with visibility:hidden instead of clipping. ([1192](https://github.com/WordPress/performance/pull/1192))
-
-**Other**
-
-* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 0.1.1 =
 

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -181,7 +181,7 @@ function od_construct_preload_links( array $lcp_elements_by_minimum_viewport_wid
 /**
  * Determines whether the response has an HTML Content-Type.
  *
- * @since n.e.x.t
+ * @since 0.2.0
  * @private
  *
  * @return bool Whether Content-Type is HTML.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -144,17 +144,13 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 * Add optimization_detective_disabled query var to disable behavior. ([1193](https://github.com/WordPress/performance/pull/1193))
 * Facilitate embedding Optimization Detective in other plugins/themes. ([1185](https://github.com/WordPress/performance/pull/1185))
 * Use PHP 7.2 features in Optimization Detective. ([1162](https://github.com/WordPress/performance/pull/1162))
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 **Bug Fixes**
 
 * Avoid _doing_it_wrong() for Server-Timing in Optimization Detective when output buffering is not enabled. ([1194](https://github.com/WordPress/performance/pull/1194))
 * Ensure only HTML responses are optimized. ([1189](https://github.com/WordPress/performance/pull/1189))
-* Fix PHPStan issues in Optimization Detective. ([1195](https://github.com/WordPress/performance/pull/1195))
 * Fix XPath indices to be 1-based instead of 0-based. ([1191](https://github.com/WordPress/performance/pull/1191))
-
-**Other**
-
-* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 0.1.1 =
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -145,6 +145,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 * Facilitate embedding Optimization Detective in other plugins/themes. ([1185](https://github.com/WordPress/performance/pull/1185))
 * Use PHP 7.2 features in Optimization Detective. ([1162](https://github.com/WordPress/performance/pull/1162))
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 **Bug Fixes**
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -139,6 +139,21 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.2.0 =
 
+**Enhancements**
+
+* Add optimization_detective_disabled query var to disable behavior. ([1193](https://github.com/WordPress/performance/pull/1193))
+* Facilitate embedding Optimization Detective in other plugins/themes. ([1185](https://github.com/WordPress/performance/pull/1185))
+* Use PHP 7.2 features in Optimization Detective. ([1162](https://github.com/WordPress/performance/pull/1162))
+
+**Bug Fixes**
+
+* Avoid _doing_it_wrong() for Server-Timing in Optimization Detective when output buffering is not enabled. ([1194](https://github.com/WordPress/performance/pull/1194))
+* Ensure only HTML responses are optimized. ([1189](https://github.com/WordPress/performance/pull/1189))
+* Fix PHPStan issues in Optimization Detective. ([1195](https://github.com/WordPress/performance/pull/1195))
+* Fix XPath indices to be 1-based instead of 0-based. ([1191](https://github.com/WordPress/performance/pull/1191))
+
+**Other**
+
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 0.1.1 =

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -116,6 +116,13 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.3.0 =
 
+**Enhancements**
+
+* Facilitate embedding Speculative Loading in other plugins/themes. ([1159](https://github.com/WordPress/performance/pull/1159))
+* Prevent speculatively loading links to the uploads, content, plugins, template, or stylesheet directories. ([1167](https://github.com/WordPress/performance/pull/1167))
+
+**Other**
+
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.2.2 =

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -118,11 +118,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 **Enhancements**
 
-* Facilitate embedding Speculative Loading in other plugins/themes. ([1159](https://github.com/WordPress/performance/pull/1159))
 * Prevent speculatively loading links to the uploads, content, plugins, template, or stylesheet directories. ([1167](https://github.com/WordPress/performance/pull/1167))
-
-**Other**
-
+* Facilitate embedding Speculative Loading in other plugins/themes. ([1159](https://github.com/WordPress/performance/pull/1159))
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.2.2 =

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -121,6 +121,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 * Prevent speculatively loading links to the uploads, content, plugins, template, or stylesheet directories. ([1167](https://github.com/WordPress/performance/pull/1167))
 * Facilitate embedding Speculative Loading in other plugins/themes. ([1159](https://github.com/WordPress/performance/pull/1159))
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 1.2.2 =
 

--- a/plugins/webp-uploads/deprecated.php
+++ b/plugins/webp-uploads/deprecated.php
@@ -4,7 +4,7 @@
  *
  * @package webp-uploads
  *
- * @since n.e.x.t
+ * @since 1.1.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -65,14 +65,11 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 **Enhancements**
 
 * Prepend Settings link in webp-uploads. ([1146](https://github.com/WordPress/performance/pull/1146))
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 **Documentation**
 
 * Updated inline documentation. ([1160](https://github.com/WordPress/performance/pull/1160))
-
-**Other**
-
-* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.1.0 =
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -62,6 +62,16 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 1.1.1 =
 
+**Enhancements**
+
+* Prepend Settings link in webp-uploads. ([1146](https://github.com/WordPress/performance/pull/1146))
+
+**Documentation**
+
+* Updated inline documentation. ([1160](https://github.com/WordPress/performance/pull/1160))
+
+**Other**
+
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 1.1.0 =

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -66,6 +66,7 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 * Prepend Settings link in webp-uploads. ([1146](https://github.com/WordPress/performance/pull/1146))
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 **Documentation**
 

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -92,7 +92,7 @@ add_action( 'admin_head-options-media.php', 'webp_uploads_media_setting_style' )
  * Adds a settings link to the plugin's action links.
  *
  * @since 1.1.0
- * @since n.e.x.t Renamed from webp_uploads_settings_link() to webp_uploads_add_settings_action_link()
+ * @since 1.1.1 Renamed from webp_uploads_settings_link() to webp_uploads_add_settings_action_link()
  *
  * @param string[]|mixed $links An array of plugin action links.
  * @return string[]|mixed The modified list of actions.

--- a/readme.txt
+++ b/readme.txt
@@ -62,6 +62,35 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.1.0 =
 
+**Enhancements**
+
+* Add Progress indicator when activating a feature. ([1190](https://github.com/WordPress/performance/pull/1190))
+* Add plugin dependency support for activating performance features. ([1184](https://github.com/WordPress/performance/pull/1184))
+* Add support for AVIF image in site health. ([1177](https://github.com/WordPress/performance/pull/1177))
+* Added server timing to REST API response. ([1206](https://github.com/WordPress/performance/pull/1206))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
+* Fix function stub docs. ([1204](https://github.com/WordPress/performance/pull/1204))
+* Improve static analysis in Performance Lab plugin files. ([1188](https://github.com/WordPress/performance/pull/1188))
+* Refine logic in perflab_install_activate_plugin_callback() to rely only on validated slug. ([1170](https://github.com/WordPress/performance/pull/1170))
+* Update PHPStan to 1.11.1. ([1213](https://github.com/WordPress/performance/pull/1213))
+* Updated code to display plugin settings link in the features screen and fix responsive layout for mobile. ([1208](https://github.com/WordPress/performance/pull/1208))
+
+**Bug Fixes**
+
+* Avoid passing incomplete data to perflab_render_plugin_card() and show error when plugin directory API query fails. ([1175](https://github.com/WordPress/performance/pull/1175))
+* Do not show on the settings page and dismiss the pointer. ([1147](https://github.com/WordPress/performance/pull/1147))
+* Fix `WordPress.DB.DirectDatabaseQuery.DirectQuery` warning for Autoloaded Options Health Check. ([1179](https://github.com/WordPress/performance/pull/1179))
+* Update PHPStan level to 1. ([1198](https://github.com/WordPress/performance/pull/1198))
+* Update PHPStan level to 2. ([1199](https://github.com/WordPress/performance/pull/1199))
+* Update PHPStan level to 3. ([1200](https://github.com/WordPress/performance/pull/1200))
+* Update PHPStan level to 4. ([1201](https://github.com/WordPress/performance/pull/1201))
+* Update PHPStan level to 5. ([1202](https://github.com/WordPress/performance/pull/1202))
+* Update PHPStan level to 6. ([1203](https://github.com/WordPress/performance/pull/1203))
+* Update PHPStan level to 7. ([1205](https://github.com/WordPress/performance/pull/1205))
+* Update PHPStan level to 8. ([1210](https://github.com/WordPress/performance/pull/1210))
+
+**Other**
+
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 3.0.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -64,34 +64,20 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 **Enhancements**
 
-* Add Progress indicator when activating a feature. ([1190](https://github.com/WordPress/performance/pull/1190))
+* Add progress indicator when activating a feature. ([1190](https://github.com/WordPress/performance/pull/1190))
+* Display plugin settings links in the features screen and fix responsive layout for mobile. ([1208](https://github.com/WordPress/performance/pull/1208))
 * Add plugin dependency support for activating performance features. ([1184](https://github.com/WordPress/performance/pull/1184))
-* Add support for AVIF image in site health. ([1177](https://github.com/WordPress/performance/pull/1177))
-* Added server timing to REST API response. ([1206](https://github.com/WordPress/performance/pull/1206))
+* Add support for AVIF image format in site health. ([1177](https://github.com/WordPress/performance/pull/1177))
+* Add server timing to REST API response. ([1206](https://github.com/WordPress/performance/pull/1206))
 * Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
-* Fix function stub docs. ([1204](https://github.com/WordPress/performance/pull/1204))
-* Improve static analysis in Performance Lab plugin files. ([1188](https://github.com/WordPress/performance/pull/1188))
 * Refine logic in perflab_install_activate_plugin_callback() to rely only on validated slug. ([1170](https://github.com/WordPress/performance/pull/1170))
-* Update PHPStan to 1.11.1. ([1213](https://github.com/WordPress/performance/pull/1213))
-* Updated code to display plugin settings link in the features screen and fix responsive layout for mobile. ([1208](https://github.com/WordPress/performance/pull/1208))
+* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 **Bug Fixes**
 
 * Avoid passing incomplete data to perflab_render_plugin_card() and show error when plugin directory API query fails. ([1175](https://github.com/WordPress/performance/pull/1175))
-* Do not show on the settings page and dismiss the pointer. ([1147](https://github.com/WordPress/performance/pull/1147))
+* Do not show admin pointer on the Performance screen and dismiss the pointer when visited. ([1147](https://github.com/WordPress/performance/pull/1147))
 * Fix `WordPress.DB.DirectDatabaseQuery.DirectQuery` warning for Autoloaded Options Health Check. ([1179](https://github.com/WordPress/performance/pull/1179))
-* Update PHPStan level to 1. ([1198](https://github.com/WordPress/performance/pull/1198))
-* Update PHPStan level to 2. ([1199](https://github.com/WordPress/performance/pull/1199))
-* Update PHPStan level to 3. ([1200](https://github.com/WordPress/performance/pull/1200))
-* Update PHPStan level to 4. ([1201](https://github.com/WordPress/performance/pull/1201))
-* Update PHPStan level to 5. ([1202](https://github.com/WordPress/performance/pull/1202))
-* Update PHPStan level to 6. ([1203](https://github.com/WordPress/performance/pull/1203))
-* Update PHPStan level to 7. ([1205](https://github.com/WordPress/performance/pull/1205))
-* Update PHPStan level to 8. ([1210](https://github.com/WordPress/performance/pull/1210))
-
-**Other**
-
-* Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
 
 = 3.0.0 =
 


### PR DESCRIPTION
Previously: https://github.com/WordPress/performance/pull/1125

- [x] Bump stable tag in `readme.txt`
- [x] Bump versions in `load.php`
- [x] Run `npm run since`
- [x] Run `npm run readme`
- [x] Review changelogs for accuracy.
- [x] Review diff with previous plugin versions.
- [x] Test the builds.

Fixes #1212