### PR TITLE
Remove chalk package

### DIFF
--- a/bin/plugin/lib/logger.js
+++ b/bin/plugin/lib/logger.js
@@ -1,21 +1,30 @@
 /**
  * External dependencies
  */
-const chalk = require( 'chalk' );
+const { styleText } = require( 'node:util' );
 
-const title = chalk.bold;
-const error = chalk.bold.red;
-const warning = chalk.bold.keyword( 'orange' );
-const success = chalk.bold.green;
+/**
+ * Create a function that applies a style to text using `node:util.styleText`.
+ *
+ * @param {string} style Style to apply to the text
+ *
+ * @return {Function} Function that applies the style to the text
+ */
+const createStyledText = ( style ) => ( text ) => styleText( style, text );
+
+const bold = createStyledText( 'bold' );
+const error = createStyledText( 'red' );
+const warning = createStyledText( 'yellowBright' );
+const success = createStyledText( 'green' );
 
 const log = console.log; // eslint-disable-line no-console
 
 module.exports = {
 	log,
 	formats: {
-		title,
-		error,
-		warning,
-		success,
+		title: bold,
+		error: ( text ) => bold( error( text ) ),
+		warning: ( text ) => bold( warning( text ) ),
+		success: ( text ) => bold( success( text ) ),
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@octokit/rest": "^19.0.5",
         "@wordpress/env": "^9.6.0",
         "@wordpress/scripts": "^26.19.0",
-        "chalk": "^4.1.2",
         "commander": "^9.4.1",
         "copy-webpack-plugin": "^12.0.2",
         "fast-glob": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@octokit/rest": "^19.0.5",
     "@wordpress/env": "^9.6.0",
     "@wordpress/scripts": "^26.19.0",
-    "chalk": "^4.1.2",
     "commander": "^9.4.1",
     "copy-webpack-plugin": "^12.0.2",
     "fast-glob": "^3.3.2",


### PR DESCRIPTION
## Summary

We are currently using an outdated version of the chalk package, which is now ESM-only. The good news is that Node.js has introduced the [`util.styleText`](https://nodejs.org/api/util.html#utilstyletextformat-text) API, which provides the same functionality.

This PR replaces the chalk package with Node.js-specific utilities, streamlining our dependencies and leveraging the latest Node.js features.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
