### PR TITLE
Bump minimum WP versions and WP version tested up to

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -42,10 +42,10 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2']
-        wp: [ 'latest' ]
+        wp: [ '6.6-RC1' ] # TODO: Change this back to latest.
         include:
           - php: '7.4'
-            wp: '6.4'
+            wp: '6.5'
           - php: '8.3'
             wp: 'trunk'
     env:

--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2']
-        wp: [ '6.6-RC1' ] # TODO: Change this back to latest.
+        wp: [ '6.6-RC2' ] # TODO: Change this back to latest.
         include:
           - php: '7.4'
             wp: '6.5'

--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Auto-sizes for Lazy-loaded Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
  * Description: Instructs browsers to automatically choose the right image size for lazy-loaded images.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 1.0.2
  * Author: WordPress Performance Team

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -1,8 +1,8 @@
 === Auto-sizes for Lazy-loaded Images ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        1.0.2
 License:           GPLv2 or later

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Image Placeholders
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
  * Description: Displays placeholders based on an image's dominant color while the image is loading.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 1.1.1
  * Author: WordPress Performance Team

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -1,8 +1,8 @@
 === Image Placeholders ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        1.1.1
 License:           GPLv2 or later

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -43,7 +43,7 @@ function embed_optimizer_filter_oembed_html( string $html ): string {
 			if ( empty( $loading_value ) ) {
 				++$iframe_count;
 				if ( ! $html_processor->set_bookmark( 'iframe' ) ) {
-					embed_optimizer_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to set iframe bookmark.', 'embed-optimizer' ) );
+					wp_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to set iframe bookmark.', 'embed-optimizer' ) );
 					return $html;
 				}
 			}
@@ -53,7 +53,7 @@ function embed_optimizer_filter_oembed_html( string $html ): string {
 			} else {
 				++$script_count;
 				if ( ! $html_processor->set_bookmark( 'script' ) ) {
-					embed_optimizer_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to set script bookmark.', 'embed-optimizer' ) );
+					wp_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to set script bookmark.', 'embed-optimizer' ) );
 					return $html;
 				}
 			}
@@ -68,7 +68,7 @@ function embed_optimizer_filter_oembed_html( string $html ): string {
 			}
 			$html_processor->set_attribute( 'type', 'application/vnd.embed-optimizer.javascript' );
 		} else {
-			embed_optimizer_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to seek to script bookmark.', 'embed-optimizer' ) );
+			wp_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to seek to script bookmark.', 'embed-optimizer' ) );
 		}
 	}
 	// If there was only one iframe, make it lazy.
@@ -92,7 +92,7 @@ function embed_optimizer_filter_oembed_html( string $html ): string {
 				}
 			}
 		} else {
-			embed_optimizer_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to seek to iframe bookmark.', 'embed-optimizer' ) );
+			wp_trigger_error( __FUNCTION__, esc_html__( 'Embed Optimizer unable to seek to iframe bookmark.', 'embed-optimizer' ) );
 		}
 	}
 	return $html_processor->get_updated_html();
@@ -145,29 +145,6 @@ function embed_optimizer_lazy_load_scripts(): void {
 		}
 JS;
 	wp_print_inline_script_tag( $js, array( 'type' => 'module' ) );
