### PR TITLE
Avoid sending Server-Timing header when buffer is being cleaned

### DIFF
--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -61,7 +61,7 @@ class Perflab_Server_Timing {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: metric slug */
-				sprintf( esc_html__( 'A metric with the slug %s is already registered.', 'performance-lab' ), esc_attr( $metric_slug ) ),
+				esc_html( sprintf( __( 'A metric with the slug %s is already registered.', 'performance-lab' ), $metric_slug ) ),
 				''
 			);
 			return;
@@ -71,7 +71,7 @@ class Perflab_Server_Timing {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: WordPress action name */
-				sprintf( esc_html__( 'The method must be called before or during the %s action.', 'performance-lab' ), 'perflab_server_timing_send_header' ),
+				esc_html( sprintf( __( 'The method must be called before or during the %s action.', 'performance-lab' ), 'perflab_server_timing_send_header' ) ),
 				''
 			);
 			return;
@@ -88,7 +88,7 @@ class Perflab_Server_Timing {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: PHP parameter name */
-				sprintf( esc_html__( 'The %s argument is required and must be a callable.', 'performance-lab' ), 'measure_callback' ),
+				esc_html( sprintf( __( 'The %s argument is required and must be a callable.', 'performance-lab' ), 'measure_callback' ) ),
 				''
 			);
 			return;
@@ -97,7 +97,7 @@ class Perflab_Server_Timing {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: PHP parameter name */
-				sprintf( esc_html__( 'The %s argument is required and must be a string.', 'performance-lab' ), 'access_cap' ),
+				esc_html( sprintf( __( 'The %s argument is required and must be a string.', 'performance-lab' ), 'access_cap' ) ),
 				''
 			);
 			return;

--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -268,8 +268,11 @@ class Perflab_Server_Timing {
 	 */
 	public function start_output_buffer(): void {
 		ob_start(
-			function ( $output ) {
-				$this->send_header();
+			function ( string $output, ?int $phase ): string {
+				// Only send the header when the buffer is not being cleaned.
+				if ( ( $phase & PHP_OUTPUT_HANDLER_CLEAN ) === 0 ) {
+					$this->send_header();
+				}
 				return $output;
 			}
 		);

--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -88,7 +88,7 @@ class Perflab_Server_Timing {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: PHP parameter name */
-				sprintf( esc_html__( 'The %s argument is required and must be a callable.', 'performance-lab' ), esc_attr( $args['measure_callback'] ) ),
+				sprintf( esc_html__( 'The %s argument is required and must be a callable.', 'performance-lab' ), 'measure_callback' ),
 				''
 			);
 			return;
@@ -97,7 +97,7 @@ class Perflab_Server_Timing {
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: PHP parameter name */
-				sprintf( esc_html__( 'The %s argument is required and must be a string.', 'performance-lab' ), esc_attr( $args['access_cap'] ) ),
+				sprintf( esc_html__( 'The %s argument is required and must be a string.', 'performance-lab' ), 'access_cap' ),
 				''
 			);
 			return;


### PR DESCRIPTION
_This is a sub-PR of #1317. Merge it first._

As @felixarntz pointed out in https://github.com/WordPress/performance/pull/1317#issuecomment-2272019860, when a template calls `ob_clean()` it can currently result in the `Server-Timing` header being sent prematurely. When the buffer is being cleaned, the output buffer callback should not send the header yet because no output is being printed, so it can continue waiting until the output is flushed.

This also fixes a bug with passing the argument names when they are missing from the `$args` passed to `\Perflab_Server_Timing::register_metric()`. The PR also improves escaping the resultant strings.