### PR TITLE
Picture element images: Add missing alt text

### DIFF
--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -81,10 +81,12 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	// Extract sizes using regex to parse image tag, then use to retrieve tag.
 	$width     = 0;
 	$height    = 0;
+	$alt       = '';
 	$processor = new WP_HTML_Tag_Processor( $image );
 	if ( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
 		$width  = (int) $processor->get_attribute( 'width' );
 		$height = (int) $processor->get_attribute( 'height' );
+		$alt    = (string) $processor->get_attribute( 'alt' );
 	}
 	$size_to_use = ( $width > 0 && $height > 0 ) ? array( $width, $height ) : 'full';
 
@@ -124,10 +126,11 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 			continue;
 		}
 		$picture_sources .= sprintf(
-			'<source type="%s" srcset="%s" sizes="%s">',
+			'<source type="%s" srcset="%s" sizes="%s" alt="%s">',
 			esc_attr( $image_mime_type ),
 			esc_attr( $image_srcset ),
-			esc_attr( $sizes )
+			esc_attr( $sizes ),
+			esc_attr( $alt )
 		);
 	}
 
@@ -142,7 +145,15 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		return false;
 	};
 	add_filter( 'wp_calculate_image_srcset_meta', $filter );
-	$original_image_without_srcset = wp_get_attachment_image( $attachment_id, $original_sizes, false, array( 'src' => $original_image ) );
+	$original_image_without_srcset = wp_get_attachment_image(
+		$attachment_id,
+		$original_sizes,
+		false,
+		array(
+			'src' => $original_image,
+			'alt' => $alt,
+		)
+	);
 	remove_filter( 'wp_calculate_image_srcset_meta', $filter );
 
 	return sprintf(

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -81,12 +81,10 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	// Extract sizes using regex to parse image tag, then use to retrieve tag.
 	$width     = 0;
 	$height    = 0;
-	$alt       = '';
 	$processor = new WP_HTML_Tag_Processor( $image );
 	if ( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
 		$width  = (int) $processor->get_attribute( 'width' );
 		$height = (int) $processor->get_attribute( 'height' );
-		$alt    = (string) $processor->get_attribute( 'alt' );
 	}
 	$size_to_use = ( $width > 0 && $height > 0 ) ? array( $width, $height ) : 'full';
 
@@ -126,11 +124,10 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 			continue;
 		}
 		$picture_sources .= sprintf(
-			'<source type="%s" srcset="%s" sizes="%s" alt="%s">',
+			'<source type="%s" srcset="%s" sizes="%s">',
 			esc_attr( $image_mime_type ),
 			esc_attr( $image_srcset ),
-			esc_attr( $sizes ),
-			esc_attr( $alt )
+			esc_attr( $sizes )
 		);
 	}
 
@@ -145,15 +142,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		return false;
 	};
 	add_filter( 'wp_calculate_image_srcset_meta', $filter );
-	$original_image_without_srcset = wp_get_attachment_image(
-		$attachment_id,
-		$original_sizes,
-		false,
-		array(
-			'src' => $original_image,
-			'alt' => $alt,
-		)
-	);
+	$original_image_without_srcset = wp_get_attachment_image( $attachment_id, $original_sizes, false, array( 'src' => $original_image ) );
 	remove_filter( 'wp_calculate_image_srcset_meta', $filter );
 
 	return sprintf(

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -131,16 +131,6 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		);
 	}
 
-	// Fall back to the original image without a srcset.
-	$original_image = wp_get_original_image_url( $attachment_id );
-	// Fail gracefully if the original image is not found.
-	if ( false === $original_image ) {
-		return $image;
-	}
-	$filter = static function (): bool {
-		return false;
-	};
-
 	return sprintf(
 		'<picture class="%s" style="display: contents;">%s%s</picture>',
 		esc_attr( 'wp-picture-' . $attachment_id ),

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -132,7 +132,6 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	}
 
 	// Fall back to the original image without a srcset.
