### PR TITLE
Update PHPStan to 1.11.5

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -732,16 +732,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.1",
+            "version": "1.11.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b"
+                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e524358f930e41a2b4cca1320e3b04fc26b39e0b",
-                "reference": "e524358f930e41a2b4cca1320e3b04fc26b39e0b",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/490f0ae1c92b082f154681d7849aee776a7c1443",
+                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443",
                 "shasum": ""
             },
             "require": {
@@ -786,7 +786,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-05-15T08:00:59+00:00"
+            "time": "2024-06-17T15:10:54+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
@@ -35,10 +35,10 @@ class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 		if ( false === $shorted_image ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
-		// Note: These two functions only return integers, but PHPStan thinks they return int|false. PhpStorm's stubs also think this. However, from looking at
-		// <https://github.com/php/php-src/blob/5db847e/ext/gd/gd.stub.php#L716-L718> these functions only ever returned integers. Nevertheless, the PHP docs
-		// did used to have int|false as the return type but this was removed for PHP 8: <https://github.com/php/doc-en/commit/0462f49>.
-		// So this is why there is type casting to integer, just for the sake of PHPStan, and possibly for PHP<8.
+		// Note: These two functions only return integers, but they used to return int|false in PHP<8. This was changed in the PHP documentation in
+		// <https://github.com/php/doc-en/commit/0462f49> and <https://github.com/php/doc-en/commit/37f858a>. However, PhpStorm's stubs still think
+		// they return int|false. However, from looking at <https://github.com/php/php-src/blob/5db847e/ext/gd/gd.stub.php#L716-L718> these functions
+		// apparently only ever returned integers. So the type casting is here for the possible sake PHP<8.
 		$image_width  = (int) imagesx( $this->image );
 		$image_height = (int) imagesy( $this->image );
 		imagecopyresampled( $shorted_image, $this->image, 0, 0, 0, 0, 1, 1, $image_width, $image_height );

--- a/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
@@ -32,11 +32,11 @@ class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 		}
 		// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 		$shorted_image = imagecreatetruecolor( 1, 1 );
-		$image_width   = imagesx( $this->image );
-		$image_height  = imagesy( $this->image );
-		if ( false === $shorted_image || false === $image_width || false === $image_height ) {
+		if ( false === $shorted_image ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
+		$image_width  = imagesx( $this->image );
+		$image_height = imagesy( $this->image );
 		imagecopyresampled( $shorted_image, $this->image, 0, 0, 0, 0, 1, 1, $image_width, $image_height );
 
 		$rgb = imagecolorat( $shorted_image, 0, 0 );
@@ -78,9 +78,6 @@ class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 					return new WP_Error( 'unable_to_obtain_rgb_via_imagecolorat' );
 				}
 				$rgba = imagecolorsforindex( $this->image, $rgb );
-				if ( ! is_array( $rgba ) ) {
-					return new WP_Error( 'unable_to_obtain_rgba_via_imagecolorsforindex' );
-				}
 				if ( $rgba['alpha'] > 0 ) {
 					return true;
 				}

--- a/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
@@ -35,7 +35,10 @@ class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 		if ( false === $shorted_image ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
-		// Note: These two functions only return integers, but PHPStan thinks they return int|false. PhpStorm's stubs also think this.
+		// Note: These two functions only return integers, but PHPStan thinks they return int|false. PhpStorm's stubs also think this. However, from looking at
+		// <https://github.com/php/php-src/blob/5db847e/ext/gd/gd.stub.php#L716-L718> these functions only ever returned integers. Nevertheless, the PHP docs
+		// did used to have int|false as the return type but this was removed for PHP 8: <https://github.com/php/doc-en/commit/0462f49>.
+		// So this is why there is type casting to integer, just for the sake of PHPStan, and possibly for PHP<8.
 		$image_width  = (int) imagesx( $this->image );
 		$image_height = (int) imagesy( $this->image );
 		imagecopyresampled( $shorted_image, $this->image, 0, 0, 0, 0, 1, 1, $image_width, $image_height );

--- a/plugins/webp-uploads/tests/test-image-edit.php
+++ b/plugins/webp-uploads/tests/test-image-edit.php
@@ -47,18 +47,12 @@ class Test_WebP_Uploads_Image_Edit extends TestCase {
 		$this->assertArrayHasKey( 'full-orig', $backup_sources );
 		$this->assertSame( $metadata['sources'], $backup_sources['full-orig'] );
 
+		unset( $backup_sizes['full-orig'] );
 		foreach ( $backup_sizes as $size => $properties ) {
 			$size_name = str_replace( '-orig', '', $size );
-
-			if ( 'full-orig' === $size ) {
-				continue;
-			}
-
 			$this->assertArrayHasKey( 'sources', $properties );
 			$this->assertSame( $metadata['sizes'][ $size_name ]['sources'], $properties['sources'] );
 		}
-
-		$metadata = wp_get_attachment_metadata( $attachment_id );
 	}
 
 	/**
@@ -136,7 +130,7 @@ class Test_WebP_Uploads_Image_Edit extends TestCase {
 		$backup_sizes = get_post_meta( $attachment_id, '_wp_attachment_backup_sizes', true );
 		$this->assertIsArray( $backup_sizes );
 
-		foreach ( $backup_sizes as $size_name => $properties ) {
+		foreach ( $backup_sizes as $properties ) {
 			$this->assertArrayNotHasKey( 'sources', $properties );
 		}
 	}
@@ -281,7 +275,7 @@ class Test_WebP_Uploads_Image_Edit extends TestCase {
 		foreach ( $metadata['sizes'] as $size_name => $properties ) {
 			$this->assertImageNotHasSizeSource( $attachment_id, $size_name, 'image/jpeg' );
 			$this->assertImageHasSizeSource( $attachment_id, $size_name, 'image/webp' );
-			foreach ( $properties['sources'] as $mime_type => $values ) {
+			foreach ( $properties['sources'] as $values ) {
 				if ( 'thumbnail' === $size_name ) {
 					$this->assertFileNameIsNotEdited( $values['file'], "'{$size_name}' is not valid." );
 					$this->assertStringNotContainsString( '-scaled-', $values['file'] );

--- a/plugins/webp-uploads/tests/test-image-edit.php
+++ b/plugins/webp-uploads/tests/test-image-edit.php
@@ -109,7 +109,7 @@ class Test_WebP_Uploads_Image_Edit extends TestCase {
 	}
 
 	/**
-	 * Prevent to back up the sources when the sources attributes does not exists
+	 * Prevent to back up the sources when the sources attribute does not exist.
 	 */
 	public function test_it_should_prevent_to_back_up_the_sources_when_the_sources_attributes_does_not_exists(): void {
 		// Disable the generation of the sources attributes.
@@ -136,7 +136,7 @@ class Test_WebP_Uploads_Image_Edit extends TestCase {
 	}
 
 	/**
-	 * Prevent to backup the full size image if only the thumbnail is edited
+	 * Prevent backing up the full size image if only the thumbnail is edited.
 	 */
 	public function test_it_should_prevent_to_backup_the_full_size_image_if_only_the_thumbnail_is_edited(): void {
 		if ( ! webp_uploads_image_edit_thumbnails_separately() ) {


### PR DESCRIPTION
The following PHPStan failures are occurring in PHPStan 1.11.5:

```
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   plugins/dominant-color-images/class-dominant-color-image-editor-gd.php                                                                             
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 
  37     Strict comparison using === between false and int<1, max> will always evaluate to false.                                                           
         🪪  identical.alwaysFalse                                                                                                                          
  37     Strict comparison using === between false and int<1, max> will always evaluate to false.                                                           
         🪪  identical.alwaysFalse                                                                                                                          
  81     Call to function is_array() with array{red: int<0, 255>, green: int<0, 255>, blue: int<0, 255>, alpha: int<0, 127>} will always evaluate to true.  
         🪪  function.alreadyNarrowedType                                                                                                                   
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ -------------------------------------------------------------------------------------------- 
  Line   plugins/webp-uploads/tests/test-image-edit.php                                              
 ------ -------------------------------------------------------------------------------------------- 
  53     Strict comparison using === between 'full-orig' and *NEVER* will always evaluate to false.  
         🪪  identical.alwaysFalse                                                                   
 ------ -------------------------------------------------------------------------------------------- 
```