### PR TITLE
Fix background-image styled tag visitor's handling of parsing style without background-image

### DIFF
--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -39,7 +39,7 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 		if (
 			is_string( $style )
 			&&
-			false !== preg_match( '/background(-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
+			0 < (int) preg_match( '/background(-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
 			&&
 			'' !== $matches['background_image'] // PHPStan should ideally know that this is a non-empty string based on the `.+?` regular expression.
 			&&

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.4
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.1.0
+ * Version: 0.1.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.1.0',
+	'0.1.1',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.5
 Requires PHP:      7.2
-Stable tag:        0.1.0
+Stable tag:        0.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, optimization, image, lcp, lazy-load
@@ -63,6 +63,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.1.1 =
+
+* Fix background-image styled tag visitor's handling of parsing style without background-image. ([1288](https://github.com/WordPress/performance/pull/1288))
 
 = 0.1.0 =
 

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -86,6 +86,34 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 				',
 			),
 
+			'no-url-metrics-with-non-background-image-style' => array(
+				'set_up'   => static function (): void {},
+				'buffer'   => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							<div style="background-color: black; color: white; width:100%; height: 200px;">This is so background!</div>
+						</body>
+					</html>
+				',
+				// There should be no data-od-xpath added to the DIV because it is using a data: URL for the background-image.
+				'expected' => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							<div style="background-color: black; color: white; width:100%; height: 200px;">This is so background!</div>
+							<script type="module">/* import detect ... */</script>
+						</body>
+					</html>
+				',
+			),
+
 			'no-url-metrics-with-data-url-image'          => array(
 				'set_up'   => static function (): void {},
 				// Smallest PNG courtesy of <https://evanhahn.com/worlds-smallest-png/>.


### PR DESCRIPTION
In a [support forum topic](https://wordpress.org/support/topic/php-warning-fatal-error-in-php-errorlog/), a user reported Image Prioritizer was causing a warning and fatal error in the `Image_Prioritizer_Background_Image_Styled_Tag_Visitor` class.

> PHP Warning: Undefined array key “background_image” in .../image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php on line 44

<details><summary><code>PHP Fatal error: Uncaught TypeError: Image_Prioritizer_Tag_Visitor::is_data_url(): Argument #1 ($url) must be of type string, null given, called in .../image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php on line 46 and defined in .../image-prioritizer/class-image-prioritizer-tag-visitor.php:61</code></summary>

```
Stack trace:
#0 /srv/data/web/vhosts/[domain removed]/htdocs/wp-content/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php(46): Image_Prioritizer_Tag_Visitor->is_data_url()
#1 /srv/data/web/vhosts/[domain removed]/htdocs/wp-content/plugins/optimization-detective/optimization.php(183): Image_Prioritizer_Background_Image_Styled_Tag_Visitor->__invoke()
#2 /srv/data/web/vhosts/[domain removed]/htdocs/wp-includes/class-wp-hook.php(324): od_optimize_template_output_buffer()
#3 /srv/data/web/vhosts/[domain removed]/htdocs/wp-includes/plugin.php(205): WP_Hook->apply_filters()
#4 /srv/data/web/vhosts/[domain removed]/htdocs/wp-content/plugins/optimization-detective/optimization.php(44): apply_filters()
#5 [internal function]: {closure}()
#6 /srv/data/web/vhosts/[domain removed]/htdocs/wp-includes/functions.php(5420): ob_end_flush()
#7 /srv/data/web/vhosts/[domain removed]/htdocs/wp-includes/class-wp-hook.php(324): wp_ob_end_flush_all()
#8 /srv/data/web/vhosts/[domain removed]/htdocs/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters()
#9 /srv/data/web/vhosts/[domain removed]/htdocs/wp-includes/plugin.php(517): WP_Hook->do_action()
#10 /srv/data/web/vhosts/[domain removed]/htdocs/wp-includes/load.php(1270): do_action()
#11 [internal function]: shutdown_action_hook()
#12 {main} thrown in /srv/data/web/vhosts/[domain removed]/htdocs/wp-content/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php on line 61
```

</details> 

The issue is faulty logic here:

https://github.com/WordPress/performance/blob/5a2d306460345dd05731f583505f7f01fb2d6bae/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php#L42

Namely, `preg_match()` returns `false` only if there is a pattern compilation error. It returns zero (`0`) when no matches are made. So this should have rather been:

```php
0 < (int) preg_match( '/background(-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
```

Which handles _both_ the error case and the non-match case.