### PR TITLE
Update tag visitor registration with unique ID constants

### DIFF
--- a/plugins/auto-sizes/optimization-detective.php
+++ b/plugins/auto-sizes/optimization-detective.php
@@ -59,8 +59,12 @@ function auto_sizes_visit_tag( OD_Tag_Visitor_Context $context ): bool {
  * @param OD_Tag_Visitor_Registry $registry Tag visitor registry.
  */
 function auto_sizes_register_tag_visitors( OD_Tag_Visitor_Registry $registry ): void {
-	$registry->register( 'auto-sizes', 'auto_sizes_visit_tag' );
+	$registry->register(
+		'auto-sizes',
+		'auto_sizes_visit_tag',
+		defined( 'Image_Prioritizer_Img_Tag_Visitor::ID' ) ? array( Image_Prioritizer_Img_Tag_Visitor::ID => new Image_Prioritizer_Img_Tag_Visitor() ) : array()
+	);
 }
 
 // Important: The Image Prioritizer's IMG tag visitor is registered at priority 10, so priority 100 ensures that the loading attribute has been correctly set by the time the Auto Sizes visitor runs.
-add_action( 'od_register_tag_visitors', 'auto_sizes_register_tag_visitors', 100 );
+add_action( 'od_register_tag_visitors', 'auto_sizes_register_tag_visitors' );

--- a/plugins/auto-sizes/optimization-detective.php
+++ b/plugins/auto-sizes/optimization-detective.php
@@ -62,7 +62,7 @@ function auto_sizes_register_tag_visitors( OD_Tag_Visitor_Registry $registry ): 
 	$registry->register(
 		'auto-sizes',
 		'auto_sizes_visit_tag',
-		defined( 'Image_Prioritizer_Img_Tag_Visitor::ID' ) ? array( Image_Prioritizer_Img_Tag_Visitor::ID => new Image_Prioritizer_Img_Tag_Visitor() ) : array()
+		defined( 'Image_Prioritizer_Img_Tag_Visitor::ID' ) ? array( Image_Prioritizer_Img_Tag_Visitor::ID ) : array()
 	);
 }
 

