### PR TITLE
Improve Performance screen when external requests to WordPress.org fail

### DIFF
--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -103,12 +103,15 @@ function perflab_render_plugins_ui(): void {
 		// Skip if the plugin is not on WordPress.org or there was a network error.
 		if ( $api_data instanceof WP_Error ) {
 			wp_admin_notice(
-				esc_html(
+				wp_kses(
 					sprintf(
 						/* translators: 1: plugin slug. 2: error message. */
-						__( 'Failed to query WordPress.org Plugin Directory for plugin "%1$s". %2$s', 'performance-lab' ),
+						esc_html__( 'Failed to query WordPress.org Plugin Directory for plugin "%1$s". %2$s', 'performance-lab' ),
 						$plugin_slug,
 						$api_data->get_error_message()
+					),
+					array(
+						'a' => array( 'href' => true ),
 					)
 				),
 				array( 'type' => 'error' )

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -152,7 +152,17 @@ function perflab_render_plugins_ui(): void {
 			) .
 			$plugin_list .
 			'<p>' . esc_html( _n( 'The following error occurred:', 'The following errors occurred:', count( $error_messages ), 'performance-lab' ) ) . '</p>' .
-			'<ul><li>' . join( '</li><li>', $error_messages ) . '</li></ul>' .
+			'<ul><li>' .
+			join(
+				'</li><li>',
+				array_map(
+					static function ( string $error_message ): string {
+						return wp_kses( $error_message, array( 'a' => array( 'href' => true ) ) );
+					},
+					$error_messages
+				)
+			)
+			. '</li></ul>' .
 			esc_html__( 'Please consider manual plugin installation and activation. You can then access each plugin\'s settings via its respective "Settings" link on the Plugins screen.', 'performance-lab' ),
 			array( 'type' => 'error' )
 		);

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -163,8 +163,11 @@ function perflab_render_plugins_ui(): void {
 				)
 			)
 			. '</li></ul>' .
-			esc_html__( 'Please consider manual plugin installation and activation. You can then access each plugin\'s settings via its respective "Settings" link on the Plugins screen.', 'performance-lab' ),
-			array( 'type' => 'error' )
+			'<p>' . esc_html__( 'Please consider manual plugin installation and activation. You can then access each plugin\'s settings via its respective "Settings" link on the Plugins screen.', 'performance-lab' ) . '</p>',
+			array(
+				'type'           => 'error',
+				'paragraph_wrap' => false,
+			)
 		);
 	}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -98,7 +98,8 @@ function perflab_render_plugins_ui(): void {
 	$plugins = array();
 	$errors  = array();
 
-	foreach ( perflab_get_standalone_plugin_data() as $plugin_slug => $plugin_data ) {
+	$standalone_plugin_data = perflab_get_standalone_plugin_data();
+	foreach ( $standalone_plugin_data as $plugin_slug => $plugin_data ) {
 		$api_data = perflab_query_plugin_info( $plugin_slug ); // Data from wordpress.org.
 
 		// Skip if the plugin is not on WordPress.org or there was a network error.
@@ -125,11 +126,19 @@ function perflab_render_plugins_ui(): void {
 		$plugin_list    = '<ul>';
 		$error_messages = array();
 		foreach ( $errors as $plugin_slug => $error ) {
+			if ( defined( $standalone_plugin_data[ $plugin_slug ]['constant'] ) ) {
+				$status = __( '(active)', 'performance-lab' );
+			} elseif ( in_array( $plugin_slug, $active_plugins, true ) ) {
+				$status = __( '(installed)', 'performance-lab' );
+			} else {
+				$status = '';
+			}
+
 			$plugin_list     .= sprintf(
-				'<li><a target="_blank" href="%s"><code>%s</code></a>%s</li>',
+				'<li><a target="_blank" href="%s"><code>%s</code></a> %s</li>',
 				esc_url( trailingslashit( __( 'https://wordpress.org/plugins/', 'default' ) . $plugin_slug ) ),
 				esc_html( $plugin_slug ),
-				in_array( $plugin_slug, $active_plugins, true ) ? ' ' . esc_html__( '(already installed)', 'performance-lab' ) : ''
+				esc_html( $status )
 			);
 			$error_messages[] = $error->get_error_message();
 		}
@@ -144,7 +153,7 @@ function perflab_render_plugins_ui(): void {
 			$plugin_list .
 			'<p>' . esc_html( _n( 'The following error occurred:', 'The following errors occurred:', count( $error_messages ), 'performance-lab' ) ) . '</p>' .
 			'<ul><li>' . join( '</li><li>', $error_messages ) . '</li></ul>' .
-			esc_html__( 'Please consider manual installation.', 'performance-lab' ),
+			esc_html__( 'Please consider manual plugin installation and activation.', 'performance-lab' ),
 			array( 'type' => 'error' )
 		);
 	}

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -153,7 +153,7 @@ function perflab_render_plugins_ui(): void {
 			$plugin_list .
 			'<p>' . esc_html( _n( 'The following error occurred:', 'The following errors occurred:', count( $error_messages ), 'performance-lab' ) ) . '</p>' .
 			'<ul><li>' . join( '</li><li>', $error_messages ) . '</li></ul>' .
-			esc_html__( 'Please consider manual plugin installation and activation.', 'performance-lab' ),
+			esc_html__( 'Please consider manual plugin installation and activation. You can then access each plugin\'s settings via its respective "Settings" link on the Plugins screen.', 'performance-lab' ),
 			array( 'type' => 'error' )
 		);
 	}

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -147,9 +147,9 @@ function perflab_render_plugins_ui(): void {
 		$error_messages = array_unique( $error_messages );
 
 		wp_admin_notice(
-			esc_html(
+			'<p>' . esc_html(
 				_n( 'Failed to query WordPress.org Plugin Directory for the following plugin:', 'Failed to query WordPress.org Plugin Directory for the following plugins:', count( $errors ), 'performance-lab' )
-			) .
+			) . '</p>' .
 			$plugin_list .
 			'<p>' . esc_html( _n( 'The following error occurred:', 'The following errors occurred:', count( $error_messages ), 'performance-lab' ) ) . '</p>' .
 			'<ul><li>' .


### PR DESCRIPTION
Fixes #1473.

With the following plugin code active:

```php
add_filter( 
	'pre_http_request',
	static function ( $pre, $args, $url ) {
		if ( strpos( $url, 'wordpress.org' ) ) {
			return true;
		} else {
			return $pre;
		}
	}, 
	10,
	3 
);
```

Before:

![image](https://github.com/user-attachments/assets/6b4a7a3f-39d0-49fa-8b70-d92f94946bae)

After:

![image](https://github.com/user-attachments/assets/6324a61e-646d-42cb-a827-32895109ce8f)


