### PR TITLE
Harden autoloaded-options site health test for mis-implemented external object cache plugins

### DIFF
--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -98,6 +98,11 @@ function perflab_aao_autoloaded_options_test(): array {
  * @return int autoloaded data in bytes.
  */
 function perflab_aao_autoloaded_options_size(): int {
+	/**
+	 * External object cache plugins may return mixed values including arrays and objects instead of them being serialized.
+	 *
+	 * @var array<string, string|array<int|string, mixed>|object> $all_options
+	 */
 	$all_options = wp_load_alloptions();
 
 	$total_length = 0;

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -107,8 +107,11 @@ function perflab_aao_autoloaded_options_size(): int {
 
 	$total_length = 0;
 
-	foreach ( $all_options as $option_name => $option_value ) {
-		$total_length += strlen( $option_value );
+	foreach ( $all_options as $option_value ) {
+		if ( is_array( $option_value ) || is_object( $option_value ) ) {
+			$option_value = serialize( $option_value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		}
+		$total_length += strlen( (string) $option_value );
 	}
 
 	return $total_length;


### PR DESCRIPTION
Fixes #1237

In core, `wp_load_alloptions()` returns strings, with arrays and objects being serialized. However, some object cache plugins (namely Docket Cache) may return mixed values, including arrays and objects. This hardens `perflab_aao_autoloaded_options_size()` to account for this by ensuring all array and object values are serialized before computing the string length.