### PR TITLE
Fix logic for seeking during optimization loop to prevent emitting seek() notices

### DIFF
--- a/plugins/auto-sizes/tests/test-optimization-detective.php
+++ b/plugins/auto-sizes/tests/test-optimization-detective.php
@@ -87,7 +87,7 @@ class Test_Auto_Sizes_Optimization_Detective extends WP_UnitTestCase {
 					'intersectionRatio' => 1,
 				),
 				'buffer'          => '<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" loading="lazy" srcset="https://example.com/foo-480w.jpg 480w, https://example.com/foo-800w.jpg 800w" sizes="auto, (max-width: 600px) 480px, 800px">',
-				'expected'        => '<img data-od-replaced-sizes="auto, (max-width: 600px) 480px, 800px" data-od-removed-loading="lazy" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800"  srcset="https://example.com/foo-480w.jpg 480w, https://example.com/foo-800w.jpg 800w" sizes="(max-width: 600px) 480px, 800px">',
+				'expected'        => '<img data-od-removed-loading="lazy" data-od-replaced-sizes="auto, (max-width: 600px) 480px, 800px" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800"  srcset="https://example.com/foo-480w.jpg 480w, https://example.com/foo-800w.jpg 800w" sizes="(max-width: 600px) 480px, 800px">',
 			),
 		);
 	}

--- a/plugins/embed-optimizer/tests/test-optimization-detective.php
+++ b/plugins/embed-optimizer/tests/test-optimization-detective.php
@@ -522,7 +522,7 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 										// Set a bunch of bookmarks to fill up the total allowed.
 										$remaining_bookmark_count = WP_HTML_Tag_Processor::MAX_BOOKMARKS - count( $bookmarks );
 										for ( $i = 0; $i < $remaining_bookmark_count; $i++ ) {
-											$processor->set_bookmark( "body_bookmark_{$i}" );
+											$this->assertTrue( $processor->set_bookmark( "body_bookmark_{$i}" ) );
 										}
 										return true;
 									}

--- a/plugins/embed-optimizer/tests/test-optimization-detective.php
+++ b/plugins/embed-optimizer/tests/test-optimization-detective.php
@@ -476,14 +476,14 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 						<body>
 							<figure data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]" class="wp-block-embed is-type-video">
 								<div class="wp-block-embed__wrapper">
-									<video data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]/*[1][self::VIDEO]" data-od-added-preload preload="auto" src="https://example.com/video1.mp4" poster="https://example.com/poster1.jpg" width="640" height="480"></video>
+									<video data-od-added-preload data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]/*[1][self::VIDEO]" preload="auto" src="https://example.com/video1.mp4" poster="https://example.com/poster1.jpg" width="640" height="480"></video>
 								</div>
 							</figure>
 							<figure data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[2][self::FIGURE]" class="wp-block-embed is-type-rich is-provider-figurine wp-block-embed-figurine">
 								<div class="wp-block-embed__wrapper">
 									<figure>
 										<p>So I heard you like <code>FIGURE</code>?</p>
-										<video data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[2][self::FIGURE]/*[1][self::DIV]/*[1][self::FIGURE]/*[2][self::VIDEO]" data-od-added-preload preload="none" src="https://example.com/video2.mp4" poster="https://example.com/poster2.jpg" width="640" height="480"></video>
+										<video data-od-added-preload data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[2][self::FIGURE]/*[1][self::DIV]/*[1][self::FIGURE]/*[2][self::VIDEO]" preload="none" src="https://example.com/video2.mp4" poster="https://example.com/poster2.jpg" width="640" height="480"></video>
 										<figcaption>Tagline from Figurine embed.</figcaption>
 									</figure>
 									<iframe data-od-added-loading loading="lazy" src="https://example.com/" width="640" height="480"></iframe>

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -48,7 +48,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 							<title>...</title>
 						</head>
 						<body>
-							<img data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]" data-od-unknown-tag src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" loading="lazy">
+							<img data-od-unknown-tag data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" loading="lazy">
 							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>
@@ -340,8 +340,8 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 							<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (min-width: 783px)">
 						</head>
 						<body>
-							<img data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]" data-od-removed-loading="lazy" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" >
-							<img data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]" data-od-removed-loading="lazy" src="https://example.com/bar.jpg" alt="Bar" width="10" height="10"  fetchpriority="high">
+							<img data-od-removed-loading="lazy" data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" >
+							<img data-od-removed-loading="lazy" data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]" src="https://example.com/bar.jpg" alt="Bar" width="10" height="10"  fetchpriority="high">
 							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -107,6 +107,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Bookmark for the end of the HEAD.
 	 *
+	 * @todo Consider reserving this.
 	 * @since 0.4.0
 	 * @var string
 	 */
@@ -115,6 +116,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Bookmark for the end of the BODY.
 	 *
+	 * @todo Consider reserving this.
 	 * @since 0.4.0
 	 * @var string
 	 */
@@ -175,6 +177,15 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * @var array<string, string[]>
 	 */
 	private $buffered_text_replacements = array();
