### PR TITLE
Add missing PHP version bump changelog

### DIFF
--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -51,6 +51,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 = 1.0.2 =
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 1.0.1 =
 

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -52,6 +52,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 = 1.1.1 =
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 1.1.0 =
 

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -52,6 +52,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 = 0.1.2 =
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 0.1.1 =
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -140,6 +140,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 = 0.2.0 =
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 0.1.1 =
 

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -117,6 +117,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 = 1.3.0 =
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 1.2.2 =
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -63,6 +63,7 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 = 1.1.1 =
 
 * Improve overall code quality with stricter static analysis checks. ([775](https://github.com/WordPress/performance/issues/775))
+* Bump minimum PHP requirement to 7.2. ([1130](https://github.com/WordPress/performance/pull/1130))
 
 = 1.1.0 =
 


### PR DESCRIPTION
## Summary

Fix https://github.com/WordPress/performance/pull/1225#pullrequestreview-2065283614 

In this PR we added the missing changelog entry.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
