### PR TITLE
Improve disabling checkbox for Picture Element on Media settings screen

### DIFF
--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -214,7 +214,7 @@ function webp_uploads_use_picture_element_callback(): void {
 				type="checkbox"
 				id="webp_uploads_use_picture_element"
 				aria-describedby="webp_uploads_use_picture_element_description"
-				<?php checked( get_option( 'webp_uploads_use_picture_element', false ) ); // Option intentionally used instead of webp_uploads_is_picture_element_enabled() to persist when perflab_generate_webp_and_jpeg is updated. ?>
+				<?php checked( $picture_element_option ); // Option intentionally used instead of webp_uploads_is_picture_element_enabled() to persist when perflab_generate_webp_and_jpeg is updated. ?>
 				<?php disabled( ! $jpeg_fallback_enabled ); ?>
 				onchange="document.getElementById('webp_uploads_use_picture_element_value').value = this.checked ? 1 : 0"
 			>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -185,8 +185,9 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
  */
 function webp_uploads_use_picture_element_callback(): void {
 	// Picture element support requires the JPEG output to be enabled.
-	$picture_element_option = 1 === (int) get_option( 'webp_uploads_use_picture_element', 0 );
-	$jpeg_fallback_enabled  = webp_uploads_is_jpeg_fallback_enabled();
+	$picture_element_option    = 1 === (int) get_option( 'webp_uploads_use_picture_element', 0 );
+	$jpeg_fallback_enabled     = webp_uploads_is_jpeg_fallback_enabled();
+	$picture_element_hidden_id = 'webp_uploads_use_picture_element_hidden';
 	?>
 	<style>
 		#webp_uploads_picture_element_fieldset.disabled label,
@@ -217,7 +218,7 @@ function webp_uploads_use_picture_element_callback(): void {
 				?>
 				<input
 					type="hidden"
-					id="webp_uploads_use_picture_element_hidden"
+					id="<?php echo esc_attr( $picture_element_hidden_id ); ?>"
 					name="webp_uploads_use_picture_element"
 					value="1"
 				>
@@ -233,6 +234,7 @@ function webp_uploads_use_picture_element_callback(): void {
 		</div>
 	</div>
 	<script>
+	( function ( pictureElementHiddenId ) {
 		document.getElementById( 'webp_uploads_use_picture_element' ).addEventListener( 'change', function () {
 			document.getElementById( 'webp_uploads_jpeg_fallback_notice' ).hidden = ! this.checked;
 		} );
@@ -249,20 +251,21 @@ function webp_uploads_use_picture_element_callback(): void {
 
 			// Remove or inject hidden input to preserve original setting value as needed.
 			if ( this.checked ) {
-				const hiddenInput = document.getElementById( 'webp_uploads_use_picture_element_hidden' );
+				const hiddenInput = document.getElementById( pictureElementHiddenId );
 				if ( hiddenInput ) {
 					hiddenInput.parentElement.removeChild( hiddenInput );
 				}
-			} else if ( checkbox.checked && ! document.getElementById( 'webp_uploads_use_picture_element_hidden' ) ) {
+			} else if ( checkbox.checked && ! document.getElementById( pictureElementHiddenId ) ) {
 				// The hidden input is only needed if the value was originally set (i.e. the checkbox enabled).
 				const hiddenInput = document.createElement( 'input' );
 				hiddenInput.setAttribute( 'type', 'hidden' );
-				hiddenInput.setAttribute( 'id', 'webp_uploads_use_picture_element_hidden' );
+				hiddenInput.setAttribute( 'id', pictureElementHiddenId );
 				hiddenInput.setAttribute( 'name', checkbox.getAttribute( 'name' ) );
 				hiddenInput.setAttribute( 'value', checkbox.getAttribute( 'value' ) );
 				checkbox.parentElement.insertBefore( hiddenInput, checkbox.nextSibling );
 			}
 		} );
+	} )( <?php echo wp_json_encode( $picture_element_hidden_id ); ?> );
 	</script>
 	<?php
 }

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -244,18 +244,18 @@ function webp_uploads_use_picture_element_callback(): void {
 			document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
 			document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
 
-			var checkbox = document.getElementById( 'webp_uploads_use_picture_element' );
+			const checkbox = document.getElementById( 'webp_uploads_use_picture_element' );
 			checkbox.disabled = ! this.checked;
 
 			// Remove or inject hidden input to preserve original setting value as needed.
 			if ( this.checked ) {
-				var hiddenInput = document.getElementById( 'webp_uploads_use_picture_element_hidden' );
+				const hiddenInput = document.getElementById( 'webp_uploads_use_picture_element_hidden' );
 				if ( hiddenInput ) {
 					hiddenInput.parentElement.removeChild( hiddenInput );
 				}
 			} else if ( checkbox.checked && ! document.getElementById( 'webp_uploads_use_picture_element_hidden' ) ) {
 				// The hidden input is only needed if the value was originally set (i.e. the checkbox enabled).
-				var hiddenInput = document.createElement( 'input' );
+				const hiddenInput = document.createElement( 'input' );
 				hiddenInput.setAttribute( 'type', 'hidden' );
 				hiddenInput.setAttribute( 'id', 'webp_uploads_use_picture_element_hidden' );
 				hiddenInput.setAttribute( 'name', checkbox.getAttribute( 'name' ) );

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -214,7 +214,16 @@ function webp_uploads_use_picture_element_callback(): void {
 	</div>
 	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
-			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( get_option( 'webp_uploads_use_picture_element', false ) ); ?> class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>" aria-disabled="<?php echo ! $jpeg_fallback_enabled ? 'true' : 'false'; ?>">
+			<input
+				name="webp_uploads_use_picture_element"
+				type="checkbox"
+				id="webp_uploads_use_picture_element"
+				aria-describedby="webp_uploads_use_picture_element_description"
+				value="1"
+				<?php checked( get_option( 'webp_uploads_use_picture_element', false ) ); // Option intentionally used instead of webp_uploads_is_picture_element_enabled() to persist when perflab_generate_webp_and_jpeg is updated. ?>
+				class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>"
+				aria-disabled="<?php echo ! $jpeg_fallback_enabled ? 'true' : 'false'; ?>"
+			>
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -26,7 +26,7 @@ function webp_uploads_register_media_settings_field(): void {
 		array(
 			'sanitize_callback' => 'webp_uploads_sanitize_image_format',
 			'type'              => 'string',
-			'default'           => 'avif',                                                                                                                                    // AVIF is the default if the editor supports it.
+			'default'           => 'avif', // AVIF is the default if the editor supports it.
 			'show_in_rest'      => false,
 		)
 	);

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -183,6 +183,7 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
 				document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
 				document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
 				document.getElementById( 'webp_uploads_use_picture_element' ).classList.toggle( 'disabled', ! this.checked );
+				document.getElementById( 'webp_uploads_use_picture_element' ).setAttribute( 'aria-disabled', ! this.checked ? 'true' : 'false' );
 				document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
 			} );
 		</script>
@@ -213,7 +214,7 @@ function webp_uploads_use_picture_element_callback(): void {
 	</div>
 	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
-			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>" >
+			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>" aria-disabled="<?php echo ! $jpeg_fallback_enabled ? 'true' : 'false'; ?>">
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -258,10 +258,10 @@ function webp_uploads_use_picture_element_callback(): void {
 			} else if ( checkbox.checked && ! document.getElementById( pictureElementHiddenId ) ) {
 				// The hidden input is only needed if the value was originally set (i.e. the checkbox enabled).
 				const hiddenInput = document.createElement( 'input' );
-				hiddenInput.setAttribute( 'type', 'hidden' );
-				hiddenInput.setAttribute( 'id', pictureElementHiddenId );
-				hiddenInput.setAttribute( 'name', checkbox.getAttribute( 'name' ) );
-				hiddenInput.setAttribute( 'value', checkbox.getAttribute( 'value' ) );
+				hiddenInput.type = 'hidden';
+				hiddenInput.id = pictureElementHiddenId;
+				hiddenInput.name = checkbox.name;
+				hiddenInput.value = checkbox.value;
 				checkbox.parentElement.insertBefore( hiddenInput, checkbox.nextSibling );
 			}
 		} );

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -204,6 +204,9 @@ function webp_uploads_use_picture_element_callback(): void {
 		#webp_uploads_picture_element_fieldset.disabled p {
 			opacity: 0.7;
 		}
+		#webp_uploads_picture_element_fieldset.disabled #webp_uploads_use_picture_element_label {
+			pointer-events: none;
+		}
 	</style>
 	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php echo $jpeg_fallback_enabled ? 'hidden' : ''; ?>>
 		<p><?php esc_html_e( 'This setting requires JPEG also be output as a fallback option.', 'webp-uploads' ); ?></p>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -219,7 +219,8 @@ function webp_uploads_use_picture_element_callback(): void {
 				onchange="document.getElementById('webp_uploads_use_picture_element_value').value = this.checked ? 1 : 0"
 			>
 			<input
-				type="hidden" name="webp_uploads_use_picture_element"
+				type="hidden"
+				name="webp_uploads_use_picture_element"
 				id="webp_uploads_use_picture_element_value"
 				value="<?php echo $picture_element_enabled ? 1 : 0; ?>"
 			>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -169,41 +169,12 @@ function webp_uploads_generate_avif_webp_setting_callback(): void {
  * @since 1.0.0
  */
 function webp_uploads_generate_webp_jpeg_setting_callback(): void {
-
 	?>
 		<label for="perflab_generate_webp_and_jpeg">
 			<input name="perflab_generate_webp_and_jpeg" type="checkbox" id="perflab_generate_webp_and_jpeg" aria-describedby="perflab_generate_webp_and_jpeg_description" value="1"<?php checked( '1', get_option( 'perflab_generate_webp_and_jpeg' ) ); ?> />
 			<?php esc_html_e( 'Output JPEG images in addition to the modern format', 'webp-uploads' ); ?>
 		</label>
 		<p class="description" id="perflab_generate_webp_and_jpeg_description"><?php esc_html_e( 'Enabling JPEG output can improve compatibility, but will increase the filesystem storage use of your images.', 'webp-uploads' ); ?></p>
-		<script>
-			// Listen for clicks on the JPEG output checkbox, enabling/disabling the
-			// picture element checkbox accordingly.
-			document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
-				document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
-				document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
-				document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
-
-				var checkbox = document.getElementById( 'webp_uploads_use_picture_element' );
-				checkbox.disabled = ! this.checked;
-
-				// Remove or inject hidden input to preserve original setting value as needed.
-				if ( this.checked ) {
-					var hiddenInput = document.getElementById( 'webp_uploads_use_picture_element_hidden' );
-					if ( hiddenInput ) {
-						hiddenInput.parentElement.removeChild( hiddenInput );
-					}
-				} else if ( checkbox.checked && ! document.getElementById( 'webp_uploads_use_picture_element_hidden' ) ) {
-					// The hidden input is only needed if the value was originally set (i.e. the checkbox enabled).
-					var hiddenInput = document.createElement( 'input' );
-					hiddenInput.setAttribute( 'type', 'hidden' );
-					hiddenInput.setAttribute( 'id', 'webp_uploads_use_picture_element_hidden' );
-					hiddenInput.setAttribute( 'name', checkbox.getAttribute( 'name' ) );
-					hiddenInput.setAttribute( 'value', checkbox.getAttribute( 'value' ) );
-					checkbox.parentElement.insertBefore( hiddenInput, checkbox.nextSibling );
-				}
-			} );
-		</script>
 	<?php
 }
 
@@ -264,6 +235,33 @@ function webp_uploads_use_picture_element_callback(): void {
 	<script>
 		document.getElementById( 'webp_uploads_use_picture_element' ).addEventListener( 'change', function () {
 			document.getElementById( 'webp_uploads_jpeg_fallback_notice' ).hidden = ! this.checked;
+		} );
+
+		// Listen for clicks on the JPEG output checkbox, enabling/disabling the
+		// picture element checkbox accordingly.
+		document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
+			document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
+			document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
+			document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
+
+			var checkbox = document.getElementById( 'webp_uploads_use_picture_element' );
+			checkbox.disabled = ! this.checked;
+
+			// Remove or inject hidden input to preserve original setting value as needed.
+			if ( this.checked ) {
+				var hiddenInput = document.getElementById( 'webp_uploads_use_picture_element_hidden' );
+				if ( hiddenInput ) {
+					hiddenInput.parentElement.removeChild( hiddenInput );
+				}
+			} else if ( checkbox.checked && ! document.getElementById( 'webp_uploads_use_picture_element_hidden' ) ) {
+				// The hidden input is only needed if the value was originally set (i.e. the checkbox enabled).
+				var hiddenInput = document.createElement( 'input' );
+				hiddenInput.setAttribute( 'type', 'hidden' );
+				hiddenInput.setAttribute( 'id', 'webp_uploads_use_picture_element_hidden' );
+				hiddenInput.setAttribute( 'name', checkbox.getAttribute( 'name' ) );
+				hiddenInput.setAttribute( 'value', checkbox.getAttribute( 'value' ) );
+				checkbox.parentElement.insertBefore( hiddenInput, checkbox.nextSibling );
+			}
 		} );
 	</script>
 	<?php

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -182,8 +182,7 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
 			document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
 				document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
 				document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
