### PR TITLE
Bump latest test version to 6.6-RC3 in php-test-plugins workflow

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2']
-        wp: [ '6.6-RC2' ] # TODO: Change this back to latest.
+        wp: [ '6.6-RC3' ] # TODO: Change this back to latest.
         include:
           - php: '7.4'
             wp: '6.5'


### PR DESCRIPTION
See https://wordpress.org/news/2024/07/wordpress-6-6-rc3/