### PR TITLE
Fix Modern Image Formats picture element support for selected image sizes

### DIFF
--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -98,7 +98,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	foreach ( $mime_types as $image_mime_type ) {
 		$sizes = wp_calculate_image_sizes( $size_array, $src, $image_meta, $attachment_id );
 		if ( false === $sizes ) {
-			$image_srcset = $src;
+			continue;
 		}
 
 		// Filter core's wp_get_attachment_image_srcset to return the sources for the current mime type.

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -98,7 +98,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	foreach ( $mime_types as $image_mime_type ) {
 		$sizes = wp_calculate_image_sizes( $size_array, $src, $image_meta, $attachment_id );
 		if ( false === $sizes ) {
-			continue;
+			$image_srcset = $src;
 		}
 
 		// Filter core's wp_get_attachment_image_srcset to return the sources for the current mime type.
@@ -121,7 +121,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		$image_srcset = wp_get_attachment_image_srcset( $attachment_id, $size_array, $image_meta );
 		remove_filter( 'wp_calculate_image_srcset', $filter );
 		if ( false === $image_srcset ) {
-			continue;
+			$image_srcset = $src;
 		}
 		$picture_sources .= sprintf(
 			'<source type="%s" srcset="%s" sizes="%s">',

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -111,11 +111,10 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 
 		// Check that the generated HTML contains the expected image URL and has the correct class.
 		$this->assertStringContainsString( $thumbnail_url, $the_image );
-		$this->assertStringContainsString( "wp-picture-{$attachment_id}", $the_image );
 
 		// Ensure that the source element exists in the picture element and has the correct mime type.
-		$webp_source = sprintf( '<source type="image/webp"', $attachment_id );
-		$jpg_source  = sprintf( '<source type="image/jpeg"', $attachment_id );
+		$webp_source = '<source type="image/webp"';
+		$jpg_source  = '<source type="image/jpeg"';
 		$this->assertStringContainsString( $webp_source, $the_image );
 		$this->assertStringContainsString( $jpg_source, $the_image );
 	}

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -83,4 +83,40 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * Test the correct image size rendered in the picture element.
+	 */
+	public function test_thumbnail_image_size_in_picture_element(): void {
+		// Enable necessary plugin settings.
+		$this->opt_in_to_jpeg_and_webp();
+		$this->opt_in_to_picture_element();
+
+		// Create an image attachment with jpeg image.
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/car.jpeg' );
+
+		$image_size = 'thumbnail';
+
+		// Get the thumbnail size URL directly (simulate Gutenberg usage).
+		$thumbnail_url = wp_get_attachment_image_url( $attachment_id, $image_size );
+
+		// Check if the URL is not empty and contains the expected thumbnail size dimension.
+		$this->assertNotEmpty( $thumbnail_url );
+
+		// Fetch the HTML output of the image in Gutenberg.
+		$the_image = wp_get_attachment_image( $attachment_id, $image_size, false, array( 'class' => "wp-image-{$attachment_id}" ) );
+
+		// Apply the wp_content_img_tag filter.
+		$the_image = apply_filters( 'wp_content_img_tag', $the_image, 'the_content', $attachment_id );
+
+		// Check that the generated HTML contains the expected image URL and has the correct class.
+		$this->assertStringContainsString( $thumbnail_url, $the_image );
+		$this->assertStringContainsString( "wp-picture-{$attachment_id}", $the_image );
+
+		// Ensure that the source element exists in the picture element and has the correct mime type.
+		$webp_source = sprintf( '<source type="image/webp"', $attachment_id );
+		$jpg_source  = sprintf( '<source type="image/jpeg"', $attachment_id );
+		$this->assertStringContainsString( $webp_source, $the_image );
+		$this->assertStringContainsString( $jpg_source, $the_image );
+	}
 }


### PR DESCRIPTION
## Description
This PR addresses an issue with the Modern Image Formats plugin's picture element support, where the generated markup did not account for the image sizes selected from the editor.
Fixes #1316 


## Problem
When using the Modern Image Formats plugin with picture element support enabled, the generated markup would load the full-size image instead of the selected image size (e.g., Thumbnail) and the <source> elements were missing for the selected image size.


## Solution
To fix this issue, the PR introduces the following changes:
- When the `$sizes` is false or `$image_srcset` is empty, then `$image_srcset` should be set to the modern image format version of the `$src`.
- `$image_srcset` then correctly generates the source tags and correct image size is set based on the value selected in the editor

## Testing
All the test are passing locally.


## Outcome

<img width="1604" alt="Screenshot 2024-07-02 at 6 15 07 PM" src="https://github.com/WordPress/performance/assets/71687258/ae291ec3-87d9-43a1-9946-20ceb8b603e7">
