### PR TITLE
Fix Server-Timing compatibility with other plugins that do output buffering

### DIFF
--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -238,19 +238,22 @@ class Perflab_Server_Timing {
 	 * @return mixed Unmodified value of $passthrough.
 	 */
 	public function on_template_include( $passthrough = null ) {
-		if ( ! $this->use_output_buffer() ) {
-			$this->send_header();
-			return $passthrough;
-		}
+		$this->send_header();
+		return $passthrough;
+	}
 
+	/**
+	 * Starts output buffering to send the Server-Timing header right before returning the buffer.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function start_output_buffer(): void {
 		ob_start(
 			function ( $output ) {
-				#$output .= 'SENT HEADER';
 				$this->send_header();
 				return $output;
 			}
 		);
-		return $passthrough;
 	}
 
 	/**

--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -245,6 +245,7 @@ class Perflab_Server_Timing {
 
 		ob_start(
 			function ( $output ) {
+				#$output .= 'SENT HEADER';
 				$this->send_header();
 				return $output;
 			}

--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -226,6 +226,25 @@ class Perflab_Server_Timing {
 	}
 
 	/**
+	 * Adds hooks to send the Server-Timing header.
+	 *
+	 * When output buffering is enabled, buffer as early as possible so that any other plugins that also do output
+	 * buffering will be able to register Server-Timing metrics. The first output buffer callback to be registered
+	 * is the last one to be called, so by starting the Server-Timing output buffer as soon as possible we can be
+	 * assured that other plugins' output buffer callbacks will run before the Server-Timing one that sends the
+	 * Server-Timing header.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function add_hooks(): void {
+		if ( $this->use_output_buffer() ) {
+			add_action( 'template_redirect', array( $this, 'start_output_buffer' ), PHP_INT_MIN );
+		} else {
+			add_filter( 'template_include', array( $this, 'on_template_include' ), PHP_INT_MAX );
+		}
+	}
+
+	/**
 	 * Hook callback for the 'template_include' filter.
 	 *
 	 * This effectively initializes the class to send the Server-Timing header at the right point.

--- a/plugins/performance-lab/includes/server-timing/load.php
+++ b/plugins/performance-lab/includes/server-timing/load.php
@@ -46,13 +46,17 @@ function perflab_server_timing(): Perflab_Server_Timing {
 		}
 
 		/*
-		 * Send the Server-Timing header right before the template is included (and rendered on the page) or else start
-		 * output buffering at this point to then send the Server-Timing header in the output buffer callback. Note that
-		 * a priority of PHP_INT_MAX-1 is used so that other plugins that also do output buffering can start their
-		 * buffering at PHP_INT_MAX and ensure that they can register their own Server-Timing metrics successfully when
-		 * the outer output buffer callback here for Server-Timing is called. Otherwise, a _doing_it_wrong() may ensue.
+		 * When output buffering is enabled, buffer as early as possible so that any other plugins that also do output
+		 * buffering will be able to register Server-Timing metrics. The first output buffer callback to be registered
+		 * is the last one to be called, so by starting the Server-Timing output buffer as soon as possible we can be
+		 * assured that other plugins' output buffer callbacks will run before the Server-Timing one that sends the
+		 * Server-Timing header.
 		 */
-		add_filter( 'template_include', array( $server_timing, 'on_template_include' ), PHP_INT_MAX - 1 );
+		if ( $server_timing->use_output_buffer() ) {
+			add_action( 'template_redirect', array( $server_timing, 'start_output_buffer' ), PHP_INT_MIN );
+		} else {
+			add_filter( 'template_include', array( $server_timing, 'on_template_include' ), PHP_INT_MAX );
+		}
 	}
 
 	return $server_timing;

--- a/plugins/performance-lab/includes/server-timing/load.php
+++ b/plugins/performance-lab/includes/server-timing/load.php
@@ -45,18 +45,7 @@ function perflab_server_timing(): Perflab_Server_Timing {
 			return $server_timing;
 		}
 
