### PR TITLE
Add install note after each PerfLab feature plugin in the plugin list table

### DIFF
--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -485,7 +485,7 @@ function perflab_print_row_meta_install_notice( string $plugin_file ): void {
 	}
 
 	$message = sprintf(
-		/* translators: placeholder is link to Performance Lab screen */
+		/* translators: %s: link to Performance Lab settings screen */
 		__( 'This plugin is installed by %s.', 'performance-lab' ),
 		sprintf(
 			'<a href="%s">%s</a>',

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -487,7 +487,7 @@ function perflab_print_row_meta_install_notice( string $plugin_file ): void {
 	$message = sprintf(
 		/* translators: %s: link to Performance Lab settings screen */
 		__( 'This plugin is installed by <a href="%s">Performance Lab</a>', 'performance-lab' ),
-		esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' )
+		esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) )
 	);
 
 	printf(

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -471,3 +471,28 @@ function perflab_get_plugin_settings_url( string $plugin_slug ): ?string {
 
 	return null;
 }
+
+/**
+ * Prints the Performance Lab install notice after each feature plugin's row meta.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $plugin_file Plugin file.
+ */
+function perflab_print_row_meta_install_notice( string $plugin_file ): void {
+	if ( ! in_array( strtok( $plugin_file, '/' ), perflab_get_standalone_plugins(), true ) ) {
+		return;
+	}
+
+	$message = sprintf(
+		/* translators: placeholder is URL to Performance Lab screen */
+		__( 'This plugin is installed by <a href="%s">Performance Lab</a>.', 'performance-lab' ),
+		esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) )
+	);
+
+	printf(
+		'<div class="requires"><p>%1$s</p></div>',
+		wp_kses( $message, array( 'a' => array( 'href' => array() ) ) )
+	);
+}
+add_action( 'after_plugin_row_meta', 'perflab_print_row_meta_install_notice' );

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -486,12 +486,8 @@ function perflab_print_row_meta_install_notice( string $plugin_file ): void {
 
 	$message = sprintf(
 		/* translators: %s: link to Performance Lab settings screen */
-		__( 'This plugin is installed by %s.', 'performance-lab' ),
-		sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) ),
-			__( 'Performance Lab', 'performance-lab' )
-		)
+		__( 'This plugin is installed by <a href="%s">Performance Lab</a>', 'performance-lab' ),
+		esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' )
 	);
 
 	printf(

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -485,9 +485,13 @@ function perflab_print_row_meta_install_notice( string $plugin_file ): void {
 	}
 
 	$message = sprintf(
-		/* translators: placeholder is URL to Performance Lab screen */
-		__( 'This plugin is installed by <a href="%s">Performance Lab</a>.', 'performance-lab' ),
-		esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) )
+		/* translators: placeholder is link to Performance Lab screen */
+		__( 'This plugin is installed by %s.', 'performance-lab' ),
+		sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) ),
+			__( 'Performance Lab', 'performance-lab' )
+		)
 	);
 
 	printf(


### PR DESCRIPTION
Fixes #1222

As suggested by @justlevine in https://github.com/WordPress/performance/issues/1222#issuecomment-2126933903:

> Has adopting the design language from the `Plugin Dependencies` feature already been discussed and discarded?
> 
> A standard _`Note: This plugin was installed by...`_ that's _below_ the plugin meta, similar in style to the new `Note: this plugin cannot be activated or deactivated...`, would provide a straightforward solve without worrying about prefixes, slug lengths, metadata density, or over/underengineering

Here's what that looks like in WP 6.5+:

Before | After
--|--
![Screenshot 2024-05-31 12 19 31](https://github.com/WordPress/performance/assets/134745/9299b6c6-1a44-4193-afa0-c0604b7ae624) | ![Screenshot 2024-05-31 12 19 46](https://github.com/WordPress/performance/assets/134745/1ff52a8d-5b3e-4f09-8554-1e7eb94de830)

The Performance Lab link goes to the Performance settings screen.

Note that I chose to say "This plugin is installed" as opposed to "This plugin was installed" because we don't keep track of whether or not a given feature plugin was indeed installed by the Performance Lab plugin. So it is intended to say that the Performance Lab _in general_ installs a given feature plugin, but that's not to say it couldn't be installed directly.