### PR TITLE
Improve compatibility of styling picture elements

### DIFF
--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -146,7 +146,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	remove_filter( 'wp_calculate_image_srcset_meta', $filter );
 
 	return sprintf(
-		'<picture class="%s">%s%s</picture>',
+		'<picture class="%s" style="display: contents;">%s%s</picture>',
 		esc_attr( 'wp-picture-' . $attachment_id ),
 		$picture_sources,
 		$original_image_without_srcset

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -43,7 +43,7 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		$the_image = apply_filters( 'wp_content_img_tag', $the_image, 'the_content', $attachment_id );
 
 		// Check that the image is wrapped in a picture element with the correct class.
-		$picture_element = sprintf( '<picture class="wp-picture-%s">', $attachment_id );
+		$picture_element = sprintf( '<picture class="wp-picture-%s" style="display: contents;">', $attachment_id );
 		if ( $expect_picture_element ) {
 			$this->assertStringContainsString( $picture_element, $the_image );
 		} else {


### PR DESCRIPTION
## Summary
Fixes #1300 

## Relevant technical choices
Added following style to picture tag and updated the test for the same.
```html
style="display: contents;"
```

The `wp:gallery` style was not getting applying due to the `img` getting inside the `picture` tag.