### PR TITLE
Remove picture element if sources is empty

### DIFF
--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -129,10 +129,10 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		);
 	}
 
-	return sprintf(
+	return ( '' === $picture_sources ? $image : sprintf(
 		'<picture class="%s" style="display: contents;">%s%s</picture>',
 		esc_attr( 'wp-picture-' . $attachment_id ),
 		$picture_sources,
 		$image
-	);
+	) );
 }


### PR DESCRIPTION
## Summary

Issue found at https://github.com/WordPress/performance/issues/1417#issuecomment-2265517786

> Image itself is 600 × 400 in jpg, in admin there are thumbnail (150x150px and full size ). No medium, no medium_large etc, because medium is 768x512px with center crop.

If someone use smaller size image then the register sizes or thumbnail size image the picture element only return PICTURE > IMG tag no `source` tags.

**Before PR:**
```
<picture class="wp-picture-44" style="display: contents;">
  <img decoding="async" width="150" height="150" src="http://localhost:8888/wp-content/uploads/2024/08/car-150x150-jpeg.avif" alt="" class="wp-image-44">
</picture>
```

**After PR:** The PR removes the picture element if the `source` is null.
```
<img decoding="async" width="150" height="150" src="http://localhost:8888/wp-content/uploads/2024/08/car-150x150-jpeg.avif" alt="" class="wp-image-44">
```


## Steps to reproduce
- Activate the Modern Image Formats plugin and enable picture support from the Media Settings screen.
- Add an image block
- Select `Thumbnail` in block settings.
- Preview the page in the front end, Check the image.

## Todos:
- [ ] Add Unit tests

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
