### PR TITLE
Disable Optimization Detective by default on the embed template

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -107,6 +107,11 @@ function od_can_optimize_response(): bool {
 		// Since there is no predictability in whether posts in the loop will have featured images assigned or not. If a
 		// theme template for search results doesn't even show featured images, then this wouldn't be an issue.
 		is_search() ||
+		// Avoid optimizing embed responses because the Post Embed iframes include a sandbox attribute with the value of
+		// "allow-scripts" but without "allow-same-origin". This can result in an error in the console:
+		// > Access to script at '.../detect.js?ver=0.4.1' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
+		// So it's better to just avoid attempting to optimize Post Embed responses (which don't need optimization anyway).
+		is_embed() ||
 		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
 		is_customize_preview() ||
 		// Since the images detected in the response body of a POST request cannot, by definition, be cached.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -48,10 +48,11 @@ The default breakpoints are reused from Gutenberg which appear to be used the mo
 
 Filters whether the current response can be optimized. By default, detection and optimization are only performed when:
 
-1. It’s not a search template (i.e. `is_search()`).
-2. It’s not the Customizer preview.
-3. It’s not the response to a `POST` request.
-4. The user is not an administrator (i.e. the `customize` capability).
+1. It’s not a search template (`is_search()`).
+2. It’s not a post embed template (`is_embed()`).
+3. It’s not the Customizer preview (`is_customize_preview()`)
+4. It’s not the response to a `POST` request.
+5. The user is not an administrator (`current_user_can( 'customize' )`).
 
 During development, you may want to force this to always be enabled:
 


### PR DESCRIPTION
I was doing some testing with post embeds and I tried embedding a post embed from my blog onto my local test environment. When I did so, I saw an error in the console:

> Access to script at '.../detect.js?ver=0.4.1' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

Normally the embed template doesn't have any external scripts, but since Optimization Detective is running on my site it is adding a script module to the page that does a dynamic import of `detect.js`. This then is causing an error because the WordPress post iframe is served with `sandbox="allow-scripts"` which doesn't include `allow-same-origin`, meaning the Same-Origin Policy is being enforced, blocking the loading of the script (as I understand).

The solution is simply to disable Optimization Detective for the embed template. In reality there is not really a need for optimizations to run on the basic embed template, as there is at most only one or two images and everything is in the viewport. WordPress core is already adding `fetchpriority=high` to the featured image in a post embed template.