### PR TITLE
Remove `web-worker-offloading` from plugins.json for now since it is not yet ready for release

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -7,7 +7,6 @@
     "optimization-detective",
     "performance-lab",
     "speculation-rules",
-    "web-worker-offloading",
     "webp-uploads"
   ]
 }


### PR DESCRIPTION
## Summary

See #1440: The next set of Performance Lab plugin releases will happen next Monday, August 19.

We don't have a .org repo for `web-worker-offloading` yet, and haven't decided whether we want to release it already or what else we want to have in the plugin for a first version.

## Relevant technical choices

* Remove `web-worker-offloading` from `plugins.json` so that we don't attempt any release processes for it. It can be re-added later once we are ready to release a first version.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
