### PR TITLE
Fix fatal error when another the_content filter callback returns null instead of a string

### DIFF
--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -519,10 +519,14 @@ add_action( 'delete_attachment', 'webp_uploads_remove_sources_files', 10, 1 );
  *
  * @see wp_filter_content_tags()
  *
- * @param string $content The content of the current post.
+ * @param string|mixed $content The content of the current post.
  * @return string The content with the updated references to the images.
  */
-function webp_uploads_update_image_references( string $content ): string {
+function webp_uploads_update_image_references( $content ): string {
+	if ( ! is_string( $content ) ) {
+		$content = '';
+	}
+
 	// Bail early if request is not for the frontend.
 	if ( ! webp_uploads_in_frontend_body() ) {
 		return $content;

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 2.0.0
+ * Version: 2.0.1-alpha
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.0.0' );
+define( 'WEBP_UPLOADS_VERSION', '2.0.1-alpha' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -851,20 +851,6 @@ class Test_WebP_Uploads_Load extends TestCase {
 	}
 
 	/**
-	 * Tests that the fallback script is not added when a post with no updated images is rendered.
-	 */
-	public function test_it_should_not_add_fallback_script_if_content_has_no_updated_images(): void {
-		remove_all_actions( 'wp_footer' );
-
-		apply_filters( 'the_content', '<p>no image</p>' );
-
-		$this->assertFalse( has_action( 'wp_footer', 'webp_uploads_webp_fallback' ) );
-
-		$footer = get_echo( 'wp_footer' );
-		$this->assertStringNotContainsString( 'webp;base64,UklGR', $footer );
-	}
-
-	/**
 	 * Tests whether additional mime types generated only for allowed image sizes or not when the filter is used.
 	 */
 	public function test_it_should_create_mime_types_for_allowed_sizes_only_via_filter(): void {


### PR DESCRIPTION
In a [support topic](https://wordpress.org/support/topic/fatal-error-uncaught-typeerror-webp_uploads_update_image_references-argumen/), a user reported a fatal error:

<details><summary><code>Uncaught TypeError: webp_uploads_update_image_references(): Argument #1 ($content) must be of type string, null given</code></summary>

```
#0 /home/******/public_html/wp-includes/class-wp-hook.php(324): webp_uploads_update_image_references() 
#1 /home/******/public_html/wp-includes/plugin.php(205): WP_Hook->apply_filters() 
#2 /home/******/public_html/wp-includes/formatting.php(3992): apply_filters() 
#3 /home/******/public_html/wp-includes/class-wp-hook.php(324): wp_trim_excerpt() 
#4 /home/******/public_html/wp-includes/plugin.php(205): WP_Hook->apply_filters() 
#5 /home/******/public_html/wp-includes/post-template.php(434): apply_filters() 
#6 /home/******/public_html/wp-content/plugins/seo-by-rank-math/includes/opengraph/class-opengraph.php(148): get_the_excerpt() 
#7 /home/******/public_html/wp-content/plugins/seo-by-rank-math/includes/opengraph/class-opengraph.php(125): RankMath\OpenGraph\OpenGraph->fallback_description() 
#8 /home/******/public_html/wp-content/plugins/seo-by-rank-math/includes/opengraph/class-facebook.php(200): RankMath\OpenGraph\OpenGraph->get_description() 
#9 /home/******/public_html/wp-includes/class-wp-hook.php(324): RankMath\OpenGraph\Facebook->description() 
#10 /home/******/public_html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters() 
#11 /home/******/public_html/wp-includes/plugin.php(565): WP_Hook->do_action() 
#12 /home/******/public_html/wp-content/plugins/seo-by-rank-math/includes/traits/class-hooker.php(90): do_action_ref_array() 
#13 /home/******/public_html/wp-content/plugins/seo-by-rank-math/includes/opengraph/class-opengraph.php(74): RankMath\OpenGraph\OpenGraph->do_action() 
#14 /home/******/public_html/wp-includes/class-wp-hook.php(324): RankMath\OpenGraph\OpenGraph->output_tags() 
#15 /home/******/public_html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters() 
#16 /home/******/public_html/wp-includes/plugin.php(565): WP_Hook->do_action() 
#17 /home/******/public_html/wp-content/plugins/seo-by-rank-math/includes/traits/class-hooker.php(90): do_action_ref_array() 
#18 /home/******/public_html/wp-content/plugins/seo-by-rank-math/includes/frontend/class-head.php(180): RankMath\Frontend\Head->do_action() 
#19 /home/******/public_html/wp-includes/class-wp-hook.php(324): RankMath\Frontend\Head->head() 
#20 /home/******/public_html/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters() 
#21 /home/******/public_html/wp-includes/plugin.php(517): WP_Hook->do_action() 
#22 /home/******/public_html/wp-includes/general-template.php(3050): do_action() 
#23 /home/******/public_html/wp-content/themes/elessi-theme/header.php(24): wp_head() 
#24 /home/******/public_html/wp-includes/template.php(810): require_once(‘…’) 
#25 /home/******/public_html/wp-includes/template.php(745): load_template() 
#26 /home/******/public_html/wp-includes/general-template.php(48): locate_template() 
#27 /home/******/public_html/wp-content/themes/elessi-theme/woocommerce/single-product.php(20): get_header() 
#28 /home/******/public_html/wp-includes/template-loader.php(106): include(‘…’) 
#29 /home/******/public_html/wp-blog-header.php(19): require_once(‘…’) 
#30 /home//public_html/index.php(17): require(‘…’) 
#31 {main} thrown in /home//public_html/wp-content/plugins/webp-uploads/hooks.php on line 525
```

</details> 

It appears there is some other plugin which adds a `the_content` filter which returns `null` instead of a `string`. Since `webp_uploads_update_image_references()` is added as a filter, it should be updated to guard against this case by allowing `mixed` as the input, as we've done for other filters. This stems from work in #775.