### PR TITLE
Use 0.1.0 for initial version instead of n.e.x.t for Web Worker Offloading

### DIFF
--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -2,7 +2,7 @@
 /**
  * Hook callback for Web Worker Offloading.
  *
- * @since n.e.x.t
+ * @since 0.1.0
  * @package web-worker-offloading
  */
 
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Gets configuration for Web Worker Offloading.
  *
- * @since n.e.x.t
+ * @since 0.1.0
  * @link https://partytown.builder.io/configuration
  *
  * @return array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } Configuration for Partytown.
@@ -27,7 +27,7 @@ function wwo_get_configuration(): array {
 	/**
 	 * Add configuration for Web Worker Offloading.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.1.0
 	 * @link https://partytown.builder.io/configuration
 	 *
 	 * @param array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } $config Configuration for Partytown.
@@ -38,7 +38,7 @@ function wwo_get_configuration(): array {
 /**
  * Initializes Web Worker Offloading.
  *
- * @since n.e.x.t
+ * @since 0.1.0
  */
 function wwo_init(): void {
 	$partytown_js = file_get_contents( __DIR__ . '/build/partytown.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
@@ -74,7 +74,7 @@ add_action( 'wp_enqueue_scripts', 'wwo_init' );
  * scripts that need sequential execution. Once marked as async, `filter_eligible_strategies()` determines if the
  * script is eligible for async execution. If so, it will be offloaded to the worker thread.
  *
- * @since n.e.x.t
+ * @since 0.1.0
  *
  * @param string[]|mixed $script_handles Array of script handles.
  * @return string[] Array of script handles.
@@ -97,7 +97,7 @@ add_filter( 'print_scripts_array', 'wwo_update_script_strategy' );
 /**
  * Updates script type for handles having `web-worker-offloading` as dependency.
  *
- * @since n.e.x.t
+ * @since 0.1.0
  *
  * @param string|mixed $tag    Script tag.
  * @param string       $handle Script handle.
@@ -125,7 +125,7 @@ function wwo_update_script_type( $tag, string $handle ) {
 							$handle
 						)
 					),
-					'Web Worker Offloading n.e.x.t'
+					'Web Worker Offloading 0.1.0'
 				);
 			} else {
 				$html_processor->set_attribute( 'type', 'text/partytown' );

--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -5,7 +5,7 @@
  * Description: Offload JavaScript execution to a Web Worker.
  * Requires at least: 6.4
  * Requires PHP: 7.2
- * Version: n.e.x.t
+ * Version: 0.1.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -43,7 +43,7 @@ if (
 	);
 }
 
-define( 'WEB_WORKER_OFFLOADING_VERSION', 'n.e.x.t' );
+define( 'WEB_WORKER_OFFLOADING_VERSION', '0.1.0' );
 
 // Load the hooks.
 require_once __DIR__ . '/hooks.php';

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -3,7 +3,7 @@
 Contributors:      wordpressdotorg
 Requires at least: 6.4
 Tested up to:      6.6
-Stable tag:        n.e.x.t
+Stable tag:        0.1.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, JavaScript, web worker, partytown


### PR DESCRIPTION
When attempting to run `npm run build-plugins:zip` currently, I get an error:

```
[webpack-cli] Error: Plugin version not found for "web-worker-offloading".
```

This is because Web Worker Offloading is currently using `n.e.x.t` for all of its versions. Since it hasn't been released yet, I think it makes more sense to use `0.1.0` for the version until we get it deployed to WordPress.org.