### PR TITLE
Re-remove unneeded phpcs:ignore

### DIFF
--- a/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
@@ -32,7 +32,6 @@ class Dominant_Color_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 		}
 
 		try {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 			$this->image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
 			$pixel = $this->image->getImagePixelColor( 0, 0 );


### PR DESCRIPTION
Re-applies 1c27166abef745414b56c77eae89e0d320e2ad3b which was somehow undone.

With this, there are no other instances of `phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged` in the codebase.

Fixes #709