-	$original_sizes = array( $image_src[1], $image_src[2] );
 	$original_image = wp_get_original_image_url( $attachment_id );
 	// Fail gracefully if the original image is not found.
 	if ( false === $original_image ) {
@@ -141,14 +140,11 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	$filter = static function (): bool {
 		return false;
 	};
-	add_filter( 'wp_calculate_image_srcset_meta', $filter );
-	$original_image_without_srcset = wp_get_attachment_image( $attachment_id, $original_sizes, false, array( 'src' => $original_image ) );
-	remove_filter( 'wp_calculate_image_srcset_meta', $filter );
 
 	return sprintf(
 		'<picture class="%s" style="display: contents;">%s%s</picture>',
 		esc_attr( 'wp-picture-' . $attachment_id ),
 		$picture_sources,
-		$original_image_without_srcset
+		$image
 	);
 }

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -15,11 +15,12 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 	 *
 	 * @dataProvider data_provider_it_should_maybe_wrap_images_in_picture_element
 	 *
-	 * @param bool $jpeg_and_webp          Whether to enable JPEG and WebP output.
-	 * @param bool $picture_element        Whether to enable picture element output.
-	 * @param bool $expect_picture_element Whether to expect the image to be wrapped in a picture element.
+	 * @param bool   $jpeg_and_webp          Whether to enable JPEG and WebP output.
+	 * @param bool   $picture_element        Whether to enable picture element output.
+	 * @param bool   $expect_picture_element Whether to expect the image to be wrapped in a picture element.
+	 * @param string $expected_html          The expected HTML output.
 	 */
-	public function test_maybe_wrap_images_in_picture_element( bool $jpeg_and_webp, bool $picture_element, bool $expect_picture_element ): void {
+	public function test_maybe_wrap_images_in_picture_element( bool $jpeg_and_webp, bool $picture_element, bool $expect_picture_element, string $expected_html ): void {
 		$mime_type = 'image/webp';
 		if ( ! wp_image_editor_supports( array( 'mime_type' => $mime_type ) ) ) {
 			$this->markTestSkipped( "Mime type $mime_type is not supported." );
@@ -47,6 +48,43 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 			)
 		);
 
+		$processor = new WP_HTML_Tag_Processor( $the_image );
+		$width     = 0;
+		$height    = 0;
+		$alt       = '';
+		if ( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+			$width  = (int) $processor->get_attribute( 'width' );
+			$height = (int) $processor->get_attribute( 'height' );
+			$alt    = (string) $processor->get_attribute( 'alt' );
+		}
+
+		$size_to_use                  = ( $width > 0 && $height > 0 ) ? array( $width, $height ) : 'full';
+		$image_src                    = wp_get_attachment_image_src( $attachment_id, $size_to_use );
+		list( $src, $width, $height ) = $image_src;
+		$size_array                   = array( absint( $width ), absint( $height ) );
+		$image_meta                   = wp_get_attachment_metadata( $attachment_id );
+		$sizes                        = wp_calculate_image_sizes( $size_array, $src, $image_meta, $attachment_id );
+		$image_srcset                 = wp_get_attachment_image_srcset( $attachment_id, $size_to_use );
+
+		$img_src = '';
+		if ( $image_src ) {
+			$img_src = $image_src[0];
+		}
+		// Remove the last size in the srcset, as it is not needed.
+		$jpeg_srcset = substr( $image_srcset, 0, strrpos( $image_srcset, ',' ) );
+		$webp_srcset = str_replace( '.jpg', '-jpg.webp', $jpeg_srcset );
+
+		// Prepare the expected HTML by replacing placeholders with expected values.
+		$expected_html = str_replace( '{{img-width}}', $width, $expected_html );
+		$expected_html = str_replace( '{{img-height}}', $height, $expected_html );
+		$expected_html = str_replace( '{{img-src}}', $img_src, $expected_html );
+		$expected_html = str_replace( '{{img-attachment-id}}', $attachment_id, $expected_html );
+		$expected_html = str_replace( '{{img-alt}}', $alt, $expected_html );
+		$expected_html = str_replace( '{{img-srcset}}', $image_srcset, $expected_html );
+		$expected_html = str_replace( '{{img-sizes}}', $sizes, $expected_html );
+		$expected_html = str_replace( '{{jpeg-srcset}}', $jpeg_srcset, $expected_html );
+		$expected_html = str_replace( '{{webp-srcset}}', $webp_srcset, $expected_html );
+
 		// Apply the wp_content_img_tag filter.
 		$the_image = apply_filters( 'wp_content_img_tag', $the_image, 'the_content', $attachment_id );
 
@@ -58,6 +96,7 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 			$this->assertStringNotContainsString( $picture_element, $the_image );
 		}
 