--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -20,6 +20,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_Prioritizer_Tag_Visitor {
 
 	/**
+	 * The ID used the register the class
+	 */
+
+	public const ID = 'image-prioritizer-bg-img';
+	/**
 	 * Visits a tag.
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -20,6 +20,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visitor {
 
 	/**
+	 * The ID used the register the class
+	 */
+	public const ID = 'image-prioritizer-img';
+
+	/**
 	 * Visits a tag.
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.

--- a/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
@@ -20,6 +20,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class Image_Prioritizer_Tag_Visitor {
 
 	/**
+	 * The ID used the register the class
+	 */
+	public const ID = 'image-prioritizer-tag';
+
+	/**
 	 * Visits a tag.
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -32,8 +32,8 @@ function image_prioritizer_render_generator_meta_tag(): void {
 function image_prioritizer_register_tag_visitors( OD_Tag_Visitor_Registry $registry ): void {
 	// Note: The class is invocable (it has an __invoke() method).
 	$img_visitor = new Image_Prioritizer_Img_Tag_Visitor();
-	$registry->register( 'img-tags', $img_visitor );
+	$registry->register( $img_visitor::ID, $img_visitor );
 
 	$bg_image_visitor = new Image_Prioritizer_Background_Image_Styled_Tag_Visitor();
-	$registry->register( 'bg-image-tags', $bg_image_visitor );
+	$registry->register( $bg_image_visitor::ID, $bg_image_visitor );
 }

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -35,5 +35,5 @@ function image_prioritizer_register_tag_visitors( OD_Tag_Visitor_Registry $regis
 	$registry->register( Image_Prioritizer_Img_Tag_Visitor::ID, $img_visitor );
 
 	$bg_image_visitor = new Image_Prioritizer_Background_Image_Styled_Tag_Visitor();
-	$registry->register( $bg_image_visitor::ID, $bg_image_visitor );
+	$registry->register( Image_Prioritizer_Background_Image_Styled_Tag_Visitor::ID, $bg_image_visitor );
 }

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -32,7 +32,7 @@ function image_prioritizer_render_generator_meta_tag(): void {
 function image_prioritizer_register_tag_visitors( OD_Tag_Visitor_Registry $registry ): void {
 	// Note: The class is invocable (it has an __invoke() method).
 	$img_visitor = new Image_Prioritizer_Img_Tag_Visitor();
-	$registry->register( $img_visitor::ID, $img_visitor );
+	$registry->register( Image_Prioritizer_Img_Tag_Visitor::ID, $img_visitor );
 
 	$bg_image_visitor = new Image_Prioritizer_Background_Image_Styled_Tag_Visitor();
 	$registry->register( $bg_image_visitor::ID, $bg_image_visitor );

--- a/plugins/optimization-detective/class-od-tag-visitor-registry.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-registry.php
@@ -35,16 +35,15 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	 *
 	 * @phpstan-param TagVisitorCallback $tag_visitor_callback
 	 *
-	 * @param string   $id                   Identifier for the tag visitor.
+	 * @param string   $id Identifier for the tag visitor.
 	 * @param callable $tag_visitor_callback Tag visitor callback.
-	 * @param array<mixed> $dependencies array with ID as key and Callable as value
+	 * @param string[] $dependencies Tag visitors that must run before this tag visitor.
 	 */
-	public function register( string $id, callable $tag_visitor_callback, array $dependencies = array() ): void
-	{
+	public function register( string $id, callable $tag_visitor_callback, array $dependencies = array() ): void {
 		if ( ! empty( $dependencies ) ) {
 			foreach ( $dependencies as $dependency_id => $dependency_callback ) {
 				if ( ! self::is_registered( $dependency_id ) ) {
-					$this->visitors[ $dependency_id ] = $dependency_callback;
+					$this->register( $dependency_id, $dependency_callback );
 				}
 			}
 		}

--- a/plugins/optimization-detective/class-od-tag-visitor-registry.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-registry.php
@@ -40,16 +40,10 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	 * @param string[] $dependencies Tag visitors that must run before this tag visitor.
 	 */
 	public function register( string $id, callable $tag_visitor_callback, array $dependencies = array() ): void {
-		if ( ! empty( $dependencies ) ) {
-			foreach ( $dependencies as $dependency_id => $dependency_callback ) {
-				if ( ! self::is_registered( $dependency_id ) ) {
-					$this->register( $dependency_id, $dependency_callback );
-				}
-			}
-		}
-		if ( ! self::is_registered( $id ) ) {
-			$this->visitors[ $id ] = $tag_visitor_callback;
-		}
+		$this->visitors[ $id ] = array(
+			'callback'     => $tag_visitor_callback,
+			'dependencies' => $dependencies,
+		);
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-tag-visitor-registry.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-registry.php
@@ -37,9 +37,20 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	 *
 	 * @param string   $id                   Identifier for the tag visitor.
 	 * @param callable $tag_visitor_callback Tag visitor callback.
+	 * @param array<mixed> $dependencies array with ID as key and Callable as value
 	 */
-	public function register( string $id, callable $tag_visitor_callback ): void {
-		$this->visitors[ $id ] = $tag_visitor_callback;
+	public function register( string $id, callable $tag_visitor_callback, array $dependencies = array() ): void
+	{
+		if (!empty($dependencies)) {
+			foreach ($dependencies as $dependency_id => $dependency_callback) {
+				if (!self::is_registered($dependency_id)) {
+					$this->visitors[$dependency_id] = $dependency_callback;
+				}
+			}
+		}
+		if (!self::is_registered($id)) {
+			$this->visitors[$id] = $tag_visitor_callback;
+		}
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-tag-visitor-registry.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-registry.php
@@ -41,15 +41,15 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	 */
 	public function register( string $id, callable $tag_visitor_callback, array $dependencies = array() ): void
 	{
-		if (!empty($dependencies)) {
-			foreach ($dependencies as $dependency_id => $dependency_callback) {
-				if (!self::is_registered($dependency_id)) {
-					$this->visitors[$dependency_id] = $dependency_callback;
+		if ( ! empty( $dependencies ) ) {
+			foreach ( $dependencies as $dependency_id => $dependency_callback ) {
+				if ( ! self::is_registered( $dependency_id ) ) {
+					$this->visitors[ $dependency_id ] = $dependency_callback;
 				}
 			}
 		}
-		if (!self::is_registered($id)) {
-			$this->visitors[$id] = $tag_visitor_callback;
+		if ( ! self::is_registered( $id ) ) {
+			$this->visitors[ $id ] = $tag_visitor_callback;
 		}
 	}
 


### PR DESCRIPTION
Replaced hardcoded ID strings with unique ID constants for tag visitors to ensure consistency and maintainability. Updated the `OD_Tag_Visitor_Registry::register` method to handle dependencies, adding them only if they are not already registered.

## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1419 

## Relevant technical choices

<!-- Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
