### PR TITLE
Add data-od-related-tag attribute to links to assist with debugging

### DIFF
--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -109,8 +109,9 @@ final class Embed_Optimizer_Tag_Visitor {
 			foreach ( $preconnect_hrefs as $preconnect_href ) {
 				$context->link_collection->add_link(
 					array(
-						'rel'  => 'preconnect',
-						'href' => $preconnect_href,
+						'rel'                 => 'preconnect',
+						'href'                => $preconnect_href,
+						'data-od-related-tag' => $context->processor->get_xpath(),
 					)
 				);
 			}

--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -57,11 +57,12 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 		// If this element is the LCP (for a breakpoint group), add a preload link for it.
 		foreach ( $context->url_metrics_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
 			$link_attributes = array(
-				'rel'           => 'preload',
-				'fetchpriority' => 'high',
-				'as'            => 'image',
-				'href'          => $background_image_url,
-				'media'         => 'screen',
+				'rel'                 => 'preload',
+				'fetchpriority'       => 'high',
+				'as'                  => 'image',
+				'href'                => $background_image_url,
+				'media'               => 'screen',
+				'data-od-related-tag' => $xpath,
 			);
 
 			$context->link_collection->add_link(

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -117,6 +117,8 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 
 			$link_attributes['media'] = 'screen';
 
+			$link_attributes['data-od-related-tag'] = $context->processor->get_xpath();
+
 			$context->link_collection->add_link(
 				$link_attributes,
 				$group->get_minimum_viewport_width(),

--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -96,6 +96,16 @@ final class OD_Link_Collection implements Countable {
 			}
 		}
 
+		// Allow for custom attributes to be added as well, namely data attributes.
+		foreach ( $attributes as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				$throw_invalid_argument_exception( __( 'All attribute keys must be strings.', 'optimization-detective' ) );
+			}
+			if ( ! is_string( $value ) ) {
+				$throw_invalid_argument_exception( __( 'All attribute values must be strings.', 'optimization-detective' ) );
+			}
+		}
+
 		$this->links_by_rel[ $attributes['rel'] ][] = array(
 			'attributes'             => $attributes,
 			'minimum_viewport_width' => $minimum_viewport_width,


### PR DESCRIPTION
When a `preload` or `preconnect` link is added, there currently isn't any indication from looking at the HTML for which element specifically caused the link to be added. Sure, it can be clear by looking at the `href` of the link and then just searching the HTML for that string elsewhere in the HTML to find the corresponding tag that the link is associated with. But we could make it more explicit by adding a data attribute to the link tag indicating the XPath of the related tag.

For example, a preload link added by Image Prioritizer for an LCP image:

```html
<link
  data-od-added-tag
  rel="preload"
  fetchpriority="high"
  as="image"
  href="https://example.com/foo.jpg"
  media="screen and (max-width: 480px)"
  data-od-related-tag="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]"
>
```

Or a preconnect link added for an above-the-fold embed by Embed Optimizer:

```html
<link
  data-od-added-tag
  rel="preconnect"
  href="https://i.ytimg.com"
  data-od-related-tag="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]"
>
```

I'm not totally sold on the need to do this, and perhaps this should only be done if `WP_DEBUG` is enabled, but I wanted to throw up a PR to get it off my mind.

Tests have not been updated to account for this new attribute.