### PR TITLE
Update test-optimization.php

### DIFF
--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -109,6 +109,8 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 		ob_clean(); // Note the lack of flush here.
 		echo $template_override; // This should get passed into the od_template_output_buffer filter.
 
+		ob_end_flush();
+
 		$buffer = ob_get_clean(); // Get the buffer from our wrapper output buffer.
 
 		$this->assertSame( 1, $filter_count, 'Expected filter to be called once.' );


### PR DESCRIPTION
Amends https://github.com/WordPress/performance/pull/1317

See https://github.com/WordPress/gutenberg/pull/62770

https://github.com/WordPress/gutenberg/pull/62770#issuecomment-2264634425:
> @westonruter I think the missing piece is to call `ob_end_flush();` before calling `ob_get_clean();`.
> 
> On line 91, a new output buffer is created. This output buffer is necessary as it allows you to access the output in the same way the PHP runtime does when outputting the default output buffer.
> 
> In the original code, the following happened:
> 
> * System [1] output buffer <- This will be sent to the browser.
>   
>   * Line 91 -> [2] output buffer
>     
>     * `od_buffer_output` -> [3] output buffer
>     * This part is tricky: Calling `ob_get_contents()` at this point does not trigger the `ob callbac`k, as there might be more text to add to the buffer after calling `ob_get_contents`. Example: https://gist.github.com/nextend/ac5c90de0e2d628fba02355819998a34
>     * If you check the source code of PHP, `ob_get_clean` has two parts: first, it calls `ob_get_contents`, and then it discards the output buffer. This is where a common misunderstanding occurs. In the first example, I showed why `ob_get_contents` does not trigger the `ob callback`, and since it is used inside `ob_get_clean`, there will be no `ob callback` call. Reference: https://github.com/php/php-src/blob/48916cec3383e5ac83bd9486d5445f847a36b922/main/output.c#L1408
> 
> In the new code:
> 
> * System [1] output buffer <- This will be sent to the browser.
>   
>   * Line 91 -> [2] output buffer
>     
>     * `od_buffer_output` -> [3] output buffer
>     * `ob_end_flush` -> Output buffer [3] is closed -> `ob callback`  gets called -> Result of the callback is flushed into [2] buffer
>   * Now we can access the real output with `ob_get_clean`, which gives us the content of the [2] buffer (and then discards the output).

