### PR TITLE
Prepare webp-uploads 2.0.1

### DIFF
--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 2.0.1-alpha
+ * Version: 2.0.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.0.1-alpha' );
+define( 'WEBP_UPLOADS_VERSION', '2.0.1' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        2.0.0
+Stable tag:        2.0.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, webp, avif, modern image formats
@@ -61,6 +61,12 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.0.1 =
+
+**Bug Fixes**
+
+* Fix fatal error when another the_content filter callback returns null instead of a string. ([1283](https://github.com/WordPress/performance/pull/1283))
 
 = 2.0.0 =
 


### PR DESCRIPTION
## `webp-uploads`

`svn status`:
```
M       hooks.php
M       load.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: hooks.php
===================================================================
--- hooks.php	(revision 3098984)
+++ hooks.php	(working copy)
@@ -519,10 +519,14 @@
  *
  * @see wp_filter_content_tags()
  *
- * @param string $content The content of the current post.
+ * @param string|mixed $content The content of the current post.
  * @return string The content with the updated references to the images.
  */
-function webp_uploads_update_image_references( string $content ): string {
+function webp_uploads_update_image_references( $content ): string {
+	if ( ! is_string( $content ) ) {
+		$content = '';
+	}
+
 	// Bail early if request is not for the frontend.
 	if ( ! webp_uploads_in_frontend_body() ) {
 		return $content;
Index: load.php
===================================================================
--- load.php	(revision 3098984)
+++ load.php	(working copy)
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: 2.0.0
+ * Version: 2.0.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.0.0' );
+define( 'WEBP_UPLOADS_VERSION', '2.0.1' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';
Index: readme.txt
===================================================================
--- readme.txt	(revision 3098984)
+++ readme.txt	(working copy)
@@ -4,7 +4,7 @@
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        2.0.0
+Stable tag:        2.0.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, images, webp, avif, modern image formats
@@ -62,6 +62,12 @@
 
 == Changelog ==
 
+= 2.0.1 =
+
+**Bug Fixes**
+
+* Fix fatal error when another the_content filter callback returns null instead of a string. ([1283](https://github.com/WordPress/performance/pull/1283))
+
 = 2.0.0 =
 
 **Features**
```
</details>