+		$this->assertEquals( $expected_html, $the_image );
 		$this->assertStringContainsString( '<img', $the_image );
 
 		// Check that the image has the correct alt text.
@@ -87,7 +126,7 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 	/**
 	 * Data provider for it_should_maybe_wrap_images_in_picture_element.
 	 *
-	 * @return array<string, array<string, bool>>
+	 * @return array<string, array<string, bool|string>>
 	 */
 	public function data_provider_it_should_maybe_wrap_images_in_picture_element(): array {
 		return array(
@@ -95,21 +134,25 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 				'jpeg_and_webp'          => true,
 				'picture_element'        => true,
 				'expect_picture_element' => true,
+				'expected_html'          => '<picture class="wp-picture-{{img-attachment-id}}" style="display: contents;"><source type="image/webp" srcset="{{webp-srcset}}" sizes="{{img-sizes}}"><source type="image/jpeg" srcset="{{jpeg-srcset}}" sizes="{{img-sizes}}"><img width="{{img-width}}" height="{{img-height}}" src="{{img-src}}" class="wp-image-{{img-attachment-id}}" alt="{{img-alt}}" decoding="async" loading="lazy" srcset="{{img-srcset}}" sizes="{{img-sizes}}" /></picture>',
 			),
 			'only picture enabled'     => array(
 				'jpeg_and_webp'          => false,
 				'picture_element'        => true,
 				'expect_picture_element' => true,
+				'expected_html'          => '<picture class="wp-picture-{{img-attachment-id}}" style="display: contents;"><source type="image/webp" srcset="{{webp-srcset}}" sizes="{{img-sizes}}"><img width="{{img-width}}" height="{{img-height}}" src="{{img-src}}" class="wp-image-{{img-attachment-id}}" alt="{{img-alt}}" decoding="async" loading="lazy" srcset="{{img-srcset}}" sizes="{{img-sizes}}" /></picture>',
 			),
 			'only jpeg enabled'        => array(
 				'jpeg_and_webp'          => true,
 				'picture_element'        => false,
 				'expect_picture_element' => false,
+				'expected_html'          => '<img width="{{img-width}}" height="{{img-height}}" src="{{img-src}}" class="wp-image-{{img-attachment-id}}" alt="{{img-alt}}" decoding="async" loading="lazy" srcset="{{img-srcset}}" sizes="{{img-sizes}}" />',
 			),
 			'neither enabled'          => array(
 				'jpeg_and_webp'          => false,
 				'picture_element'        => false,
 				'expect_picture_element' => false,
+				'expected_html'          => '<img width="{{img-width}}" height="{{img-height}}" src="{{img-src}}" class="wp-image-{{img-attachment-id}}" alt="{{img-alt}}" decoding="async" loading="lazy" srcset="{{img-srcset}}" sizes="{{img-sizes}}" />',
 			),
 		);
 	}

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -37,7 +37,15 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
 
 		// Create some content with the image.