+
+	/**
+	 * Count for the number of times next_token() was called
+	 *
+	 * @since n.e.x.t
+	 * @var int
+	 * @see self::next_token()
+	 */
+	private $next_token_count = 0;
 
 	/**
 	 * Finds the next tag.
@@ -247,6 +258,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 */
 	public function next_token(): bool {
 		$this->current_xpath = null; // Clear cache.
+		++$this->next_token_count;
 		if ( ! parent::next_token() ) {
 			$this->open_stack_tags    = array();
 			$this->open_stack_indices = array();
@@ -323,6 +335,18 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Gets the number of times next_token() was called.
+	 *
+	 * @since n.e.x.t
+	 * @see self::next_token()
+	 *
+	 * @return int Count of next_token() calls.
+	 */
+	public function get_next_token_count(): int {
+		return $this->next_token_count;
 	}
 
 	/**
@@ -409,11 +433,12 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Gets the seek count.
+	 * Gets the number of times seek() was called.
 	 *
 	 * @since n.e.x.t
+	 * @see self::seek()
 	 *
-	 * @return int Seek count.
+	 * @return int Count of seek() calls.
 	 */
 	public function get_seek_count(): int {
 		return $this->seek_count;

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -181,7 +181,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Count for the number of times next_token() was called
 	 *
-	 * @since n.e.x.t
+	 * @since 0.4.1
 	 * @var int
 	 * @see self::next_token()
 	 */
@@ -340,7 +340,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Gets the number of times next_token() was called.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.4.1
 	 * @see self::next_token()
 	 *
 	 * @return int Count of next_token() calls.
@@ -435,7 +435,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Gets the number of times seek() was called.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.4.1
 	 * @see self::seek()
 	 *
 	 * @return int Count of seek() calls.

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -409,6 +409,17 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Gets the seek count.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return int Seek count.
+	 */
+	public function get_seek_count(): int {
+		return $this->seek_count;
+	}
+
+	/**
 	 * Sets a bookmark in the HTML document.
 	 *
 	 * @inheritDoc

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -550,8 +550,11 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 			}
 			if ( ! $this->has_bookmark( $bookmark ) ) {
 				$this->warn(
-					/* translators: %s is the bookmark name */
-					__( 'Unable to append markup to %s since the bookmark no longer exists.', 'optimization-detective' )
+					sprintf(
+						/* translators: %s is the bookmark name */
+						__( 'Unable to append markup to %s since the bookmark no longer exists.', 'optimization-detective' ),
+						$bookmark
+					)
 				);
 			} else {
 				$start = $this->bookmarks[ $bookmark ]->start;

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.4.0
+ * Version: 0.4.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.4.0',
+	'0.4.1',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -176,16 +176,17 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	$visitors             = iterator_to_array( $tag_visitor_registry );
 	while ( $processor->next_open_tag() ) {
 		$did_visit = false;
-		$processor->set_bookmark( $current_tag_bookmark );
+		$processor->set_bookmark( $current_tag_bookmark ); // TODO: Should we break if this returns false?
 
 		foreach ( $visitors as $visitor ) {
-			$seek_count = $processor->get_seek_count();
-			$did_visit  = $visitor( $tag_visitor_context ) || $did_visit;
+			$seek_count       = $processor->get_seek_count();
+			$next_token_count = $processor->get_next_token_count();
+			$did_visit        = $visitor( $tag_visitor_context ) || $did_visit;
 
 			// If the visitor traversed HTML tags, we need to go back to this tag so that in the next iteration any
 			// relevant tag visitors may apply, in addition to properly setting the data-od-xpath on this tag below.
-			if ( $seek_count !== $processor->get_seek_count() ) {
-				$processor->seek( $current_tag_bookmark );
+			if ( $seek_count !== $processor->get_seek_count() || $next_token_count !== $processor->get_next_token_count() ) {
+				$processor->seek( $current_tag_bookmark ); // TODO: Should this break out of the optimization loop if it returns false?
 			}
 		}
 		$processor->release_bookmark( $current_tag_bookmark );

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -177,13 +177,16 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	while ( $processor->next_open_tag() ) {
 		$did_visit = false;
 		$processor->set_bookmark( $current_tag_bookmark );
-		foreach ( $visitors as $visitor ) {
-			$did_visit = $visitor( $tag_visitor_context ) || $did_visit;
 
-			// Since the visitor may have traversed HTML tags, we need to make sure we go back to this tag so that
-			// in the next iteration any relevant tag visitors may apply, in addition to properly setting the data-od-xpath
-			// on this tag below.
-			$processor->seek( $current_tag_bookmark );
+		foreach ( $visitors as $visitor ) {
+			$seek_count = $processor->get_seek_count();
+			$did_visit  = $visitor( $tag_visitor_context ) || $did_visit;
+
+			// If the visitor traversed HTML tags, we need to go back to this tag so that in the next iteration any
+			// relevant tag visitors may apply, in addition to properly setting the data-od-xpath on this tag below.
+			if ( $seek_count !== $processor->get_seek_count() ) {
+				$processor->seek( $current_tag_bookmark );
+			}
 		}
 		$processor->release_bookmark( $current_tag_bookmark );
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.4.0
+Stable tag:   0.4.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -132,6 +132,16 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.4.1 =
+
+**Enhancements**
+
+* Upgrade web-vitals.js from [v3.5.0](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v350-2023-09-28) to [v4.2.1](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v422-2024-07-17).
+
+**Bug Fixes**
+
+* Fix logic for seeking during optimization loop to prevent emitting seek() notices. ([1376](https://github.com/WordPress/performance/pull/1376))
 
 = 0.4.0 =
 

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -494,7 +494,6 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	/**
 	 * Test bookmarking and seeking.
 	 *
-	 * @covers ::get_seek_count
 	 * @covers ::set_bookmark
 	 * @covers ::seek
 	 * @covers ::release_bookmark
@@ -603,6 +602,38 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 		$this->assertFalse( $processor->has_bookmark( 'FIGURE' ) );
 
 		// TODO: Try adding too many bookmarks.
+	}
+
+	/**
+	 * Test get_seek_count.
+	 *
+	 * @covers ::get_seek_count
+	 */
+	public function test_get_next_token_count(): void {
+		$processor = new OD_HTML_Tag_Processor(
+			trim(
+				'
+				<html>
+					<head></head>
+					<body></body>
+				</html>
+				'
+			)
+		);
+		$this->assertSame( 0, $processor->get_next_token_count() );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'HTML', $processor->get_tag() );
+		$this->assertSame( 1, $processor->get_next_token_count() );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'HEAD', $processor->get_tag() );
+		$this->assertSame( 3, $processor->get_next_token_count() ); // Note that next_token() call #2 was for the whitespace between <html> and <head>.
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'HEAD', $processor->get_tag() );
+		$this->assertTrue( $processor->is_tag_closer() );
+		$this->assertSame( 4, $processor->get_next_token_count() );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'BODY', $processor->get_tag() );
+		$this->assertSame( 6, $processor->get_next_token_count() ); // Note that next_token() call #5 was for the whitespace between </head> and <body>.
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -494,6 +494,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	/**
 	 * Test bookmarking and seeking.
 	 *
+	 * @covers ::get_seek_count
 	 * @covers ::set_bookmark
 	 * @covers ::seek
 	 * @covers ::release_bookmark
@@ -519,6 +520,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 		);
 
 		$actual_figure_contents = array();
+		$this->assertSame( 0, $processor->get_seek_count() );
 
 		$bookmarks = array();
 		while ( $processor->next_open_tag() ) {
@@ -580,6 +582,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 				'depth' => $processor->get_current_depth(),
 			);
 		}
+		$this->assertSame( count( $bookmarks ), $processor->get_seek_count() );
 
 		$this->assertSame( $expected_figure_contents, $sought_actual_contents );
 

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -262,7 +262,6 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 			'video'                => array(
 				'set_up'   => function (): void {
 					$slug = od_get_url_metrics_slug( od_get_normalized_query_vars() );
-					$sample_size = od_get_url_metrics_breakpoint_sample_size();
 					foreach ( array_merge( od_get_breakpoint_max_widths(), array( 1000 ) ) as $viewport_width ) {
 						OD_URL_Metrics_Post_Type::store_url_metric(
 							$slug,
@@ -303,6 +302,79 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 								<source src="https://archive.org/download/ElephantsDream/ed_hd.avi" type="video/avi" />
 								<source src="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4" type="video/mp4" />
 							</video>
+							<script type="module">/* import detect ... */</script>
+						</body>
+					</html>
+				',
+			),
+
+			'many_images'          => array(
+				'set_up'   => function (): void {
+					$slug = od_get_url_metrics_slug( od_get_normalized_query_vars() );
+					foreach ( array_merge( od_get_breakpoint_max_widths(), array( 1000 ) ) as $viewport_width ) {
+
+						$elements = array();
+						for ( $i = 1; $i < WP_HTML_Tag_Processor::MAX_SEEK_OPS; $i++ ) {
+							$elements[] = array(
+								'xpath' => sprintf( '/*[1][self::HTML]/*[2][self::BODY]/*[%d][self::IMG]', $i ),
+								'isLCP' => false,
+							);
+						}
+
+						OD_URL_Metrics_Post_Type::store_url_metric(
+							$slug,
+							$this->get_validated_url_metric(
+								$viewport_width,
+								$elements
+							)
+						);
+					}
+				},
+				'buffer'   => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							' .
+							join(
+								"\n",
+								call_user_func(
+									static function () {
+										$tags = array();
+										for ( $i = 1; $i < WP_HTML_Tag_Processor::MAX_SEEK_OPS + 1; $i++ ) {
+											$tags[] = sprintf( '<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" loading="lazy">' );
+										}
+										return $tags;
+									}
+								)
+							) .
+							'
+						</body>
+					</html>
+				',
+				'expected' => '
+					<html lang="en">
+						<head>
+							<meta charset="utf-8">
+							<title>...</title>
+						</head>
+						<body>
+							' .
+							join(
+								"\n",
+								call_user_func(
+									static function () {
+										$tags = array();
+										for ( $i = 1; $i < WP_HTML_Tag_Processor::MAX_SEEK_OPS + 1; $i++ ) {
+											$tags[] = sprintf( '<img data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[%d][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" loading="lazy">', $i );
+										}
+										return $tags;
+									}
+								)
+							) .
+							'
 							<script type="module">/* import detect ... */</script>
 						</body>
 					</html>


### PR DESCRIPTION
## Summary

As observed by @thelovekesh, Optimization Detective is causing many notices to show up in the error log:

> Function WP_HTML_Tag_Processor::seek was called incorrectly. Too many calls to seek() - this can lead to performance issues. (This message was added in version 6.2.0.)

This is due to my incorrect implementation of the optimization loop, where it is seeking back to the current tag after calling a visitor, even if that visitor never seeked (sought?) or called `next_tag()`. I guess HTML Tag Processor should actually short-circuit if the bookmark being seeked to is the same as the current cursor (`bytes_already_parsed`). In any case, we can work around this by exposing the `seek_count` with a getter and only seeking back to the current tag if the seek count has increased and doing the same by counting the number of times that `next_token()` was called and seeking back if it was incremented. 

This also fixes a bug with a translation string I noticed.

## `optimization-detective`

> [!IMPORTANT]
> Stable tag change: 0.4.0 → **0.4.1**

`svn status`:
```
M       build/web-vitals.js
M       class-od-html-tag-processor.php
M       optimization.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: build/web-vitals.js
===================================================================
--- build/web-vitals.js	(revision 3121783)
+++ build/web-vitals.js	(working copy)
@@ -1 +1 @@
-var e,n,t,r,i,a=-1,o=function(e){addEventListener("pageshow",(function(n){n.persisted&&(a=n.timeStamp,e(n))}),!0)},c=function(){return window.performance&&performance.getEntriesByType&&performance.getEntriesByType("navigation")[0]},u=function(){var e=c();return e&&e.activationStart||0},f=function(e,n){var t=c(),r="navigate";return a>=0?r="back-forward-cache":t&&(document.prerendering||u()>0?r="prerender":document.wasDiscarded?r="restore":t.type&&(r=t.type.replace(/_/g,"-"))),{name:e,value:void 0===n?-1:n,rating:"good",delta:0,entries:[],id:"v3-".concat(Date.now(),"-").concat(Math.floor(8999999999999*Math.random())+1e12),navigationType:r}},s=function(e,n,t){try{if(PerformanceObserver.supportedEntryTypes.includes(e)){var r=new PerformanceObserver((function(e){Promise.resolve().then((function(){n(e.getEntries())}))}));return r.observe(Object.assign({type:e,buffered:!0},t||{})),r}}catch(e){}},d=function(e,n,t,r){var i,o;return function(a){n.value>=0&&(a||r)&&((o=n.value-(i||0))||void 0===i)&&(i=n.value,n.delta=o,n.rating=function(e,n){return e>n[1]?"poor":e>n[0]?"needs-improvement":"good"}(n.value,t),e(n))}},l=function(e){requestAnimationFrame((function(){return requestAnimationFrame((function(){return e()}))}))},p=function(e){var n=function(n){"pagehide"!==n.type&&"hidden"!==document.visibilityState||e(n)};addEventListener("visibilitychange",n,!0),addEventListener("pagehide",n,!0)},v=function(e){var n=!1;return function(t){n||(e(t),n=!0)}},m=-1,h=function(){return"hidden"!==document.visibilityState||document.prerendering?1/0:0},g=function(e){"hidden"===document.visibilityState&&m>-1&&(m="visibilitychange"===e.type?e.timeStamp:0,T())},y=function(){addEventListener("visibilitychange",g,!0),addEventListener("prerenderingchange",g,!0)},T=function(){removeEventListener("visibilitychange",g,!0),removeEventListener("prerenderingchange",g,!0)},E=function(){return m<0&&(m=h(),y(),o((function(){setTimeout((function(){m=h(),y()}),0)}))),{get firstHiddenTime(){return m}}},C=function(e){document.prerendering?addEventListener("prerenderingchange",(function(){return e()}),!0):e()},L=[1800,3e3],b=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("FCP"),a=s("paint",(function(e){e.forEach((function(e){"first-contentful-paint"===e.name&&(a.disconnect(),e.startTime<r.firstHiddenTime&&(i.value=Math.max(e.startTime-u(),0),i.entries.push(e),t(!0)))}))}));a&&(t=d(e,i,L,n.reportAllChanges),o((function(r){i=f("FCP"),t=d(e,i,L,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,t(!0)}))})))}))},w=[.1,.25],S=function(e,n){n=n||{},b(v((function(){var t,r=f("CLS",0),i=0,a=[],c=function(e){e.forEach((function(e){if(!e.hadRecentInput){var n=a[0],t=a[a.length-1];i&&e.startTime-t.startTime<1e3&&e.startTime-n.startTime<5e3?(i+=e.value,a.push(e)):(i=e.value,a=[e])}})),i>r.value&&(r.value=i,r.entries=a,t())},u=s("layout-shift",c);u&&(t=d(e,r,w,n.reportAllChanges),p((function(){c(u.takeRecords()),t(!0)})),o((function(){i=0,r=f("CLS",0),t=d(e,r,w,n.reportAllChanges),l((function(){return t()}))})),setTimeout(t,0))})))},A={passive:!0,capture:!0},I=new Date,P=function(r,i){e||(e=i,n=r,t=new Date,k(removeEventListener),F())},F=function(){if(n>=0&&n<t-I){var i={entryType:"first-input",name:e.type,target:e.target,cancelable:e.cancelable,startTime:e.timeStamp,processingStart:e.timeStamp+n};r.forEach((function(e){e(i)})),r=[]}},M=function(e){if(e.cancelable){var n=(e.timeStamp>1e12?new Date:performance.now())-e.timeStamp;"pointerdown"==e.type?function(e,n){var t=function(){P(e,n),i()},r=function(){i()},i=function(){removeEventListener("pointerup",t,A),removeEventListener("pointercancel",r,A)};addEventListener("pointerup",t,A),addEventListener("pointercancel",r,A)}(n,e):P(n,e)}},k=function(e){["mousedown","keydown","touchstart","pointerdown"].forEach((function(n){return e(n,M,A)}))},D=[100,300],x=function(t,i){i=i||{},C((function(){var a,c=E(),u=f("FID"),l=function(e){e.startTime<c.firstHiddenTime&&(u.value=e.processingStart-e.startTime,u.entries.push(e),a(!0))},m=function(e){e.forEach(l)},h=s("first-input",m);a=d(t,u,D,i.reportAllChanges),h&&p(v((function(){m(h.takeRecords()),h.disconnect()}))),h&&o((function(){var o;u=f("FID"),a=d(t,u,D,i.reportAllChanges),r=[],n=-1,e=null,k(addEventListener),o=l,r.push(o),F()}))}))},B=0,R=1/0,H=0,N=function(e){e.forEach((function(e){e.interactionId&&(R=Math.min(R,e.interactionId),H=Math.max(H,e.interactionId),B=H?(H-R)/7+1:0)}))},O=function(){return i?B:performance.interactionCount||0},q=function(){"interactionCount"in performance||i||(i=s("event",N,{type:"event",buffered:!0,durationThreshold:0}))},j=[200,500],_=0,z=function(){return O()-_},G=[],J={},K=function(e){var n=G[G.length-1],t=J[e.interactionId];if(t||G.length<10||e.duration>n.latency){if(t)t.entries.push(e),t.latency=Math.max(t.latency,e.duration);else{var r={id:e.interactionId,latency:e.duration,entries:[e]};J[r.id]=r,G.push(r)}G.sort((function(e,n){return n.latency-e.latency})),G.splice(10).forEach((function(e){delete J[e.id]}))}},Q=function(e,n){n=n||{},C((function(){var t;q();var r,i=f("INP"),a=function(e){e.forEach((function(e){e.interactionId&&K(e),"first-input"===e.entryType&&!G.some((function(n){return n.entries.some((function(n){return e.duration===n.duration&&e.startTime===n.startTime}))}))&&K(e)}));var n,t=(n=Math.min(G.length-1,Math.floor(z()/50)),G[n]);t&&t.latency!==i.value&&(i.value=t.latency,i.entries=t.entries,r())},c=s("event",a,{durationThreshold:null!==(t=n.durationThreshold)&&void 0!==t?t:40});r=d(e,i,j,n.reportAllChanges),c&&("interactionId"in PerformanceEventTiming.prototype&&c.observe({type:"first-input",buffered:!0}),p((function(){a(c.takeRecords()),i.value<0&&z()>0&&(i.value=0,i.entries=[]),r(!0)})),o((function(){G=[],_=O(),i=f("INP"),r=d(e,i,j,n.reportAllChanges)})))}))},U=[2500,4e3],V={},W=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("LCP"),a=function(e){var n=e[e.length-1];n&&n.startTime<r.firstHiddenTime&&(i.value=Math.max(n.startTime-u(),0),i.entries=[n],t())},c=s("largest-contentful-paint",a);if(c){t=d(e,i,U,n.reportAllChanges);var m=v((function(){V[i.id]||(a(c.takeRecords()),c.disconnect(),V[i.id]=!0,t(!0))}));["keydown","click"].forEach((function(e){addEventListener(e,(function(){return setTimeout(m,0)}),!0)})),p(m),o((function(r){i=f("LCP"),t=d(e,i,U,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,V[i.id]=!0,t(!0)}))}))}}))},X=[800,1800],Y=function e(n){document.prerendering?C((function(){return e(n)})):"complete"!==document.readyState?addEventListener("load",(function(){return e(n)}),!0):setTimeout(n,0)},Z=function(e,n){n=n||{};var t=f("TTFB"),r=d(e,t,X,n.reportAllChanges);Y((function(){var i=c();if(i){var a=i.responseStart;if(a<=0||a>performance.now())return;t.value=Math.max(a-u(),0),t.entries=[i],r(!0),o((function(){t=f("TTFB",0),(r=d(e,t,X,n.reportAllChanges))(!0)}))}}))};export{w as CLSThresholds,L as FCPThresholds,D as FIDThresholds,j as INPThresholds,U as LCPThresholds,X as TTFBThresholds,S as getCLS,b as getFCP,x as getFID,Q as getINP,W as getLCP,Z as getTTFB,S as onCLS,b as onFCP,x as onFID,Q as onINP,W as onLCP,Z as onTTFB};
\ No newline at end of file
+var e,n,t,r,i,o=-1,a=function(e){addEventListener("pageshow",(function(n){n.persisted&&(o=n.timeStamp,e(n))}),!0)},c=function(){var e=self.performance&&performance.getEntriesByType&&performance.getEntriesByType("navigation")[0];if(e&&e.responseStart>0&&e.responseStart<performance.now())return e},u=function(){var e=c();return e&&e.activationStart||0},f=function(e,n){var t=c(),r="navigate";return o>=0?r="back-forward-cache":t&&(document.prerendering||u()>0?r="prerender":document.wasDiscarded?r="restore":t.type&&(r=t.type.replace(/_/g,"-"))),{name:e,value:void 0===n?-1:n,rating:"good",delta:0,entries:[],id:"v4-".concat(Date.now(),"-").concat(Math.floor(8999999999999*Math.random())+1e12),navigationType:r}},s=function(e,n,t){try{if(PerformanceObserver.supportedEntryTypes.includes(e)){var r=new PerformanceObserver((function(e){Promise.resolve().then((function(){n(e.getEntries())}))}));return r.observe(Object.assign({type:e,buffered:!0},t||{})),r}}catch(e){}},d=function(e,n,t,r){var i,a;return function(o){n.value>=0&&(o||r)&&((a=n.value-(i||0))||void 0===i)&&(i=n.value,n.delta=a,n.rating=function(e,n){return e>n[1]?"poor":e>n[0]?"needs-improvement":"good"}(n.value,t),e(n))}},l=function(e){requestAnimationFrame((function(){return requestAnimationFrame((function(){return e()}))}))},p=function(e){document.addEventListener("visibilitychange",(function(){"hidden"===document.visibilityState&&e()}))},v=function(e){var n=!1;return function(){n||(e(),n=!0)}},m=-1,h=function(){return"hidden"!==document.visibilityState||document.prerendering?1/0:0},g=function(e){"hidden"===document.visibilityState&&m>-1&&(m="visibilitychange"===e.type?e.timeStamp:0,T())},y=function(){addEventListener("visibilitychange",g,!0),addEventListener("prerenderingchange",g,!0)},T=function(){removeEventListener("visibilitychange",g,!0),removeEventListener("prerenderingchange",g,!0)},E=function(){return m<0&&(m=h(),y(),a((function(){setTimeout((function(){m=h(),y()}),0)}))),{get firstHiddenTime(){return m}}},C=function(e){document.prerendering?addEventListener("prerenderingchange",(function(){return e()}),!0):e()},b=[1800,3e3],S=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("FCP"),o=s("paint",(function(e){e.forEach((function(e){"first-contentful-paint"===e.name&&(o.disconnect(),e.startTime<r.firstHiddenTime&&(i.value=Math.max(e.startTime-u(),0),i.entries.push(e),t(!0)))}))}));o&&(t=d(e,i,b,n.reportAllChanges),a((function(r){i=f("FCP"),t=d(e,i,b,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,t(!0)}))})))}))},L=[.1,.25],w=function(e,n){n=n||{},S(v((function(){var t,r=f("CLS",0),i=0,o=[],c=function(e){e.forEach((function(e){if(!e.hadRecentInput){var n=o[0],t=o[o.length-1];i&&e.startTime-t.startTime<1e3&&e.startTime-n.startTime<5e3?(i+=e.value,o.push(e)):(i=e.value,o=[e])}})),i>r.value&&(r.value=i,r.entries=o,t())},u=s("layout-shift",c);u&&(t=d(e,r,L,n.reportAllChanges),p((function(){c(u.takeRecords()),t(!0)})),a((function(){i=0,r=f("CLS",0),t=d(e,r,L,n.reportAllChanges),l((function(){return t()}))})),setTimeout(t,0))})))},A=0,I=1/0,P=0,M=function(e){e.forEach((function(e){e.interactionId&&(I=Math.min(I,e.interactionId),P=Math.max(P,e.interactionId),A=P?(P-I)/7+1:0)}))},k=function(){"interactionCount"in performance||e||(e=s("event",M,{type:"event",buffered:!0,durationThreshold:0}))},F=[],D=new Map,x=0,R=function(){return(e?A:performance.interactionCount||0)-x},B=[],H=function(e){if(B.forEach((function(n){return n(e)})),e.interactionId||"first-input"===e.entryType){var n=F[F.length-1],t=D.get(e.interactionId);if(t||F.length<10||e.duration>n.latency){if(t)e.duration>t.latency?(t.entries=[e],t.latency=e.duration):e.duration===t.latency&&e.startTime===t.entries[0].startTime&&t.entries.push(e);else{var r={id:e.interactionId,latency:e.duration,entries:[e]};D.set(r.id,r),F.push(r)}F.sort((function(e,n){return n.latency-e.latency})),F.length>10&&F.splice(10).forEach((function(e){return D.delete(e.id)}))}}},q=function(e){var n=self.requestIdleCallback||self.setTimeout,t=-1;return e=v(e),"hidden"===document.visibilityState?e():(t=n(e),p(e)),t},O=[200,500],N=function(e,n){"PerformanceEventTiming"in self&&"interactionId"in PerformanceEventTiming.prototype&&(n=n||{},C((function(){var t;k();var r,i=f("INP"),o=function(e){q((function(){e.forEach(H);var n,t=(n=Math.min(F.length-1,Math.floor(R()/50)),F[n]);t&&t.latency!==i.value&&(i.value=t.latency,i.entries=t.entries,r())}))},c=s("event",o,{durationThreshold:null!==(t=n.durationThreshold)&&void 0!==t?t:40});r=d(e,i,O,n.reportAllChanges),c&&(c.observe({type:"first-input",buffered:!0}),p((function(){o(c.takeRecords()),r(!0)})),a((function(){x=0,F.length=0,D.clear(),i=f("INP"),r=d(e,i,O,n.reportAllChanges)})))})))},j=[2500,4e3],_={},z=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("LCP"),o=function(e){n.reportAllChanges||(e=e.slice(-1)),e.forEach((function(e){e.startTime<r.firstHiddenTime&&(i.value=Math.max(e.startTime-u(),0),i.entries=[e],t())}))},c=s("largest-contentful-paint",o);if(c){t=d(e,i,j,n.reportAllChanges);var m=v((function(){_[i.id]||(o(c.takeRecords()),c.disconnect(),_[i.id]=!0,t(!0))}));["keydown","click"].forEach((function(e){addEventListener(e,(function(){return q(m)}),!0)})),p(m),a((function(r){i=f("LCP"),t=d(e,i,j,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,_[i.id]=!0,t(!0)}))}))}}))},G=[800,1800],J=function e(n){document.prerendering?C((function(){return e(n)})):"complete"!==document.readyState?addEventListener("load",(function(){return e(n)}),!0):setTimeout(n,0)},K=function(e,n){n=n||{};var t=f("TTFB"),r=d(e,t,G,n.reportAllChanges);J((function(){var i=c();i&&(t.value=Math.max(i.responseStart-u(),0),t.entries=[i],r(!0),a((function(){t=f("TTFB",0),(r=d(e,t,G,n.reportAllChanges))(!0)})))}))},Q={passive:!0,capture:!0},U=new Date,V=function(e,i){n||(n=i,t=e,r=new Date,Y(removeEventListener),W())},W=function(){if(t>=0&&t<r-U){var e={entryType:"first-input",name:n.type,target:n.target,cancelable:n.cancelable,startTime:n.timeStamp,processingStart:n.timeStamp+t};i.forEach((function(n){n(e)})),i=[]}},X=function(e){if(e.cancelable){var n=(e.timeStamp>1e12?new Date:performance.now())-e.timeStamp;"pointerdown"==e.type?function(e,n){var t=function(){V(e,n),i()},r=function(){i()},i=function(){removeEventListener("pointerup",t,Q),removeEventListener("pointercancel",r,Q)};addEventListener("pointerup",t,Q),addEventListener("pointercancel",r,Q)}(n,e):V(n,e)}},Y=function(e){["mousedown","keydown","touchstart","pointerdown"].forEach((function(n){return e(n,X,Q)}))},Z=[100,300],$=function(e,r){r=r||{},C((function(){var o,c=E(),u=f("FID"),l=function(e){e.startTime<c.firstHiddenTime&&(u.value=e.processingStart-e.startTime,u.entries.push(e),o(!0))},m=function(e){e.forEach(l)},h=s("first-input",m);o=d(e,u,Z,r.reportAllChanges),h&&(p(v((function(){m(h.takeRecords()),h.disconnect()}))),a((function(){var a;u=f("FID"),o=d(e,u,Z,r.reportAllChanges),i=[],t=-1,n=null,Y(addEventListener),a=l,i.push(a),W()})))}))};export{L as CLSThresholds,b as FCPThresholds,Z as FIDThresholds,O as INPThresholds,j as LCPThresholds,G as TTFBThresholds,w as onCLS,S as onFCP,$ as onFID,N as onINP,z as onLCP,K as onTTFB};
\ No newline at end of file
Index: class-od-html-tag-processor.php
===================================================================
--- class-od-html-tag-processor.php	(revision 3121783)
+++ class-od-html-tag-processor.php	(working copy)
@@ -107,6 +107,7 @@
 	/**
 	 * Bookmark for the end of the HEAD.
 	 *
+	 * @todo Consider reserving this.
 	 * @since 0.4.0
 	 * @var string
 	 */
@@ -115,6 +116,7 @@
 	/**
 	 * Bookmark for the end of the BODY.
 	 *
+	 * @todo Consider reserving this.
 	 * @since 0.4.0
 	 * @var string
 	 */
@@ -177,6 +179,15 @@
 	private $buffered_text_replacements = array();
 
 	/**
+	 * Count for the number of times next_token() was called
+	 *
+	 * @since 0.4.1
+	 * @var int
+	 * @see self::next_token()
+	 */
+	private $next_token_count = 0;
+
+	/**
 	 * Finds the next tag.
 	 *
 	 * Unlike the base class, this subclass disallows querying. This is to ensure the breadcrumbs can be tracked.
@@ -247,6 +258,7 @@
 	 */
 	public function next_token(): bool {
 		$this->current_xpath = null; // Clear cache.
+		++$this->next_token_count;
 		if ( ! parent::next_token() ) {
 			$this->open_stack_tags    = array();
 			$this->open_stack_indices = array();
@@ -326,6 +338,18 @@
 	}
 
 	/**
+	 * Gets the number of times next_token() was called.
+	 *
+	 * @since 0.4.1
+	 * @see self::next_token()
+	 *
+	 * @return int Count of next_token() calls.
+	 */
+	public function get_next_token_count(): int {
+		return $this->next_token_count;
+	}
+
+	/**
 	 * Updates or creates a new attribute on the currently matched tag with the passed value.
 	 *
 	 * @inheritDoc
@@ -409,6 +433,18 @@
 	}
 
 	/**
+	 * Gets the number of times seek() was called.
+	 *
+	 * @since 0.4.1
+	 * @see self::seek()
+	 *
+	 * @return int Count of seek() calls.
+	 */
+	public function get_seek_count(): int {
+		return $this->seek_count;
+	}
+
+	/**
 	 * Sets a bookmark in the HTML document.
 	 *
 	 * @inheritDoc
@@ -539,8 +575,11 @@
 			}
 			if ( ! $this->has_bookmark( $bookmark ) ) {
 				$this->warn(
-					/* translators: %s is the bookmark name */
-					__( 'Unable to append markup to %s since the bookmark no longer exists.', 'optimization-detective' )
+					sprintf(
+						/* translators: %s is the bookmark name */
+						__( 'Unable to append markup to %s since the bookmark no longer exists.', 'optimization-detective' ),
+						$bookmark
+					)
 				);
 			} else {
 				$start = $this->bookmarks[ $bookmark ]->start;
Index: optimization.php
===================================================================
--- optimization.php	(revision 3121783)
+++ optimization.php	(working copy)
@@ -176,14 +176,18 @@
 	$visitors             = iterator_to_array( $tag_visitor_registry );
 	while ( $processor->next_open_tag() ) {
 		$did_visit = false;
-		$processor->set_bookmark( $current_tag_bookmark );
+		$processor->set_bookmark( $current_tag_bookmark ); // TODO: Should we break if this returns false?
+
 		foreach ( $visitors as $visitor ) {
-			$did_visit = $visitor( $tag_visitor_context ) || $did_visit;
+			$seek_count       = $processor->get_seek_count();
+			$next_token_count = $processor->get_next_token_count();
+			$did_visit        = $visitor( $tag_visitor_context ) || $did_visit;
 
-			// Since the visitor may have traversed HTML tags, we need to make sure we go back to this tag so that
-			// in the next iteration any relevant tag visitors may apply, in addition to properly setting the data-od-xpath
-			// on this tag below.
-			$processor->seek( $current_tag_bookmark );
+			// If the visitor traversed HTML tags, we need to go back to this tag so that in the next iteration any
+			// relevant tag visitors may apply, in addition to properly setting the data-od-xpath on this tag below.
+			if ( $seek_count !== $processor->get_seek_count() || $next_token_count !== $processor->get_next_token_count() ) {
+				$processor->seek( $current_tag_bookmark ); // TODO: Should this break out of the optimization loop if it returns false?
+			}
 		}
 		$processor->release_bookmark( $current_tag_bookmark );
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3121783)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.4.0
+Stable tag:   0.4.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -133,6 +133,16 @@
 
 == Changelog ==
 
+= 0.4.1 =
+
+**Enhancements**
+
+* Upgrade web-vitals.js from [v3.5.0](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v350-2023-09-28) to [v4.2.1](https://github.com/GoogleChrome/web-vitals/blob/main/CHANGELOG.md#v422-2024-07-17).
+
+**Bug Fixes**
+
+* Fix logic for seeking during optimization loop to prevent emitting seek() notices. ([1376](https://github.com/WordPress/performance/pull/1376))
+
 = 0.4.0 =
 
 **Enhancements**
```
</details>

