### PR TITLE
Ensure only HTML documents are processed by Optimization Detective

### DIFF
--- a/plugins/optimization-detective/tests/test-cases/json-response-without-proper-content-type.php
+++ b/plugins/optimization-detective/tests/test-cases/json-response-without-proper-content-type.php
@@ -1,0 +1,12 @@
+<?php
+return array(
+	'set_up'   => static function (): void {
+		/*
+		 * This is intentionally not 'application/json'. This is to test whether od_optimize_template_output_buffer()
+		 * is checking whether the output starts with '<' (after whitespace is trimmed).
+		 */
+		ini_set( 'default_mimetype', 'text/html' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+	},
+	'buffer'   => ' {"doc": "<html lang="en"><body><img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" /></body></html>"}',
+	'expected' => ' {"doc": "<html lang="en"><body><img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" /></body></html>"}',
+);

--- a/plugins/optimization-detective/tests/test-cases/json-response.php
+++ b/plugins/optimization-detective/tests/test-cases/json-response.php
@@ -1,0 +1,8 @@
+<?php
+return array(
+	'set_up'   => static function (): void {
+		ini_set( 'default_mimetype', 'application/json' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+	},
+	'buffer'   => ' {"doc": "<html lang="en"><body><img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" /></body></html>"}',
+	'expected' => ' {"doc": "<html lang="en"><body><img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" /></body></html>"}',
+);

--- a/plugins/optimization-detective/tests/test-cases/rss-response-without-proper-content-type.php
+++ b/plugins/optimization-detective/tests/test-cases/rss-response-without-proper-content-type.php
@@ -1,0 +1,34 @@
+<?php
+return array(
+	'set_up'   => static function (): void {
+		// This is intentionally not application/rss+xml as it is testing whether the first tag is HTML.
+		ini_set( 'default_mimetype', 'text/html' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+	},
+	// Also omitting the XML processing instruction.
+	'buffer'   => '
+		<rss version="2.0">
+			<channel>
+				<title>Example Blog</title>
+				<link>https://www.example.com</link>
+				<description>
+					<img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" />
+					A blog about technology, design, and culture.
+				</description>
+				<language>en-us</language>
+			</channel>
+		</rss>
+	',
+	'expected' => '
+		<rss version="2.0">
+			<channel>
+				<title>Example Blog</title>
+				<link>https://www.example.com</link>
+				<description>
+					<img src="https://www.example.com/logo.jpg" alt="Example Blog Logo" />
+					A blog about technology, design, and culture.
+				</description>
+				<language>en-us</language>
+			</channel>
+		</rss>
+	',
+);


### PR DESCRIPTION
_This is a sub-PR of https://github.com/WordPress/performance/pull/1317. Merge it first._

This fixes a couple cases where Optimization Detective could erroneously attempt to optimize a non-HTML response:

* A JSON response body that erroneously sends a `Content-Type: text/html` header.
* An XML response body that erroneously sends a `Content-Type: text/html` header.