### PR TITLE
Use more robust HTML Tag Processor for Image Placeholders

### DIFF
--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -95,20 +95,18 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, string $con
 		$filtered_image = '';
 	}
 
-	$processor = new WP_HTML_Tag_Processor( $filtered_image );
-
-	if ( ! $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
-		return $filtered_image;
-	}
-
 	// Only apply this in `the_content` for now, since otherwise it can result in duplicate runs due to a problem with full site editing logic.
 	if ( 'the_content' !== $context ) {
 		return $filtered_image;
 	}
 
-	// Only apply the dominant color to images that have a src attribute that
-	// starts with a double quote, ensuring escaped JSON is also excluded.
-	if ( ! str_contains( $filtered_image, ' src="' ) ) {
+	$processor = new WP_HTML_Tag_Processor( $filtered_image );
+	if ( ! $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+		return $filtered_image;
+	}
+
+	// Only apply the dominant color to images that have a src attribute.
+	if ( null === $processor->get_attribute( 'src' ) || ! is_string( $processor->get_attribute( 'src' ) ) ) {
 		return $filtered_image;
 	}
 
@@ -141,9 +139,9 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, string $con
 	}
 
 	if ( ! empty( $image_meta['dominant_color'] ) ) {
-		$processor->set_attribute( 'data-dominant-color', esc_attr( $image_meta['dominant_color'] ) );
+		$processor->set_attribute( 'data-dominant-color', $image_meta['dominant_color'] );
 
-		$style_attribute = '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . '; ';
+		$style_attribute = '--dominant-color: #' . $image_meta['dominant_color'] . '; ';
 		if ( null !== $processor->get_attribute( 'style' ) ) {
 			$style_attribute .= $processor->get_attribute( 'style' );
 		}
@@ -152,7 +150,7 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, string $con
 
 	if ( isset( $image_meta['has_transparency'] ) ) {
 		$transparency = $image_meta['has_transparency'] ? 'true' : 'false';
-		$processor->set_attribute( 'data-has-transparency', esc_attr( $transparency ) );
+		$processor->set_attribute( 'data-has-transparency', $transparency );
 		$processor->add_class( $image_meta['has_transparency'] ? 'has-transparency' : 'not-transparent' );
 	}
 

--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -95,6 +95,12 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, string $con
 		$filtered_image = '';
 	}
 
+	$processor = new WP_HTML_Tag_Processor( $filtered_image );
+
+	if ( ! $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+		return $filtered_image;
+	}
+
 	// Only apply this in `the_content` for now, since otherwise it can result in duplicate runs due to a problem with full site editing logic.
 	if ( 'the_content' !== $context ) {
 		return $filtered_image;
@@ -107,7 +113,7 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, string $con
 	}
 
 	// Ensure to not run the logic below in case relevant attributes are already present.
-	if ( str_contains( $filtered_image, ' data-dominant-color="' ) || str_contains( $filtered_image, ' data-has-transparency="' ) ) {
+	if ( null !== $processor->get_attribute( 'data-dominant-color' ) || null !== $processor->get_attribute( 'data-has-transparency' ) ) {
 		return $filtered_image;
 	}
 
@@ -134,34 +140,23 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, string $con
 		return $filtered_image;
 	}
 
-	$data        = '';
-	$extra_class = '';
-
 	if ( ! empty( $image_meta['dominant_color'] ) ) {
-		$data .= sprintf( 'data-dominant-color="%s" ', esc_attr( $image_meta['dominant_color'] ) );
+		$processor->set_attribute( 'data-dominant-color', esc_attr( $image_meta['dominant_color'] ) );
 
-		if ( str_contains( $filtered_image, ' style="' ) ) {
-			$filtered_image = str_replace( ' style="', ' style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . '; ', $filtered_image );
-		} else {
-			$filtered_image = str_replace( '<img ', '<img style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';" ', $filtered_image );
+		$style_attribute = '--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . '; ';
+		if ( null !== $processor->get_attribute( 'style' ) ) {
+			$style_attribute .= $processor->get_attribute( 'style' );
 		}
+		$processor->set_attribute( 'style', trim( $style_attribute ) );
 	}
 
 	if ( isset( $image_meta['has_transparency'] ) ) {
 		$transparency = $image_meta['has_transparency'] ? 'true' : 'false';
-		$data        .= sprintf( 'data-has-transparency="%s" ', $transparency );
-		$extra_class  = $image_meta['has_transparency'] ? 'has-transparency' : 'not-transparent';
+		$processor->set_attribute( 'data-has-transparency', esc_attr( $transparency ) );
+		$processor->add_class( $image_meta['has_transparency'] ? 'has-transparency' : 'not-transparent' );
 	}
 
-	if ( '' !== $data ) {
-		$filtered_image = str_replace( '<img ', '<img ' . $data, $filtered_image );
-	}
-
-	if ( '' !== $extra_class ) {
-		$filtered_image = str_replace( ' class="', ' class="' . $extra_class . ' ', $filtered_image );
-	}
-
-	return $filtered_image;
+	return $processor->get_updated_html();
 }
 add_filter( 'wp_content_img_tag', 'dominant_color_img_tag_add_dominant_color', 20, 3 );
 

--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -106,7 +106,7 @@ function dominant_color_img_tag_add_dominant_color( $filtered_image, string $con
 	}
 
 	// Only apply the dominant color to images that have a src attribute.
-	if ( null === $processor->get_attribute( 'src' ) || ! is_string( $processor->get_attribute( 'src' ) ) ) {
+	if ( ! is_string( $processor->get_attribute( 'src' ) ) ) {
 		return $filtered_image;
 	}
 

--- a/plugins/dominant-color-images/tests/test-dominant-color.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color.php
@@ -183,16 +183,12 @@ class Test_Dominant_Color extends TestCase {
 	 */
 	public function data_dominant_color_img_tag_add_dominant_color_requires_proper_quotes(): array {
 		return array(
-			'double quotes'         => array(
+			'double quotes' => array(
 				'image'    => '<img src="%s">',
 				'expected' => true,
 			),
-			'single quotes'         => array(
+			'single quotes' => array(
 				'image'    => "<img src='%s'>",
-				'expected' => true,
-			),
-			'escaped double quotes' => array(
-				'image'    => '<img src=\"%s\">',
 				'expected' => true,
 			),
 		);

--- a/plugins/dominant-color-images/tests/test-dominant-color.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color.php
@@ -189,11 +189,11 @@ class Test_Dominant_Color extends TestCase {
 			),
 			'single quotes'         => array(
 				'image'    => "<img src='%s'>",
-				'expected' => false,
+				'expected' => true,
 			),
 			'escaped double quotes' => array(
 				'image'    => '<img src=\"%s\">',
-				'expected' => false,
+				'expected' => true,
 			),
 		);
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1475

- Use more robust HTML Tag Processor for Image Placeholder.