-		$the_image = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
+		$the_image = wp_get_attachment_image(
+			$attachment_id,
+			'medium',
+			false,
+			array(
+				'class' => "wp-image-{$attachment_id}",
+				'alt'   => 'Green Leaves',
+			)
+		);
 
 		// Apply the wp_content_img_tag filter.
 		$the_image = apply_filters( 'wp_content_img_tag', $the_image, 'the_content', $attachment_id );
@@ -50,9 +58,16 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 			$this->assertStringNotContainsString( $picture_element, $the_image );
 		}
 
+		$this->assertStringContainsString( '<img', $the_image );
+
+		// Check that the image has the correct alt text.
+		$this->assertStringContainsString( 'alt="Green Leaves"', $the_image );
+
 		// When both features are enabled, the picture element will contain 3 srcset elements.
 		if ( $jpeg_and_webp && $expect_picture_element ) {
 			$this->assertEquals( 3, substr_count( $the_image, 'srcset=' ) );
+			$this->assertStringContainsString( '<source type="image/webp"', $the_image );
+			$this->assertStringContainsString( '<source type="image/jpeg"', $the_image );
 		}
 		// When neither features are enabled, the picture element will contain 1 srcset elements.
 		if ( ! $jpeg_and_webp && ! $expect_picture_element ) {
@@ -65,6 +80,7 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		// When only picture_element is enabled, the picture element will contain 2 srcset elements.
 		if ( ! $jpeg_and_webp && $expect_picture_element ) {
 			$this->assertEquals( 2, substr_count( $the_image, 'srcset=' ) );
+			$this->assertStringContainsString( '<source type="image/webp"', $the_image );
 		}
 	}
 

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -50,8 +50,22 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 			$this->assertStringNotContainsString( $picture_element, $the_image );
 		}
 
