### PR TITLE
Restore WP version to latest instead of 6.6-RC

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.2', '8.1', '8.0', '7.4', '7.3', '7.2']
-        wp: [ '6.6-RC3' ] # TODO: Change this back to latest.
+        wp: [ 'latest' ]
         include:
           - php: '7.4'
             wp: '6.5'


### PR DESCRIPTION
Now that WordPress 6.6 has been released, we can go back to using `latest` instead of `6.6-RC*` for testing.