### PR TITLE
Fix outdated `CODEOWNERS` after changing repo directory structure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,53 +2,32 @@
 /.github                                    @mukeshpanchal27 @felixarntz @thelovekesh
 /bin                                        @mukeshpanchal27 @felixarntz @thelovekesh
 
-# Performance Lab Plugin Admin
-/includes/admin                             @mukeshpanchal27 @felixarntz
-/tests/includes/admin                       @mukeshpanchal27 @felixarntz
+# Performance Lab Plugin
+/plugins/performance-lab                    @mukeshpanchal27 @felixarntz
 
-# Server Timing API
-/includes/server-timing                    @felixarntz
-/tests/includes/server-timing              @felixarntz
-
-# Site Health: AVIF Support Health Check
-/includes/site-health/avif-support                                          @adamsilverstein
-
-# Site Health: WebP Support Health Check
-/includes/site-health/webp-support                                          @adamsilverstein
-
-# Site Health: Autoloaded Options Health Check
-/includes/site-health/audit-autoloaded-options                              @manuelRod @felixarntz @mukeshpanchal27
-/tests/includes/site-health/audit-autoloaded-options                        @manuelRod @felixarntz @mukeshpanchal27
-
-# Site Health: Enqueued Assets Health Check
-/includes/site-health/audit-enqueued-assets                                 @manuelRod
-/tests/includes/site-health/audit-enqueued-assets                           @manuelRod
-/tests/testdata/modules/site-health/audit-enqueued-assets                   @manuelRod
+# Performance Lab Plugin: Individual Site Health checks
+/plugins/performance-lab/includes/site-health/avif-support              @adamsilverstein
+/plugins/performance-lab/includes/site-health/webp-support              @adamsilverstein
+/plugins/performance-lab/includes/site-health/audit-autoloaded-options  @manuelRod @felixarntz @mukeshpanchal27
+/plugins/performance-lab/includes/site-health/audit-enqueued-assets     @manuelRod
 
 # Plugin: Enhanced Responsive Images
 /plugins/auto-sizes                         @joemcgill @mukeshpanchal27
-/tests/plugins/auto-sizes                   @joemcgill @mukeshpanchal27
 
 # Plugin: Embed Optimizer
 /plugins/embed-optimizer                    @adamsilverstein @westonruter
-/tests/plugins/embed-optimizer              @adamsilverstein @westonruter
 
 # Plugin: Image Placeholders
 /plugins/dominant-color-images              @pbearne
-/tests/plugins/dominant-color-images        @pbearne
 
 # Plugin: Image Prioritizer
 /plugins/image-prioritizer                  @westonruter @felixarntz
-/tests/plugins/image-prioritizer            @westonruter @felixarntz
 
 # Plugin: Modern Image Formats
 /plugins/webp-uploads                       @adamsilverstein @felixarntz @westonruter
-/tests/plugins/webp-uploads                 @adamsilverstein @felixarntz @westonruter
 
 # Plugin: Optimization Detective
 /plugins/optimization-detective             @westonruter @felixarntz
-/tests/plugins/optimization-detective       @westonruter @felixarntz
 
 # Plugin: Speculative Loading
 /plugins/speculation-rules                  @felixarntz
-/tests/plugins/speculation-rules            @felixarntz


### PR DESCRIPTION
## Summary

After #1182 and #1262, the `CODEOWNERS` file is out of date, so we should update it to use the correct paths for the Performance Lab plugin and the tests locations.

## Relevant technical choices

* Update paths to rely on the current locations after the changes from the above PRs.
* Keep one entry for overall Performance Lab plugin, and separate entries for the individual Site Health checks as part of it, since those fall under a different kind of expertise/responsibility than the overall plugin.
* Remove all test specific entries since those are now implied by their respective overall plugin location (and they should match the code owners for those overall plugins anyway).
* Keep Performance Lab on top of the file since it still has a different role than the other plugins, plus it has the special circumstance where it has additional code owners for the individual Site Health checks.
<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
