### PR TITLE
Check if rel contains nofollow instead of being just nofollow when excluding speculative loading

### DIFF
--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -103,7 +103,7 @@ function plsr_get_speculation_rules(): array {
 					// Also exclude rel=nofollow links, as plugins like WooCommerce use that on their add-to-cart links.
 					array(
 						'not' => array(
-							'selector_matches' => 'a[rel=nofollow]',
+							'selector_matches' => 'a[rel*=nofollow]',
 						),
 					),
 				),

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -103,7 +103,7 @@ function plsr_get_speculation_rules(): array {
 					// Also exclude rel=nofollow links, as plugins like WooCommerce use that on their add-to-cart links.
 					array(
 						'not' => array(
-							'selector_matches' => 'a[rel*=nofollow]',
+							'selector_matches' => 'a[rel~="nofollow"]',
 						),
 					),
 				),

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Enables browsers to speculatively prerender or prefetch pages when hovering over links.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 1.3.0
+ * Version: 1.3.1-alpha
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'plsr_pending_plugin_info',
-	'1.3.0',
+	'1.3.1-alpha',
 	static function ( string $version ): void {
 
 		// Define the constant.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

Fixes issue raised here: https://wordpress.org/support/topic/arelnofollow-exact-match-only/

## Relevant technical choices

<!-- Please describe your changes. -->

Made the selector wider as [detailed here](https://stackoverflow.com/a/8714421/2144578).

There were no unit tests for this one. Maybe should add some but didn't see an easy one I could copy and paste as none of the existing ones are attribute based.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
