### PR TITLE
Implement speculative loading of the search form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@octokit/rest": "^19.0.5",
         "@wordpress/env": "^9.6.0",
+        "@wordpress/interactivity": "6.0.0",
         "@wordpress/scripts": "^26.19.0",
         "commander": "^9.4.1",
         "copy-webpack-plugin": "^12.0.2",
@@ -3097,6 +3098,32 @@
       "integrity": "sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==",
       "dev": true
     },
+    "node_modules/@preact/signals": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.3.tgz",
+      "integrity": "sha512-M2DXse3Wi8HwjI1d2vQWOLJ3lHogvqTsJYvl4ofXRXgMFQzJ7kmlZvlt5i8x5S5VwgZu0ghru4HkLqOoFfU2JQ==",
+      "dev": true,
+      "dependencies": {
+        "@preact/signals-core": "^1.6.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact": "10.x"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.6.0.tgz",
+      "integrity": "sha512-O/XGxwP85h1F7+ouqTMOIZ3+V1whfaV9ToIVcuyGriD4JkSD00cQo54BKdqjvBJxbenvp7ynfqRHEwI6e+NIhw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
@@ -5000,6 +5027,21 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "dev": true
+    },
+    "node_modules/@wordpress/interactivity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/interactivity/-/interactivity-6.0.0.tgz",
+      "integrity": "sha512-s86Bj54jaUpY6lvwAqLLI7H9DhpYC470Rv0kEigL0S1bwtejOUE4diftSRbp4RGt2aFiDtPE3tlQihVUzf2e6A==",
+      "dev": true,
+      "dependencies": {
+        "@preact/signals": "^1.2.2",
+        "deepsignal": "^1.4.0",
+        "preact": "^10.19.3"
+      },
+      "engines": {
+        "node": ">=18.12.0",
+        "npm": ">=8.19.2"
+      }
     },
     "node_modules/@wordpress/jest-console": {
       "version": "7.19.0",
@@ -7920,6 +7962,32 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/deepsignal": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/deepsignal/-/deepsignal-1.5.0.tgz",
+      "integrity": "sha512-bFywDpBUUWMs576H2dgLFLLFuQ/UWXbzHfKD98MZTfGsl7+twIzvz4ihCNrRrZ/Emz3kqJaNIAp5eBWUEWhnAw==",
+      "dev": true,
+      "peerDependencies": {
+        "@preact/signals": "^1.1.4",
+        "@preact/signals-core": "^1.5.1",
+        "@preact/signals-react": "^1.3.8 || ^2.0.0",
+        "preact": "^10.16.0"
+      },
+      "peerDependenciesMeta": {
+        "@preact/signals": {
+          "optional": true
+        },
+        "@preact/signals-core": {
+          "optional": true
+        },
+        "@preact/signals-react": {
+          "optional": true
+        },
+        "preact": {
+          "optional": true
+        }
       }
     },
     "node_modules/default-gateway": {
@@ -16254,6 +16322,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
+    },
+    "node_modules/preact": {
+      "version": "10.22.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.22.0.tgz",
+      "integrity": "sha512-RRurnSjJPj4rp5K6XoP45Ui33ncb7e4H7WiOHVpjbkvqvA3U+N8Z6Qbo0AE6leGYBV66n8EhEaFixvIu3SkxFw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@octokit/rest": "^19.0.5",
     "@wordpress/env": "^9.6.0",
+    "@wordpress/interactivity": "6.0.0",
     "@wordpress/scripts": "^26.19.0",
     "commander": "^9.4.1",
     "copy-webpack-plugin": "^12.0.2",

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -22,19 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array<string, array<int, array<string, mixed>>> Associative array of speculation rules by type.
  */
 function plsr_get_speculation_rules(): array {
-	$option = get_option( 'plsr_speculation_rules' );
-
-	/*
-	 * This logic is only relevant for edge-cases where the setting may not be registered,
-	 * a.k.a. defensive coding.
-	 */
-	if ( ! $option || ! is_array( $option ) ) {
-		$option = plsr_get_setting_default();
-	} else {
-		$option = array_merge( plsr_get_setting_default(), $option );
-	}
-
-	$mode      = (string) $option['mode'];
+	$option    = plsr_get_setting();
+	$mode      = $option['mode'];
 	$eagerness = $option['eagerness'];
 
 	$prefixer = new PLSR_URL_Pattern_Prefixer();

--- a/plugins/speculation-rules/helper.php
+++ b/plugins/speculation-rules/helper.php
@@ -112,3 +112,13 @@ function plsr_get_speculation_rules(): array {
 
 	return array( $mode => $rules );
 }
+
+/**
+ * Adds config for the speculative-loading search form.
+ *
+ * @since n.e.x.t
+ */
+function plsr_add_search_form_config(): void {
+	$setting = plsr_get_setting();
+	wp_interactivity_config( 'speculationRules', array( 'mode' => $setting['mode'] ) );
+}

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -101,6 +101,12 @@ function plsr_filter_searchform( $form ): string {
 		) {
 			$p->set_attribute( "{$directive_prefix}--focus--{$namespace}", "{$namespace}::actions.updateSpeculativeLoadUrl" );
 			$p->set_attribute( "{$directive_prefix}--pointerover--{$namespace}", "{$namespace}::actions.updateSpeculativeLoadUrl" );
+		} elseif (
+			'INPUT' === $p->get_tag()
+			&&
+			's' === $p->get_attribute( 'name' )
+		) {
+			$p->set_attribute( "{$directive_prefix}--keydown--{$namespace}", "{$namespace}::actions.handleInputKeydown" );
 		}
 	}
 

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -86,7 +86,7 @@ function plsr_filter_searchform( $form ): string {
 			if ( ! $p->get_attribute( 'data-wp-context' ) ) {
 				$p->set_attribute( 'data-wp-context', '{}' );
 			}
-			// TODO: Shouldn't we just watch changes to the one context key?
+			// Note: This directive only subscribes to the properties that are accessed during its execution.
 			$p->set_attribute( "data-wp-watch--{$namespace}", "{$namespace}::callbacks.doSpeculativeLoad" );
 			$p->set_attribute( "data-wp-on--submit--{$namespace}", "{$namespace}::actions.handleFormSubmit" );
 

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -58,3 +58,69 @@ function plsr_render_generator_meta_tag(): void {
 	echo '<meta name="generator" content="speculation-rules ' . esc_attr( SPECULATION_RULES_VERSION ) . '">' . "\n";
 }
 add_action( 'wp_head', 'plsr_render_generator_meta_tag' );
+
+/**
+ * Filters the HTML output of the search form to inject speculative loading interactivity.
+ *
+ * @since n.e.x.t
+ *
+ * @param string|mixed $form The search form HTML output.
+ * @return string Filtered HTML.
+ */
+function plsr_filter_searchform( $form ): string {
+	if ( ! is_string( $form ) ) {
+		return '';
+	}
+
+	$namespace        = 'speculationRules';
+	$directive_prefix = 'data-wp-on'; // TODO: Use data-wp-on-async when available.
+
+	$p = new WP_HTML_Tag_Processor( $form );
+	while ( $p->next_tag() ) {
+		if ( 'FORM' === $p->get_tag() ) {
+			if ( ! $p->get_attribute( 'data-wp-interactive' ) ) {
+				$p->set_attribute( 'data-wp-interactive', $namespace );
+			}
+			// Create context if not already present.
+			// TODO: Should there be namespaced context?
+			if ( ! $p->get_attribute( 'data-wp-context' ) ) {
+				$p->set_attribute( 'data-wp-context', '{}' );
+			}
+			// TODO: Shouldn't we just watch changes to the one context key?
+			$p->set_attribute( "data-wp-watch--{$namespace}", "{$namespace}::callbacks.doSpeculativeLoad" );
+			$p->set_attribute( "data-wp-on--submit--{$namespace}", "{$namespace}::actions.handleFormSubmit" );
+
+			$p->set_attribute( "{$directive_prefix}--change--{$namespace}", "{$namespace}::actions.updateSpeculativeLoadUrl" );
+
+			wp_enqueue_script_module( 'speculation-rules-search-form' );
+			plsr_add_search_form_config();
+		} elseif (
+			( 'INPUT' === $p->get_tag() || 'BUTTON' === $p->get_tag() )
+			&&
+			'submit' === $p->get_attribute( 'type' )
+		) {
+			$p->set_attribute( "{$directive_prefix}--focus--{$namespace}", "{$namespace}::actions.updateSpeculativeLoadUrl" );
+			$p->set_attribute( "{$directive_prefix}--pointerover--{$namespace}", "{$namespace}::actions.updateSpeculativeLoadUrl" );
+		}
+	}
+
+	return $p->get_updated_html();
+}
+add_filter( 'get_search_form', 'plsr_filter_searchform' );
+add_filter( 'render_block_core/search', 'plsr_filter_searchform' );
+
+/**
+ * Registers script module for the speculatively loading search form.
+ *
+ * @since n.e.x.t
+ */
+function plsr_register_script_module(): void {
+	wp_register_script_module(
+		'speculation-rules-search-form',
+		plugin_dir_url( __FILE__ ) . 'search-form.js',
+		array(
+			array( 'id' => '@wordpress/interactivity' ),
+		)
+	);
+}
+add_action( 'wp_enqueue_scripts', 'plsr_register_script_module' );

--- a/plugins/speculation-rules/search-form.js
+++ b/plugins/speculation-rules/search-form.js
@@ -5,7 +5,7 @@ import {
 	getElement,
 } from '@wordpress/interactivity';
 
-store( 'speculationRules', {
+const { actions } = store( 'speculationRules', {
 	callbacks: {
 		doSpeculativeLoad: () => {
 			/**
@@ -42,6 +42,7 @@ store( 'speculationRules', {
 		},
 	},
 	actions: {
+		// TODO: Is this really actually callback?
 		updateSpeculativeLoadUrl: () => {
 			const context = getContext();
 			const { ref } = getElement();
@@ -53,6 +54,12 @@ store( 'speculationRules', {
 				const url = new URL( form.action || location.href );
 				url.search = new URLSearchParams( formData ).toString();
 				context.speculativeLoadUrl = url.href;
+			}
+		},
+		handleInputKeydown: ( event ) => {
+			// Eke out a few milliseconds when hitting enter on the input to submit.
+			if ( event.key === 'Enter' ) {
+				actions.updateSpeculativeLoadUrl();
 			}
 		},
 		handleFormSubmit: ( event ) => {

--- a/plugins/speculation-rules/search-form.js
+++ b/plugins/speculation-rules/search-form.js
@@ -1,0 +1,66 @@
+import {
+	store,
+	getConfig,
+	getContext,
+	getElement,
+} from '@wordpress/interactivity';
+
+store( 'speculationRules', {
+	callbacks: {
+		doSpeculativeLoad: () => {
+			/**
+			 * @type {Object}
+			 * @property {string} [speculativeLoadUrl] Speculative load URL.
+			 */
+			const context = getContext();
+			const scriptId = 'speculation-rules-search-form';
+			const existingScript = document.getElementById( scriptId );
+			if ( ! context.speculativeLoadUrl ) {
+				if ( existingScript ) {
+					existingScript.remove();
+				}
+			} else {
+				const script = document.createElement( 'script' );
+				script.type = 'speculationrules';
+				script.id = scriptId;
+				const rules = {
+					[ getConfig().mode ]: [
+						{
+							source: 'list',
+							urls: [ context.speculativeLoadUrl ],
+						},
+					],
+				};
+				script.textContent = JSON.stringify( rules );
+
+				if ( existingScript ) {
+					existingScript.replaceWith( script );
+				} else {
+					document.body.appendChild( script );
+				}
+			}
+		},
+	},
+	actions: {
+		updateSpeculativeLoadUrl: () => {
+			const context = getContext();
+			const { ref } = getElement();
+			const form = ref.closest( 'form' );
+			const formData = new FormData( form );
+			if ( ! formData.get( 's' ) ) {
+				context.speculativeLoadUrl = null;
+			} else {
+				const url = new URL( form.action || location.href );
+				url.search = new URLSearchParams( formData ).toString();
+				context.speculativeLoadUrl = url.href;
+			}
+		},
+		handleFormSubmit: ( event ) => {
+			const context = getContext();
+			if ( context.speculativeLoadUrl ) {
+				event.preventDefault();
+				location.href = context.speculativeLoadUrl;
+			}
+		},
+	},
+} );

--- a/plugins/speculation-rules/search-form.js
+++ b/plugins/speculation-rules/search-form.js
@@ -51,7 +51,7 @@ const { actions } = store( 'speculationRules', {
 			if ( ! formData.get( 's' ) ) {
 				context.speculativeLoadUrl = null;
 			} else {
-				const url = new URL( form.action || location.href );
+				const url = new URL( form.action );
 				url.search = new URLSearchParams( formData ).toString();
 				context.speculativeLoadUrl = url.href;
 			}
@@ -63,11 +63,12 @@ const { actions } = store( 'speculationRules', {
 			}
 		},
 		handleFormSubmit: ( event ) => {
-			const context = getContext();
-			if ( context.speculativeLoadUrl ) {
-				event.preventDefault();
-				location.href = context.speculativeLoadUrl;
-			}
+			event.preventDefault();
+			const form = event.target;
+			const formData = new FormData( form );
+			const url = new URL( form.action );
+			url.search = new URLSearchParams( formData ).toString();
+			location.href = url.href;
 		},
 	},
 } );

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -45,6 +45,7 @@ function plsr_get_eagerness_labels(): array {
  *
  * @since 1.0.0
  *
+ * @phpstan-return array{ mode: 'prerender', eagerness: 'moderate' }
  * @return array<string, string> {
  *     Default setting value.
  *
@@ -60,11 +61,58 @@ function plsr_get_setting_default(): array {
 }
 
 /**
+ * Gets setting.
+ *
+ * @since n.e.x.t
+ *
+ * @phpstan-return array{
+ *                     mode: 'prerender'|'prefetch',
+ *                     eagerness: 'conservative'|'moderate'|'eager'
+ *                 }
+ * @return array<string, string> {
+ *     Setting value.
+ *
+ *     @type string $mode      Mode.
+ *     @type string $eagerness Eagerness.
+ * }
+ */
+function plsr_get_setting(): array {
+	$setting = get_option( 'plsr_speculation_rules' );
+
+	/*
+	 * This logic is only relevant for edge-cases where the setting may not be registered,
+	 * a.k.a. defensive coding.
+	 */
+	if ( ! $setting || ! is_array( $setting ) ) {
+		$setting = plsr_get_setting_default();
+	} else {
+		$setting = array_merge( plsr_get_setting_default(), $setting );
+	}
+
+	/**
+	 * Validated setting.
+	 *
+	 * The value is validated by {@see plsr_sanitize_setting()}.
+	 *
+	 * @var array{
+	 *          mode: 'prerender'|'prefetch',
+	 *          eagerness: 'conservative'|'moderate'|'eager'
+	 *      } $setting
+	 */
+	return $setting;
+}
+
+/**
  * Sanitizes the setting for Speculative Loading configuration.
  *
  * @since 1.0.0
  *
  * @param mixed $input Setting to sanitize.
+
+ * @phpstan-return array{
+ *                     mode: 'prerender'|'prefetch',
+ *                     eagerness: 'conservative'|'moderate'|'eager'
+ *                 }
  * @return array<string, string> {
  *     Sanitized setting.
  *

--- a/plugins/speculation-rules/tests/test-speculation-rules-settings.php
+++ b/plugins/speculation-rules/tests/test-speculation-rules-settings.php
@@ -102,6 +102,26 @@ class Test_Speculation_Rules_Settings extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::plsr_get_setting
+	 */
+	public function test_plsr_get_setting_not_set(): void {
+		delete_option( 'plsr_speculation_rules' );
+		$this->assertSame( plsr_get_setting_default(), plsr_get_setting() );
+	}
+
+	/**
+	 * @covers ::plsr_get_setting
+	 * @dataProvider data_plsr_sanitize_setting
+	 *
+	 * @param mixed                $input    Input.
+	 * @param array<string, mixed> $expected Expected.
+	 */
+	public function test_plsr_get_setting( $input, array $expected ): void {
+		update_option( 'plsr_speculation_rules', $input );
+		$this->assertSame( $expected, plsr_get_setting() );
+	}
+
+	/**
 	 * @covers ::plsr_add_settings_action_link
 	 */
 	public function test_plsr_add_settings_action_link(): void {


### PR DESCRIPTION
## Summary

Fixes #1291

This speeds up searches by doing speculative loading of the search results page when the user has entered a search query and is signaling they are about to perform a search.

Here's a test site with this patched version of the plugin installed: https://speculative-loading-test.instawp.xyz/search/

[Screen recording 2024-06-11 03.22.30.webm](https://github.com/WordPress/performance/assets/134745/6e0539fb-82ee-4786-aa55-4b5454893f6d)

(Note the TTFB of 0 ms. This was recorded on airplane wifi!)

## Relevant technical choices

The Interactivity API is leveraged to listen for events which signal that a pending search has been entered, namely on the `change` event as well as whenever a submit button gets a `focus` event or `pointerover`. Additionally, when hitting <kbd>Enter</kbd> in the search `input` field it will start to speculatively-load at `keydown` which could in theory save a few milliseconds. (Alternatively to this, a debounced `input` event may make more sense.)

The HTML Tag Processor is used to inject the Interactivity API directives on the search form, both in the Search block variant as well as in the classic variant returned by `get_search_form()`. 

It seems the key is how the form `submit` event is handled. If the default form submission handling is done, then the speculative prerender is not reused. However, if the `submit` event handler does `preventDefault` and then manually navigates to the URL that the search submission was going to go to anyway, then it works!

https://github.com/WordPress/performance/blob/d45eb1c9455915e1fa32aeb29da5d7b7679a9453/plugins/speculation-rules/search-form.js#L65-L72

This seems like a hacky workaround for something the browser should be doing automatically for `GET` form submissions.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