-				document.getElementById( 'webp_uploads_use_picture_element' ).classList.toggle( 'disabled', ! this.checked );
-				document.getElementById( 'webp_uploads_use_picture_element' ).setAttribute( 'aria-disabled', ! this.checked ? 'true' : 'false' );
+				document.getElementById( 'webp_uploads_use_picture_element' ).disabled = ! this.checked;
 				document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
 			} );
 		</script>
@@ -197,16 +196,13 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
  */
 function webp_uploads_use_picture_element_callback(): void {
 	// Picture element support requires the JPEG output to be enabled.
-	$picture_element_enabled = webp_uploads_is_picture_element_enabled();
+	$picture_element_enabled = 1 === (int) get_option( 'webp_uploads_use_picture_element', 0 );
 	$jpeg_fallback_enabled   = webp_uploads_is_jpeg_fallback_enabled();
 	?>
 	<style>
 		#webp_uploads_picture_element_fieldset.disabled label,
 		#webp_uploads_picture_element_fieldset.disabled p {
 			opacity: 0.7;
-		}
-		#webp_uploads_picture_element_fieldset.disabled #webp_uploads_use_picture_element_label {
-			pointer-events: none;
 		}
 	</style>
 	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php echo $jpeg_fallback_enabled ? 'hidden' : ''; ?>>
