### PR TITLE
I18N: Add context to Modern Image Formats section title

### DIFF
--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -62,7 +62,7 @@ add_action( 'init', 'webp_uploads_register_media_settings_field' );
 function webp_uploads_add_media_settings_fields(): void {
 	add_settings_section(
 		'perflab_modern_image_format_settings',
-		_x( 'Modern Image Formats', 'Setting Page Section Name', 'webp-uploads' ),
+		_x( 'Modern Image Formats', 'settings page section name', 'webp-uploads' ),
 		'__return_empty_string',
 		'media',
 		array(

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -62,7 +62,7 @@ add_action( 'init', 'webp_uploads_register_media_settings_field' );
 function webp_uploads_add_media_settings_fields(): void {
 	add_settings_section(
 		'perflab_modern_image_format_settings',
-		__( 'Modern Image Formats', 'webp-uploads' ),
+		_x( 'Modern Image Formats', 'Setting Page Section Name', 'webp-uploads' ),
 		'__return_empty_string',
 		'media',
 		array(


### PR DESCRIPTION
## Summary

The plugin name and the Media setting page section name are the same, "Modern Image Formats," so they are the same string, but they should be disambiguated by context.

## Relevant technical choices

We don't translate plugin names, but even if the "Modern Image Formats" string in the Media setting page is the same as the plugin name, I think it should be a localizable setting page section name. 



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
