### PR TITLE
Add period to the end of the installed-by message

### DIFF
--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -486,7 +486,7 @@ function perflab_print_row_meta_install_notice( string $plugin_file ): void {
 
 	$message = sprintf(
 		/* translators: %s: link to Performance Lab settings screen */
-		__( 'This plugin is installed by <a href="%s">Performance Lab</a>', 'performance-lab' ),
+		__( 'This plugin is installed by <a href="%s">Performance Lab</a>.', 'performance-lab' ),
 		esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) )
 	);
 


### PR DESCRIPTION
This is a follow-up nit to #1265. I noticed that the sentence is lacking a period at the end:

![image](https://github.com/WordPress/performance/assets/134745/c80d73d7-f80e-4edf-b602-901a87f71097)

This rectifies that omission:

![image](https://github.com/WordPress/performance/assets/134745/1ef46581-2790-4bd4-a22e-509dd91cf2d5)
