### PR TITLE
Web Worker Offloading: Minor `readme.txt` and plugin header updates

### DIFF
--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Web Worker Offloading
  * Plugin URI: https://github.com/WordPress/performance/issues/176
  * Description: Offload JavaScript execution to a Web Worker.
- * Requires at least: 6.4
+ * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 0.1.0
  * Author: WordPress Performance Team

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -1,7 +1,6 @@
 === Web Worker Offloading ===
 
 Contributors:      wordpressdotorg
-Requires at least: 6.4
 Tested up to:      6.6
 Stable tag:        0.1.0
 License:           GPLv2 or later


### PR DESCRIPTION
## Summary

This PR will update the following:
- Per #1334, Remove 'Requires at least' from plugin `readme.txt`
- Per #1333, bump the `Requires at least` from 6.4 to 6.5.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
