### PR TITLE
Prevent lint-staged from linting unstaged plugin files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -25,7 +25,7 @@ const joinFiles = ( files ) => {
 const PLUGIN_BASE_NAME = path.basename( __dirname );
 
 module.exports = {
-	'**/*.js': ( files ) => `npm run lint-js ${ joinFiles( files ) }`,
+	'**/*.js': ( files ) => `npm run lint-js -- ${ joinFiles( files ) }`,
 	'**/*.php': ( files ) => {
 		const commands = [ 'composer phpstan' ];
 
@@ -53,7 +53,7 @@ module.exports = {
 		);
 
 		if ( otherFiles.length ) {
-			commands.push( `composer lint ${ joinFiles( otherFiles ) }` );
+			commands.push( `composer lint -- ${ joinFiles( otherFiles ) }` );
 		}
 
 		return commands;

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -37,8 +37,11 @@ module.exports = {
 			);
 
 			if ( pluginFiles.length ) {
+				// Note: The lint command has to be used directly because the plugin-specific lint command includes the entire plugin directory as an argument.
 				commands.push(
-					`composer lint:${ plugin } ${ joinFiles( pluginFiles ) }`
+					`composer lint -- --standard=./plugins/${ plugin }/phpcs.xml.dist ${ joinFiles(
+						pluginFiles
+					) }`
 				);
 			}
 		} );


### PR DESCRIPTION
This is a follow up to #1264. I had an unstaged file in a plugin directory, and I found that lint-staged was running PHPCS on it. This is because the `composer lint:${ plugin }` command includes the plugin directory as its initial argument. This has the effect of checking _all_ of the files in the directory tree, in addition to the staged files passed by lint-staged. To avoid this we have to run the underlying `composer lint` command and manually pass the `--standard` arg.