### PR TITLE
Remove Server-Timing metric for the autoloaded options query time

### DIFF
--- a/plugins/performance-lab/includes/server-timing/defaults.php
+++ b/plugins/performance-lab/includes/server-timing/defaults.php
@@ -87,42 +87,6 @@ function perflab_register_default_server_timing_before_template_metrics(): void 
 		},
 		PHP_INT_MAX
 	);
-
-	// Measure duration of autoloaded options query.
-	// Requires the Performance Lab object-cache.php drop-in to be present in order to work,
-	// which is why the constant is checked below.
-	if ( PERFLAB_OBJECT_CACHE_DROPIN_VERSION ) {
-		add_filter(
-			'query',
-			static function ( $query ) {
-				global $wpdb;
-				if ( "SELECT option_name, option_value FROM $wpdb->options WHERE autoload = 'yes'" !== $query ) {
-					return $query;
-				}
-				// In case the autoloaded options query is run again, prevent re-registering it and do not measure again.
-				if ( perflab_server_timing()->has_registered_metric( 'load-alloptions-query' ) ) {
-					return $query;
-				}
-				perflab_server_timing_register_metric(
-					'load-alloptions-query',
-					array(
-						'measure_callback' => static function ( $metric ): void {
-							$metric->measure_before();
-							add_filter(
-								'pre_cache_alloptions',
-								static function ( $passthrough ) use ( $metric ) {
-									$metric->measure_after();
-									return $passthrough;
-								}
-							);
-						},
-						'access_cap'       => 'exist',
-					)
-				);
-				return $query;
-			}
-		);
-	}
 }
 perflab_register_default_server_timing_before_template_metrics();
 


### PR DESCRIPTION
## Summary

The Server-Timing metric to capture the time that the autoloaded options query takes was initially introduced primarily to get a better idea for how severe the problem of autoloading options is across WordPress sites. This research was completed more than a year ago and has since already led to several WP core projects and enhancements, see e.g. https://make.wordpress.org/core/2024/06/18/options-api-disabling-autoload-for-large-options/.

At this point, there's no longer a good reason to keep this very specific Server-Timing metric in the Performance Lab plugin, so we can remove it - particularly since it's now slightly incorrect given that WordPress 6.6 introduced additional autoload values than `yes` that would need to be considered. It's not worth updating this though, it just made me remember this existed and should probably be removed now.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
