### PR TITLE
Fix lint-staged config for plugins

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const micromatch = require( 'micromatch' );
+
+/**
+ * Internal dependencies
+ */
+const { plugins } = require( './plugins.json' );
+
+/**
+ * Join and escape filenames for shell.
+ *
+ * @param {string[]} files Files to join.
+ *
+ * @return {string} Joined files.
+ */
+const joinFiles = ( files ) => {
+	return files.map( ( file ) => `'${ file }'` ).join( ' ' );
+};
+
+// Get plugin base name to match regex more accurately.
+// Else it can cause issues when this plugin is places in `wp-content/plugins` directory.
+const PLUGIN_BASE_NAME = path.basename( __dirname );
+
+module.exports = {
+	'**/*.js': ( files ) => `npm run lint-js ${ joinFiles( files ) }`,
+	'**/*.php': ( files ) => {
+		const commands = [ 'composer phpstan' ];
+
+		plugins.forEach( ( plugin ) => {
+			const pluginFiles = micromatch(
+				files,
+				`**/${ PLUGIN_BASE_NAME }/plugins/${ plugin }/**`,
+				{ dot: true }
+			);
+
+			if ( pluginFiles.length ) {
+				commands.push(
+					`npm run lint:php:plugins --plugin=${ plugin } ${ joinFiles(
+						pluginFiles
+					) }`
+				);
+			}
+		} );
+
+		const otherFiles = micromatch(
+			files,
+			`!**/${ PLUGIN_BASE_NAME }/plugins/**`,
+			{ dot: true }
+		);
+
+		if ( otherFiles.length ) {
+			commands.push( `composer lint ${ joinFiles( otherFiles ) }` );
+		}
+
+		return commands;
+	},
+};

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -21,7 +21,7 @@ const joinFiles = ( files ) => {
 };
 
 // Get plugin base name to match regex more accurately.
-// Else it can cause issues when this plugin is places in `wp-content/plugins` directory.
+// Else it can cause issues when this plugin is placed in `wp-content/plugins` directory.
 const PLUGIN_BASE_NAME = path.basename( __dirname );
 
 module.exports = {

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -38,9 +38,7 @@ module.exports = {
 
 			if ( pluginFiles.length ) {
 				commands.push(
-					`npm run lint:php:plugins --plugin=${ plugin } ${ joinFiles(
-						pluginFiles
-					) }`
+					`composer lint:${ plugin } ${ joinFiles( pluginFiles ) }`
 				);
 			}
 		} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "husky": "^8.0.2",
         "lint-staged": "^13.1.0",
         "lodash": "4.17.21",
+        "micromatch": "^4.0.7",
         "npm-run-all": "^4.1.5",
         "webpackbar": "^6.0.1"
       },
@@ -6231,12 +6232,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -9861,9 +9862,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -13916,12 +13917,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
+      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -48,14 +48,5 @@
     "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance composer test-multisite:plugins",
     "wp-env": "wp-env",
     "prepare": "husky install"
-  },
-  "lint-staged": {
-    "*.php": [
-      "composer run-script lint",
-      "composer run-script phpstan"
-    ],
-    "*.js": [
-      "npm run lint-js"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "husky": "^8.0.2",
     "lint-staged": "^13.1.0",
     "lodash": "4.17.21",
+    "micromatch": "^4.0.7",
     "npm-run-all": "^4.1.5",
     "webpackbar": "^6.0.1"
   },


### PR DESCRIPTION
## Summary

See https://github.com/WordPress/performance/pull/1089

## Relevant technical choices

- Move lint-staged config from `package.json` to `lint-staged.config.js`.
- Add dynamic config based on staged files.
