### PR TITLE
Add notices to generate-pending-release-diffs which indicate whether a release will occur

### DIFF
--- a/bin/generate-pending-release-diffs.sh
+++ b/bin/generate-pending-release-diffs.sh
@@ -35,7 +35,7 @@ for plugin_slug in $( if [ $# -gt 0 ]; then echo "$@"; else jq '.plugins[]' -r p
 	if [ ! -d "$stable_dir/$plugin_slug" ]; then
 		svn co "https://plugins.svn.wordpress.org/$plugin_slug/trunk/" "$stable_dir/$plugin_slug" >&2
 	else
-		svn revert "$stable_dir/$plugin_slug" >&2
+		svn revert -R "$stable_dir/$plugin_slug" >&2
 		svn up --force "$stable_dir/$plugin_slug" >&2
 	fi
 


### PR DESCRIPTION
During the Performance Lab 3.3.0 release, a release for Image Prioritizer plugin was not performed when it should have been. This was in part due to the `generate-pending-release-diffs` script not highlighting it as having changes but where the `Stable tag` is unchanged, meaning no release would occur. So this PR improves the script by adding notices for the three different states a plugin can be in:

1. No changes
2. Changes, but the stable tag is unmodified
3. Changes and the stable tag has been bumped

Examples:


## `auto-sizes`

> [!NOTE]
> No changes.

## `dominant-color-images`

> [!WARNING]
> Stable tag is unchanged at 1.1.1, so no plugin release will occur.

`svn status`:
```
M       class-dominant-color-image-editor-gd.php
M       class-dominant-color-image-editor-imagick.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-dominant-color-image-editor-gd.php
===================================================================
--- class-dominant-color-image-editor-gd.php	(revision 3119685)
+++ class-dominant-color-image-editor-gd.php	(working copy)
@@ -32,11 +32,15 @@
 		}
 		// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 		$shorted_image = imagecreatetruecolor( 1, 1 );
-		$image_width   = imagesx( $this->image );
-		$image_height  = imagesy( $this->image );
-		if ( false === $shorted_image || false === $image_width || false === $image_height ) {
+		if ( false === $shorted_image ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
+		// Note: These two functions only return integers, but they used to return int|false in PHP<8. This was changed in the PHP documentation in
+		// <https://github.com/php/doc-en/commit/0462f49> and <https://github.com/php/doc-en/commit/37f858a>. However, PhpStorm's stubs still think
+		// they return int|false. However, from looking at <https://github.com/php/php-src/blob/5db847e/ext/gd/gd.stub.php#L716-L718> these functions
+		// apparently only ever returned integers. So the type casting is here for the possible sake PHP<8.
+		$image_width  = (int) imagesx( $this->image );
+		$image_height = (int) imagesy( $this->image );
 		imagecopyresampled( $shorted_image, $this->image, 0, 0, 0, 0, 1, 1, $image_width, $image_height );
 
 		$rgb = imagecolorat( $shorted_image, 0, 0 );
@@ -77,7 +81,12 @@
 				if ( false === $rgb ) {
 					return new WP_Error( 'unable_to_obtain_rgb_via_imagecolorat' );
 				}
-				$rgba = imagecolorsforindex( $this->image, $rgb );
+				try {
+					// Note: In PHP<8, this returns false if the color is out of range. In PHP8, this throws a ValueError instead.
+					$rgba = imagecolorsforindex( $this->image, $rgb );
+				} catch ( ValueError $error ) {
+					$rgba = false;
+				}
 				if ( ! is_array( $rgba ) ) {
 					return new WP_Error( 'unable_to_obtain_rgba_via_imagecolorsforindex' );
 				}
Index: class-dominant-color-image-editor-imagick.php
===================================================================
--- class-dominant-color-image-editor-imagick.php	(revision 3119685)
+++ class-dominant-color-image-editor-imagick.php	(working copy)
@@ -32,7 +32,6 @@
 		}
 
 		try {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 			$this->image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
 			$pixel = $this->image->getImagePixelColor( 0, 0 );
Index: readme.txt
===================================================================
--- readme.txt	(revision 3119685)
+++ readme.txt	(working copy)
@@ -1,13 +1,11 @@
 === Image Placeholders ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
-Requires PHP:      7.2
-Stable tag:        1.1.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, dominant color
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.1.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, images, dominant color
 
 Displays placeholders based on an image's dominant color while the image is loading.
 
```
</details>

## `speculation-rules`

> [!IMPORTANT]
> Stable tag change: 1.3.1 → **1.3.2**

`svn status`:
```
M       hooks.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: hooks.php
===================================================================
--- hooks.php	(revision 3119685)
+++ hooks.php	(working copy)
@@ -24,25 +24,10 @@
 		return;
 	}
 
-	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/60320>.
-	$needs_html5_workaround = (
-		! current_theme_supports( 'html5', 'script' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.4', '>=' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.5', '<' )
-	);
-	if ( $needs_html5_workaround ) {
-		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];
-		add_theme_support( 'html5', array( 'script' ) );
-	}
-
 	wp_print_inline_script_tag(
 		(string) wp_json_encode( $rules ),
 		array( 'type' => 'speculationrules' )
 	);
-
-	if ( $needs_html5_workaround ) {
-		$GLOBALS['_wp_theme_features'] = $backup_wp_theme_features; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-	}
 }
 add_action( 'wp_footer', 'plsr_print_speculation_rules' );
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3119685)
+++ readme.txt	(working copy)
@@ -1,13 +1,11 @@
 === Speculative Loading ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
-Requires PHP:      7.2
-Stable tag:        1.3.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, javascript, speculation rules, prerender, prefetch
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.3.2
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, javascript, speculation rules, prerender, prefetch
 
 Enables browsers to speculatively prerender or prefetch pages when hovering over links.
 
```
</details>