### PR TITLE
Harden logic to add `auto` keyword to `sizes` attribute to prevent duplicate keyword

### DIFF
--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -63,7 +63,7 @@ function auto_sizes_update_content_img_tag( $html ): string {
 	}
 
 	// Bail early if the image is not responsive.
-	if ( preg_match( '/sizes="([^"]+)"/', $html, $match ) === 0 || ! isset( $match[1] ) ) {
+	if ( 1 !== preg_match( '/sizes="([^"]+)"/', $html, $match ) ) {
 		return $html;
 	}
 

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -34,7 +34,7 @@ function auto_sizes_update_image_attributes( $attr ): array {
 	}
 
 	// Don't add 'auto' to the sizes attribute if it already exists.
-	if ( str_contains( $attr['sizes'], 'auto,' ) ) {
+	if ( auto_sizes_attribute_includes_auto( $attr['sizes'] ) ) {
 		return $attr;
 	}
 
@@ -63,12 +63,12 @@ function auto_sizes_update_content_img_tag( $html ): string {
 	}
 
 	// Bail early if the image is not responsive.
-	if ( false === strpos( $html, 'sizes="' ) ) {
+	if ( preg_match( '/sizes="([^"]+)"/', $html, $match ) === 0 || ! isset( $match[1] ) ) {
 		return $html;
 	}
 
-	// Don't double process content images.
-	if ( false !== strpos( $html, 'sizes="auto,' ) ) {
+	// Don't add 'auto' to the sizes attribute if it already exists.
+	if ( auto_sizes_attribute_includes_auto( $match[1] ) ) {
 		return $html;
 	}
 
@@ -77,6 +77,26 @@ function auto_sizes_update_content_img_tag( $html ): string {
 	return $html;
 }
 add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
+
+/**
+ * Checks whether the given 'sizes' attribute includes the 'auto' keyword.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $sizes_attr The 'sizes' attribute value.
+ * @return bool True if the 'auto' keyword is present, false otherwise.
+ */
+function auto_sizes_attribute_includes_auto( string $sizes_attr ): bool {
+	if ( str_contains( $sizes_attr, 'auto,' ) ) {
+		return true;
+	}
+
+	if ( 'auto' === $sizes_attr ) {
+		return true;
+	}
+
+	return str_ends_with( $sizes_attr, ' auto' ) || str_ends_with( $sizes_attr, ',auto' );
+}
 
 /**
  * Displays the HTML generator tag for the plugin.

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -87,11 +87,12 @@ add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
  * @return bool True if the 'auto' keyword is present, false otherwise.
  */
 function auto_sizes_attribute_includes_auto( string $sizes_attr ): bool {
-	return in_array( 
-		'auto', 
-		preg_split( '/\s*,\s*/', strtolower( trim( $sizes_attr ) ) ), 
-		true 
-	);
+	$parts = preg_split( '/\s*,\s*/', strtolower( trim( $sizes_attr ) ) );
+	if ( ! is_array( $parts ) ) {
+		return false;
+	}
+
+	return in_array( 'auto', $parts, true );
 }
 
 /**

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -89,12 +89,8 @@ add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
  * @return bool True if the 'auto' keyword is present, false otherwise.
  */
 function auto_sizes_attribute_includes_valid_auto( string $sizes_attr ): bool {
-	$parts = preg_split( '/\s*,\s*/', strtolower( trim( $sizes_attr ) ) );
-	if ( ! is_array( $parts ) || ! isset( $parts[0] ) ) {
-		return false;
-	}
-
-	return 'auto' === $parts[0];
+	$token = strtok( strtolower( $sizes_attr ), ',' );
+	return false !== $token && 'auto' === trim( $token, " \t\f\r\n" );
 }
 
 /**

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -34,7 +34,7 @@ function auto_sizes_update_image_attributes( $attr ): array {
 	}
 
 	// Don't add 'auto' to the sizes attribute if it already exists.
-	if ( auto_sizes_attribute_includes_auto( $attr['sizes'] ) ) {
+	if ( auto_sizes_attribute_includes_valid_auto( $attr['sizes'] ) ) {
 		return $attr;
 	}
 
@@ -68,7 +68,7 @@ function auto_sizes_update_content_img_tag( $html ): string {
 	}
 
 	// Don't add 'auto' to the sizes attribute if it already exists.
-	if ( auto_sizes_attribute_includes_auto( $match[1] ) ) {
+	if ( auto_sizes_attribute_includes_valid_auto( $match[1] ) ) {
 		return $html;
 	}
 
@@ -79,20 +79,22 @@ function auto_sizes_update_content_img_tag( $html ): string {
 add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
 
 /**
- * Checks whether the given 'sizes' attribute includes the 'auto' keyword.
+ * Checks whether the given 'sizes' attribute includes the 'auto' keyword as the first item in the list.
+ *
+ * Per the HTML spec, if present it must be the first entry.
  *
  * @since n.e.x.t
  *
  * @param string $sizes_attr The 'sizes' attribute value.
  * @return bool True if the 'auto' keyword is present, false otherwise.
  */
-function auto_sizes_attribute_includes_auto( string $sizes_attr ): bool {
+function auto_sizes_attribute_includes_valid_auto( string $sizes_attr ): bool {
 	$parts = preg_split( '/\s*,\s*/', strtolower( trim( $sizes_attr ) ) );
-	if ( ! is_array( $parts ) ) {
+	if ( ! is_array( $parts ) || ! isset( $parts[0] ) ) {
 		return false;
 	}
 
-	return in_array( 'auto', $parts, true );
+	return 'auto' === $parts[0];
 }
 
 /**

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -87,15 +87,11 @@ add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
  * @return bool True if the 'auto' keyword is present, false otherwise.
  */
 function auto_sizes_attribute_includes_auto( string $sizes_attr ): bool {
-	if ( str_contains( $sizes_attr, 'auto,' ) ) {
-		return true;
-	}
-
-	if ( 'auto' === $sizes_attr ) {
-		return true;
-	}
-
-	return str_ends_with( $sizes_attr, ' auto' ) || str_ends_with( $sizes_attr, ',auto' );
+	return in_array( 
+		'auto', 
+		preg_split( '/\s*,\s*/', strtolower( trim( $sizes_attr ) ) ), 
+		true 
+	);
 }
 
 /**

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -188,11 +188,11 @@ class Test_AutoSizes extends WP_UnitTestCase {
 				'auto',
 				false,
 			),
-			'with space at beginning'                => array(
+			'with space at beginning'     => array(
 				' auto, (max-width: 1024px) 100vw, 1024px',
 				false,
 			),
-			'with uppercase'                => array(
+			'with uppercase'              => array(
 				'AUTO, (max-width: 1024px) 100vw, 1024px',
 				false,
 			),

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -98,7 +98,7 @@ class Test_AutoSizes extends WP_UnitTestCase {
 	 * Test generated markup for an image with 'auto' keyword already present in sizes does not receive it again.
 	 *
 	 * @covers ::auto_sizes_update_image_attributes
-	 * @covers ::auto_sizes_attribute_includes_auto
+	 * @covers ::auto_sizes_attribute_includes_valid_auto
 	 * @dataProvider data_image_with_existing_auto_sizes
 	 */
 	public function test_image_with_existing_auto_sizes_is_not_processed_again( string $initial_sizes, bool $expected_processed ): void {
@@ -123,7 +123,7 @@ class Test_AutoSizes extends WP_UnitTestCase {
 	 * Test content filtered markup with 'auto' keyword already present in sizes does not receive it again.
 	 *
 	 * @covers ::auto_sizes_update_content_img_tag
-	 * @covers ::auto_sizes_attribute_includes_auto
+	 * @covers ::auto_sizes_attribute_includes_valid_auto
 	 * @dataProvider data_image_with_existing_auto_sizes
 	 */
 	public function test_content_image_with_existing_auto_sizes_is_not_processed_again( string $initial_sizes, bool $expected_processed ): void {
@@ -168,33 +168,41 @@ class Test_AutoSizes extends WP_UnitTestCase {
 				'auto, (max-width: 1024px) 100vw, 1024px',
 				false,
 			),
-			'within, without space'       => array(
-				'(max-width: 1024px) 100vw, auto,1024px',
-				false,
-			),
-			'within, with space'          => array(
-				'(max-width: 1024px) 100vw, auto, 1024px',
-				false,
-			),
-			'at the end, without space'   => array(
-				'(max-width: 1024px) 100vw,auto',
-				false,
-			),
-			'at the end, with space'      => array(
-				'(max-width: 1024px) 100vw, auto',
-				false,
-			),
 			'sole keyword'                => array(
 				'auto',
 				false,
 			),
-			'with space at beginning'     => array(
+			'with space before'           => array(
 				' auto, (max-width: 1024px) 100vw, 1024px',
 				false,
 			),
 			'with uppercase'              => array(
 				'AUTO, (max-width: 1024px) 100vw, 1024px',
 				false,
+			),
+
+			/*
+			 * The following scenarios technically include the 'auto' keyword,
+			 * but it is in the wrong place, as per the HTML spec it must be
+			 * the first entry in the list.
+			 * Therefore in these invalid cases the 'auto' keyword should still
+			 * be added to the beginning of the list.
+			 */
+			'within, without space'       => array(
+				'(max-width: 1024px) 100vw, auto,1024px',
+				true,
+			),
+			'within, with space'          => array(
+				'(max-width: 1024px) 100vw, auto, 1024px',
+				true,
+			),
+			'at the end, without space'   => array(
+				'(max-width: 1024px) 100vw,auto',
+				true,
+			),
+			'at the end, with space'      => array(
+				'(max-width: 1024px) 100vw, auto',
+				true,
 			),
 		);
 	}

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -169,11 +169,11 @@ class Test_AutoSizes extends WP_UnitTestCase {
 				false,
 			),
 			'within, without space'       => array(
-				'(max-width: 1024px) auto,1024px',
+				'(max-width: 1024px) 100vw, auto,1024px',
 				false,
 			),
 			'within, with space'          => array(
-				'(max-width: 1024px) auto, 1024px',
+				'(max-width: 1024px) 100vw, auto, 1024px',
 				false,
 			),
 			'at the end, without space'   => array(

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -188,6 +188,14 @@ class Test_AutoSizes extends WP_UnitTestCase {
 				'auto',
 				false,
 			),
+			'with space at beginning'                => array(
+				' auto, (max-width: 1024px) 100vw, 1024px',
+				false,
+			),
+			'with uppercase'                => array(
+				'AUTO, (max-width: 1024px) 100vw, 1024px',
+				false,
+			),
 		);
 	}
 

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -168,6 +168,14 @@ class Test_AutoSizes extends WP_UnitTestCase {
 				'auto, (max-width: 1024px) 100vw, 1024px',
 				false,
 			),
+			'within, without space'       => array(
+				'(max-width: 1024px) auto,1024px',
+				false,
+			),
+			'within, with space'          => array(
+				'(max-width: 1024px) auto, 1024px',
+				false,
+			),
 			'at the end, without space'   => array(
 				'(max-width: 1024px) 100vw,auto',
 				false,

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -95,6 +95,95 @@ class Test_AutoSizes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test generated markup for an image with 'auto' keyword already present in sizes does not receive it again.
+	 *
+	 * @covers ::auto_sizes_update_image_attributes
+	 * @covers ::auto_sizes_attribute_includes_auto
+	 * @dataProvider data_image_with_existing_auto_sizes
+	 */
+	public function test_image_with_existing_auto_sizes_is_not_processed_again( string $initial_sizes, bool $expected_processed ): void {
+		$image_tag = wp_get_attachment_image(
+			self::$image_id,
+			'large',
+			false,
+			array(
+				// Force pre-existing 'sizes' attribute and lazy-loading.
+				'sizes'   => $initial_sizes,
+				'loading' => 'lazy',
+			)
+		);
+		if ( $expected_processed ) {
+			$this->assertStringContainsString( 'sizes="auto, ' . $initial_sizes . '"', $image_tag );
+		} else {
+			$this->assertStringContainsString( 'sizes="' . $initial_sizes . '"', $image_tag );
+		}
+	}
+
+	/**
+	 * Test content filtered markup with 'auto' keyword already present in sizes does not receive it again.
+	 *
+	 * @covers ::auto_sizes_update_content_img_tag
+	 * @covers ::auto_sizes_attribute_includes_auto
+	 * @dataProvider data_image_with_existing_auto_sizes
+	 */
+	public function test_content_image_with_existing_auto_sizes_is_not_processed_again( string $initial_sizes, bool $expected_processed ): void {
+		// Force lazy loading attribute.
+		add_filter( 'wp_img_tag_add_loading_attr', '__return_true' );
+
+		add_filter(
+			'get_image_tag',
+			static function ( $html ) use ( $initial_sizes ) {
+				return str_replace(
+					'" />',
+					'" sizes="' . $initial_sizes . '" />',
+					$html
+				);
+			}
+		);
+
+		$image_content = wp_filter_content_tags( $this->get_image_tag( self::$image_id ) );
+		if ( $expected_processed ) {
+			$this->assertStringContainsString( 'sizes="auto, ' . $initial_sizes . '"', $image_content );
+		} else {
+			$this->assertStringContainsString( 'sizes="' . $initial_sizes . '"', $image_content );
+		}
+	}
+
+	/**
+	 * Returns data for the above test methods to assert correct behavior with a pre-existing sizes attribute.
+	 *
+	 * @return array<string, mixed[]> Arguments for the test scenarios.
+	 */
+	public function data_image_with_existing_auto_sizes(): array {
+		return array(
+			'not present'                 => array(
+				'(max-width: 1024px) 100vw, 1024px',
+				true,
+			),
+			'in beginning, without space' => array(
+				'auto,(max-width: 1024px) 100vw, 1024px',
+				false,
+			),
+			'in beginning, with space'    => array(
+				'auto, (max-width: 1024px) 100vw, 1024px',
+				false,
+			),
+			'at the end, without space'   => array(
+				'(max-width: 1024px) 100vw,auto',
+				false,
+			),
+			'at the end, with space'      => array(
+				'(max-width: 1024px) 100vw, auto',
+				false,
+			),
+			'sole keyword'                => array(
+				'auto',
+				false,
+			),
+		);
+	}
+
+	/**
 	 * Test printing the meta generator tag.
 	 *
 	 * @covers ::auto_sizes_render_generator


### PR DESCRIPTION
Currently, the Enhanced Responsive Images functions that conditionally add the `auto` keyword to the image `sizes` attribute only check for the attribute in one specific way. This works to prevent double processing of an image that the plugin itself has added, but may lead to problems if the `auto` keyword was added through another means, where it can appear in a different position within the `sizes` attribute.

## Relevant technical choices

* Create new helper function `auto_sizes_attribute_includes_auto( string $sizes_attr ): bool` that checks a sizes attribute for presence of the `auto` keyword, so that this logic can be reused between both filter callbacks.
* Add test coverage for both the existing and new logic to prevent duplicate `auto` keywords.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
