### PR TITLE
Try setting aspect-ratio on images lacking width and height

### DIFF
--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -73,6 +73,19 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 			$processor->remove_attribute( 'fetchpriority' );
 		}
 
+		// Set the aspect-ratio of the image when it lacks a width and height.
+		// TODO: Big problem: once the aspect-ratio is set, then future measurements in URL metrics will never result in anything different! Should detect.js also capture intrinsic width/height when available (e.g. for image, video, svg, canvas, iframe(?), and input[type=image])?
+		if (
+			null === $processor->get_attribute( 'width' ) &&
+			null === $processor->get_attribute( 'height' ) &&
+			method_exists( $context->url_metrics_group_collection, 'get_element_aspect_ratio' )
+		) {
+			$aspect_ratio = $context->url_metrics_group_collection->get_element_aspect_ratio( $xpath );
+			if ( null !== $aspect_ratio ) {
+				$processor->set_attribute( 'style', sprintf( 'aspect-ratio: %f; width: 100%%;', $aspect_ratio ) );
+			}
+		}
+
 		$element_max_intersection_ratio = $context->url_metrics_group_collection->get_element_max_intersection_ratio( $xpath );
 
 		// If the element was not found, we don't know if it was visible for not, so don't do anything.


### PR DESCRIPTION
## Summary

I started looking at this because I was checking [how well Image Prioritizer optimizes a Timber-based theme](https://core.trac.wordpress.org/ticket/59331#comment:5). It adds `fetchpriority=high` and lazy-loading correctly, but the Timber starter theme does not include `width` and `height` attributes on the featured image, and Image Prioritizer hasn't yet implemented this either. So I wanted to see what it would take.

This experiment tries to set an `aspect-ratio` on `img` tags that are missing `width` and `height` attributes. There is currently a big problem, however, in that it is setting the `aspect-ratio` based on the `clientBoundingRect` and not the intrinsic dimensions of the image. This means that once the `aspect-ratio` is set the next time that `detect.js` measures the image, it will use the `aspect-ratio` for subsequent measurements, meaning that the image dimensions will become locked in place. In order to get around this, I think `detect.js` may need to be extend to obtain the _intrinsic dimensions_ of elements that have them: `img`, `video`, `canvas`, `svg` (maybe), and `input[type=image]` (ewwww).

Another problem is that in order to set the `aspect-ratio`, the element has to also have `width:100%` added. This may not be what is intended!

Fixes #10