@@ -215,14 +211,17 @@ function webp_uploads_use_picture_element_callback(): void {
 	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
 			<input
-				name="webp_uploads_use_picture_element"
 				type="checkbox"
 				id="webp_uploads_use_picture_element"
 				aria-describedby="webp_uploads_use_picture_element_description"
-				value="1"
 				<?php checked( get_option( 'webp_uploads_use_picture_element', false ) ); // Option intentionally used instead of webp_uploads_is_picture_element_enabled() to persist when perflab_generate_webp_and_jpeg is updated. ?>
-				class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>"
-				aria-disabled="<?php echo ! $jpeg_fallback_enabled ? 'true' : 'false'; ?>"
+				<?php disabled( ! $jpeg_fallback_enabled ); ?>
+				onchange="document.getElementById('webp_uploads_use_picture_element_value').value = this.checked ? 1 : 0"
+			>
+			<input
+				type="hidden" name="webp_uploads_use_picture_element"
+				id="webp_uploads_use_picture_element_value"
+				value="<?php echo $picture_element_enabled ? 1 : 0; ?>"
 			>
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -214,7 +214,7 @@ function webp_uploads_use_picture_element_callback(): void {
 	</div>
 	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
-			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>" aria-disabled="<?php echo ! $jpeg_fallback_enabled ? 'true' : 'false'; ?>">
+			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( get_option( 'webp_uploads_use_picture_element', false ) ); ?> class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>" aria-disabled="<?php echo ! $jpeg_fallback_enabled ? 'true' : 'false'; ?>">
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -196,8 +196,8 @@ function webp_uploads_generate_webp_jpeg_setting_callback(): void {
  */
 function webp_uploads_use_picture_element_callback(): void {
 	// Picture element support requires the JPEG output to be enabled.
-	$picture_element_enabled = 1 === (int) get_option( 'webp_uploads_use_picture_element', 0 );
-	$jpeg_fallback_enabled   = webp_uploads_is_jpeg_fallback_enabled();
+	$picture_element_option = 1 === (int) get_option( 'webp_uploads_use_picture_element', 0 );
+	$jpeg_fallback_enabled  = webp_uploads_is_jpeg_fallback_enabled();
 	?>
 	<style>
 		#webp_uploads_picture_element_fieldset.disabled label,
@@ -222,13 +222,13 @@ function webp_uploads_use_picture_element_callback(): void {
 				type="hidden"
 				name="webp_uploads_use_picture_element"
 				id="webp_uploads_use_picture_element_value"
-				value="<?php echo $picture_element_enabled ? 1 : 0; ?>"
+				value="<?php echo $picture_element_option ? 1 : 0; ?>"
 			>
 			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>
 		<p class="description" id="webp_uploads_use_picture_element_description"><?php esc_html_e( 'The picture element serves a modern image format with a fallback to JPEG. Warning: Make sure you test your theme and plugins for compatibility. In particular, CSS selectors will not match images when using the child combinator (e.g. figure > img).', 'webp-uploads' ); ?></p>
-		<div id="webp_uploads_jpeg_fallback_notice" class="notice notice-info inline" <?php echo $picture_element_enabled ? '' : 'hidden'; ?>>
+		<div id="webp_uploads_jpeg_fallback_notice" class="notice notice-info inline" <?php echo $picture_element_option ? '' : 'hidden'; ?>>
 			<p><?php esc_html_e( 'Picture elements will only be used when JPEG fallback images are available. So this will not apply to any images you may have uploaded while the "Also generate JPEG" setting was disabled.', 'webp-uploads' ); ?></p>
 		</div>
 	</div>


### PR DESCRIPTION
## Summary

In #1273, we improved the Settings -> Media controls for Modern Image Formats, where the `Use <picture> Element (experimental)` option is disabled if the fallback JPEG checkbox is not selected. However, the checkbox remains clickable even when disabled because we only added the disabled class without actually adding the `disabled` attribute to the checkbox.

This PR provides a quick workaround by disabling pointer events for the checkbox when the disabled class is present.


https://github.com/user-attachments/assets/cd2d4792-46a7-4cbd-be8b-8db94a12227f

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