-		// When both features are enabled, the picture element will contain two srcset elements.
-		$this->assertEquals( ( $jpeg_and_webp && $expect_picture_element ) ? 2 : 1, substr_count( $the_image, 'srcset=' ) );
+		// When both features are enabled, the picture element will contain 3 srcset elements.
+		if ( $jpeg_and_webp && $expect_picture_element ) {
+			$this->assertEquals( 3, substr_count( $the_image, 'srcset=' ) );
+		}
+		// When neither features are enabled, the picture element will contain 1 srcset elements.
+		if ( ! $jpeg_and_webp && ! $expect_picture_element ) {
+			$this->assertEquals( 1, substr_count( $the_image, 'srcset=' ) );
+		}
+		// When only jpeg_and_webp is enabled, the picture element will contain 1 srcset elements.
+		if ( $jpeg_and_webp && ! $expect_picture_element ) {
+			$this->assertEquals( 1, substr_count( $the_image, 'srcset=' ) );
+		}
+		// When only picture_element is enabled, the picture element will contain 2 srcset elements.
+		if ( ! $jpeg_and_webp && $expect_picture_element ) {
+			$this->assertEquals( 2, substr_count( $the_image, 'srcset=' ) );
+		}
 	}
 
 	/**

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -49,14 +49,10 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		);
 
 		$processor = new WP_HTML_Tag_Processor( $the_image );
-		$width     = 0;
-		$height    = 0;
-		$alt       = '';
-		if ( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
-			$width  = (int) $processor->get_attribute( 'width' );
-			$height = (int) $processor->get_attribute( 'height' );
-			$alt    = (string) $processor->get_attribute( 'alt' );
-		}
+		$this->assertTrue( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) );
+		$width  = (int) $processor->get_attribute( 'width' );
+		$height = (int) $processor->get_attribute( 'height' );
+		$alt    = (string) $processor->get_attribute( 'alt' );
 
 		$size_to_use                  = ( $width > 0 && $height > 0 ) ? array( $width, $height ) : 'full';
 		$image_src                    = wp_get_attachment_image_src( $attachment_id, $size_to_use );

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -88,39 +88,8 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		// Apply the wp_content_img_tag filter.
 		$the_image = apply_filters( 'wp_content_img_tag', $the_image, 'the_content', $attachment_id );
 
-		// Check that the image is wrapped in a picture element with the correct class.
-		$picture_element = sprintf( '<picture class="wp-picture-%s" style="display: contents;">', $attachment_id );
-		if ( $expect_picture_element ) {
-			$this->assertStringContainsString( $picture_element, $the_image );
-		} else {
-			$this->assertStringNotContainsString( $picture_element, $the_image );
-		}
-
+		// Check that the image has the expected HTML.
 		$this->assertEquals( $expected_html, $the_image );
-		$this->assertStringContainsString( '<img', $the_image );
-
-		// Check that the image has the correct alt text.
-		$this->assertStringContainsString( 'alt="Green Leaves"', $the_image );
-
-		// When both features are enabled, the picture element will contain 3 srcset elements.
-		if ( $jpeg_and_webp && $expect_picture_element ) {
-			$this->assertEquals( 3, substr_count( $the_image, 'srcset=' ) );
-			$this->assertStringContainsString( '<source type="image/webp"', $the_image );
-			$this->assertStringContainsString( '<source type="image/jpeg"', $the_image );
-		}
-		// When neither features are enabled, the picture element will contain 1 srcset elements.
-		if ( ! $jpeg_and_webp && ! $expect_picture_element ) {
-			$this->assertEquals( 1, substr_count( $the_image, 'srcset=' ) );
-		}
-		// When only jpeg_and_webp is enabled, the picture element will contain 1 srcset elements.
-		if ( $jpeg_and_webp && ! $expect_picture_element ) {
-			$this->assertEquals( 1, substr_count( $the_image, 'srcset=' ) );
-		}
-		// When only picture_element is enabled, the picture element will contain 2 srcset elements.
-		if ( ! $jpeg_and_webp && $expect_picture_element ) {
-			$this->assertEquals( 2, substr_count( $the_image, 'srcset=' ) );
-			$this->assertStringContainsString( '<source type="image/webp"', $the_image );
-		}
 	}
 
 	/**

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -75,15 +75,19 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		$webp_srcset = str_replace( '.jpg', '-jpg.webp', $jpeg_srcset );
 
 		// Prepare the expected HTML by replacing placeholders with expected values.
-		$expected_html = str_replace( '{{img-width}}', $width, $expected_html );
-		$expected_html = str_replace( '{{img-height}}', $height, $expected_html );
-		$expected_html = str_replace( '{{img-src}}', $img_src, $expected_html );
-		$expected_html = str_replace( '{{img-attachment-id}}', $attachment_id, $expected_html );
-		$expected_html = str_replace( '{{img-alt}}', $alt, $expected_html );
-		$expected_html = str_replace( '{{img-srcset}}', $image_srcset, $expected_html );
-		$expected_html = str_replace( '{{img-sizes}}', $sizes, $expected_html );
-		$expected_html = str_replace( '{{jpeg-srcset}}', $jpeg_srcset, $expected_html );
-		$expected_html = str_replace( '{{webp-srcset}}', $webp_srcset, $expected_html );
+		$replacements = array(
+			'{{img-width}}'         => $width,
+			'{{img-height}}'        => $height,
+			'{{img-src}}'           => $img_src,
+			'{{img-attachment-id}}' => $attachment_id,
+			'{{img-alt}}'           => $alt,
+			'{{img-srcset}}'        => $image_srcset,
+			'{{img-sizes}}'         => $sizes,
+			'{{jpeg-srcset}}'       => $jpeg_srcset,
+			'{{webp-srcset}}'       => $webp_srcset,
+		);
+
+		$expected_html = str_replace( array_keys( $replacements ), array_values( $replacements ), $expected_html );
 
 		// Apply the wp_content_img_tag filter.
 		$the_image = apply_filters( 'wp_content_img_tag', $the_image, 'the_content', $attachment_id );


### PR DESCRIPTION
## Summary
- Add alt text to original_image_without_srcset variable which was missing.

Fixes #1315

## Relevant technical choices


For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
