### PR TITLE
Update new banner image for `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Performance Lab
-![Performance Lab plugin banner with icon](https://user-images.githubusercontent.com/3531426/159084476-af352db4-192e-4927-a383-7f76bb3641df.png)
+![Performance Lab plugin banner with icon](https://github.com/WordPress/performance/assets/10103365/99d37ba5-27e3-47ea-8ab8-48de75ee69bf)
 
 Monorepo for the [WordPress Performance Team](https://make.wordpress.org/performance/), primarily for the Performance Lab plugin, which is a collection of standalone performance features.
 


### PR DESCRIPTION
## Summary

In #1272, we updated the banner image for the Performance Lab plugin. In this PR, I have updated the new banner for the README.md file.

Check new banner image at https://github.com/WordPress/performance/tree/update/banner-image

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
