### PR TITLE
Prevent PICTURE element when JPEG output is disabled

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -393,7 +393,7 @@ function webp_uploads_sanitize_image_format( string $image_format ): string {
  * @return bool True if the option is enabled, false otherwise.
  */
 function webp_uploads_is_picture_element_enabled(): bool {
-	return (bool) get_option( 'webp_uploads_use_picture_element', false );
+	return webp_uploads_is_jpeg_fallback_enabled() && (bool) get_option( 'webp_uploads_use_picture_element', false );
 }
 
 /**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes [#1375](https://github.com/WordPress/performance/issues/1375)

## Relevant technical choices
This PR addresses an issue where the `<picture>` element was being served even when the "Also output JPEG" option was disabled. The fix involves updating the `webp_uploads_is_picture_element_enabled()` function to check if JPEG fallback is enabled before returning true.

The change is as follows:
```php
function webp_uploads_is_picture_element_enabled(): bool {
	return webp_uploads_is_jpeg_fallback_enabled() && (bool) get_option( 'webp_uploads_use_picture_element', false );
}
```

This ensures that the picture element is only used when both the "Also output JPEG" and "Picture element" options are enabled, preventing scenarios where both the <source> and <img> elements reference the same AVIF image.

<img width="586" alt="Screenshot 2024-07-19 at 1 01 54 PM" src="https://github.com/user-attachments/assets/02811b52-a26f-4926-9e91-dc254c456773">


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
