### PR TITLE
Fix format scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
       "@format:embed-optimizer",
       "@format:image-prioritizer",
       "@format:optimization-detective",
+      "@format:performance-lab",
       "@format:speculation-rules",
       "@format:webp-uploads"
     ],
@@ -60,6 +61,7 @@
     "format:embed-optimizer":        "@format -- ./plugins/embed-optimizer --standard=./plugins/embed-optimizer/phpcs.xml.dist",
     "format:image-prioritizer":      "@format -- ./plugins/image-prioritizer --standard=./plugins/image-prioritizer/phpcs.xml.dist",
     "format:optimization-detective": "@format -- ./plugins/optimization-detective --standard=./plugins/optimization-detective/phpcs.xml.dist",
+    "format:performance-lab":        "@format -- ./plugins/performance-lab --standard=./plugins/performance-lab/phpcs.xml.dist",
     "format:speculation-rules":      "@format -- ./plugins/speculation-rules --standard=./plugins/speculation-rules/phpcs.xml.dist",
     "format:webp-uploads":           "@format -- ./plugins/webp-uploads --standard=./plugins/webp-uploads/phpcs.xml.dist",
     "lint": "phpcs",

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,7 @@
       "@format:auto-sizes",
       "@format:dominant-color-images",
       "@format:embed-optimizer",
+      "@format:image-prioritizer",
       "@format:optimization-detective",
       "@format:speculation-rules",
       "@format:webp-uploads"
@@ -57,6 +58,7 @@
     "format:auto-sizes":             "@format -- ./plugins/auto-sizes --standard=./plugins/auto-sizes/phpcs.xml.dist",
     "format:dominant-color-images":  "@format -- ./plugins/dominant-color-images --standard=./plugins/dominant-color-images/phpcs.xml.dist",
     "format:embed-optimizer":        "@format -- ./plugins/embed-optimizer --standard=./plugins/embed-optimizer/phpcs.xml.dist",
+    "format:image-prioritizer":      "@format -- ./plugins/image-prioritizer --standard=./plugins/image-prioritizer/phpcs.xml.dist",
     "format:optimization-detective": "@format -- ./plugins/optimization-detective --standard=./plugins/optimization-detective/phpcs.xml.dist",
     "format:speculation-rules":      "@format -- ./plugins/speculation-rules --standard=./plugins/speculation-rules/phpcs.xml.dist",
     "format:webp-uploads":           "@format -- ./plugins/webp-uploads --standard=./plugins/webp-uploads/phpcs.xml.dist",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "generate-pending-release-diffs": "bin/generate-pending-release-diffs.sh",
     "format-js": "wp-scripts format",
     "lint-js": "wp-scripts lint-js",
-    "format-php": "composer format",
+    "format-php": "composer format:all",
     "phpstan": "composer phpstan",
     "lint-php": "composer lint:all",
     "test-php": "wp-env run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance composer test:plugins",


### PR DESCRIPTION
I noticed that Image Prioritizer was missing from the `format` scripts in `composer.json`. Also, `performance-lab` was missing from the format scripts. Additionally, I noticed that `npm run format-php` was calling `composer run format` instead of the expected `composer run format:all` in the same way that `npm run lint-php` calls `composer run `lint:all`. This PR fixes these issues.