-}
-
-/**
- * Generates a user-level error/warning/notice/deprecation message.
- *
- * Generates the message when `WP_DEBUG` is true.
- *
- * @since 0.1.0
- *
- * @param string $function_name The function that triggered the error.
- * @param string $message       The message explaining the error.
- *                              The message can contain allowed HTML 'a' (with href), 'code',
- *                              'br', 'em', and 'strong' tags and http or https protocols.
- *                              If it contains other HTML tags or protocols, the message should be escaped
- *                              before passing to this function to avoid being stripped {@see wp_kses()}.
- * @param int    $error_level   Optional. The designated error type for this error.
- *                              Only works with E_USER family of constants. Default E_USER_NOTICE.
- */
-function embed_optimizer_trigger_error( string $function_name, string $message, int $error_level = E_USER_NOTICE ): void {
-	if ( ! function_exists( 'wp_trigger_error' ) ) {
-		return;
-	}
-	wp_trigger_error( $function_name, $message, $error_level );
 }
 
 /**

--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Embed Optimizer
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer
  * Description: Optimizes the performance of embeds by lazy-loading iframes and scripts.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 0.1.2
  * Author: WordPress Performance Team

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -1,8 +1,8 @@
 === Embed Optimizer ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        0.1.2
 License:           GPLv2 or later

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Image Prioritizer
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer
  * Description: Optimizes LCP image loading with <code>fetchpriority=high</code> and applies image lazy-loading by leveraging client-side detection with real user metrics.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
  * Version: 0.1.1

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -1,8 +1,8 @@
 === Image Prioritizer ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        0.1.1
 License:           GPLv2 or later

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -20,25 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 
 	/**
-	 * Whether the old (pre-WP 6.5) signature for WP_HTML_Text_Replacement is needed.
-	 *
-	 * WordPress 6.5 changed the $end arg in the WP_HTML_Text_Replacement constructor to $length.
-	 *
-	 * @var bool
-	 */
-	private $old_text_replacement_signature_needed;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param string $html HTML to process.
-	 */
-	public function __construct( string $html ) {
-		$this->old_text_replacement_signature_needed = version_compare( get_bloginfo( 'version' ), '6.5', '<' );
-		parent::__construct( $html );
-	}
-
-	/**
 	 * Appends HTML to the provided bookmark.
 	 *
 	 * @param string $bookmark Bookmark.
@@ -54,7 +35,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 
 		$this->lexical_updates[] = new WP_HTML_Text_Replacement(
 			$start,
-			$this->old_text_replacement_signature_needed ? $start : 0,
+			0,
 			$html
 		);
 		return true;

--- a/plugins/optimization-detective/class-od-html-tag-walker.php
+++ b/plugins/optimization-detective/class-od-html-tag-walker.php
@@ -23,36 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class OD_HTML_Tag_Walker {
 
 	/**
-	 * HTML void tags (i.e. those which are self-closing).
-	 *
-	 * @link https://html.spec.whatwg.org/multipage/syntax.html#void-elements
-	 * @see WP_HTML_Processor::is_void()
-	 * @todo Reuse `WP_HTML_Processor::is_void()` once WordPress 6.5 is the minimum-supported version. See <https://github.com/WordPress/performance/pull/1115>.
-	 *
-	 * @var string[]
-	 */
-	const VOID_TAGS = array(
-		'AREA',
-		'BASE',
-		'BASEFONT', // Obsolete.
-		'BGSOUND', // Obsolete.
-		'BR',
-		'COL',
-		'EMBED',
-		'FRAME', // Deprecated.
-		'HR',
-		'IMG',
-		'INPUT',
-		'KEYGEN', // Obsolete.
-		'LINK',
-		'META',
-		'PARAM', // Deprecated.
-		'SOURCE',
-		'TRACK',
-		'WBR',
-	);
-
-	/**
 	 * Raw text tags.
 	 *
 	 * These are treated like void tags for the purposes of walking over the document since we do not process any text
@@ -269,7 +239,7 @@ final class OD_HTML_Tag_Walker {
 
 				// Immediately pop off self-closing and raw text tags.
 				if (
-					in_array( $tag_name, self::VOID_TAGS, true )
+					WP_HTML_Processor::is_void( $tag_name )
 					||
 					in_array( $tag_name, self::RAW_TEXT_TAGS, true )
 					||
@@ -280,7 +250,7 @@ final class OD_HTML_Tag_Walker {
 			} else {
 				// If the closing tag is for self-closing or raw text tag, we ignore it since it was already handled above.
 				if (
-					in_array( $tag_name, self::VOID_TAGS, true )
+					WP_HTML_Processor::is_void( $tag_name )
 					||
 					in_array( $tag_name, self::RAW_TEXT_TAGS, true )
 				) {

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Optimization Detective
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 0.3.1
  * Author: WordPress Performance Team

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -1,8 +1,8 @@
 === Optimization Detective ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        0.3.1
 License:           GPLv2 or later

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Performance Lab
  * Plugin URI: https://github.com/WordPress/performance
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 3.2.0
  * Author: WordPress Performance Team

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -1,8 +1,8 @@
 === Performance Lab ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        3.2.0
 License:           GPLv2 or later

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -24,25 +24,10 @@ function plsr_print_speculation_rules(): void {
 		return;
 	}
 
-	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/60320>.
-	$needs_html5_workaround = (
-		! current_theme_supports( 'html5', 'script' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.4', '>=' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.5', '<' )
-	);
-	if ( $needs_html5_workaround ) {
-		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];
-		add_theme_support( 'html5', array( 'script' ) );
-	}
-
 	wp_print_inline_script_tag(
 		(string) wp_json_encode( $rules ),
 		array( 'type' => 'speculationrules' )
 	);
-
-	if ( $needs_html5_workaround ) {
-		$GLOBALS['_wp_theme_features'] = $backup_wp_theme_features; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-	}
 }
 add_action( 'wp_footer', 'plsr_print_speculation_rules' );
 

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Speculative Loading
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/speculation-rules
  * Description: Enables browsers to speculatively prerender or prefetch pages when hovering over links.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 1.3.1
  * Author: WordPress Performance Team

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -1,8 +1,8 @@
 === Speculative Loading ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        1.3.1
 License:           GPLv2 or later

--- a/plugins/speculation-rules/tests/test-speculation-rules.php
+++ b/plugins/speculation-rules/tests/test-speculation-rules.php
@@ -25,29 +25,10 @@ class Test_Speculation_Rules extends WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'wp_head', 'plsr_render_generator_meta_tag' ) );
 	}
 
-	/** @return array<string, array{ html5_support: bool }> */
-	public function data_provider_to_test_print_speculation_rules(): array {
-		return array(
-			'xhtml' => array(
-				'html5_support' => false,
-			),
-			'html5' => array(
-				'html5_support' => true,
-			),
-		);
-	}
-
 	/**
-	 * @dataProvider data_provider_to_test_print_speculation_rules
 	 * @covers ::plsr_print_speculation_rules
 	 */
