### PR TITLE
Add test-php-watch command

### DIFF
--- a/bin/test-php-watch.sh
+++ b/bin/test-php-watch.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+if ! which inotifywait >/dev/null 2>&1; then
+  echo "Error: the inotifywait command is not available. Make sure you have inotify-tools installed."
+  exit 1
+fi
+
+while true; do
+	echo "Waiting for a change in the plugins directory..."
+	output=$(inotifywait -e modify,create,delete -r ./plugins 2> /dev/null)
+	plugin_slug=$(echo "$output" | awk -F/ '{print $3}')
+	sleep 1 # Give the user a chance to copy text from terminal before IDE auto-saves.
+	clear
+	echo "Running phpunit tests for $(tput bold)$plugin_slug$(tput sgr0):"
+	# TODO: Interrupt when a change is made while running tests or re-run if change made since tests started running.
+	# Note: This is calling phpunit directly and not the composer script due to extra noise it outputs.
+	npm run wp-env --silent -- run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance -- vendor/bin/phpunit --testsuite "$plugin_slug" "$@"
+done

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "phpstan": "composer phpstan",
     "lint-php": "composer lint:all",
     "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance composer test:plugins",
+    "test-php-watch": "./bin/test-php-watch.sh",
     "test-php-multisite": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance composer test-multisite:plugins",
     "wp-env": "wp-env",
     "prepare": "husky"


### PR DESCRIPTION
Running unit tests for all plugins can take a long time (e.g. #1397, #1398). It would be ideal to just run the tests for a single plugin during development, and for tests to run as soon as a change has been made. This PR implements a `npm run test-php-watch` command which watches for changes in the `plugins` directory and then automatically runs the unit tests for the plugin which had the changed file.

[Screen recording 2024-07-25 09.55.55.webm](https://github.com/user-attachments/assets/02f5f664-fd96-4177-a918-a9326e57ab1c)
