### PR TITLE
Fix disabled options from reappearing in Site Health after external update

### DIFF
--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -211,7 +211,24 @@ function perflab_aao_get_autoloaded_options_table(): string {
 function perflab_aao_get_disabled_autoloaded_options_table(): string {
 	$disabled_options = get_option( 'perflab_aao_disabled_options', array() );
 
-	if ( ! is_array( $disabled_options ) ) {
+	$autoload_option_names = array_map(
+		static function ( $option ) {
+			return $option->option_name;
+		},
+		perflab_aao_query_autoloaded_options()
+	);
+
+	// Filter out the $disabled_options that are present in $autoload_option_names.
+	$disabled_options = array_filter(
+		$disabled_options,
+		static function ( $option ) use ( $autoload_option_names ) {
+			return ! in_array( $option, $autoload_option_names, true );
+		}
+	);
+
+	update_option( 'perflab_aao_disabled_options', $disabled_options );
+
+	if ( ! $disabled_options ) {
 		return '';
 	}
 

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -212,7 +212,7 @@ function perflab_aao_get_disabled_autoloaded_options_table(): string {
 	$disabled_options = (array) get_option( 'perflab_aao_disabled_options', array() );
 
 	$autoload_option_names = array_map(
-		static function ( $option ) {
+		static function ( object $option ): string {
 			return $option->option_name;
 		},
 		perflab_aao_query_autoloaded_options()
@@ -221,14 +221,14 @@ function perflab_aao_get_disabled_autoloaded_options_table(): string {
 	// Filter out the $disabled_options that are present in $autoload_option_names.
 	$disabled_options = array_filter(
 		$disabled_options,
-		static function ( $option ) use ( $autoload_option_names ) {
+		static function ( $option ) use ( $autoload_option_names ): bool {
 			return ! in_array( $option, $autoload_option_names, true );
 		}
 	);
 
 	update_option( 'perflab_aao_disabled_options', $disabled_options );
 
-	if ( ! $disabled_options ) {
+	if ( count( $disabled_options ) === 0 ) {
 		return '';
 	}
 

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -209,26 +209,9 @@ function perflab_aao_get_autoloaded_options_table(): string {
  * @return string HTML formatted table.
  */
 function perflab_aao_get_disabled_autoloaded_options_table(): string {
-	$disabled_options = (array) get_option( 'perflab_aao_disabled_options', array() );
+	$disabled_options = get_option( 'perflab_aao_disabled_options', array() );
 
-	$autoload_option_names = array_map(
-		static function ( object $option ): string {
-			return $option->option_name;
-		},
-		perflab_aao_query_autoloaded_options()
-	);
-
-	// Filter out the $disabled_options that are present in $autoload_option_names.
-	$disabled_options = array_filter(
-		$disabled_options,
-		static function ( $option ) use ( $autoload_option_names ): bool {
-			return ! in_array( $option, $autoload_option_names, true );
-		}
-	);
-
-	update_option( 'perflab_aao_disabled_options', $disabled_options );
-
-	if ( count( $disabled_options ) === 0 ) {
+	if ( ! is_array( $disabled_options ) ) {
 		return '';
 	}
 

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -209,7 +209,7 @@ function perflab_aao_get_autoloaded_options_table(): string {
  * @return string HTML formatted table.
  */
 function perflab_aao_get_disabled_autoloaded_options_table(): string {
-	$disabled_options = get_option( 'perflab_aao_disabled_options', array() );
+	$disabled_options = (array) get_option( 'perflab_aao_disabled_options', array() );
 
 	$autoload_option_names = array_map(
 		static function ( $option ) {

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
@@ -129,3 +129,27 @@ function perflab_aao_extend_core_check( string $description ): string {
 	return $description . perflab_aao_get_autoloaded_options_table() . perflab_aao_get_disabled_autoloaded_options_table();
 }
 add_filter( 'site_status_autoloaded_options_limit_description', 'perflab_aao_extend_core_check' );
+
+/**
+ * Filter the list of disabled options to exclude options that are autoloaded.
+ *
+ * This filter modifies the 'option_perflab_aao_disabled_options' to ensure
+ * that autoloaded options are not included in the disabled options list.
+ *
+ * @since n.e.x.t
+ *
+ * @param array $disabled_options Array of disabled options.
+ * @return array Filtered array of disabled options excluding autoloaded options.
+ */
+add_filter(
+	'option_perflab_aao_disabled_options',
+	static function ( $disabled_options ): array {
+		$autoload_option_names = wp_list_pluck( perflab_aao_query_autoloaded_options(), 'option_name' );
+		return array_filter(
+			(array) $disabled_options,
+			static function ( $option ) use ( $autoload_option_names ): bool {
+				return ! in_array( $option, $autoload_option_names, true );
+			}
+		);
+	}
+);

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
@@ -131,25 +131,23 @@ function perflab_aao_extend_core_check( string $description ): string {
 add_filter( 'site_status_autoloaded_options_limit_description', 'perflab_aao_extend_core_check' );
 
 /**
- * Filter the list of disabled options to exclude options that are autoloaded.
+ * Filters the list of disabled options to exclude options that are autoloaded.
  *
  * This filter modifies the 'option_perflab_aao_disabled_options' to ensure
  * that autoloaded options are not included in the disabled options list.
  *
  * @since n.e.x.t
  *
- * @param array $disabled_options Array of disabled options.
- * @return array Filtered array of disabled options excluding autoloaded options.
+ * @param string[]|mixed $disabled_options Array of disabled options.
+ * @return string[] Filtered array of disabled options excluding autoloaded options.
  */
-add_filter(
-	'option_perflab_aao_disabled_options',
-	static function ( $disabled_options ): array {
-		$autoload_option_names = wp_list_pluck( perflab_aao_query_autoloaded_options(), 'option_name' );
-		return array_filter(
-			(array) $disabled_options,
-			static function ( $option ) use ( $autoload_option_names ): bool {
-				return ! in_array( $option, $autoload_option_names, true );
-			}
-		);
-	}
-);
+function perflab_filter_option_perflab_aao_disabled_options( $disabled_options ): array {
+	$autoload_option_names = wp_list_pluck( perflab_aao_query_autoloaded_options(), 'option_name' );
+	return array_filter(
+		(array) $disabled_options,
+		static function ( $option ) use ( $autoload_option_names ): bool {
+			return ! in_array( $option, $autoload_option_names, true );
+		}
+	);
+}
+add_filter( 'option_perflab_aao_disabled_options', 'perflab_filter_option_perflab_aao_disabled_options' );

--- a/plugins/performance-lab/tests/includes/site-health/audit-autoloaded-options/test-audit-autoloaded-options.php
+++ b/plugins/performance-lab/tests/includes/site-health/audit-autoloaded-options/test-audit-autoloaded-options.php
@@ -121,12 +121,7 @@ class Test_Audit_Autoloaded_Options extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		// Mock wp_redirect to avoid actual redirection.
-		add_filter(
-			'wp_redirect',
-			static function () {
-				return false;
-			}
-		);
+		add_filter( 'wp_redirect', '__return_false' );
 
 		// Add an autoload option with small size length value for testing.
 		$test_option_string       = 'test';
@@ -177,14 +172,6 @@ class Test_Audit_Autoloaded_Options extends WP_UnitTestCase {
 		// Test that the reverted autoloaded option is displayed in the autoloaded options perflab_aao_get_autoloaded_options_table().
 		$table_html = perflab_aao_get_autoloaded_options_table();
 		$this->assertStringContainsString( self::AUTOLOADED_OPTION_KEY, $table_html );
-
-		// Remove the mock filter.
-		remove_filter(
-			'wp_redirect',
-			static function () {
-				return false;
-			}
-		);
 	}
 
 	public function test_perflab_aao_autoloaded_options_auto_enable_functionality(): void {
@@ -193,12 +180,7 @@ class Test_Audit_Autoloaded_Options extends WP_UnitTestCase {
 		wp_set_current_user( $user_id );
 
 		// Mock wp_redirect to avoid actual redirection.
-		add_filter(
-			'wp_redirect',
-			static function () {
-				return false;
-			}
-		);
+		add_filter( 'wp_redirect', '__return_false' );
 
 		// Add an autoload option with bigger size length value for testing.
 		self::set_autoloaded_option( self::WARNING_AUTOLOADED_SIZE_LIMIT_IN_BYTES );
@@ -227,14 +209,6 @@ class Test_Audit_Autoloaded_Options extends WP_UnitTestCase {
 		// Test that the disabled autoloaded option is displayed in the disabled options perflab_aao_get_disabled_autoloaded_options_table().
 		$table_html = perflab_aao_get_disabled_autoloaded_options_table();
 		$this->assertStringNotContainsString( self::AUTOLOADED_OPTION_KEY, $table_html );
-
-		// Remove the mock filter.
-		remove_filter(
-			'wp_redirect',
-			static function () {
-				return false;
-			}
-		);
 	}
 
 	/**

--- a/plugins/performance-lab/tests/includes/site-health/audit-autoloaded-options/test-audit-autoloaded-options.php
+++ b/plugins/performance-lab/tests/includes/site-health/audit-autoloaded-options/test-audit-autoloaded-options.php
@@ -174,6 +174,11 @@ class Test_Audit_Autoloaded_Options extends WP_UnitTestCase {
 		$this->assertStringContainsString( self::AUTOLOADED_OPTION_KEY, $table_html );
 	}
 
+	/**
+	 * Test that the list of disabled options excludes options that are autoloaded.
+	 *
+	 * @covers ::perflab_filter_option_perflab_aao_disabled_options
+	 */
 	public function test_perflab_aao_autoloaded_options_auto_enable_functionality(): void {
 
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1340


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