-		/*
-		 * When output buffering is enabled, buffer as early as possible so that any other plugins that also do output
-		 * buffering will be able to register Server-Timing metrics. The first output buffer callback to be registered
-		 * is the last one to be called, so by starting the Server-Timing output buffer as soon as possible we can be
-		 * assured that other plugins' output buffer callbacks will run before the Server-Timing one that sends the
-		 * Server-Timing header.
-		 */
-		if ( $server_timing->use_output_buffer() ) {
-			add_action( 'template_redirect', array( $server_timing, 'start_output_buffer' ), PHP_INT_MIN );
-		} else {
-			add_filter( 'template_include', array( $server_timing, 'on_template_include' ), PHP_INT_MAX );
-		}
+		$server_timing->add_hooks();
 	}
 
 	return $server_timing;

--- a/plugins/performance-lab/includes/server-timing/load.php
+++ b/plugins/performance-lab/includes/server-timing/load.php
@@ -45,7 +45,14 @@ function perflab_server_timing(): Perflab_Server_Timing {
 			return $server_timing;
 		}
 
-		add_filter( 'template_include', array( $server_timing, 'on_template_include' ), PHP_INT_MAX );
+		/*
+		 * Send the Server-Timing header right before the template is included (and rendered on the page) or else start
+		 * output buffering at this point to then send the Server-Timing header in the output buffer callback. Note that
+		 * a priority of PHP_INT_MAX-1 is used so that other plugins that also do output buffering can start their
+		 * buffering at PHP_INT_MAX and ensure that they can register their own Server-Timing metrics successfully when
+		 * the outer output buffer callback here for Server-Timing is called. Otherwise, a _doing_it_wrong() may ensue.
+		 */
+		add_filter( 'template_include', array( $server_timing, 'on_template_include' ), PHP_INT_MAX - 1 );
 	}
 
 	return $server_timing;


### PR DESCRIPTION
## Summary

When testing with WordPress core trunk (6.6-alpha), I noticed a `_doing_it_wrong()` notice:

> PHP Notice:  Function Perflab_Server_Timing::register_metric was called incorrectly. The method must be called before or during the perflab_server_timing_send_header action. Please see <a>Debugging in WordPress</a> for more information.  in /var/www/html/wp-includes/functions.php on line 6078

In looking at Query Monitor, it identifies Optimization Detective in the stack trace:

![Perflab_Server_Timing->register_metric()
wp-content/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php:71
perflab_server_timing_register_metric()
wp-content/plugins/performance-lab/includes/server-timing/load.php:85
{closure}()
wp-content/plugins/performance-lab/includes/server-timing/load.php:118
apply_filters('od_template_output_buffer')
wp-includes/plugin.php:205
{closure}()
wp-content/plugins/optimization-detective/optimization.php:44
ob_end_flush()
wp-content/plugins/optimization-detective/optimization.php:44
wp_ob_end_flush_all()
wp-includes/functions.php:5420
do_action('shutdown')
wp-includes/plugin.php:517
shutdown_action_hook()
wp-includes/load.php:1270](https://github.com/WordPress/performance/assets/134745/bea4bc00-600d-4eff-83e8-f53072b9d952)

With `git bisect` I discovered the issue started with r57920 for Core-42441. Nevertheless, in looking at that commit I see nothing which would seem to be related to this. There seems to be some race condition happening due to the fact that the Server-Timing component is starting output buffering at `PHP_INT_MAX` while Optimization Detective is doing the same. In order for Optimization Detective to register its Server-Timing metric and for Server-Timing to be able to send the header successfully, the Server-Timing component (counter intuitively) needs to start its output buffer _first_ so that it wraps the output buffer of Optimization Detective and and other plugins which may be starting the output buffer at `PHP_INT_MAX`. The callback for the first output buffer is executed last. 

So this PR changes the priority for the Server-Timing output buffer to start now at the minimum `template_redirect` action priority so that its output buffer callback is invoked _last_, allowing any other plugins that do output buffering and add server-timing metrics (e.g. Optimization Detective) to be able to do so in their own output buffer callbacks which run before the the Server-Timing callback is invoked.

Note: To test this you need to (1) enable output buffering in the Server-Timing screen, and (2) access the site while logged-out of the admin or add a `add_filter( 'od_can_optimize_response', '__return_true' )` filter since by default Optimization Detective does not run for admins.