### PR TITLE
Improve changelog generation script to support closed milestones and avoid adding an empty other section

### DIFF
--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -74,9 +74,14 @@ function updateReadmeChangelog( readmeFile, changelog ) {
 	let newContent = fileContent.replace(
 		regex,
 		( match, changelogHeading, _versionHeading, existingChangelog ) => {
-			status =
-				'Merged existing changelog with the new changelog in an Other section.';
-			return `${ changelogHeading }${ _versionHeading }${ normalizedChangelog }\n**Other**\n\n${ existingChangelog }`;
+			const newChangelog = `${ changelogHeading }${ _versionHeading.trimEnd() }\n\n${ normalizedChangelog }`;
+			if ( existingChangelog.trim() !== '' ) {
+				status =
+					'Merged existing changelog with the new changelog in an Other section.';
+				return `${ newChangelog }\n**Other**\n\n${ existingChangelog }`;
+			}
+			status = 'Populated empty changelog section.';
+			return `${ newChangelog }${ existingChangelog }`;
 		}
 	);
 

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -20,6 +20,7 @@ async function getMilestoneByTitle( octokit, owner, repo, title ) {
 	const options = octokit.issues.listMilestones.endpoint.merge( {
 		owner,
 		repo,
+		state: 'all',
 	} );
 
 	/**

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -70,7 +70,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 **Bug Fixes**
 
 * Extend core's Autoloaded Options Site Health test if present (in WP 6.6). ([1298](https://github.com/WordPress/performance/pull/1298))
-* Generate phpunit-multisite.xml on the fly. ([1327](https://github.com/WordPress/performance/pull/1327))
+* Fix unit tests for multisite. ([1327](https://github.com/WordPress/performance/pull/1327))
 
 = 3.2.0 =
 


### PR DESCRIPTION
During the release process for Performance Lab 3.3.0, there were a couple papercuts I noticed when generating the changelogs.

First, in order to satisfy `npm run versions` I added an empty changelog entry to the changelog. When running `npm run readme`, it would then take that empty changelog entry and put it in the `**Other**` section, erroneously. This PR fixes this by omitting this other section if it is empty. It also fixes insertion of a blank line break after the version heading.

Secondly, when attempting to generate a changelog for a closed milestone, the script would fail saying `Cannot find milestone by title`. This was confusing because the milestone does exist, but it is just closed. So this PR includes both open and closed milestones in the lookup.

Lastly, I corrected a changelog entry for Performance Lab.