### PR TITLE
Web Worker Offloading: Update `build` command

### DIFF
--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -36,7 +36,7 @@ if (
 				/* translators: 1: File path. 2: CLI command. */
 				'[Web Worker Offloading] ' . __( 'Unable to load %1$s. Please make sure you have run %2$s.', 'web-worker-offloading' ),
 				'build/partytown.asset.php',
-				'`npm install && npm run build:web-worker-offloading`'
+				'`npm install && npm run build:plugin:web-worker-offloading`'
 			)
 		),
 		E_USER_ERROR


### PR DESCRIPTION
## Summary

Follow-up #1247, the Web Worker Offloading has been merged into the trunk. When the build command is not run, it shows an error:

```
Fatal error: [Web Worker Offloading] Unable to load build/partytown.asset.php. Please make sure you have run `npm install && npm run build:web-worker-offloading`. in /var/www/html/wp-content/plugins/web-worker-offloading/load.php on line 33
```

The error suggests running `npm run build:web-worker-offloading` to build the plugin assets, but the correct command is `npm run build:plugin:web-worker-offloading`.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