-	public function test_plsr_print_speculation_rules_without_html5_support( bool $html5_support ): void {
-		if ( $html5_support ) {
-			add_theme_support( 'html5', array( 'script' ) );
-		} else {
-			remove_theme_support( 'html5' );
-		}
-
+	public function test_plsr_print_speculation_rules_without_html5_support(): void {
 		$output = get_echo( 'plsr_print_speculation_rules' );
 		$this->assertStringContainsString( '<script type="speculationrules">', $output );
 
@@ -55,13 +36,6 @@ class Test_Speculation_Rules extends WP_UnitTestCase {
 		$rules = json_decode( $json, true );
 		$this->assertIsArray( $rules );
 		$this->assertArrayHasKey( 'prerender', $rules );
-
-		// Make sure that theme support was restored. This is only relevant to WordPress 6.4 per https://core.trac.wordpress.org/ticket/60320.
-		if ( $html5_support ) {
-			$this->assertStringNotContainsString( '/* <![CDATA[ */', wp_get_inline_script_tag( '/*...*/' ) );
-		} else {
-			$this->assertStringContainsString( '/* <![CDATA[ */', wp_get_inline_script_tag( '/*...*/' ) );
-		}
 	}
 
 	/**

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Modern Image Formats
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 2.0.1
  * Author: WordPress Performance Team

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -1,8 +1,8 @@
 === Modern Image Formats ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
+Requires at least: 6.5
+Tested up to:      6.6
 Requires PHP:      7.2
 Stable tag:        2.0.1
 License:           GPLv2 or later


### PR DESCRIPTION
In preparation for the WordPress 6.6 release, we need to update the `Tested up to` field to reflect 6.6. In the same way, we can now bump the `Requires at least` from 6.4 to 6.5. In addition to bumping these versions, this PR also removes obsolete code which was present exclusively for WP 6.4.

This cherry-picks some commits from https://github.com/WordPress/performance/pull/1302.