### PR TITLE
Eliminate use of empty() in Embed Optimizer and Optimization Detective

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -66,3 +66,9 @@ parameters:
 		-
 			# TODO: Remove this to fix https://github.com/WordPress/performance/issues/1219
 			identifier: empty.notAllowed
+			paths:
+				- */tests/*
+				- plugins/dominant-color-images
+				- plugins/performance-lab
+				- plugins/speculation-rules
+				- plugins/webp-uploads

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -60,44 +60,47 @@ final class Embed_Optimizer_Tag_Visitor {
 			 * for GET requests, as POST requests are not likely to be part of the critical rendering path.
 			 */
 			$preconnect_hrefs = array();
-			if ( true === $processor->has_class( 'wp-block-embed-youtube' ) ) {
+			$has_class        = static function ( string $wanted_class ) use ( $processor ): bool {
+				return true === $processor->has_class( $wanted_class );
+			};
+			if ( $has_class( 'wp-block-embed-youtube' ) ) {
 				$preconnect_hrefs[] = 'https://www.youtube.com';
 				$preconnect_hrefs[] = 'https://i.ytimg.com';
-			} elseif ( true === $processor->has_class( 'wp-block-embed-twitter' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-twitter' ) ) {
 				$preconnect_hrefs[] = 'https://syndication.twitter.com';
 				$preconnect_hrefs[] = 'https://pbs.twimg.com';
-			} elseif ( true === $processor->has_class( 'wp-block-embed-vimeo' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-vimeo' ) ) {
 				$preconnect_hrefs[] = 'https://player.vimeo.com';
 				$preconnect_hrefs[] = 'https://f.vimeocdn.com';
 				$preconnect_hrefs[] = 'https://i.vimeocdn.com';
-			} elseif ( true === $processor->has_class( 'wp-block-embed-spotify' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-spotify' ) ) {
 				$preconnect_hrefs[] = 'https://apresolve.spotify.com';
 				$preconnect_hrefs[] = 'https://embed-cdn.spotifycdn.com';
 				$preconnect_hrefs[] = 'https://encore.scdn.co';
 				$preconnect_hrefs[] = 'https://i.scdn.co';
-			} elseif ( true === $processor->has_class( 'wp-block-embed-videopress' ) || true === $processor->has_class( 'wp-block-embed-wordpress-tv' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-videopress' ) || $has_class( 'wp-block-embed-wordpress-tv' ) ) {
 				$preconnect_hrefs[] = 'https://video.wordpress.com';
 				$preconnect_hrefs[] = 'https://public-api.wordpress.com';
 				$preconnect_hrefs[] = 'https://videos.files.wordpress.com';
 				$preconnect_hrefs[] = 'https://v0.wordpress.com'; // This does not appear to be a load-balanced domain since v1.wordpress.com is not valid.
-			} elseif ( true === $processor->has_class( 'wp-block-embed-instagram' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-instagram' ) ) {
 				$preconnect_hrefs[] = 'https://www.instagram.com';
 				$preconnect_hrefs[] = 'https://static.cdninstagram.com';
 				$preconnect_hrefs[] = 'https://scontent.cdninstagram.com';
-			} elseif ( true === $processor->has_class( 'wp-block-embed-tiktok' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-tiktok' ) ) {
 				$preconnect_hrefs[] = 'https://www.tiktok.com';
 				// Note: The other domains used for TikTok embeds include https://lf16-tiktok-web.tiktokcdn-us.com,
 				// https://lf16-cdn-tos.tiktokcdn-us.com, and https://lf16-tiktok-common.tiktokcdn-us.com among others
 				// which either appear to be geo-targeted ('-us') _or_ load-balanced ('lf16'). So these are not added
 				// to the preconnected hosts.
-			} elseif ( true === $processor->has_class( 'wp-block-embed-amazon' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-amazon' ) ) {
 				$preconnect_hrefs[] = 'https://read.amazon.com';
 				$preconnect_hrefs[] = 'https://m.media-amazon.com';
-			} elseif ( true === $processor->has_class( 'wp-block-embed-soundcloud' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-soundcloud' ) ) {
 				$preconnect_hrefs[] = 'https://w.soundcloud.com';
 				$preconnect_hrefs[] = 'https://widget.sndcdn.com';
 				// Note: There is also https://i1.sndcdn.com which is for the album art, but the '1' indicates it may be geotargeted/load-balanced.
-			} elseif ( true === $processor->has_class( 'wp-block-embed-pinterest' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-pinterest' ) ) {
 				$preconnect_hrefs[] = 'https://assets.pinterest.com';
 				$preconnect_hrefs[] = 'https://widgets.pinterest.com';
 				$preconnect_hrefs[] = 'https://i.pinimg.com';

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -120,7 +120,8 @@ function embed_optimizer_update_markup( WP_HTML_Tag_Processor $html_processor, b
 
 			if ( 'IFRAME' === $html_processor->get_tag() ) {
 				$loading_value = $html_processor->get_attribute( 'loading' );
-				if ( empty( $loading_value ) ) {
+				// Per the HTML spec: "The attribute's missing value default and invalid value default are both the Eager state".
+				if ( 'lazy' !== $loading_value ) {
 					++$iframe_count;
 					if ( ! $html_processor->set_bookmark( $bookmark_names['iframe'] ) ) {
 						throw new Exception(

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -102,7 +102,7 @@ function od_get_current_url(): string {
 		$parsed_url = array();
 	}
 
-	if ( empty( $parsed_url['scheme'] ) ) {
+	if ( ! isset( $parsed_url['scheme'] ) ) {
 		$parsed_url['scheme'] = is_ssl() ? 'https' : 'http';
 	}
 	if ( ! isset( $parsed_url['host'] ) ) {


### PR DESCRIPTION
This is a follow-up to #1241 to edge closer to full strict rule compliance for PHPStan. See #1219

See also https://github.com/WordPress/performance/issues/775.