### PR TITLE
Implement full support for intersectionRect/boundingClientRect, fix viewportRect typing, and harden JSON schema

### DIFF
--- a/plugins/auto-sizes/tests/test-optimization-detective.php
+++ b/plugins/auto-sizes/tests/test-optimization-detective.php
@@ -102,7 +102,7 @@ class Test_Auto_Sizes_Optimization_Detective extends WP_UnitTestCase {
 	 * @covers ::auto_sizes_visit_tag
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
-	 * @phpstan-param array<string, mixed> $element_metrics
+	 * @phpstan-param array{ xpath: string, isLCP: bool, intersectionRatio: int } $element_metrics
 	 */
 	public function test_od_optimize_template_output_buffer( array $element_metrics, string $buffer, string $expected ): void {
 		$this->populate_url_metrics( array( $element_metrics ) );

--- a/plugins/auto-sizes/tests/test-optimization-detective.php
+++ b/plugins/auto-sizes/tests/test-optimization-detective.php
@@ -3,6 +3,8 @@
  * Tests for auto-sizes plugin's optimization-detective.php.
  *
  * @package auto-sizes
+ *
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 class Test_Auto_Sizes_Optimization_Detective extends WP_UnitTestCase {
@@ -100,7 +102,6 @@ class Test_Auto_Sizes_Optimization_Detective extends WP_UnitTestCase {
 	 * @covers ::auto_sizes_visit_tag
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
-	 * @throws Exception But it won't.
 	 * @phpstan-param array<string, mixed> $element_metrics
 	 */
 	public function test_od_optimize_template_output_buffer( array $element_metrics, string $buffer, string $expected ): void {

--- a/plugins/embed-optimizer/tests/test-optimization-detective.php
+++ b/plugins/embed-optimizer/tests/test-optimization-detective.php
@@ -3,6 +3,8 @@
  * Tests for embed-optimizer plugin hooks.php.
  *
  * @package embed-optimizer
+ *
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
@@ -51,7 +53,6 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 	 * @covers ::embed_optimizer_update_markup
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
-	 * @throws Exception But it won't.
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ): void {
 		$set_up( $this );

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data.php
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data.php
@@ -8,31 +8,33 @@ return array(
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
 					$test_case->get_validated_url_metric(
-						$viewport_width,
 						array(
-							array(
-								'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-								'isLCP' => true,
-							),
-							array(
-								'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[3][self::IMG]',
-								'isLCP'             => false,
-								'intersectionRatio' => 0 === $i ? 0.5 : 0.0, // Make sure that the _max_ intersection ratio is considered.
-							),
-							array(
-								'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[5][self::IMG]',
-								'isLCP'             => false,
-								'intersectionRatio' => 0.0,
-							),
-							array(
-								'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[6][self::IMG]',
-								'isLCP'             => false,
-								'intersectionRatio' => 0.0,
-							),
-							array(
-								'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[7][self::IMG]',
-								'isLCP'             => false,
-								'intersectionRatio' => 0.0,
+							'viewport_width' => $viewport_width,
+							'elements'       => array(
+								array(
+									'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+									'isLCP' => true,
+								),
+								array(
+									'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[3][self::IMG]',
+									'isLCP'             => false,
+									'intersectionRatio' => 0 === $i ? 0.5 : 0.0, // Make sure that the _max_ intersection ratio is considered.
+								),
+								array(
+									'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[5][self::IMG]',
+									'isLCP'             => false,
+									'intersectionRatio' => 0.0,
+								),
+								array(
+									'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[6][self::IMG]',
+									'isLCP'             => false,
+									'intersectionRatio' => 0.0,
+								),
+								array(
+									'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[7][self::IMG]',
+									'isLCP'             => false,
+									'intersectionRatio' => 0.0,
+								),
 							),
 						)
 					)

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data.php
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data.php
@@ -7,7 +7,7 @@ return array(
 			for ( $i = 0; $i < $sample_size; $i++ ) {
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
-					$test_case->get_validated_url_metric(
+					$test_case->get_sample_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
 							'elements'       => array(

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
@@ -9,15 +9,17 @@ return array(
 			OD_URL_Metrics_Post_Type::store_url_metric(
 				$slug,
 				$test_case->get_validated_url_metric(
-					1000,
 					array(
-						array(
-							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-							'isLCP' => true,
-						),
-						array(
-							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
-							'isLCP' => false,
+						'viewport_width' => 1000,
+						'elements'       => array(
+							array(
+								'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+								'isLCP' => true,
+							),
+							array(
+								'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+								'isLCP' => false,
+							),
 						),
 					)
 				)

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
@@ -8,7 +8,7 @@ return array(
 		for ( $i = 0; $i < $sample_size; $i++ ) {
 			OD_URL_Metrics_Post_Type::store_url_metric(
 				$slug,
-				$test_case->get_validated_url_metric(
+				$test_case->get_sample_url_metric(
 					array(
 						'viewport_width' => 1000,
 						'elements'       => array(

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-non-consecutive-viewport-groups-with-missing-data-for-middle-group.php
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-non-consecutive-viewport-groups-with-missing-data-for-middle-group.php
@@ -4,7 +4,7 @@ return array(
 	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case ): void {
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 400,
 					'elements'       => array(
@@ -24,7 +24,7 @@ return array(
 		);
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 800,
 					'elements'       => array(

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-non-consecutive-viewport-groups-with-missing-data-for-middle-group.php
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-non-consecutive-viewport-groups-with-missing-data-for-middle-group.php
@@ -5,17 +5,19 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				400,
 				array(
-					array(
-						'isLCP'             => true,
-						'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-						'intersectionRatio' => 1.0,
-					),
-					array(
-						'isLCP'             => false,
-						'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
-						'intersectionRatio' => 0.0,
+					'viewport_width' => 400,
+					'elements'       => array(
+						array(
+							'isLCP'             => true,
+							'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+							'intersectionRatio' => 1.0,
+						),
+						array(
+							'isLCP'             => false,
+							'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+							'intersectionRatio' => 0.0,
+						),
 					),
 				)
 			)
@@ -23,17 +25,19 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				800,
 				array(
-					array(
-						'isLCP'             => false,
-						'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-						'intersectionRatio' => 0.0,
-					),
-					array(
-						'isLCP'             => true,
-						'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
-						'intersectionRatio' => 1.0,
+					'viewport_width' => 800,
+					'elements'       => array(
+						array(
+							'isLCP'             => false,
+							'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+							'intersectionRatio' => 0.0,
+						),
+						array(
+							'isLCP'             => true,
+							'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+							'intersectionRatio' => 1.0,
+						),
 					),
 				)
 			)

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale.php
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale.php
@@ -11,15 +11,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				500,
 				array(
-					array(
-						'isLCP' => true,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 500,
+					'elements'       => array(
+						array(
+							'isLCP' => true,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)
@@ -27,15 +29,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				650,
 				array(
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 650,
+					'elements'       => array(
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)
@@ -43,15 +47,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				800,
 				array(
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => true,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 800,
+					'elements'       => array(
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => true,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)
@@ -59,15 +65,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				800,
 				array(
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 800,
+					'elements'       => array(
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale.php
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale.php
@@ -10,7 +10,7 @@ return array(
 
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 500,
 					'elements'       => array(
@@ -28,7 +28,7 @@ return array(
 		);
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 650,
 					'elements'       => array(
@@ -46,7 +46,7 @@ return array(
 		);
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 800,
 					'elements'       => array(
@@ -64,7 +64,7 @@ return array(
 		);
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 800,
 					'elements'       => array(

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints.php
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints.php
@@ -11,15 +11,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				400,
 				array(
-					array(
-						'isLCP' => true,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 400,
+					'elements'       => array(
+						array(
+							'isLCP' => true,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)
@@ -27,15 +29,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				500,
 				array(
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 500,
+					'elements'       => array(
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)
@@ -43,15 +47,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				700,
 				array(
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => true,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 700,
+					'elements'       => array(
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => true,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)
@@ -59,15 +65,17 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				800,
 				array(
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-					),
-					array(
-						'isLCP' => false,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+					'viewport_width' => 800,
+					'elements'       => array(
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
+						array(
+							'isLCP' => false,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]',
+						),
 					),
 				)
 			)

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints.php
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints.php
@@ -10,7 +10,7 @@ return array(
 
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 400,
 					'elements'       => array(
@@ -28,7 +28,7 @@ return array(
 		);
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 500,
 					'elements'       => array(
@@ -46,7 +46,7 @@ return array(
 		);
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 700,
 					'elements'       => array(
@@ -64,7 +64,7 @@ return array(
 		);
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 800,
 					'elements'       => array(

--- a/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated.php
+++ b/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated.php
@@ -16,7 +16,7 @@ return array(
 			for ( $i = 0; $i < $sample_size; $i++ ) {
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
-					$test_case->get_validated_url_metric(
+					$test_case->get_sample_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
 							'element'        => array(

--- a/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated.php
+++ b/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated.php
@@ -17,12 +17,14 @@ return array(
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
 					$test_case->get_validated_url_metric(
-						$viewport_width,
 						array(
-							array(
-								'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::MAIN]/*[2][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::IMG]',
-								'isLCP'             => $viewport_width > 600,
-								'intersectionRatio' => $viewport_width > 600 ? 1.0 : 0.1,
+							'viewport_width' => $viewport_width,
+							'elements'       => array(
+								array(
+									'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::MAIN]/*[2][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::IMG]',
+									'isLCP'             => $viewport_width > 600,
+									'intersectionRatio' => $viewport_width > 600 ? 1.0 : 0.1,
+								),
 							),
 						)
 					)

--- a/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated.php
+++ b/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated.php
@@ -19,12 +19,10 @@ return array(
 					$test_case->get_validated_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
-							'elements'       => array(
-								array(
-									'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::MAIN]/*[2][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::IMG]',
-									'isLCP'             => $viewport_width > 600,
-									'intersectionRatio' => $viewport_width > 600 ? 1.0 : 0.1,
-								),
+							'element'        => array(
+								'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::MAIN]/*[2][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::IMG]',
+								'isLCP'             => $viewport_width > 600,
+								'intersectionRatio' => $viewport_width > 600 ? 1.0 : 0.1,
 							),
 						)
 					)

--- a/plugins/image-prioritizer/tests/test-cases/responsive-background-images.php
+++ b/plugins/image-prioritizer/tests/test-cases/responsive-background-images.php
@@ -23,7 +23,7 @@ return array(
 			for ( $i = 0; $i < $sample_size; $i++ ) {
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
-					$test_case->get_validated_url_metric(
+					$test_case->get_sample_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
 							'element'        => array(

--- a/plugins/image-prioritizer/tests/test-cases/responsive-background-images.php
+++ b/plugins/image-prioritizer/tests/test-cases/responsive-background-images.php
@@ -24,11 +24,13 @@ return array(
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
 					$test_case->get_validated_url_metric(
-						$viewport_width,
 						array(
-							array(
-								'xpath' => sprintf( '/*[1][self::HTML]/*[2][self::BODY]/*[%d][self::DIV]', $div_index + 1 ),
-								'isLCP' => true,
+							'viewport_width' => $viewport_width,
+							'elements'       => array(
+								array(
+									'xpath' => sprintf( '/*[1][self::HTML]/*[2][self::BODY]/*[%d][self::DIV]', $div_index + 1 ),
+									'isLCP' => true,
+								),
 							),
 						)
 					)

--- a/plugins/image-prioritizer/tests/test-cases/responsive-background-images.php
+++ b/plugins/image-prioritizer/tests/test-cases/responsive-background-images.php
@@ -26,11 +26,9 @@ return array(
 					$test_case->get_validated_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
-							'elements'       => array(
-								array(
-									'xpath' => sprintf( '/*[1][self::HTML]/*[2][self::BODY]/*[%d][self::DIV]', $div_index + 1 ),
-									'isLCP' => true,
-								),
+							'element'        => array(
+								'xpath' => sprintf( '/*[1][self::HTML]/*[2][self::BODY]/*[%d][self::DIV]', $div_index + 1 ),
+								'isLCP' => true,
 							),
 						)
 					)

--- a/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint.php
+++ b/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint.php
@@ -6,11 +6,9 @@ return array(
 			$test_case->get_validated_url_metric(
 				array(
 					'viewport_width' => 400,
-					'elements'       => array(
-						array(
-							'isLCP' => true,
-							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
-						),
+					'element'        => array(
+						'isLCP' => true,
+						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
 					),
 				)
 			)

--- a/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint.php
+++ b/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint.php
@@ -3,7 +3,7 @@ return array(
 	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case ): void {
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
-			$test_case->get_validated_url_metric(
+			$test_case->get_sample_url_metric(
 				array(
 					'viewport_width' => 400,
 					'element'        => array(

--- a/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint.php
+++ b/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint.php
@@ -4,11 +4,13 @@ return array(
 		OD_URL_Metrics_Post_Type::store_url_metric(
 			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
 			$test_case->get_validated_url_metric(
-				400,
 				array(
-					array(
-						'isLCP' => true,
-						'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+					'viewport_width' => 400,
+					'elements'       => array(
+						array(
+							'isLCP' => true,
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+						),
 					),
 				)
 			)

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -3,6 +3,8 @@
  * Tests for image-prioritizer plugin helper.php.
  *
  * @package image-prioritizer
+ *
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
@@ -45,7 +47,6 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 * @covers Image_Prioritizer_Background_Image_Styled_Tag_Visitor
 	 *
 	 * @dataProvider data_provider_test_filter_tag_visitors
-	 * @throws Exception But it won't.
 	 */
 	public function test_image_prioritizer_register_tag_visitors( Closure $set_up, string $buffer, string $expected ): void {
 		$set_up( $this );

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -315,6 +315,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 			$popped_tag_name = array_pop( $this->open_stack_tags );
 			if ( $popped_tag_name !== $tag_name ) {
 				$this->warn(
+					__METHOD__,
 					sprintf(
 						/* translators: 1: Popped tag name, 2: Closing tag name */
 						__( 'Expected popped tag stack element %1$s to match the currently visited closing tag %2$s.', 'optimization-detective' ),
@@ -476,6 +477,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	public function release_bookmark( $name ): bool {
 		if ( in_array( $name, array( self::END_OF_HEAD_BOOKMARK, self::END_OF_BODY_BOOKMARK ), true ) ) {
 			$this->warn(
+				__METHOD__,
 				/* translators: %s is the bookmark name */
 				sprintf( 'The %s bookmark is not allowed to be released.', 'optimization-detective' )
 			);
@@ -575,6 +577,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 			}
 			if ( ! $this->has_bookmark( $bookmark ) ) {
 				$this->warn(
+					__METHOD__,
 					sprintf(
 						/* translators: %s is the bookmark name */
 						__( 'Unable to append markup to %s since the bookmark no longer exists.', 'optimization-detective' ),
@@ -602,11 +605,12 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param string $message Warning message.
+	 * @param string $function_name Function name.
+	 * @param string $message       Warning message.
 	 */
-	private function warn( string $message ): void {
+	private function warn( string $function_name, string $message ): void {
 		wp_trigger_error(
-			__CLASS__ . '::open_tags',
+			$function_name,
 			esc_html( $message )
 		);
 	}

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -90,46 +90,37 @@ final class OD_URL_Metric implements JsonSerializable {
 	 * @return array<string, mixed> Schema.
 	 */
 	public static function get_json_schema(): array {
-		// See <https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly>.
+		/*
+		 * The intersectionRect and clientBoundingRect are both instances of the DOMRectReadOnly, which
+		 * the following schema describes. See <https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly>.
+		 * Note that 'number' is used specifically instead of 'integer' because the values are all specified as
+		 * floats/doubles.
+		 */
+		$properties = array_fill_keys(
+			array(
+				'width',
+				'height',
+				'x',
+				'y',
+				'top',
+				'right',
+				'bottom',
+				'left',
+			),
+			array(
+				'type'     => 'number',
+				'required' => true,
+			)
+		);
+
+		// The spec allows these to be negative but this doesn't make sense in the context of intersectionRect and boundingClientRect.
+		$properties['width']['minimum']  = 0.0;
+		$properties['height']['minimum'] = 0.0;
+
 		$dom_rect_schema = array(
 			'type'                 => 'object',
 			'required'             => true,
-			'properties'           => array(
-				'width'  => array(
-					'type'     => 'number', // An 'unrestricted double'.
-					'required' => true,
-					'minimum'  => 0.0,      // The spec allows this to be negative in DOMRectReadOnly, but this doesn't make sense in the context of intersectionRect and boundingClientRect.
-				),
-				'height' => array(
-					'type'     => 'number', // An 'unrestricted double'.
-					'required' => true,
-					'minimum'  => 0.0,      // The spec allows this to be negative in DOMRectReadOnly, but this doesn't make sense in the context of intersectionRect and boundingClientRect.
-				),
-				'x'      => array(
-					'type'     => 'number', // A 'double'.
-					'required' => true,
-				),
-				'y'      => array(
-					'type'     => 'number', // A 'double'.
-					'required' => true,
-				),
-				'top'    => array(
-					'type'     => 'number', // A 'double'.
-					'required' => true,
-				),
-				'right'  => array(
-					'type'     => 'number', // A 'double'.
-					'required' => true,
-				),
-				'bottom' => array(
-					'type'     => 'number', // A 'double'.
-					'required' => true,
-				),
-				'left'   => array(
-					'type'     => 'number', // A 'double'.
-					'required' => true,
-				),
-			),
+			'properties'           => $properties,
 			'additionalProperties' => false,
 		);
 

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -14,21 +14,34 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Representation of the measurements taken from a single client's visit to a specific URL.
  *
- * @phpstan-type RectData    array{ width: int, height: int }
- * @phpstan-type ElementData array{
- *                               isLCP: bool,
- *                               isLCPCandidate: bool,
- *                               xpath: string,
- *                               intersectionRatio: float,
- *                               intersectionRect: RectData,
- *                               boundingClientRect: RectData,
- *                           }
- * @phpstan-type Data        array{
- *                               url: string,
- *                               timestamp: float,
- *                               viewport: RectData,
- *                               elements: ElementData[]
- *                           }
+ * @phpstan-type ViewportRect array{
+ *                                width: int,
+ *                                height: int
+ *                            }
+ * @phpstan-type DOMRect      array{
+ *                                width: float,
+ *                                height: float,
+ *                                x: float,
+ *                                y: float,
+ *                                top: float,
+ *                                right: float,
+ *                                bottom: float,
+ *                                left: float
+ *                            }
+ * @phpstan-type ElementData  array{
+ *                                isLCP: bool,
+ *                                isLCPCandidate: bool,
+ *                                xpath: string,
+ *                                intersectionRatio: float,
+ *                                intersectionRect: DOMRect,
+ *                                boundingClientRect: DOMRect,
+ *                            }
+ * @phpstan-type Data         array{
+ *                                url: string,
+ *                                timestamp: float,
+ *                                viewport: ViewportRect,
+ *                                elements: ElementData[]
+ *                            }
  *
  * @since 0.1.0
  * @access private
@@ -77,39 +90,67 @@ final class OD_URL_Metric implements JsonSerializable {
 	 * @return array<string, mixed> Schema.
 	 */
 	public static function get_json_schema(): array {
+		// See <https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly>.
 		$dom_rect_schema = array(
 			'type'                 => 'object',
+			'required'             => true,
 			'properties'           => array(
 				'width'  => array(
-					'type'    => 'number',
-					'minimum' => 0,
+					'type'     => 'number', // An 'unrestricted double'.
+					'required' => true,
+					'minimum'  => 0.0,      // The spec allows this to be negative in DOMRectReadOnly, but this doesn't make sense in the context of intersectionRect and boundingClientRect.
 				),
 				'height' => array(
-					'type'    => 'number',
-					'minimum' => 0,
+					'type'     => 'number', // An 'unrestricted double'.
+					'required' => true,
+					'minimum'  => 0.0,      // The spec allows this to be negative in DOMRectReadOnly, but this doesn't make sense in the context of intersectionRect and boundingClientRect.
+				),
+				'x'      => array(
+					'type'     => 'number', // A 'double'.
+					'required' => true,
+				),
+				'y'      => array(
+					'type'     => 'number', // A 'double'.
+					'required' => true,
+				),
+				'top'    => array(
+					'type'     => 'number', // A 'double'.
+					'required' => true,
+				),
+				'right'  => array(
+					'type'     => 'number', // A 'double'.
+					'required' => true,
+				),
+				'bottom' => array(
+					'type'     => 'number', // A 'double'.
+					'required' => true,
+				),
+				'left'   => array(
+					'type'     => 'number', // A 'double'.
+					'required' => true,
 				),
 			),
-			// TODO: There are other properties to define if we need them: x, y, top, right, bottom, left.
-			'additionalProperties' => true,
+			'additionalProperties' => false,
 		);
 
 		return array(
 			'$schema'              => 'http://json-schema.org/draft-04/schema#',
 			'title'                => 'od-url-metric',
 			'type'                 => 'object',
+			'required'             => true,
 			'properties'           => array(
 				'url'       => array(
-					'type'        => 'string',
 					'description' => __( 'The URL for which the metric was obtained.', 'optimization-detective' ),
+					'type'        => 'string',
 					'required'    => true,
 					'format'      => 'uri',
 					'pattern'     => '^https?://',
 				),
 				'viewport'  => array(
-					'description' => __( 'Viewport dimensions', 'optimization-detective' ),
-					'type'        => 'object',
-					'required'    => true,
-					'properties'  => array(
+					'description'          => __( 'Viewport dimensions', 'optimization-detective' ),
+					'type'                 => 'object',
+					'required'             => true,
+					'properties'           => array(
 						'width'  => array(
 							'type'     => 'integer',
 							'required' => true,
@@ -121,6 +162,7 @@ final class OD_URL_Metric implements JsonSerializable {
 							'minimum'  => 0,
 						),
 					),
+					'additionalProperties' => false,
 				),
 				'timestamp' => array(
 					'description' => __( 'Timestamp at which the URL metric was captured.', 'optimization-detective' ),
@@ -137,13 +179,15 @@ final class OD_URL_Metric implements JsonSerializable {
 					'items'       => array(
 						// See the ElementMetrics in detect.js.
 						'type'                 => 'object',
+						'required'             => true,
 						'properties'           => array(
 							'isLCP'              => array(
 								'type'     => 'boolean',
 								'required' => true,
 							),
 							'isLCPCandidate'     => array(
-								'type' => 'boolean',
+								'type'     => 'boolean',
+								'required' => true,
 							),
 							'xpath'              => array(
 								'type'     => 'string',
@@ -179,7 +223,7 @@ final class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Gets viewport data.
 	 *
-	 * @return RectData Viewport data.
+	 * @return ViewportRect Viewport data.
 	 */
 	public function get_viewport(): array {
 		return $this->data['viewport'];

--- a/plugins/optimization-detective/class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/class-od-url-metrics-group.php
@@ -81,7 +81,7 @@ final class OD_URL_Metrics_Group implements IteratorAggregate, Countable, JsonSe
 	/**
 	 * Constructor.
 	 *
-	 * @throws InvalidArgumentException If arguments are valid.
+	 * @throws InvalidArgumentException If arguments are invalid.
 	 *
 	 * @param OD_URL_Metric[]                      $url_metrics            URL metrics to add to the group.
 	 * @param int                                  $minimum_viewport_width Minimum possible viewport width for the group. Must be zero or greater.

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -137,8 +137,6 @@ function od_is_response_html_content_type(): bool {
  *
  * @param string $buffer Template output buffer.
  * @return string Filtered template output buffer.
- *
- * @throws Exception Except it won't really.
  */
 function od_optimize_template_output_buffer( string $buffer ): string {
 	if ( ! od_is_response_html_content_type() ) {

--- a/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
@@ -9,6 +9,7 @@
  */
 
 class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
+	use Optimization_Detective_Test_Helpers;
 
 	/**
 	 * Test add_hooks().
@@ -334,16 +335,6 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 	 * @throws OD_Data_Validation_Exception When invalid data (but there won't be).
 	 */
 	private function get_sample_url_metric( string $url ): OD_URL_Metric {
-		$dom_rect = array(
-			'width'  => 100,
-			'height' => 100,
-			'x'      => 100,
-			'y'      => 100,
-			'top'    => 0,
-			'right'  => 0,
-			'bottom' => 0,
-			'left'   => 0,
-		);
 		return new OD_URL_Metric(
 			array(
 				'url'       => $url,
@@ -358,8 +349,8 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 						'isLCPCandidate'     => true,
 						'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
 						'intersectionRatio'  => 1,
-						'intersectionRect'   => $dom_rect,
-						'boundingClientRect' => $dom_rect,
+						'intersectionRect'   => $this->get_sample_dom_rect(),
+						'boundingClientRect' => $this->get_sample_dom_rect(),
 					),
 				),
 			)

--- a/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
@@ -6,6 +6,7 @@
  *
  * @coversDefaultClass OD_URL_Metrics_Post_Type
  * @noinspection PhpUnhandledExceptionInspection
+ * @noinspection PhpDocMissingThrowsInspection
  */
 
 class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
@@ -331,8 +332,6 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
 	 *
 	 * @param string $url URL.
-	 *
-	 * @throws OD_Data_Validation_Exception When invalid data (but there won't be).
 	 */
 	private function get_sample_url_metric( string $url ): OD_URL_Metric {
 		return new OD_URL_Metric(

--- a/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
@@ -155,7 +155,7 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 	public function test_store_url_metric(): void {
 		$slug = od_get_url_metrics_slug( array( 'p' => 1 ) );
 
-		$validated_url_metric = $this->get_validated_url_metric( array( 'url' => home_url( '/' ) ) );
+		$validated_url_metric = $this->get_sample_url_metric( array( 'url' => home_url( '/' ) ) );
 
 		$post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $validated_url_metric );
 		$this->assertIsInt( $post_id );
@@ -234,9 +234,9 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 		clean_post_cache( $old_generic_post );
 
 		$new_url_metrics_slug = od_get_url_metrics_slug( array( 'p' => $new_generic_post ) );
-		$new_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $new_url_metrics_slug, $this->get_validated_url_metric( array( 'url' => get_permalink( $new_generic_post ) ) ) );
+		$new_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $new_url_metrics_slug, $this->get_sample_url_metric( array( 'url' => get_permalink( $new_generic_post ) ) ) );
 		$old_url_metrics_slug = od_get_url_metrics_slug( array( 'p' => $old_generic_post ) );
-		$old_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $old_url_metrics_slug, $this->get_validated_url_metric( array( 'url' => get_permalink( $old_generic_post ) ) ) );
+		$old_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $old_url_metrics_slug, $this->get_sample_url_metric( array( 'url' => get_permalink( $old_generic_post ) ) ) );
 		$wpdb->update(
 			$wpdb->posts,
 			array(
@@ -283,7 +283,7 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 		// Now create sample URL Metrics posts.
 		for ( $i = 1; $i <= 101; $i++ ) {
 			$slug    = od_get_url_metrics_slug( array( 'p' => $i ) );
-			$post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $this->get_validated_url_metric( array( 'url' => home_url( "/?p=$i" ) ) ) );
+			$post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $this->get_sample_url_metric( array( 'url' => home_url( "/?p=$i" ) ) ) );
 			update_post_meta( $post_id, $url_metrics_post_meta_key, '' );
 		}
 

--- a/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
@@ -327,11 +327,23 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 	/**
 	 * Gets a sample URL Metric.
 	 *
+	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
+	 *
 	 * @param string $url URL.
 	 *
 	 * @throws OD_Data_Validation_Exception When invalid data (but there won't be).
 	 */
 	private function get_sample_url_metric( string $url ): OD_URL_Metric {
+		$dom_rect = array(
+			'width'  => 100,
+			'height' => 100,
+			'x'      => 100,
+			'y'      => 100,
+			'top'    => 0,
+			'right'  => 0,
+			'bottom' => 0,
+			'left'   => 0,
+		);
 		return new OD_URL_Metric(
 			array(
 				'url'       => $url,
@@ -346,14 +358,8 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 						'isLCPCandidate'     => true,
 						'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
 						'intersectionRatio'  => 1,
-						'intersectionRect'   => array(
-							'width'  => 100,
-							'height' => 100,
-						),
-						'boundingClientRect' => array(
-							'width'  => 100,
-							'height' => 100,
-						),
+						'intersectionRect'   => $dom_rect,
+						'boundingClientRect' => $dom_rect,
 					),
 				),
 			)

--- a/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
@@ -155,7 +155,7 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 	public function test_store_url_metric(): void {
 		$slug = od_get_url_metrics_slug( array( 'p' => 1 ) );
 
-		$validated_url_metric = $this->get_sample_url_metric( home_url( '/' ) );
+		$validated_url_metric = $this->get_validated_url_metric( array( 'url' => home_url( '/' ) ) );
 
 		$post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $validated_url_metric );
 		$this->assertIsInt( $post_id );
@@ -234,9 +234,9 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 		clean_post_cache( $old_generic_post );
 
 		$new_url_metrics_slug = od_get_url_metrics_slug( array( 'p' => $new_generic_post ) );
-		$new_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $new_url_metrics_slug, $this->get_sample_url_metric( get_permalink( $new_generic_post ) ) );
+		$new_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $new_url_metrics_slug, $this->get_validated_url_metric( array( 'url' => get_permalink( $new_generic_post ) ) ) );
 		$old_url_metrics_slug = od_get_url_metrics_slug( array( 'p' => $old_generic_post ) );
-		$old_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $old_url_metrics_slug, $this->get_sample_url_metric( get_permalink( $old_generic_post ) ) );
+		$old_url_metrics_post = OD_URL_Metrics_Post_Type::store_url_metric( $old_url_metrics_slug, $this->get_validated_url_metric( array( 'url' => get_permalink( $old_generic_post ) ) ) );
 		$wpdb->update(
 			$wpdb->posts,
 			array(
@@ -283,7 +283,7 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 		// Now create sample URL Metrics posts.
 		for ( $i = 1; $i <= 101; $i++ ) {
 			$slug    = od_get_url_metrics_slug( array( 'p' => $i ) );
-			$post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $this->get_sample_url_metric( home_url( "/?p=$i" ) ) );
+			$post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $this->get_validated_url_metric( array( 'url' => home_url( "/?p=$i" ) ) ) );
 			update_post_meta( $post_id, $url_metrics_post_meta_key, '' );
 		}
 
@@ -324,35 +324,5 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 		}
 		$this->assertEquals( 0, $wpdb->get_var( $wpdb->prepare( "SELECT count(*) FROM $wpdb->postmeta WHERE meta_key = %s", $url_metrics_post_meta_key ) ) );
 		$this->assertEquals( $other_post_meta_count, $wpdb->get_var( $wpdb->prepare( "SELECT count(*) FROM $wpdb->postmeta WHERE meta_key = %s and meta_value = %s", $other_post_meta_key, $other_post_meta_value ) ) );
-	}
-
-	/**
-	 * Gets a sample URL Metric.
-	 *
-	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
-	 *
-	 * @param string $url URL.
-	 */
-	private function get_sample_url_metric( string $url ): OD_URL_Metric {
-		return new OD_URL_Metric(
-			array(
-				'url'       => $url,
-				'viewport'  => array(
-					'width'  => 480,
-					'height' => 640,
-				),
-				'timestamp' => microtime( true ),
-				'elements'  => array(
-					array(
-						'isLCP'              => true,
-						'isLCPCandidate'     => true,
-						'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
-						'intersectionRatio'  => 1,
-						'intersectionRect'   => $this->get_sample_dom_rect(),
-						'boundingClientRect' => $this->get_sample_dom_rect(),
-					),
-				),
-			)
-		);
 	}
 }

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -382,7 +382,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 	 */
 	private function get_valid_params( array $extras = array() ): array {
 		$slug = od_get_url_metrics_slug( array() );
-		$data = $this->get_validated_url_metric(
+		$data = $this->get_sample_url_metric(
 			array(
 				'viewport_width' => 480,
 				'element'        => array(

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -385,10 +385,8 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		$data = $this->get_validated_url_metric(
 			array(
 				'viewport_width' => 480,
-				'elements'       => array(
-					array(
-						'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
-					),
+				'element'        => array(
+					'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
 				),
 			)
 		)->jsonSerialize();

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -117,6 +117,33 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 						),
 					),
 				),
+				'invalid_elements_additional_intersect_rect_property' => array(
+					'elements' => array(
+						array_merge(
+							$valid_element,
+							array(
+								'intersectionRect' => array(
+									'width'  => 640,
+									'height' => 480,
+									'wooHoo' => 'bad',
+								),
+							)
+						),
+					),
+				),
+				'invalid_elements_negative_width_intersect_rect_property' => array(
+					'elements' => array(
+						array_merge(
+							$valid_element,
+							array(
+								'intersectionRect' => array(
+									'width'  => -640,
+									'height' => 480,
+								),
+							)
+						),
+					),
+				),
 			)
 		);
 	}
@@ -396,9 +423,20 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 	/**
 	 * Gets sample validated URL metric data.
 	 *
+	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
 	 * @return array<string, mixed>
 	 */
 	private function get_sample_validated_url_metric(): array {
+		$dom_rect = array(
+			'width'  => 100,
+			'height' => 100,
+			'x'      => 100,
+			'y'      => 100,
+			'top'    => 0,
+			'right'  => 0,
+			'bottom' => 0,
+			'left'   => 0,
+		);
 		return array(
 			'url'       => home_url( '/' ),
 			'viewport'  => array(
@@ -408,10 +446,12 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 			'timestamp' => microtime( true ),
 			'elements'  => array(
 				array(
-					'isLCP'             => true,
-					'isLCPCandidate'    => true,
-					'xpath'             => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
-					'intersectionRatio' => 1,
+					'isLCP'              => true,
+					'isLCPCandidate'     => true,
+					'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
+					'intersectionRatio'  => 1,
+					'intersectionRect'   => $dom_rect,
+					'boundingClientRect' => $dom_rect,
 				),
 			),
 		);

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -6,6 +6,7 @@
  */
 
 class Test_OD_Storage_REST_API extends WP_UnitTestCase {
+	use Optimization_Detective_Test_Helpers;
 
 	/**
 	 * @var string
@@ -378,10 +379,18 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 	 *
 	 * @param array<string, mixed> $extras Extra params which are recursively merged on top of the valid params.
 	 * @return array<string, mixed> Params.
+	 * @throws OD_Data_Validation_Exception Except it won't.
 	 */
 	private function get_valid_params( array $extras = array() ): array {
 		$slug = od_get_url_metrics_slug( array() );
-		$data = $this->get_sample_validated_url_metric();
+		$data = $this->get_validated_url_metric(
+			480,
+			array(
+				array(
+					'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
+				),
+			)
+		)->jsonSerialize();
 		$data = array_merge(
 			array(
 				'slug'  => $slug,
@@ -418,42 +427,5 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 			}
 		}
 		return $base_array;
-	}
-
-	/**
-	 * Gets sample validated URL metric data.
-	 *
-	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
-	 * @return array<string, mixed>
-	 */
-	private function get_sample_validated_url_metric(): array {
-		$dom_rect = array(
-			'width'  => 100,
-			'height' => 100,
-			'x'      => 100,
-			'y'      => 100,
-			'top'    => 0,
-			'right'  => 0,
-			'bottom' => 0,
-			'left'   => 0,
-		);
-		return array(
-			'url'       => home_url( '/' ),
-			'viewport'  => array(
-				'width'  => 480,
-				'height' => 640,
-			),
-			'timestamp' => microtime( true ),
-			'elements'  => array(
-				array(
-					'isLCP'              => true,
-					'isLCPCandidate'     => true,
-					'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
-					'intersectionRatio'  => 1,
-					'intersectionRect'   => $dom_rect,
-					'boundingClientRect' => $dom_rect,
-				),
-			),
-		);
 	}
 }

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -383,10 +383,12 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 	private function get_valid_params( array $extras = array() ): array {
 		$slug = od_get_url_metrics_slug( array() );
 		$data = $this->get_validated_url_metric(
-			480,
 			array(
-				array(
-					'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
+				'viewport_width' => 480,
+				'elements'       => array(
+					array(
+						'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
+					),
 				),
 			)
 		)->jsonSerialize();

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -379,7 +379,6 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 	 *
 	 * @param array<string, mixed> $extras Extra params which are recursively merged on top of the valid params.
 	 * @return array<string, mixed> Params.
-	 * @throws OD_Data_Validation_Exception Except it won't.
 	 */
 	private function get_valid_params( array $extras = array() ): array {
 		$slug = od_get_url_metrics_slug( array() );

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -312,8 +312,6 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	 * @param string   $document Document.
 	 * @param string[] $open_tags Open tags.
 	 * @param string[] $xpaths XPaths.
-	 *
-	 * @throws Exception But not really.
 	 */
 	public function test_next_tag_and_get_xpath( string $document, array $open_tags, array $xpaths ): void {
 		$p = new OD_HTML_Tag_Processor( $document );
@@ -344,8 +342,6 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	 * Test append_head_html().
 	 *
 	 * @covers ::append_head_html
-	 *
-	 * @throws Exception But not really.
 	 */
 	public function test_append_head_html(): void {
 		$html           = '
@@ -413,8 +409,6 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	 *
 	 * @covers ::append_head_html
 	 * @covers ::append_body_html
-	 *
-	 * @throws Exception But not really.
 	 */
 	public function test_append_head_and_body_html(): void {
 		$html          = '
@@ -473,8 +467,6 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	 * @covers ::set_attribute
 	 * @covers ::remove_attribute
 	 * @covers ::set_meta_attribute
-	 *
-	 * @throws Exception But not really.
 	 */
 	public function test_html_tag_processor_wrapper_methods(): void {
 		$processor = new OD_HTML_Tag_Processor( '<html lang="en" class="foo" dir="ltr"></html>' );

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -168,7 +168,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check schema subset.
+	 * Checks schema subset.
 	 *
 	 * @param array<string, mixed> $schema Schema subset.
 	 */

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -7,6 +7,7 @@
  * @coversDefaultClass OD_URL_Metric
  */
 class Test_OD_URL_Metric extends WP_UnitTestCase {
+	use Optimization_Detective_Test_Helpers;
 
 	/**
 	 * Data provider.
@@ -18,23 +19,13 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			'width'  => 640,
 			'height' => 480,
 		);
-		$dom_rect      = array(
-			'width'  => 100,
-			'height' => 100,
-			'x'      => 100,
-			'y'      => 100,
-			'top'    => 0,
-			'right'  => 0,
-			'bottom' => 0,
-			'left'   => 0,
-		);
 		$valid_element = array(
 			'isLCP'              => true,
 			'isLCPCandidate'     => true,
 			'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
 			'intersectionRatio'  => 1.0,
-			'intersectionRect'   => $dom_rect,
-			'boundingClientRect' => $dom_rect,
+			'intersectionRect'   => $this->get_sample_dom_rect(),
+			'boundingClientRect' => $this->get_sample_dom_rect(),
 		);
 
 		return array(

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -555,11 +555,9 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 			return $this->get_validated_url_metric(
 				array(
 					'viewport_width' => $viewport_width,
-					'elements'       => array(
-						array(
-							'isLCP' => true,
-							'xpath' => $lcp_element_xpath,
-						),
+					'element'        => array(
+						'isLCP' => true,
+						'xpath' => $lcp_element_xpath,
 					),
 				)
 			);
@@ -623,11 +621,9 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 					$this->get_validated_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
-							'elements'       => array(
-								array(
-									'isLCP' => true,
-									'xpath' => $lcp_element_xpath,
-								),
+							'element'        => array(
+								'isLCP' => true,
+								'xpath' => $lcp_element_xpath,
 							),
 						)
 					)
@@ -655,12 +651,10 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 			return $this->get_validated_url_metric(
 				array(
 					'viewport_width' => $viewport_width,
-					'elements'       => array(
-						array(
-							'isLCP'             => true,
-							'xpath'             => $lcp_element_xpath,
-							'intersectionRatio' => $intersection_ratio,
-						),
+					'element'        => array(
+						'isLCP'             => true,
+						'xpath'             => $lcp_element_xpath,
+						'intersectionRatio' => $intersection_ratio,
 					),
 				)
 			);

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -10,6 +10,7 @@
  */
 
 class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
+	use Optimization_Detective_Test_Helpers;
 
 	/**
 	 * Data provider.
@@ -766,16 +767,6 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width = 480, string $lcp_element_xpath = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]', float $intersection_ratio = 1.0 ): OD_URL_Metric {
-		$dom_rect = array(
-			'width'  => 100,
-			'height' => 100,
-			'x'      => 100,
-			'y'      => 100,
-			'top'    => 0,
-			'right'  => 0,
-			'bottom' => 0,
-			'left'   => 0,
-		);
 		return new OD_URL_Metric(
 			array(
 				'url'       => home_url( '/' ),
@@ -790,8 +781,8 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 						'isLCPCandidate'     => true,
 						'xpath'              => $lcp_element_xpath,
 						'intersectionRatio'  => $intersection_ratio,
-						'intersectionRect'   => $dom_rect,
-						'boundingClientRect' => $dom_rect,
+						'intersectionRect'   => $this->get_sample_dom_rect(),
+						'boundingClientRect' => $this->get_sample_dom_rect(),
 					),
 				),
 			)

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -5,6 +5,7 @@
  * @package optimization-detective
  *
  * @noinspection PhpUnhandledExceptionInspection
+ * @noinspection PhpDocMissingThrowsInspection
  *
  * @coversDefaultClass OD_URL_Metrics_Group_Collection
  */
@@ -15,7 +16,6 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_construction(): array {
@@ -180,7 +180,6 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 * @param array<int, int> $expected_counts Minimum viewport widths mapped to the expected counts in each group.
 	 *
 	 * @dataProvider data_provider_sample_size_and_breakpoints
-	 * @throws OD_Data_Validation_Exception When failing to instantiate a URL metric.
 	 */
 	public function test_add_url_metric( int $sample_size, array $breakpoints, array $viewport_widths, array $expected_counts ): void {
 		$group_collection = new OD_URL_Metrics_Group_Collection( array(), $breakpoints, $sample_size, HOUR_IN_SECONDS );
@@ -209,8 +208,6 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 * Test that add_url_metric() pushes out old metrics.
 	 *
 	 * @covers ::add_url_metric
-	 *
-	 * @throws OD_Data_Validation_Exception When failing to instantiate a URL metric.
 	 */
 	public function test_adding_pushes_out_old_metrics(): void {
 		$sample_size      = 3;
@@ -310,7 +307,6 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 * @covers ::getIterator
 	 *
 	 * @dataProvider data_provider_test_get_iterator
-	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 *
 	 * @param int[]             $breakpoints Breakpoints.
 	 * @param int[]             $viewport_widths Viewport widths.
@@ -623,7 +619,6 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 * Data provider.
 	 *
 	 * @return array<string, mixed>
-	 * @throws OD_Data_Validation_Exception But it won't really.
 	 */
 	public function data_provider_element_max_intersection_ratios(): array {
 		$xpath1 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]';
@@ -764,7 +759,6 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 * @param float  $intersection_ratio Intersection ratio.
 	 *
 	 * @return OD_URL_Metric Validated URL metric.
-	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width = 480, string $lcp_element_xpath = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]', float $intersection_ratio = 1.0 ): OD_URL_Metric {
 		return new OD_URL_Metric(

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -756,37 +756,45 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	/**
 	 * Gets a validated URL metric for testing.
 	 *
+	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
+	 *
 	 * @param int    $viewport_width     Viewport width.
 	 * @param string $lcp_element_xpath  LCP element XPath.
 	 * @param float  $intersection_ratio Intersection ratio.
+	 *
 	 * @return OD_URL_Metric Validated URL metric.
 	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width = 480, string $lcp_element_xpath = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]', float $intersection_ratio = 1.0 ): OD_URL_Metric {
-		$data = array(
-			'url'       => home_url( '/' ),
-			'viewport'  => array(
-				'width'  => $viewport_width,
-				'height' => 640,
-			),
-			'timestamp' => microtime( true ),
-			'elements'  => array(
-				array(
-					'isLCP'              => true,
-					'isLCPCandidate'     => true,
-					'xpath'              => $lcp_element_xpath,
-					'intersectionRatio'  => $intersection_ratio,
-					'intersectionRect'   => array(
-						'width'  => 100,
-						'height' => 100,
-					),
-					'boundingClientRect' => array(
-						'width'  => 100,
-						'height' => 100,
+		$dom_rect = array(
+			'width'  => 100,
+			'height' => 100,
+			'x'      => 100,
+			'y'      => 100,
+			'top'    => 0,
+			'right'  => 0,
+			'bottom' => 0,
+			'left'   => 0,
+		);
+		return new OD_URL_Metric(
+			array(
+				'url'       => home_url( '/' ),
+				'viewport'  => array(
+					'width'  => $viewport_width,
+					'height' => 640,
+				),
+				'timestamp' => microtime( true ),
+				'elements'  => array(
+					array(
+						'isLCP'              => true,
+						'isLCPCandidate'     => true,
+						'xpath'              => $lcp_element_xpath,
+						'intersectionRatio'  => $intersection_ratio,
+						'intersectionRect'   => $dom_rect,
+						'boundingClientRect' => $dom_rect,
 					),
 				),
-			),
+			)
 		);
-		return new OD_URL_Metric( $data );
 	}
 }

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -78,8 +78,8 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 			),
 			'all_arguments_good'         => array(
 				'url_metrics'   => array(
-					$this->get_validated_url_metric( array( 'viewport_width' => 200 ) ),
-					$this->get_validated_url_metric( array( 'viewport_width' => 400 ) ),
+					$this->get_sample_url_metric( array( 'viewport_width' => 200 ) ),
+					$this->get_sample_url_metric( array( 'viewport_width' => 400 ) ),
 				),
 				'breakpoints'   => array( 400 ),
 				'sample_size'   => 3,
@@ -187,7 +187,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 		// Over-populate the sample size for the breakpoints by a dozen.
 		foreach ( $viewport_widths as $viewport_width => $count ) {
 			for ( $i = 0; $i < $count; $i++ ) {
-				$group_collection->add_url_metric( $this->get_validated_url_metric( array( 'viewport_width' => $viewport_width ) ) );
+				$group_collection->add_url_metric( $this->get_sample_url_metric( array( 'viewport_width' => $viewport_width ) ) );
 			}
 		}
 
@@ -223,7 +223,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 				$group_collection->add_url_metric(
 					new OD_URL_Metric(
 						array_merge(
-							$this->get_validated_url_metric( array( 'viewport_width' => $viewport_width ) )->jsonSerialize(),
+							$this->get_sample_url_metric( array( 'viewport_width' => $viewport_width ) )->jsonSerialize(),
 							array(
 								'timestamp' => $old_timestamp,
 							)
@@ -235,7 +235,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 
 		// Try adding one URL metric for each breakpoint group.
 		foreach ( $viewport_widths as $viewport_width ) {
-			$group_collection->add_url_metric( $this->get_validated_url_metric( array( 'viewport_width' => $viewport_width ) ) );
+			$group_collection->add_url_metric( $this->get_sample_url_metric( array( 'viewport_width' => $viewport_width ) ) );
 		}
 
 		$max_possible_url_metrics_count = $sample_size * ( count( $breakpoints ) + 1 );
@@ -315,7 +315,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	public function test_get_iterator( array $breakpoints, array $viewport_widths, array $expected_groups ): void {
 		$url_metrics = array_map(
 			function ( $viewport_width ) {
-				return $this->get_validated_url_metric( array( 'viewport_width' => $viewport_width ) );
+				return $this->get_sample_url_metric( array( 'viewport_width' => $viewport_width ) );
 			},
 			$viewport_widths
 		);
@@ -361,7 +361,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 						3,
 						new OD_URL_Metric(
 							array_merge(
-								$this->get_validated_url_metric( array( 'viewport_width' => 400 ) )->jsonSerialize(),
+								$this->get_sample_url_metric( array( 'viewport_width' => 400 ) )->jsonSerialize(),
 								array( 'timestamp' => $current_time )
 							)
 						)
@@ -371,7 +371,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 						3,
 						new OD_URL_Metric(
 							array_merge(
-								$this->get_validated_url_metric( array( 'viewport_width' => 600 ) )->jsonSerialize(),
+								$this->get_sample_url_metric( array( 'viewport_width' => 600 ) )->jsonSerialize(),
 								array( 'timestamp' => $current_time )
 							)
 						)
@@ -520,20 +520,20 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 		);
 		$this->assertFalse( $group_collection->is_every_group_populated() );
 		$this->assertFalse( $group_collection->is_every_group_complete() );
-		$group_collection->add_url_metric( $this->get_validated_url_metric( array( 'viewport_width' => 200 ) ) );
+		$group_collection->add_url_metric( $this->get_sample_url_metric( array( 'viewport_width' => 200 ) ) );
 		$this->assertFalse( $group_collection->is_every_group_populated() );
 		$this->assertFalse( $group_collection->is_every_group_complete() );
-		$group_collection->add_url_metric( $this->get_validated_url_metric( array( 'viewport_width' => 500 ) ) );
+		$group_collection->add_url_metric( $this->get_sample_url_metric( array( 'viewport_width' => 500 ) ) );
 		$this->assertFalse( $group_collection->is_every_group_populated() );
 		$this->assertFalse( $group_collection->is_every_group_complete() );
-		$group_collection->add_url_metric( $this->get_validated_url_metric( array( 'viewport_width' => 900 ) ) );
+		$group_collection->add_url_metric( $this->get_sample_url_metric( array( 'viewport_width' => 900 ) ) );
 		$this->assertTrue( $group_collection->is_every_group_populated() );
 		$this->assertFalse( $group_collection->is_every_group_complete() );
 
 		// Now finish completing all the groups.
 		foreach ( array_merge( $breakpoints, array( 1000 ) ) as $viewport_width ) {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
-				$group_collection->add_url_metric( $this->get_validated_url_metric( array( 'viewport_width' => $viewport_width ) ) );
+				$group_collection->add_url_metric( $this->get_sample_url_metric( array( 'viewport_width' => $viewport_width ) ) );
 			}
 		}
 		$this->assertTrue( $group_collection->is_every_group_complete() );
@@ -552,7 +552,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 		$first_child_h1_xpath     = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::H1]/*[1]';
 
 		$get_url_metric_with_one_lcp_element = function ( int $viewport_width, string $lcp_element_xpath ): OD_URL_Metric {
-			return $this->get_validated_url_metric(
+			return $this->get_sample_url_metric(
 				array(
 					'viewport_width' => $viewport_width,
 					'element'        => array(
@@ -618,7 +618,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 		foreach ( array_merge( $breakpoints, array( 1000 ) ) as $viewport_width ) {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
 				$group_collection->add_url_metric(
-					$this->get_validated_url_metric(
+					$this->get_sample_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
 							'element'        => array(
@@ -648,7 +648,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 		$xpath3 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[3]';
 
 		$get_sample_url_metric = function ( int $viewport_width, string $lcp_element_xpath, float $intersection_ratio ): OD_URL_Metric {
-			return $this->get_validated_url_metric(
+			return $this->get_sample_url_metric(
 				array(
 					'viewport_width' => $viewport_width,
 					'element'        => array(
@@ -727,9 +727,9 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 */
 	public function test_get_flattened_url_metrics(): void {
 		$url_metrics = array(
-			$this->get_validated_url_metric( array( 'viewport_width' => 400 ) ),
-			$this->get_validated_url_metric( array( 'viewport_width' => 600 ) ),
-			$this->get_validated_url_metric( array( 'viewport_width' => 800 ) ),
+			$this->get_sample_url_metric( array( 'viewport_width' => 400 ) ),
+			$this->get_sample_url_metric( array( 'viewport_width' => 600 ) ),
+			$this->get_sample_url_metric( array( 'viewport_width' => 800 ) ),
 		);
 
 		$group_collection = new OD_URL_Metrics_Group_Collection(
@@ -754,9 +754,9 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 	 */
 	public function test_json_serialize(): void {
 		$url_metrics = array(
-			$this->get_validated_url_metric( array( 'viewport_width' => 400 ) ),
-			$this->get_validated_url_metric( array( 'viewport_width' => 600 ) ),
-			$this->get_validated_url_metric( array( 'viewport_width' => 800 ) ),
+			$this->get_sample_url_metric( array( 'viewport_width' => 400 ) ),
+			$this->get_sample_url_metric( array( 'viewport_width' => 600 ) ),
+			$this->get_sample_url_metric( array( 'viewport_width' => 800 ) ),
 		);
 
 		$group_collection = new OD_URL_Metrics_Group_Collection(

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -647,7 +647,7 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 		$xpath2 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[2]';
 		$xpath3 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[3]';
 
-		$get_url_metric_with_one_lcp_element_having_intersection_ratio = function ( int $viewport_width, string $lcp_element_xpath, float $intersection_ratio ): OD_URL_Metric {
+		$get_sample_url_metric = function ( int $viewport_width, string $lcp_element_xpath, float $intersection_ratio ): OD_URL_Metric {
 			return $this->get_validated_url_metric(
 				array(
 					'viewport_width' => $viewport_width,
@@ -663,9 +663,9 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 		return array(
 			'one-element-sample-size-one'    => array(
 				'url_metrics' => array(
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 400, $xpath1, 0.0 ),
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 600, $xpath1, 0.5 ),
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 800, $xpath1, 1.0 ),
+					$get_sample_url_metric( 400, $xpath1, 0.0 ),
+					$get_sample_url_metric( 600, $xpath1, 0.5 ),
+					$get_sample_url_metric( 800, $xpath1, 1.0 ),
 				),
 				'expected'    => array(
 					$xpath1 => 1.0,
@@ -674,14 +674,14 @@ class Test_OD_URL_Metrics_Group_Collection extends WP_UnitTestCase {
 			'three-elements-sample-size-two' => array(
 				'url_metrics' => array(
 					// Group 1.
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 400, $xpath1, 0.0 ),
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 400, $xpath1, 1.0 ),
+					$get_sample_url_metric( 400, $xpath1, 0.0 ),
+					$get_sample_url_metric( 400, $xpath1, 1.0 ),
 					// Group 2.
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 600, $xpath2, 0.9 ),
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 600, $xpath2, 0.1 ),
+					$get_sample_url_metric( 600, $xpath2, 0.9 ),
+					$get_sample_url_metric( 600, $xpath2, 0.1 ),
 					// Group 3.
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 800, $xpath3, 0.5 ),
-					$get_url_metric_with_one_lcp_element_having_intersection_ratio( 800, $xpath3, 0.6 ),
+					$get_sample_url_metric( 800, $xpath3, 0.5 ),
+					$get_sample_url_metric( 800, $xpath3, 0.6 ),
 				),
 				'expected'    => array(
 					$xpath1 => 1.0,

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -227,19 +227,31 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_get_lcp_element(): array {
+		$get_sample_url_metric = function ( int $viewport_width, array $breadcrumbs, $is_lcp = true ) {
+			return $this->get_validated_url_metric(
+				array(
+					'viewport_width' => $viewport_width,
+					'element'        => array(
+						'xpath' => $this->get_xpath( ...$breadcrumbs ),
+						'isLCP' => $is_lcp,
+					),
+				)
+			);
+		};
+
 		return array(
 			'common_lcp_element_across_breakpoints'    => array(
 				'breakpoints'                 => array( 600, 800 ),
 				'url_metrics'                 => array(
 					// 0.
-					$this->get_validated_url_metric( 400, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
-					$this->get_validated_url_metric( 500, array( 'HTML', 'BODY', 'DIV', 'IMG' ) ), // Ignored since less common than the other two.
-					$this->get_validated_url_metric( 599, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
+					$get_sample_url_metric( 400, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
+					$get_sample_url_metric( 500, array( 'HTML', 'BODY', 'DIV', 'IMG' ) ), // Ignored since less common than the other two.
+					$get_sample_url_metric( 599, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
 					// 600.
-					$this->get_validated_url_metric( 600, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
-					$this->get_validated_url_metric( 700, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
+					$get_sample_url_metric( 600, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
+					$get_sample_url_metric( 700, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
 					// 800.
-					$this->get_validated_url_metric( 900, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
+					$get_sample_url_metric( 900, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
 				),
 				'expected_lcp_element_xpaths' => array_fill_keys(
 					array(
@@ -254,12 +266,12 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 				'breakpoints'                 => array( 600 ),
 				'url_metrics'                 => array(
 					// 0.
-					$this->get_validated_url_metric( 400, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
-					$this->get_validated_url_metric( 500, array( 'HTML', 'BODY', 'DIV', 'IMG' ) ), // Ignored since less common than the other two.
-					$this->get_validated_url_metric( 600, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
+					$get_sample_url_metric( 400, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
+					$get_sample_url_metric( 500, array( 'HTML', 'BODY', 'DIV', 'IMG' ) ), // Ignored since less common than the other two.
+					$get_sample_url_metric( 600, array( 'HTML', 'BODY', 'FIGURE', 'IMG' ) ),
 					// 600.
-					$this->get_validated_url_metric( 800, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
-					$this->get_validated_url_metric( 900, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
+					$get_sample_url_metric( 800, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
+					$get_sample_url_metric( 900, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
 				),
 				'expected_lcp_element_xpaths' => array(
 					'0:600' => $this->get_xpath( 'HTML', 'BODY', 'FIGURE', 'IMG' ),
@@ -270,12 +282,12 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 				'breakpoints'                 => array( 400, 600 ),
 				'url_metrics'                 => array(
 					// 0.
-					$this->get_validated_url_metric( 300, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
+					$get_sample_url_metric( 300, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
 					// 400.
-					$this->get_validated_url_metric( 500, array( 'HTML', 'BODY', 'HEADER', 'IMG' ), false ),
+					$get_sample_url_metric( 500, array( 'HTML', 'BODY', 'HEADER', 'IMG' ), false ),
 					// 600.
-					$this->get_validated_url_metric( 800, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
-					$this->get_validated_url_metric( 900, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
+					$get_sample_url_metric( 800, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
+					$get_sample_url_metric( 900, array( 'HTML', 'BODY', 'MAIN', 'IMG' ) ),
 				),
 				'expected_lcp_element_xpaths' => array(
 					'0:400'   => $this->get_xpath( 'HTML', 'BODY', 'MAIN', 'IMG' ),
@@ -287,9 +299,9 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 				'breakpoints'                 => array( 600 ),
 				'url_metrics'                 => array(
 					// 0.
-					$this->get_validated_url_metric( 300, array( 'HTML', 'BODY', 'IMG' ), false ),
+					$get_sample_url_metric( 300, array( 'HTML', 'BODY', 'IMG' ), false ),
 					// 600.
-					$this->get_validated_url_metric( 700, array( 'HTML', 'BODY', 'IMG' ), false ),
+					$get_sample_url_metric( 700, array( 'HTML', 'BODY', 'IMG' ), false ),
 				),
 				'expected_lcp_element_xpaths' => array_fill_keys(
 					array(
@@ -335,10 +347,11 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	 */
 	public function test_json_serialize(): void {
 		$group = new OD_URL_Metrics_Group(
-			array(
-				$this->get_validated_url_metric( 400 ),
-				$this->get_validated_url_metric( 600 ),
-				$this->get_validated_url_metric( 800 ),
+			array_map(
+				function ( $viewport_width ) {
+					return $this->get_validated_url_metric( array( 'viewport_width' => $viewport_width ) );
+				},
+				array( 400, 600, 800 )
 			),
 			0,
 			1000,
@@ -361,40 +374,6 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 		$this->assertSameSets(
 			$expected_keys,
 			array_keys( $parsed_json )
-		);
-	}
-
-	/**
-	 * Gets a validated URL metric for testing.
-	 *
-	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
-	 *
-	 * @param int      $viewport_width Viewport width.
-	 * @param string[] $breadcrumbs    Breadcrumb tags.
-	 * @param bool     $is_lcp         Whether LCP.
-	 *
-	 * @return OD_URL_Metric Validated URL metric.
-	 */
-	private function get_validated_url_metric( int $viewport_width = 480, array $breadcrumbs = array( 'HTML', 'BODY', 'IMG' ), bool $is_lcp = true ): OD_URL_Metric {
-		return new OD_URL_Metric(
-			array(
-				'url'       => home_url( '/' ),
-				'viewport'  => array(
-					'width'  => $viewport_width,
-					'height' => 640,
-				),
-				'timestamp' => microtime( true ),
-				'elements'  => array(
-					array(
-						'isLCP'              => $is_lcp,
-						'isLCPCandidate'     => $is_lcp,
-						'xpath'              => $this->get_xpath( ...$breadcrumbs ),
-						'intersectionRatio'  => 1,
-						'intersectionRect'   => $this->get_sample_dom_rect(),
-						'boundingClientRect' => $this->get_sample_dom_rect(),
-					),
-				),
-			)
 		);
 	}
 

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -10,6 +10,7 @@
  */
 
 class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
+	use Optimization_Detective_Test_Helpers;
 
 	/**
 	 * Data provider.
@@ -377,16 +378,6 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width = 480, array $breadcrumbs = array( 'HTML', 'BODY', 'IMG' ), bool $is_lcp = true ): OD_URL_Metric {
-		$dom_rect = array(
-			'width'  => 100,
-			'height' => 100,
-			'x'      => 100,
-			'y'      => 100,
-			'top'    => 0,
-			'right'  => 0,
-			'bottom' => 0,
-			'left'   => 0,
-		);
 		return new OD_URL_Metric(
 			array(
 				'url'       => home_url( '/' ),
@@ -401,8 +392,8 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 						'isLCPCandidate'     => $is_lcp,
 						'xpath'              => $this->get_xpath( ...$breadcrumbs ),
 						'intersectionRatio'  => 1,
-						'intersectionRect'   => $dom_rect,
-						'boundingClientRect' => $dom_rect,
+						'intersectionRect'   => $this->get_sample_dom_rect(),
+						'boundingClientRect' => $this->get_sample_dom_rect(),
 					),
 				),
 			)

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -367,6 +367,8 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	/**
 	 * Gets a validated URL metric for testing.
 	 *
+	 * @todo Replace with {@see Optimization_Detective_Test_Helpers::get_validated_url_metric()}
+	 *
 	 * @param int      $viewport_width Viewport width.
 	 * @param string[] $breadcrumbs    Breadcrumb tags.
 	 * @param bool     $is_lcp         Whether LCP.
@@ -375,31 +377,36 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width = 480, array $breadcrumbs = array( 'HTML', 'BODY', 'IMG' ), bool $is_lcp = true ): OD_URL_Metric {
-		$data = array(
-			'url'       => home_url( '/' ),
-			'viewport'  => array(
-				'width'  => $viewport_width,
-				'height' => 640,
-			),
-			'timestamp' => microtime( true ),
-			'elements'  => array(
-				array(
-					'isLCP'              => $is_lcp,
-					'isLCPCandidate'     => $is_lcp,
-					'xpath'              => $this->get_xpath( ...$breadcrumbs ),
-					'intersectionRatio'  => 1,
-					'intersectionRect'   => array(
-						'width'  => 100,
-						'height' => 100,
-					),
-					'boundingClientRect' => array(
-						'width'  => 100,
-						'height' => 100,
+		$dom_rect = array(
+			'width'  => 100,
+			'height' => 100,
+			'x'      => 100,
+			'y'      => 100,
+			'top'    => 0,
+			'right'  => 0,
+			'bottom' => 0,
+			'left'   => 0,
+		);
+		return new OD_URL_Metric(
+			array(
+				'url'       => home_url( '/' ),
+				'viewport'  => array(
+					'width'  => $viewport_width,
+					'height' => 640,
+				),
+				'timestamp' => microtime( true ),
+				'elements'  => array(
+					array(
+						'isLCP'              => $is_lcp,
+						'isLCPCandidate'     => $is_lcp,
+						'xpath'              => $this->get_xpath( ...$breadcrumbs ),
+						'intersectionRatio'  => 1,
+						'intersectionRect'   => $dom_rect,
+						'boundingClientRect' => $dom_rect,
 					),
 				),
-			),
+			)
 		);
-		return new OD_URL_Metric( $data );
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -5,6 +5,7 @@
  * @package optimization-detective
  *
  * @noinspection PhpUnhandledExceptionInspection
+ * @noinspection PhpDocMissingThrowsInspection
  *
  * @coversDefaultClass OD_URL_Metrics_Group
  */
@@ -15,7 +16,6 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @throws OD_Data_Validation_Exception If bad arguments are provided to OD_URL_Metric.
 	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_construction(): array {
@@ -224,7 +224,6 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @throws OD_Data_Validation_Exception When failing to instantiate a URL metric.
 	 * @return array<string, mixed> Data.
 	 */
 	public function data_provider_test_get_lcp_element(): array {
@@ -375,7 +374,6 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	 * @param bool     $is_lcp         Whether LCP.
 	 *
 	 * @return OD_URL_Metric Validated URL metric.
-	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	private function get_validated_url_metric( int $viewport_width = 480, array $breadcrumbs = array( 'HTML', 'BODY', 'IMG' ), bool $is_lcp = true ): OD_URL_Metric {
 		return new OD_URL_Metric(

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -228,7 +228,7 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	 */
 	public function data_provider_test_get_lcp_element(): array {
 		$get_sample_url_metric = function ( int $viewport_width, array $breadcrumbs, $is_lcp = true ) {
-			return $this->get_validated_url_metric(
+			return $this->get_sample_url_metric(
 				array(
 					'viewport_width' => $viewport_width,
 					'element'        => array(
@@ -349,7 +349,7 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 		$group = new OD_URL_Metrics_Group(
 			array_map(
 				function ( $viewport_width ) {
-					return $this->get_validated_url_metric( array( 'viewport_width' => $viewport_width ) );
+					return $this->get_sample_url_metric( array( 'viewport_width' => $viewport_width ) );
 				},
 				array( 400, 600, 800 )
 			),

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -4,6 +4,7 @@
  *
  * @package optimization-detective
  *
+ * @noinspection PhpUnhandledExceptionInspection
  * @todo There are "Cannot resolve ..." errors and "Element img doesn't have a required attribute src" warnings that should be excluded from inspection.
  */
 
@@ -200,7 +201,6 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 	 * @covers ::od_is_response_html_content_type
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
-	 * @throws Exception But it won't.
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ): void {
 		$set_up( $this );

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * @phpstan-type ElementDataSubset array{xpath: string, isLCP: bool, intersectionRatio: float}
+ * @phpstan-type ElementDataSubset array{xpath: string, isLCP?: bool, intersectionRatio: float}
  */
 trait Optimization_Detective_Test_Helpers {
 
@@ -40,7 +40,7 @@ trait Optimization_Detective_Test_Helpers {
 	 * @param int                      $viewport_width Viewport width for the URL metric.
 	 * @param array<ElementDataSubset> $elements       Elements.
 	 * @return OD_URL_Metric URL metric.
-	 * @throws Exception From OD_URL_Metric if there is a parse error, but there won't be.
+	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	public function get_validated_url_metric( int $viewport_width, array $elements = array() ): OD_URL_Metric {
 		$dom_rect = array(
@@ -66,7 +66,7 @@ trait Optimization_Detective_Test_Helpers {
 						return array_merge(
 							array(
 								'isLCP'              => false,
-								'isLCPCandidate'     => $element['isLCP'],
+								'isLCPCandidate'     => $element['isLCP'] ?? false,
 								'intersectionRatio'  => 1,
 								'intersectionRect'   => $dom_rect,
 								'boundingClientRect' => $dom_rect,

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -43,6 +43,16 @@ trait Optimization_Detective_Test_Helpers {
 	 * @throws Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	public function get_validated_url_metric( int $viewport_width, array $elements = array() ): OD_URL_Metric {
+		$dom_rect = array(
+			'width'  => 100,
+			'height' => 100,
+			'x'      => 100,
+			'y'      => 100,
+			'top'    => 0,
+			'right'  => 0,
+			'bottom' => 0,
+			'left'   => 0,
+		);
 		return new OD_URL_Metric(
 			array(
 				'url'       => home_url( '/' ),
@@ -52,20 +62,14 @@ trait Optimization_Detective_Test_Helpers {
 				),
 				'timestamp' => microtime( true ),
 				'elements'  => array_map(
-					static function ( array $element ): array {
+					static function ( array $element ) use ( $dom_rect ): array {
 						return array_merge(
 							array(
 								'isLCP'              => false,
 								'isLCPCandidate'     => $element['isLCP'],
 								'intersectionRatio'  => 1,
-								'intersectionRect'   => array(
-									'width'  => 100,
-									'height' => 100,
-								),
-								'boundingClientRect' => array(
-									'width'  => 100,
-									'height' => 100,
-								),
+								'intersectionRect'   => $dom_rect,
+								'boundingClientRect' => $dom_rect,
 							),
 							$element
 						);

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -9,7 +9,11 @@
  */
 
 /**
- * @phpstan-type ElementDataSubset array{xpath: string, isLCP?: bool, intersectionRatio: float}
+ * @phpstan-type ElementDataSubset array{
+ *     xpath: string,
+ *     isLCP?: bool,
+ *     intersectionRatio?: float
+ * }
  */
 trait Optimization_Detective_Test_Helpers {
 
@@ -42,18 +46,18 @@ trait Optimization_Detective_Test_Helpers {
 	/**
 	 * Gets a sample DOM rect for testing.
 	 *
-	 * @return int[]
+	 * @return array<string, float>
 	 */
 	public function get_sample_dom_rect(): array {
 		return array(
-			'width'  => 100,
-			'height' => 100,
-			'x'      => 100,
-			'y'      => 100,
-			'top'    => 0,
-			'right'  => 0,
-			'bottom' => 0,
-			'left'   => 0,
+			'width'  => 100.1,
+			'height' => 100.2,
+			'x'      => 100.3,
+			'y'      => 100.4,
+			'top'    => 0.1,
+			'right'  => 0.2,
+			'bottom' => 0.3,
+			'left'   => 0.4,
 		);
 	}
 

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -35,15 +35,12 @@ trait Optimization_Detective_Test_Helpers {
 	}
 
 	/**
-	 * Gets a validated URL metric.
+	 * Gets a sample DOM rect for testing.
 	 *
-	 * @param int                      $viewport_width Viewport width for the URL metric.
-	 * @param array<ElementDataSubset> $elements       Elements.
-	 * @return OD_URL_Metric URL metric.
-	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
+	 * @return int[]
 	 */
-	public function get_validated_url_metric( int $viewport_width, array $elements = array() ): OD_URL_Metric {
-		$dom_rect = array(
+	public function get_sample_dom_rect(): array {
+		return array(
 			'width'  => 100,
 			'height' => 100,
 			'x'      => 100,
@@ -53,6 +50,17 @@ trait Optimization_Detective_Test_Helpers {
 			'bottom' => 0,
 			'left'   => 0,
 		);
+	}
+
+	/**
+	 * Gets a validated URL metric.
+	 *
+	 * @param int                      $viewport_width Viewport width for the URL metric.
+	 * @param array<ElementDataSubset> $elements       Elements.
+	 * @return OD_URL_Metric URL metric.
+	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
+	 */
+	public function get_validated_url_metric( int $viewport_width, array $elements = array() ): OD_URL_Metric {
 		return new OD_URL_Metric(
 			array(
 				'url'       => home_url( '/' ),
@@ -62,14 +70,14 @@ trait Optimization_Detective_Test_Helpers {
 				),
 				'timestamp' => microtime( true ),
 				'elements'  => array_map(
-					static function ( array $element ) use ( $dom_rect ): array {
+					function ( array $element ): array {
 						return array_merge(
 							array(
 								'isLCP'              => false,
 								'isLCPCandidate'     => $element['isLCP'] ?? false,
 								'intersectionRatio'  => 1,
-								'intersectionRect'   => $dom_rect,
-								'boundingClientRect' => $dom_rect,
+								'intersectionRect'   => $this->get_sample_dom_rect(),
+								'boundingClientRect' => $this->get_sample_dom_rect(),
 							),
 							$element
 						);

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -3,6 +3,9 @@
  * Helper trait for Optimization Detective tests.
  *
  * @package performance-lab
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ * @noinspection PhpUnhandledExceptionInspection
  */
 
 /**
@@ -57,8 +60,8 @@ trait Optimization_Detective_Test_Helpers {
 	 *
 	 * @param int                      $viewport_width Viewport width for the URL metric.
 	 * @param array<ElementDataSubset> $elements       Elements.
+	 *
 	 * @return OD_URL_Metric URL metric.
-	 * @throws OD_Data_Validation_Exception From OD_URL_Metric if there is a parse error, but there won't be.
 	 */
 	public function get_validated_url_metric( int $viewport_width, array $elements = array() ): OD_URL_Metric {
 		return new OD_URL_Metric(

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -29,8 +29,10 @@ trait Optimization_Detective_Test_Helpers {
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
 					$this->get_validated_url_metric(
-						$viewport_width,
-						$elements
+						array(
+							'viewport_width' => $viewport_width,
+							'elements'       => $elements,
+						)
 					)
 				);
 			}
@@ -58,17 +60,29 @@ trait Optimization_Detective_Test_Helpers {
 	/**
 	 * Gets a validated URL metric.
 	 *
-	 * @param int                      $viewport_width Viewport width for the URL metric.
-	 * @param array<ElementDataSubset> $elements       Elements.
+	 * @phpstan-param array{
+	 *                    url?:            string,
+	 *                    viewport_width?: int,
+	 *                    elements?:       array<ElementDataSubset>
+	 *                } $params Params.
 	 *
 	 * @return OD_URL_Metric URL metric.
 	 */
-	public function get_validated_url_metric( int $viewport_width, array $elements = array() ): OD_URL_Metric {
+	public function get_validated_url_metric( array $params ): OD_URL_Metric {
+		$params = array_merge(
+			array(
+				'url'            => home_url( '/' ),
+				'viewport_width' => 480,
+				'elements'       => array(),
+			),
+			$params
+		);
+
 		return new OD_URL_Metric(
 			array(
 				'url'       => home_url( '/' ),
 				'viewport'  => array(
-					'width'  => $viewport_width,
+					'width'  => $params['viewport_width'],
 					'height' => 800,
 				),
 				'timestamp' => microtime( true ),
@@ -85,7 +99,7 @@ trait Optimization_Detective_Test_Helpers {
 							$element
 						);
 					},
-					$elements
+					$params['elements']
 				),
 			)
 		);

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -28,7 +28,7 @@ trait Optimization_Detective_Test_Helpers {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
 				OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
-					$this->get_validated_url_metric(
+					$this->get_sample_url_metric(
 						array(
 							'viewport_width' => $viewport_width,
 							'elements'       => $elements,
@@ -58,7 +58,7 @@ trait Optimization_Detective_Test_Helpers {
 	}
 
 	/**
-	 * Gets a validated URL metric.
+	 * Gets a sample URL metric.
 	 *
 	 * @phpstan-param array{
 	 *                    url?:            string,
@@ -69,7 +69,7 @@ trait Optimization_Detective_Test_Helpers {
 	 *
 	 * @return OD_URL_Metric URL metric.
 	 */
-	public function get_validated_url_metric( array $params ): OD_URL_Metric {
+	public function get_sample_url_metric( array $params ): OD_URL_Metric {
 		$params = array_merge(
 			array(
 				'url'            => home_url( '/' ),

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -63,6 +63,7 @@ trait Optimization_Detective_Test_Helpers {
 	 * @phpstan-param array{
 	 *                    url?:            string,
 	 *                    viewport_width?: int,
+	 *                    element?:        ElementDataSubset,
 	 *                    elements?:       array<ElementDataSubset>
 	 *                } $params Params.
 	 *
@@ -77,6 +78,10 @@ trait Optimization_Detective_Test_Helpers {
 			),
 			$params
 		);
+
+		if ( array_key_exists( 'element', $params ) ) {
+			$params['elements'][] = $params['element'];
+		}
 
 		return new OD_URL_Metric(
 			array(


### PR DESCRIPTION
* Add remaining properties of `intersectionRect`/`clientBoundingRect` to the JSON Schema.
* Fix type of viewport rect which has integer width/height versus DOMRect which has floats. I caught onto this via Query Monitor reporting:

```
Implicit conversion from float 739.9976196289062 to int loses precision in /var/www/html/wp-content/plugins/optimization-detective/class-od-url-metrics-group-collection.php on line 486
```

* Ensure all properties in the JSON Schema are `required` and that `additionalProperties` are not allowed.
* Refactor tests to reuse a `get_sample_url_metric()` method in the shared helper trait rather than duplicate the logic across various test classes. This is a follow-up to https://github.com/WordPress/performance/pull/1405 which refactored the tests for Optimization Detective.
* Clean up `@throws` tag usages, removing where obsolete and suppressing with `@noinspection` where irrelevant.
* Fix passing the actual function name to the `OD_HTML_Tag_Processor::warn()` method.

> [!TIP]
> Suppress whitespace when reviewing the changes in this pull request!