### PR TITLE
Extend core's Autoloaded Options Site Health test if present (in WP 6.6)

### DIFF
--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
@@ -19,6 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array{direct: array<string, array{label: string, test: string}>} Amended tests.
  */
 function perflab_aao_add_autoloaded_options_test( array $tests ): array {
+	// Bail early if check already registered in WordPress core version 6.6.
+	if ( isset( $tests['direct']['autoloaded_options'] ) ) {
+		return $tests;
+	}
+
 	$tests['direct']['autoloaded_options'] = array(
 		'label' => __( 'Autoloaded options', 'performance-lab' ),
 		'test'  => 'perflab_aao_autoloaded_options_test',
@@ -111,3 +116,15 @@ function perflab_aao_admin_notices(): void {
 	}
 }
 add_action( 'admin_notices', 'perflab_aao_admin_notices' );
+
+/**
+ * Extends the health check description that merged in WordPress 6.6.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $description Description message when autoloaded options bigger than threshold.
+ */
+function perflab_aao_extend_core_check( string $description ): string {
+	return $description . perflab_aao_get_autoloaded_options_table() . perflab_aao_get_disabled_autoloaded_options_table();
+}
+add_filter( 'site_status_autoloaded_options_limit_description', 'perflab_aao_extend_core_check' );

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
@@ -123,6 +123,7 @@ add_action( 'admin_notices', 'perflab_aao_admin_notices' );
  * @since n.e.x.t
  *
  * @param string $description Description message when autoloaded options bigger than threshold.
+ * return string Extended health check description.
  */
 function perflab_aao_extend_core_check( string $description ): string {
 	return $description . perflab_aao_get_autoloaded_options_table() . perflab_aao_get_disabled_autoloaded_options_table();

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
@@ -123,7 +123,7 @@ add_action( 'admin_notices', 'perflab_aao_admin_notices' );
  * @since n.e.x.t
  *
  * @param string $description Description message when autoloaded options bigger than threshold.
- * return string Extended health check description.
+ * @return string Extended health check description.
  */
 function perflab_aao_extend_core_check( string $description ): string {
 	return $description . perflab_aao_get_autoloaded_options_table() . perflab_aao_get_disabled_autoloaded_options_table();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1274


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
