### PR TITLE
Update the plugin header description

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Enhanced Responsive Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
- * Description: Improves responsive images with better sizes calculation and auto-sizes for lazy loaded images.
+ * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 1.0.2

--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Enhanced Responsive Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
- * Description: Instructs browsers to automatically choose the right image size for lazy-loaded images.
+ * Description: Improves responsive images with better sizes calculation and auto-sizes for lazy loaded images.
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 1.0.2


### PR DESCRIPTION
## Summary
This is a followup to #1339 to update the plugin description in the plugin header, which is what is shown in the Plugins screen in the WP admin. 

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

