### PR TITLE
Prepare 3.3.1 release of performance-lab (standalone, without other plugins)

### DIFF
--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 3.3.0
+ * Version: 3.3.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.3.0' );
+define( 'PERFLAB_VERSION', '3.3.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.3.0
+Stable tag:   3.3.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -57,6 +57,16 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.3.1 =
+
+**Enhancements**
+
+* Add PHPStan strict rules (except for empty.notAllowed). ([1241](https://github.com/WordPress/performance/pull/1241))
+
+**Bug Fixes**
+
+* Allow null to be passed into perflab_admin_pointer(). ([1393](https://github.com/WordPress/performance/pull/1393))
 
 = 3.3.0 =
 


### PR DESCRIPTION
Previously https://github.com/WordPress/performance/pull/1345

## `performance-lab`

> [!IMPORTANT]
> Stable tag change: 3.3.0 → **3.3.1**

`svn status`:
```
M       includes/admin/load.php
M       includes/admin/plugins.php
M       includes/server-timing/class-perflab-server-timing-metric.php
M       includes/server-timing/class-perflab-server-timing.php
M       includes/server-timing/defaults.php
M       includes/server-timing/hooks.php
M       includes/site-health/audit-enqueued-assets/helper.php
M       includes/site-health/audit-enqueued-assets/hooks.php
M       load.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: includes/admin/load.php
===================================================================
--- includes/admin/load.php	(revision 3124837)
+++ includes/admin/load.php	(working copy)
@@ -76,9 +76,10 @@
  *
  * @since 1.0.0
  *
- * @param string $hook_suffix The current admin page.
+ * @param string|null $hook_suffix The current admin page. Note this can be null because `iframe_header()` does not
+ *                                 ensure that `$hook_suffix` is a string when it calls `do_action( 'admin_enqueue_scripts', $hook_suffix )`.
  */
-function perflab_admin_pointer( string $hook_suffix ): void {
+function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 	// Do not show admin pointer in multisite Network admin or User admin UI.
 	if ( is_network_admin() || is_user_admin() ) {
 		return;
@@ -265,7 +266,7 @@
 	}
 
 	$plugin_slug = perflab_sanitize_plugin_slug( wp_unslash( $_GET['slug'] ) );
-	if ( ! $plugin_slug ) {
+	if ( null === $plugin_slug ) {
 		wp_die( esc_html__( 'Invalid plugin.', 'performance-lab' ) );
 	}
 
@@ -369,11 +370,11 @@
 		$activated_plugin_slug = perflab_sanitize_plugin_slug( wp_unslash( $_GET['activate'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
-	if ( $activated_plugin_slug ) {
+	if ( null !== $activated_plugin_slug ) {
 		$message = __( 'Feature activated.', 'performance-lab' );
 
 		$plugin_settings_url = perflab_get_plugin_settings_url( $activated_plugin_slug );
-		if ( $plugin_settings_url ) {
+		if ( null !== $plugin_settings_url ) {
 			/* translators: %s is the settings URL */
 			$message .= ' ' . sprintf( __( 'Review <a href="%s">settings</a>.', 'performance-lab' ), esc_url( $plugin_settings_url ) );
 		}
@@ -465,7 +466,7 @@
 		return null;
 	}
 	$href = $p->get_attribute( 'href' );
-	if ( $href && is_string( $href ) ) {
+	if ( is_string( $href ) && '' !== $href ) {
 		return $href;
 	}
 
Index: includes/admin/plugins.php
===================================================================
--- includes/admin/plugins.php	(revision 3124837)
+++ includes/admin/plugins.php	(working copy)
@@ -21,7 +21,12 @@
 function perflab_query_plugin_info( string $plugin_slug ) {
 	$plugin = get_transient( 'perflab_plugin_info_' . $plugin_slug );
 
-	if ( $plugin ) {
+	if ( is_array( $plugin ) ) {
+		/**
+		 * Validated (mostly) plugin data.
+		 *
+		 * @var array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: string[], download_link: string, version: string} $plugin
+		 */
 		return $plugin;
 	}
 
@@ -128,7 +133,7 @@
 		}
 	}
 
-	if ( ! $plugins && ! $experimental_plugins ) {
+	if ( count( $plugins ) === 0 && count( $experimental_plugins ) === 0 ) {
 		return;
 	}
 	?>
@@ -174,11 +179,11 @@
 
 	$availability = array(
 		'compatible_php' => (
-			! $plugin_data['requires_php'] ||
+			false === $plugin_data['requires_php'] ||
 			is_php_version_compatible( $plugin_data['requires_php'] )
 		),
 		'compatible_wp'  => (
-			! $plugin_data['requires'] ||
+			false === $plugin_data['requires'] ||
 			is_wp_version_compatible( $plugin_data['requires'] )
 		),
 	);
@@ -186,7 +191,7 @@
 	$plugin_status = install_plugin_install_status( $plugin_data );
 
 	$availability['installed'] = ( 'install' !== $plugin_status['status'] );
-	$availability['activated'] = $plugin_status['file'] && is_plugin_active( $plugin_status['file'] );
+	$availability['activated'] = false !== $plugin_status['file'] && is_plugin_active( $plugin_status['file'] );
 
 	// The plugin is already installed or the user can install plugins.
 	$availability['can_install'] = (
@@ -197,7 +202,7 @@
 	// The plugin is activated or the user can activate plugins.
 	$availability['can_activate'] = (
 		$availability['activated'] ||
-		$plugin_status['file'] // When not false, the plugin is installed.
+		false !== $plugin_status['file'] // When not false, the plugin is installed.
 			? current_user_can( 'activate_plugin', $plugin_status['file'] )
 			: current_user_can( 'activate_plugins' )
 	);
@@ -400,7 +405,7 @@
 
 	if ( $availability['activated'] ) {
 		$settings_url = perflab_get_plugin_settings_url( $plugin_data['slug'] );
-		if ( $settings_url ) {
+		if ( null !== $settings_url ) {
 			/* translators: %s is the settings URL */
 			$action_links[] = sprintf( '<a href="%s">%s</a>', esc_url( $settings_url ), esc_html__( 'Settings', 'performance-lab' ) );
 		}
Index: includes/server-timing/class-perflab-server-timing-metric.php
===================================================================
--- includes/server-timing/class-perflab-server-timing-metric.php	(revision 3124837)
+++ includes/server-timing/class-perflab-server-timing-metric.php	(working copy)
@@ -80,7 +80,7 @@
 			return;
 		}
 
-		if ( did_action( 'perflab_server_timing_send_header' ) && ! doing_action( 'perflab_server_timing_send_header' ) ) {
+		if ( 0 !== did_action( 'perflab_server_timing_send_header' ) && ! doing_action( 'perflab_server_timing_send_header' ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: WordPress action name */
@@ -130,7 +130,7 @@
 	 * @since 1.8.0
 	 */
 	public function measure_after(): void {
-		if ( ! $this->before_value ) {
+		if ( null === $this->before_value ) {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: PHP method name */
Index: includes/server-timing/class-perflab-server-timing.php
===================================================================
--- includes/server-timing/class-perflab-server-timing.php	(revision 3124837)
+++ includes/server-timing/class-perflab-server-timing.php	(working copy)
@@ -67,7 +67,7 @@
 			return;
 		}
 
-		if ( did_action( 'perflab_server_timing_send_header' ) && ! doing_action( 'perflab_server_timing_send_header' ) ) {
+		if ( 0 !== did_action( 'perflab_server_timing_send_header' ) && ! doing_action( 'perflab_server_timing_send_header' ) ) {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: WordPress action name */
@@ -113,7 +113,7 @@
 
 		// If the current user has already been determined, and they lack the necessary access,
 		// do not even attempt to calculate the metric.
-		if ( did_action( 'set_current_user' ) && ! current_user_can( $args['access_cap'] ) ) {
+		if ( 0 !== did_action( 'set_current_user' ) && ! current_user_can( $args['access_cap'] ) ) {
 			return;
 		}
 
@@ -160,7 +160,7 @@
 		do_action( 'perflab_server_timing_send_header' );
 
 		$header_value = $this->get_header();
-		if ( ! $header_value ) {
+		if ( '' === $header_value ) {
 			return;
 		}
 
Index: includes/server-timing/defaults.php
===================================================================
--- includes/server-timing/defaults.php	(revision 3124837)
+++ includes/server-timing/defaults.php	(working copy)
@@ -243,7 +243,7 @@
 	}
 
 	// Bail early if there are no hooks to measure.
-	if ( ! $hooks_to_measure ) {
+	if ( count( $hooks_to_measure ) === 0 ) {
 		return;
 	}
 
@@ -313,7 +313,7 @@
  * drop-in, it must not call this function right away since otherwise the cache
  * will not be loaded yet.
  */
-if ( ! did_action( 'muplugins_loaded' ) ) {
+if ( 0 === did_action( 'muplugins_loaded' ) ) {
 	add_action( 'muplugins_loaded', 'perflab_register_additional_server_timing_metrics_from_setting' );
 } else {
 	perflab_register_additional_server_timing_metrics_from_setting();
Index: includes/server-timing/hooks.php
===================================================================
--- includes/server-timing/hooks.php	(revision 3124837)
+++ includes/server-timing/hooks.php	(working copy)
@@ -32,7 +32,7 @@
 
 	$header_value = $server_timing->get_header();
 
-	if ( $header_value ) {
+	if ( '' !== $header_value ) {
 		$response->header( 'Server-Timing', $header_value, false );
 	}
 
Index: includes/site-health/audit-enqueued-assets/helper.php
===================================================================
--- includes/site-health/audit-enqueued-assets/helper.php	(revision 3124837)
+++ includes/site-health/audit-enqueued-assets/helper.php	(working copy)
@@ -249,7 +249,7 @@
 function perflab_aea_get_total_enqueued_styles() {
 	$enqueued_styles      = false;
 	$list_enqueued_styles = get_transient( 'aea_enqueued_front_page_styles' );
-	if ( $list_enqueued_styles ) {
+	if ( is_array( $list_enqueued_styles ) ) {
 		$enqueued_styles = count( $list_enqueued_styles );
 	}
 	return $enqueued_styles;
@@ -287,7 +287,7 @@
  * @return string Returns absolute path to the resource.
  */
 function perflab_aea_get_path_from_resource_url( string $resource_url ): string {
-	if ( ! $resource_url ) {
+	if ( '' === $resource_url ) {
 		return '';
 	}
 
Index: includes/site-health/audit-enqueued-assets/hooks.php
===================================================================
--- includes/site-health/audit-enqueued-assets/hooks.php	(revision 3124837)
+++ includes/site-health/audit-enqueued-assets/hooks.php	(working copy)
@@ -40,7 +40,7 @@
 			}
 
 			$path = perflab_aea_get_path_from_resource_url( $script->src );
-			if ( ! $path ) {
+			if ( '' === $path ) {
 				continue;
 			}
 
@@ -80,7 +80,7 @@
 				$path = $style->extra['path'];
 			} else { // Fallback to getting the path from the style's src.
 				$path = perflab_aea_get_path_from_resource_url( $style->src );
-				if ( ! $path ) {
+				if ( '' === $path ) {
 					continue;
 				}
 			}
Index: load.php
===================================================================
--- load.php	(revision 3124837)
+++ load.php	(working copy)
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 3.3.0
+ * Version: 3.3.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.3.0' );
+define( 'PERFLAB_VERSION', '3.3.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );
@@ -185,7 +185,7 @@
 	$current_dropin_version = apply_filters( 'perflab_object_cache_dropin_version', PERFLAB_OBJECT_CACHE_DROPIN_VERSION );
 
 	// Bail if already placed in the latest version or newer.
-	if ( $current_dropin_version && $current_dropin_version >= PERFLAB_OBJECT_CACHE_DROPIN_LATEST_VERSION ) {
+	if ( null !== $current_dropin_version && $current_dropin_version >= PERFLAB_OBJECT_CACHE_DROPIN_LATEST_VERSION ) {
 		return;
 	}
 
@@ -197,7 +197,7 @@
 		return;
 	}
 
-	if ( $wp_filesystem || WP_Filesystem() ) {
+	if ( $wp_filesystem instanceof WP_Filesystem_Base || true === WP_Filesystem() ) {
 		$dropin_path = WP_CONTENT_DIR . '/object-cache.php';
 
 		/*
@@ -214,7 +214,7 @@
 		 */
 		if ( $wp_filesystem->exists( $dropin_path ) ) {
 			// If this constant evaluates to `false`, the existing file is for sure from a third party.
-			if ( ! $current_dropin_version ) {
+			if ( false === $current_dropin_version ) {
 				// Set timeout of 1 day before retrying again (only in case the file already exists).
 				set_transient( 'perflab_set_object_cache_dropin', true, DAY_IN_SECONDS );
 				return;
@@ -271,7 +271,7 @@
 		return;
 	}
 
-	if ( $wp_filesystem || WP_Filesystem() ) {
+	if ( $wp_filesystem instanceof WP_Filesystem_Base || true === WP_Filesystem() ) {
 		$dropin_path        = WP_CONTENT_DIR . '/object-cache.php';
 		$dropin_backup_path = WP_CONTENT_DIR . '/object-cache-plst-orig.php';
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3124837)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.3.0
+Stable tag:   3.3.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -58,6 +58,16 @@
 
 == Changelog ==
 
+= 3.3.1 =
+
+**Enhancements**
+
+* Add PHPStan strict rules (except for empty.notAllowed). ([1241](https://github.com/WordPress/performance/pull/1241))
+
+**Bug Fixes**
+
+* Allow null to be passed into perflab_admin_pointer(). ([1393](https://github.com/WordPress/performance/pull/1393))
+
 = 3.3.0 =
 
 **Enhancements**
@@ -70,7 +80,7 @@
 **Bug Fixes**
 
 * Extend core's Autoloaded Options Site Health test if present (in WP 6.6). ([1298](https://github.com/WordPress/performance/pull/1298))
-* Generate phpunit-multisite.xml on the fly. ([1327](https://github.com/WordPress/performance/pull/1327))
+* Fix unit tests for multisite. ([1327](https://github.com/WordPress/performance/pull/1327))
 
 = 3.2.0 =
 
```
</details>

