### PR TITLE
Use --force when updating svn to ignore any local unversioned files when running generate-pending-release-diffs

### DIFF
--- a/bin/generate-pending-release-diffs.sh
+++ b/bin/generate-pending-release-diffs.sh
@@ -36,7 +36,7 @@ for plugin_slug in $( if [ $# -gt 0 ]; then echo "$@"; else jq '.plugins[]' -r p
 		svn co "https://plugins.svn.wordpress.org/$plugin_slug/trunk/" "$stable_dir/$plugin_slug" >&2
 	else
 		svn revert "$stable_dir/$plugin_slug" >&2
-		svn up "$stable_dir/$plugin_slug" >&2
+		svn up --force "$stable_dir/$plugin_slug" >&2
 	fi
 
 	rsync -avz --delete --exclude=".svn" "build/$plugin_slug/" "$stable_dir/$plugin_slug/" >&2


### PR DESCRIPTION
When new files are added to releases, this can cause the `generate-pending-release-diffs` command to fail with an error at `svn up` like as follows:

```
Updating '/tmp/stable-svn/webp-uploads':
D    /tmp/stable-svn/webp-uploads/fallback.js
U    /tmp/stable-svn/webp-uploads/deprecated.php
U    /tmp/stable-svn/webp-uploads/helper.php
U    /tmp/stable-svn/webp-uploads/hooks.php
U    /tmp/stable-svn/webp-uploads/load.php
   C /tmp/stable-svn/webp-uploads/picture-element.php
U    /tmp/stable-svn/webp-uploads/readme.txt
U    /tmp/stable-svn/webp-uploads/settings.php
Updated to revision 3098967.
Summary of conflicts:
  Tree conflicts: 1
Searching tree conflict details for '/tmp/stable-svn/webp-uploads/picture-element.php' in repository:
Checking r3098882... done
Tree conflict on '/tmp/stable-svn/webp-uploads/picture-element.php':
A new file appeared during update to r3098967; it was added by performanceteam in r3098882.
An unversioned file was found in the working copy.
Select: (p) Postpone, (r) Mark as resolved, (m) Merge the files, (h) Help,
        (q) Quit resolution: 
```

The issue is that for the previous release, there was no `picture-element.php` committed so it is a local untracked file. So then when `svn up` is being done, it pulls down a remote file which is tracked and is going to override the local file. SVN isn't smart enough to realize that the files are identical it seems. In any case, adding `--force` to `svn up` fixes this issue.