### PR TITLE
Remove 'Requires at least' and 'Requires PHP' from plugin readmes

### DIFF
--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -1,13 +1,11 @@
 === Auto-sizes for Lazy-loaded Images ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        1.0.2
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, auto-sizes
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.0.2
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, images, auto-sizes
 
 Instructs browsers to automatically choose the right image size for lazy-loaded images.
 

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -1,13 +1,11 @@
 === Image Placeholders ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        1.1.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, dominant color
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.1.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, images, dominant color
 
 Displays placeholders based on an image's dominant color while the image is loading.
 

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -1,13 +1,11 @@
 === Embed Optimizer ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        0.1.2
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, embeds
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   0.1.2
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, embeds
 
 Optimizes the performance of embeds by lazy-loading iframes and scripts.
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -1,13 +1,11 @@
 === Image Prioritizer ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        0.1.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, optimization, image, lcp, lazy-load
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   0.1.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, optimization, image, lcp, lazy-load
 
 Optimizes LCP image loading with `fetchpriority=high` and applies image lazy-loading by leveraging client-side detection with real user metrics.
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -1,13 +1,11 @@
 === Optimization Detective ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        0.3.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, optimization, rum
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   0.3.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, optimization, rum
 
 Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -1,13 +1,11 @@
 === Performance Lab ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        3.2.0
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, site health, measurement, optimization, diagnostics
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   3.2.0
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, site health, measurement, optimization, diagnostics
 
 Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
 

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -1,13 +1,11 @@
 === Speculative Loading ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        1.3.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, javascript, speculation rules, prerender, prefetch
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.3.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, javascript, speculation rules, prerender, prefetch
 
 Enables browsers to speculatively prerender or prefetch pages when hovering over links.
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -1,13 +1,11 @@
 === Modern Image Formats ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.5
-Tested up to:      6.6
-Requires PHP:      7.2
-Stable tag:        2.0.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, webp, avif, modern image formats
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   2.0.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, images, webp, avif, modern image formats
 
 Converts images to more modern formats such as WebP or AVIF during upload.
 


### PR DESCRIPTION
Per @swissspidy in https://github.com/WordPress/performance/pull/1333#discussion_r1669244143, the `Requires at least` and `Requires PHP` headers are no longer parsed from the readme but rather exclusively are read from the main plugin file. We can reduce the amount of redundancy and maintenance going forward by removing these.