### PR TITLE
Clean up object-cache drop-ins before starting tests

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,5 +110,22 @@ if ( 'performance-lab' === $plugin_name ) {
 	);
 }
 
+// Clean up object-cache drop-ins after possible previous failed tests.
+tests_add_filter(
+	'enable_loading_object_cache_dropin',
+	static function ( bool $passthrough ): bool {
+		$cleanup_files = array(
+			WP_CONTENT_DIR . '/object-cache.php',
+			WP_CONTENT_DIR . '/object-cache-plst-orig.php',
+		);
+		foreach ( $cleanup_files as $cleanup_file ) {
+			if ( file_exists( $cleanup_file ) ) {
+				unlink( $cleanup_file );
+			}
+		}
+		return $passthrough;
+	}
+);
+
 // Start up the WP testing environment.
 require $_test_root . '/includes/bootstrap.php';


### PR DESCRIPTION
## Summary

If unit tests start while an `object-cache.php` is present in the test environment, it ends up failing with an error:

```
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
[25-Jul-2024 18:31:31 UTC] PHP Fatal error:  Cannot declare class Perflab_Server_Timing_Metric, because the name is already in use in /var/www/html/wp-content/plugins/performance/plugins/performance-lab/includes/server-timing/class-perflab-server-timing-metric.php on line 14
```

The file is apparently there due to tests not cleaning up at tear-down because of some fatal error, resulting in a non-clean initial state to bootstrap the tests.

It's not entirely clear to me why the presence of the `object-cache.php` causes this fatal error in the first place, but it certainly seems like a bug for the `object-cache.php` file to exist when the tests first bootstrap. So it should be removed.

Fixes #1255.

