### PR TITLE
Fix Optimization Detective test case for WP 6.7-alpha

### DIFF
--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -107,18 +107,18 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 						<head></head>
 						<body>
 							<span>1</span>
-							<br></br>
+							<meta></meta>
 							<span>2</span>
 						</body>
 					</html>
 				',
-				'open_tags' => array( 'HTML', 'HEAD', 'BODY', 'SPAN', 'BR', 'SPAN' ),
+				'open_tags' => array( 'HTML', 'HEAD', 'BODY', 'SPAN', 'META', 'SPAN' ),
 				'xpaths'    => array(
 					'/*[1][self::HTML]',
 					'/*[1][self::HTML]/*[1][self::HEAD]',
 					'/*[1][self::HTML]/*[2][self::BODY]',
 					'/*[1][self::HTML]/*[2][self::BODY]/*[1][self::SPAN]',
-					'/*[1][self::HTML]/*[2][self::BODY]/*[2][self::BR]',
+					'/*[1][self::HTML]/*[2][self::BODY]/*[2][self::META]',
 					'/*[1][self::HTML]/*[2][self::BODY]/*[3][self::SPAN]',
 				),
 			),


### PR DESCRIPTION
## Summary

In Core-61576, r58779 broke a unit test in Optimization Detective due to changes with how `</br>` is handled in the tag processor, specifically this change:

![image](https://github.com/user-attachments/assets/50cd7837-a82b-4fd3-a5d7-4810a6271734)

This is a [special case in the HTML spec](https://html.spec.whatwg.org/multipage/parsing.html#tokenization:~:text=Drop%20the%20attributes%20from%20the%20token%2C%20and%20act%20as%20described%20in%20the%20next%20entry%3B%20i.e.%20act%20as%20if%20this%20was%20a%20%22br%22%20start%20tag%20token%20with%20no%20attributes%2C%20rather%20than%20the%20end%20tag%20token%20that%20it%20actually%20is.):

![image](https://github.com/user-attachments/assets/59da35f8-27b2-4979-9892-c2c945c8e48c)

So this swaps out `BR` for another void tag `META`.