### PR TITLE
Upgrade PHPStan to 1.11.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -732,16 +732,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.5",
+            "version": "1.11.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443"
+                "reference": "6ac78f1165346c83b4a753f7e4186d969c6ad0ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/490f0ae1c92b082f154681d7849aee776a7c1443",
-                "reference": "490f0ae1c92b082f154681d7849aee776a7c1443",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/6ac78f1165346c83b4a753f7e4186d969c6ad0ee",
+                "reference": "6ac78f1165346c83b4a753f7e4186d969c6ad0ee",
                 "shasum": ""
             },
             "require": {
@@ -786,7 +786,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-17T15:10:54+00:00"
+            "time": "2024-07-01T15:33:06+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",

--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -39,11 +39,9 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 		if (
 			is_string( $style )
 			&&
-			0 < (int) preg_match( '/background(?:-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
+			preg_match( '/background(?:-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches ) // Not compatible with strict rules. See <https://github.com/phpstan/phpstan/issues/11262>.
 			&&
-			isset( $matches['background_image'] ) // PHPStan should ideally know that this is set since the above preg_match() returned successfully.
-			&&
-			'' !== $matches['background_image'] // PHPStan should ideally know that this is a non-empty string based on the `.+?` regular expression.
+			'' !== $matches['background_image'] // PHPStan should ideally know that this is a non-empty string based on the `.+?` regular expression. See <https://github.com/phpstan/phpstan/issues/11222>.
 			&&
 			! $this->is_data_url( $matches['background_image'] )
 		) {

--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -41,6 +41,8 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 			&&
 			0 < (int) preg_match( '/background(-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
 			&&
+			isset( $matches['background_image'] ) // PHPStan should ideally know that this is set since the above preg_match() returned successfully.
+			&&
 			'' !== $matches['background_image'] // PHPStan should ideally know that this is a non-empty string based on the `.+?` regular expression.
 			&&
 			! $this->is_data_url( $matches['background_image'] )

--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -39,7 +39,7 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 		if (
 			is_string( $style )
 			&&
-			0 < (int) preg_match( '/background(-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
+			0 < (int) preg_match( '/background(?:-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
 			&&
 			isset( $matches['background_image'] ) // PHPStan should ideally know that this is set since the above preg_match() returned successfully.
 			&&

--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -39,7 +39,7 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 		if (
 			is_string( $style )
 			&&
-			preg_match( '/background(?:-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches ) // Not compatible with strict rules. See <https://github.com/phpstan/phpstan/issues/11262>.
+			1 === preg_match( '/background(?:-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches ) // Not compatible with strict rules. See <https://github.com/phpstan/phpstan/issues/11262>.
 			&&
 			'' !== $matches['background_image'] // PHPStan should ideally know that this is a non-empty string based on the `.+?` regular expression. See <https://github.com/phpstan/phpstan/issues/11222>.
 			&&

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -533,29 +533,28 @@ function webp_uploads_update_image_references( $content ): string {
 	}
 
 	// This content does not have any tag on it, move forward.
+	// TODO: Eventually this should use the HTML API to parse out the image tags and then update them.
 	if ( ! preg_match_all( '/<(img)\s[^>]+>/', $content, $img_tags, PREG_SET_ORDER ) ) {
 		return $content;
 	}
 
 	$images = array();
 	foreach ( $img_tags as list( $img ) ) {
-		// Find the ID of each image by the class.
-		if ( ! preg_match( '/wp-image-([\d]+)/i', $img, $class_name ) ) {
+		$processor = new WP_HTML_Tag_Processor( $img );
+		if ( ! $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+			// This condition won't ever be met since we're iterating over the IMG tags extracted with preg_match_all() above.
 			continue;
 		}
 
-		if ( empty( $class_name ) ) {
+		// Find the ID of each image by the class.
+		// TODO: It would be preferable to use the $processor->class_list() method but there seems to be some typing issues with PHPStan.
+		$class_name = $processor->get_attribute( 'class' );
+		if ( ! is_string( $class_name ) || ! preg_match( '/(?:^|\s)wp-image-([1-9]\d*)(?:\s|$)/i', $class_name, $matches ) ) {
 			continue;
 		}
 
 		// Make sure we use the last item on the list of matches.
-		$attachment_id = (int) $class_name[1];
-
-		if ( ! $attachment_id ) {
-			continue;
-		}
-
-		$images[ $img ] = $attachment_id;
+		$images[ $img ] = (int) $matches[1];
 	}
 
 	$attachment_ids = array_unique( array_filter( array_values( $images ) ) );

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -479,6 +479,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$this->assertNotEmpty( $expected_tag );
 		$this->assertNotSame( $tag, $expected_tag );
 		$this->assertSame( $expected_tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->mock_frontend_body_hooks();
+		$this->assertSame( $expected_tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	/**
@@ -521,6 +523,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$this->assertNotEmpty( $expected_tag );
 		$this->assertNotSame( $tag, $expected_tag );
 		$this->assertSame( $expected_tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->mock_frontend_body_hooks();
+		$this->assertSame( $expected_tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	/**
@@ -544,6 +548,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$tag           = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->mock_frontend_body_hooks();
+		$this->assertSame( $tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	public function provider_replace_images_with_different_extensions(): Generator {
@@ -570,8 +576,11 @@ class Test_WebP_Uploads_Load extends TestCase {
 		);
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertSame( $expected, wp_check_filetype( get_attached_file( $attachment_id ) ) );
+		$this->mock_frontend_body_hooks();
 		$this->assertStringNotContainsString( wp_basename( get_attached_file( $attachment_id ) ), webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->assertStringNotContainsString( wp_basename( get_attached_file( $attachment_id ) ), webp_uploads_update_image_references( $tag ) );
 		$this->assertStringContainsString( $metadata['sources']['image/webp']['file'], webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->assertStringNotContainsString( wp_basename( get_attached_file( $attachment_id ) ), webp_uploads_update_image_references( $tag ) );
 	}
 
 	/**
@@ -586,6 +595,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->mock_frontend_body_hooks();
+		$this->assertSame( $tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	/**
@@ -601,6 +612,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$tag = wp_get_attachment_image( $attachment_id, 'full', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 
 		$this->assertSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->mock_frontend_body_hooks();
+		$this->assertSame( $tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	public function data_provider_not_supported_webp_images(): Generator {
@@ -755,6 +768,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 
 		$tag = wp_get_attachment_image( $attachment_id, 'medium', false, array( 'class' => "wp-image-{$attachment_id}" ) );
 		$this->assertNotSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->mock_frontend_body_hooks();
+		$this->assertNotSame( $tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	/**
@@ -776,6 +791,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$result        = webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id );
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 		$this->assertImageHasSizeSource( $attachment_id, 'thumbnail', 'image/webp' );
+		$this->mock_frontend_body_hooks();
+		$this->assertSame( $result, webp_uploads_update_image_references( $tag ) );
 
 		$this->assertNotSame( $tag, $result );
 
@@ -817,6 +834,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 			$this->assertImageNotHasSizeSource( $attachment_id, $size, 'image/webp' );
 		}
 		$this->assertNotSame( $tag, webp_uploads_img_tag_update_mime_type( $tag, 'the_content', $attachment_id ) );
+		$this->mock_frontend_body_hooks();
+		$this->assertNotSame( $tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	/**
@@ -848,6 +867,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 
 		$this->assertNotSame( $tag, $updated_tag );
 		$this->assertSame( $expected_tag, $updated_tag );
+		$this->mock_frontend_body_hooks();
+		$this->assertSame( $expected_tag, webp_uploads_update_image_references( $tag ) );
 	}
 
 	/**


### PR DESCRIPTION
This upgrades PHPStan to 1.11.6 which introduced two new issues.

```
 ------ -------------------------------------------------------------------------------------------------------------------- 
  Line   plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php                           
 ------ -------------------------------------------------------------------------------------------------------------------- 
  44     Offset 'background_image' might not exist on array{0?: string, 1?: string, background_image?: string, 2?: string}.  
 ------ -------------------------------------------------------------------------------------------------------------------- 
```

This is a case where PHPStan is not aware that at this point, the array keys are actually not nullable at this point. This is a bug in PHPStan which I've filed as https://github.com/phpstan/phpstan/issues/11262. The issue seems to be that if the return value of `preg_match()` is casted to a `bool` or `int` then the array shape doesn't come through. So it's now checking to see if the return value is exactly `1` instead. Additionally, another check for `'' !== $matches['background_image']` will be able to be removed once https://github.com/phpstan/phpstan/issues/11222 is implemented, since we'll know that the array shape here has a `non-empty-string`.

```
 ------ ----------------------------------------------------------------- 
  Line   plugins/webp-uploads/hooks.php                                   
 ------ ----------------------------------------------------------------- 
  547    Variable $class_name in empty() always exists and is not falsy.  
 ------ -----------------------------------------------------------------
```

There was addressing the second `if` statement in the following code:

https://github.com/WordPress/performance/blob/b71d0a0eab14ceaed86b45a17899284fb0a14dc3/plugins/webp-uploads/hooks.php#L542-L549

It is a useless condition because since `preg_match()` is known to have succeeded, the `$class_name` will never be empty.

This fixes the issue by removing that condition, but also makes the code more robust by leveraging the HTML Tag Processor. It also adds missing test assertions for `webp_uploads_update_image_references()`.




<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
