### PR TITLE
Remove string type hint from webp_uploads_sanitize_image_format() to prevent possible fatal error

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -378,10 +378,10 @@ function webp_uploads_get_image_output_format(): string {
  *
  * @since 2.0.0
  *
- * @param string $image_format The image format to check.
+ * @param string|mixed $image_format The image format to check.
  * @return string Supported image format.
  */
-function webp_uploads_sanitize_image_format( string $image_format ): string {
+function webp_uploads_sanitize_image_format( $image_format ): string {
 	return in_array( $image_format, array( 'webp', 'avif' ), true ) ? $image_format : 'webp';
 }
 

--- a/plugins/webp-uploads/tests/test-helper.php
+++ b/plugins/webp-uploads/tests/test-helper.php
@@ -585,4 +585,43 @@ class Test_WebP_Uploads_Helper extends TestCase {
 			),
 		);
 	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function data_provider_to_test_webp_uploads_sanitize_image_format(): array {
+		return array(
+			'null'  => array(
+				'input'    => null,
+				'expected' => 'webp',
+			),
+			'array' => array(
+				'input'    => array( 'tiff' ),
+				'expected' => 'webp',
+			),
+			'webp'  => array(
+				'input'    => 'webp',
+				'expected' => 'webp',
+			),
+			'avif'  => array(
+				'input'    => 'avif',
+				'expected' => 'avif',
+			),
+			'bmp'   => array(
+				'input'    => 'bmp',
+				'expected' => 'webp',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_provider_to_test_webp_uploads_sanitize_image_format
+	 * @covers ::webp_uploads_sanitize_image_format
+	 *
+	 * @param mixed  $input    Input.
+	 * @param string $expected Expected.
+	 */
+	public function test_webp_uploads_sanitize_image_format( $input, string $expected ): void {
+		$this->assertSame( $expected, webp_uploads_sanitize_image_format( $input ) );
+	}
 }


### PR DESCRIPTION
Fixes #1409

Sanitization functions by definition should not have type hints since they are all about doing such type checking at runtime!