### PR TITLE
Fix selector for blocking speculative loading when rel attribute contains more than nofollow link type token

### DIFF
--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -103,7 +103,7 @@ function plsr_get_speculation_rules(): array {
 					// Also exclude rel=nofollow links, as plugins like WooCommerce use that on their add-to-cart links.
 					array(
 						'not' => array(
-							'selector_matches' => 'a[rel=nofollow]',
+							'selector_matches' => 'a[rel~="nofollow"]',
 						),
 					),
 				),

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Enables browsers to speculatively prerender or prefetch pages when hovering over links.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 1.3.0
+ * Version: 1.3.1-alpha
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'plsr_pending_plugin_info',
-	'1.3.0',
+	'1.3.1-alpha',
 	static function ( string $version ): void {
 
 		// Define the constant.


### PR DESCRIPTION
As reported in a [support topic](https://wordpress.org/support/topic/arelnofollow-exact-match-only/), the CSS selector for preventing speculative loading for `rel=nofollow` links is overly constrictive. It doesn't allow for the fact that other link type tokens. So it currently fails to prevent speculative loading of `<a href="/our-sponsor/" rel="nofollow sponsored">`. To fix this, the attribute contains selector should be used instead.