### PR TITLE
Add prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+"@wordpress/prettier-config"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "devDependencies": {
         "@octokit/rest": "^21.0.1",
         "@wordpress/env": "^10.4.0",
+        "@wordpress/prettier-config": "^4.4.0",
         "@wordpress/scripts": "^28.4.0",
         "commander": "12.1.0",
         "copy-webpack-plugin": "^12.0.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@octokit/rest": "^21.0.1",
     "@wordpress/env": "^10.4.0",
+    "@wordpress/prettier-config": "^4.4.0",
     "@wordpress/scripts": "^28.4.0",
     "commander": "12.1.0",
     "copy-webpack-plugin": "^12.0.2",


### PR DESCRIPTION
## Summary

We are already using prettier with ESLint in our current setup but we are missing the prettier config file which is used by the prettier extension in multiple IDEs/editors. This PR adds the missing prettier config.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
