### PR TITLE
Optimization Detective: Update build command 

### DIFF
--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -84,7 +84,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						/* translators: 1: File path. 2: CLI command. */
 						'[Optimization Detective] ' . __( 'Unable to load %1$s. Please make sure you have run %2$s.', 'optimization-detective' ),
 						'build/web-vitals.asset.php',
-						'`npm install && npm run build:optimization-detective`'
+						'`npm install && npm run build:plugin:optimization-detective`'
 					)
 				),
 				E_USER_ERROR


### PR DESCRIPTION
## Summary

This PR solve the fatal error:

```php
PHP Fatal error:  [Optimization Detective] Unable to load build/web-vitals.asset.php. 
Please make sure you have run `npm install &amp;&amp; npm run build:optimization-detective`. in /var/www/html/wp-content/plugins/optimization-detective/load.php on line 81
```

The error suggests running `npm run build:optimization-detective` to build the plugin assets, but the correct command is `npm run build:plugin:optimization-detective`.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
