### PR TITLE
Set fetchpriority to low if image is in the initial viewport

### DIFF
--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -78,6 +78,10 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 			} elseif ( ! $is_visible && 'lazy' !== $loading ) {
 				$walker->set_attribute( 'loading', 'lazy' );
 			}
+			// If the element is not visible in the initial viewport, set fetchpriority to low.
+			if ( ! $is_visible ) {
+				$walker->set_attribute( 'fetchpriority', 'low' );
+			}
 		}
 		// TODO: If an image is visible in one breakpoint but not another, add loading=lazy AND add a regular-priority preload link with media queries (unless LCP in which case it should already have a fetchpriority=high link) so that the image won't be eagerly-loaded for viewports on which it is not shown.
 

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -287,9 +287,9 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 							<p>Pretend this is a super long paragraph that pushes the next image mostly out of the initial viewport.</p>
 							<img data-od-removed-fetchpriority="high" data-od-removed-loading="lazy" src="https://example.com/bar.jpg" alt="Bar" width="10" height="10"  >
 							<p>Now the following image is definitely outside the initial viewport.</p>
-							<img data-od-added-loading data-od-removed-fetchpriority="high" loading="lazy" src="https://example.com/baz.jpg" alt="Baz" width="10" height="10" >
-							<img data-od-removed-fetchpriority="high" data-od-replaced-loading="eager" src="https://example.com/qux.jpg" alt="Qux" width="10" height="10"  loading="lazy">
-							<img src="https://example.com/quux.jpg" alt="Quux" width="10" height="10" loading="lazy"><!-- This one is all good. -->
+							<img data-od-added-fetchpriority data-od-added-loading data-od-removed-fetchpriority="high" loading="lazy" src="https://example.com/baz.jpg" alt="Baz" width="10" height="10" fetchpriority="low">
+							<img data-od-added-fetchpriority data-od-removed-fetchpriority="high" data-od-replaced-loading="eager" src="https://example.com/qux.jpg" alt="Qux" width="10" height="10" fetchpriority="low" loading="lazy">
+							<img data-od-added-fetchpriority fetchpriority="low" src="https://example.com/quux.jpg" alt="Quux" width="10" height="10" loading="lazy"><!-- This one is all good. -->
 						</body>
 					</html>
 				',


### PR DESCRIPTION
## Summary
Set fetchpriority to low if image is in the initial viewport but is not visible

Fixes #1309 

## Relevant technical choices

```php
if ( ! $is_visible ) {
	$walker->set_attribute( 'fetchpriority', 'low' );
}
```