### PR TITLE
Update versions command to account for pre-release identifier

### DIFF
--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -38,7 +38,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const readmeContents = fs.readFileSync( readmeFilePath, 'utf-8' );
 
 	const stableTagVersionMatches = readmeContents.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+)$/m
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-\w+)?)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
 		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );
@@ -46,7 +46,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const stableTagVersion = stableTagVersionMatches[ 1 ];
 
 	const latestChangelogMatches = readmeContents.match(
-		/^== Changelog ==\n+= (\d+\.\d+\.\d+) =$/m
+		/^== Changelog ==\n+= (\d+\.\d+\.\d+(?:-\w+)?) =$/m
 	);
 	if ( ! latestChangelogMatches ) {
 		throw new Error(
@@ -71,7 +71,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	}
 
 	const headerVersionMatches = phpBootstrapFileContents.match(
-		/^ \* Version:\s+(\d+\.\d+\.\d+)$/m
+		/^ \* Version:\s+(\d+\.\d+\.\d+(?:-\w+)?)$/m
 	);
 	if ( ! headerVersionMatches ) {
 		throw new Error(
@@ -80,8 +80,9 @@ async function checkPluginDirectory( pluginDirectory ) {
 	}
 	const headerVersion = headerVersionMatches[ 1 ];
 
-	const phpLiteralVersionMatches =
-		phpBootstrapFileContents.match( /'(\d+\.\d+\.\d+?)'/ );
+	const phpLiteralVersionMatches = phpBootstrapFileContents.match(
+		/'(\d+\.\d+\.\d+(?:-\w+)?)'/
+	);
 	if ( ! phpLiteralVersionMatches ) {
 		throw new Error( 'Unable to locate the PHP literal version.' );
 	}

--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -97,12 +97,16 @@ async function checkPluginDirectory( pluginDirectory ) {
 
 	if ( ! allVersions.every( ( version ) => version === stableTagVersion ) ) {
 		throw new Error(
-			`Version mismatch: ${ JSON.stringify( {
-				latestChangelogVersion,
-				headerVersion,
-				stableTagVersion,
-				phpLiteralVersion,
-			} ) }`
+			`Version mismatch: ${ JSON.stringify(
+				{
+					latestChangelogVersion,
+					headerVersion,
+					stableTagVersion,
+					phpLiteralVersion,
+				},
+				null,
+				4
+			) }`
 		);
 	}
 

--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -141,7 +141,15 @@ exports.handler = async ( opt ) => {
 		const slug = path.basename( pluginDirectory );
 		try {
 			const version = await checkPluginDirectory( pluginDirectory );
-			log( formats.success( `✅ ${ slug }: ${ version } ` ) );
+			if ( version.includes( '-' ) ) {
+				log(
+					formats.warning(
+						`⚠ ${ slug }: ${ version } (pre-release identifier is present)`
+					)
+				);
+			} else {
+				log( formats.success( `✅ ${ slug }: ${ version } ` ) );
+			}
 		} catch ( error ) {
 			errorCount++;
 			log( formats.error( `❌ ${ slug }: ${ error.message }` ) );


### PR DESCRIPTION
This is a follow-up to #1221.

Before:

![Screenshot 2024-05-20 13 39 49](https://github.com/WordPress/performance/assets/134745/e5f87da3-faef-45f8-95b8-89122b13b421)

After:

![image](https://github.com/WordPress/performance/assets/134745/09accf0b-5028-4d14-a1ca-2246804f22fd)

And if the `stable tag` and `readme.txt` changelog are also updated to reference the pre-release version:

![Screenshot 2024-05-20 13 44 24](https://github.com/WordPress/performance/assets/134745/5833028b-4d80-4416-99d7-7e538d199b29)
