### PR TITLE
Add labels for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,27 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - "no milestone"
+      - "[Type] Enhancement"
+      - "github_actions"
 
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - "no milestone"
+      - "[Type] Enhancement"
+      - "javascript"
 
   - package-ecosystem: composer
     directory: '/'
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    labels:
+      - "no milestone"
+      - "[Type] Enhancement"
+      - "php"


### PR DESCRIPTION
Labels are needed by our pr-validation workflow.

Follow up to #1355 

See #973 