### PR TITLE
Include non-intersecting elements in URL metrics to fix lazy-load optimization

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -263,9 +263,7 @@ export default async function detect( {
 			intersectionObserver = new IntersectionObserver(
 				( entries ) => {
 					for ( const entry of entries ) {
-						if ( entry.isIntersecting ) {
-							elementIntersections.push( entry );
-						}
+						elementIntersections.push( entry );
 					}
 					resolve();
 				},


### PR DESCRIPTION
The Image Prioritizer includes optimization of image lazy-loading, a feature that Optimization Detective (OD) didn't yet implement. The OD plugin only implemented the addition of the `fetchpriority=high` attribute to the LCP image. Because of this, its intersection observer was only interested in elements which were intersecting. It ignored anything with an `intersectionRatio` of `0.0`. This issue showed up by below-the-fold images having an `data-od-unknown-tag` attribute, which is also a new feature as of the Image Prioritizer, indicating which tracked elements are absent from the elements in the URL Metrics. By removing the `entry.isIntersecting` condition, we can ensure that all tracked elements are included in the URL metrics, not just the ones in the initial viewport.