### PR TITLE
Use more robust HTML Tag Processor for auto sizes injection

### DIFF
--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -65,7 +65,8 @@ function auto_sizes_update_content_img_tag( $html ): string {
 	}
 
 	// Bail early if the image is not lazy-loaded.
-	if ( 'lazy' !== $processor->get_attribute( 'loading' ) ) {
+	$value = $processor->get_attribute( 'loading' );
+	if ( ! is_string( $value ) || 'lazy' !== strtolower( trim( $value, " \t\f\r\n" ) ) ) {
 		return $html;
 	}
 

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -57,24 +57,32 @@ function auto_sizes_update_content_img_tag( $html ): string {
 		$html = '';
 	}
 
-	// Bail early if the image is not lazy-loaded.
-	if ( false === strpos( $html, 'loading="lazy"' ) ) {
+	$processor = new WP_HTML_Tag_Processor( $html );
+
+	// Bail if there is no IMG tag.
+	if ( ! $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
 		return $html;
 	}
 
+	// Bail early if the image is not lazy-loaded.
+	if ( 'lazy' !== $processor->get_attribute( 'loading' ) ) {
+		return $html;
+	}
+
+	$sizes = $processor->get_attribute( 'sizes' );
+
 	// Bail early if the image is not responsive.
-	if ( 1 !== preg_match( '/sizes="([^"]+)"/', $html, $match ) ) {
+	if ( ! is_string( $sizes ) ) {
 		return $html;
 	}
 
 	// Don't add 'auto' to the sizes attribute if it already exists.
-	if ( auto_sizes_attribute_includes_valid_auto( $match[1] ) ) {
+	if ( auto_sizes_attribute_includes_valid_auto( $sizes ) ) {
 		return $html;
 	}
 
-	$html = str_replace( 'sizes="', 'sizes="auto, ', $html );
-
-	return $html;
+	$processor->set_attribute( 'sizes', "auto, $sizes" );
+	return $processor->get_updated_html();
 }
 add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
 

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -71,8 +71,6 @@ class Test_AutoSizes extends WP_UnitTestCase {
 		// Force lazy loading attribute.
 		add_filter( 'wp_img_tag_add_loading_attr', '__return_true' );
 
-		$image_tag = $this->get_image_tag( self::$image_id );
-
 		$this->assertStringContainsString(
 			'sizes="auto, (max-width: 1024px) 100vw, 1024px"',
 			wp_filter_content_tags( $this->get_image_tag( self::$image_id ) )


### PR DESCRIPTION
## Summary

Fixes #1446

Based on the test cases mentioned in the issue description, in https://github.com/WordPress/performance/pull/1471/commits/1859613af2f2ad0aa4ad36d57ec90666375e3773, I have added unit tests that clearly demonstrate the lack of robustness in the current codebase, resulting in failing tests.

<details>

<summary>Failed unit tests:</summary>

```
1) Test_AutoSizes::test_content_image_with_single_quote_replacement_does_not_have_auto_sizes
The sizes attribute does not include "auto" as the first item in the list.
Failed asserting that false is true.

/var/www/html/wp-content/plugins/performance/plugins/auto-sizes/tests/test-auto-sizes.php:2[40](https://github.com/WordPress/performance/actions/runs/10386066002/job/28756529008?pr=1471#step:9:41)
phpvfscomposer:///var/www/html/wp-content/plugins/performance/vendor/phpunit/phpunit/phpunit:97

2) Test_AutoSizes::test_content_image_with_custom_attribute_name_with_sizes_at_the_end_does_not_have_auto_sizes
The data-tshirt-sizes attribute should not contain "auto".
Failed asserting that 'auto, S M L' does not contain "auto".

/var/www/html/wp-content/plugins/performance/plugins/auto-sizes/tests/test-auto-sizes.php:262
phpvfscomposer:///var/www/html/wp-content/plugins/performance/vendor/phpunit/phpunit/phpunit:97

3) Test_AutoSizes::test_content_image_with_lazy_load_text_in_alt_does_not_have_auto_sizes
The sizes attribute does not include "auto" as the first item in the list.
Failed asserting that true is false.

/var/www/html/wp-content/plugins/performance/plugins/auto-sizes/tests/test-auto-sizes.php:285
phpvfscomposer:///var/www/html/wp-content/plugins/performance/vendor/phpunit/phpunit/phpunit:97

4) Test_AutoSizes::test_content_image_with_custom_attribute_name_with_loading_lazy_at_the_end_does_not_have_auto_sizes
The sizes attribute does not include "auto" as the first item in the list.
Failed asserting that true is false.

/var/www/html/wp-content/plugins/performance/plugins/auto-sizes/tests/test-auto-sizes.php:311
phpvfscomposer:///var/www/html/wp-content/plugins/performance/vendor/phpunit/phpunit/phpunit:97
```
</details>

In https://github.com/WordPress/performance/pull/1471/commits/32b9abc15b847d711bd61219f112f90e5dc95c96, after updating the codebase using WP_HTML_Tag_Processor, the unit tests are now passing ✅.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
