### PR TITLE
Introduce get_cursor_move_count() to use instead of get_seek_count() and get_next_token_count()

### DIFF
--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -189,18 +189,6 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	private $cursor_move_count = 0;
 
 	/**
-	 * Count for the number of times next_token() was called.
-	 *
-	 * The method that uses this is deprecated and it will be removed in a future release.
-	 *
-	 * @since 0.4.1
-	 * @var int
-	 * @see self::next_token()
-	 * @see self::get_next_token_count()
-	 */
-	private $next_token_count = 0;
-
-	/**
 	 * Finds the next tag.
 	 *
 	 * Unlike the base class, this subclass disallows querying. This is to ensure the breadcrumbs can be tracked.
@@ -271,7 +259,6 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 */
 	public function next_token(): bool {
 		$this->current_xpath = null; // Clear cache.
-		++$this->next_token_count; // TODO: Remove when the deprecated get_next_token_count() method is removed.
 		++$this->cursor_move_count;
 		if ( ! parent::next_token() ) {
 			$this->open_stack_tags    = array();
@@ -366,20 +353,6 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
-	 * Gets the number of times next_token() was called.
-	 *
-	 * @since 0.4.1
-	 * @see self::next_token()
-	 * @deprecated Use {@see self::get_cursor_move_count()} instead.
-	 *
-	 * @return int Count of next_token() calls.
-	 */
-	public function get_next_token_count(): int {
-		_deprecated_function( __METHOD__, 'Optimization Detective n.e.x.t', __CLASS__ . '::get_cursor_move_count()' );
-		return $this->next_token_count;
-	}
-
-	/**
 	 * Updates or creates a new attribute on the currently matched tag with the passed value.
 	 *
 	 * @inheritDoc
@@ -460,20 +433,6 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 			$this->open_stack_indices = $this->bookmarked_open_stacks[ $bookmark_name ]['indices'];
 		}
 		return $result;
-	}
-
-	/**
-	 * Gets the number of times seek() was called.
-	 *
-	 * @since 0.4.1
-	 * @see self::seek()
-	 * @deprecated Use {@see self::get_cursor_move_count()} instead.
-	 *
-	 * @return int Count of seek() calls.
-	 */
-	public function get_seek_count(): int {
-		_deprecated_function( __METHOD__, 'Optimization Detective n.e.x.t', __CLASS__ . '::get_cursor_move_count()' );
-		return $this->seek_count;
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -179,7 +179,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	private $buffered_text_replacements = array();
 
 	/**
-	 * Count for the number of times that the cursor was successfully moved.
+	 * Count for the number of times that the cursor was moved.
 	 *
 	 * @since n.e.x.t
 	 * @var int

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -458,7 +458,6 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 		if ( $result ) {
 			$this->open_stack_tags    = $this->bookmarked_open_stacks[ $bookmark_name ]['tags'];
 			$this->open_stack_indices = $this->bookmarked_open_stacks[ $bookmark_name ]['indices'];
-			++$this->cursor_move_count;
 		}
 		return $result;
 	}

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -378,7 +378,9 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Sets a meta attribute.
 	 *
-	 * All meta attributes are prefixed with 'data-od-'.
+	 * All meta attributes are prefixed with data-od-.
+	 *
+	 * @since 0.4.0
 	 *
 	 * @param string      $name  Meta attribute name.
 	 * @param string|true $value Value.
@@ -556,6 +558,8 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 
 	/**
 	 * Returns the string representation of the HTML Tag Processor.
+	 *
+	 * @since 0.4.0
 	 *
 	 * @return string The processed HTML.
 	 */

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -179,11 +179,24 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	private $buffered_text_replacements = array();
 
 	/**
-	 * Count for the number of times next_token() was called
+	 * Count for the number of times that the cursor was successfully moved.
+	 *
+	 * @since n.e.x.t
+	 * @var int
+	 * @see self::next_token()
+	 * @see self::seek()
+	 */
+	private $cursor_move_count = 0;
+
+	/**
+	 * Count for the number of times next_token() was called.
+	 *
+	 * The method that uses this is deprecated and it will be removed in a future release.
 	 *
 	 * @since 0.4.1
 	 * @var int
 	 * @see self::next_token()
+	 * @see self::get_next_token_count()
 	 */
 	private $next_token_count = 0;
 
@@ -258,7 +271,8 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 */
 	public function next_token(): bool {
 		$this->current_xpath = null; // Clear cache.
-		++$this->next_token_count;
+		++$this->next_token_count; // TODO: Remove when the deprecated get_next_token_count() method is removed.
+		++$this->cursor_move_count;
 		if ( ! parent::next_token() ) {
 			$this->open_stack_tags    = array();
 			$this->open_stack_indices = array();
@@ -339,14 +353,29 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	}
 
 	/**
+	 * Gets the number of times the cursor has moved.
+	 *
+	 * @since n.e.x.t
+	 * @see self::next_token()
+	 * @see self::seek()
+	 *
+	 * @return int Count of times the cursor has moved.
+	 */
+	public function get_cursor_move_count(): int {
+		return $this->cursor_move_count;
+	}
+
+	/**
 	 * Gets the number of times next_token() was called.
 	 *
 	 * @since 0.4.1
 	 * @see self::next_token()
+	 * @deprecated Use {@see self::get_cursor_move_count()} instead.
 	 *
 	 * @return int Count of next_token() calls.
 	 */
 	public function get_next_token_count(): int {
+		_deprecated_function( __METHOD__, 'Optimization Detective n.e.x.t', __CLASS__ . '::get_cursor_move_count()' );
 		return $this->next_token_count;
 	}
 
@@ -429,6 +458,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 		if ( $result ) {
 			$this->open_stack_tags    = $this->bookmarked_open_stacks[ $bookmark_name ]['tags'];
 			$this->open_stack_indices = $this->bookmarked_open_stacks[ $bookmark_name ]['indices'];
+			++$this->cursor_move_count;
 		}
 		return $result;
 	}
@@ -438,10 +468,12 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 0.4.1
 	 * @see self::seek()
+	 * @deprecated Use {@see self::get_cursor_move_count()} instead.
 	 *
 	 * @return int Count of seek() calls.
 	 */
 	public function get_seek_count(): int {
+		_deprecated_function( __METHOD__, 'Optimization Detective n.e.x.t', __CLASS__ . '::get_cursor_move_count()' );
 		return $this->seek_count;
 	}
 

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -219,13 +219,12 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 		$processor->set_bookmark( $current_tag_bookmark ); // TODO: Should we break if this returns false?
 
 		foreach ( $visitors as $visitor ) {
-			$seek_count       = $processor->get_seek_count();
-			$next_token_count = $processor->get_next_token_count();
-			$did_visit        = $visitor( $tag_visitor_context ) || $did_visit;
+			$cursor_move_count = $processor->get_cursor_move_count();
+			$did_visit         = $visitor( $tag_visitor_context ) || $did_visit;
 
 			// If the visitor traversed HTML tags, we need to go back to this tag so that in the next iteration any
 			// relevant tag visitors may apply, in addition to properly setting the data-od-xpath on this tag below.
-			if ( $seek_count !== $processor->get_seek_count() || $next_token_count !== $processor->get_next_token_count() ) {
+			if ( $cursor_move_count !== $processor->get_cursor_move_count() ) {
 				$processor->seek( $current_tag_bookmark ); // TODO: Should this break out of the optimization loop if it returns false?
 			}
 		}

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -492,7 +492,8 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	 */
 	public function test_bookmarking_and_seeking(): void {
 		$processor = new OD_HTML_Tag_Processor(
-			'
+			trim(
+				'
 				<html>
 					<head></head>
 					<body>
@@ -507,14 +508,19 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 						<img src="https://example.com/foo.jpg">
 					</body>
 				</html>
-			'
+				'
+			)
 		);
 
 		$actual_figure_contents = array();
-		$this->assertSame( 0, $processor->get_seek_count() );
+		$last_cursor_move_count = $processor->get_cursor_move_count();
+		$this->assertSame( 0, $last_cursor_move_count );
 
 		$bookmarks = array();
 		while ( $processor->next_open_tag() ) {
+			$this_cursor_move_count = $processor->get_cursor_move_count();
+			$this->assertGreaterThan( $last_cursor_move_count, $this_cursor_move_count );
+			$last_cursor_move_count = $this_cursor_move_count;
 			if (
 				'FIGURE' === $processor->get_tag()
 				&&
@@ -573,7 +579,6 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 				'depth' => $processor->get_current_depth(),
 			);
 		}
-		$this->assertSame( count( $bookmarks ), $processor->get_seek_count() );
 
 		$this->assertSame( $expected_figure_contents, $sought_actual_contents );
 
@@ -597,11 +602,11 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test get_seek_count.
+	 * Test get_cursor_move_count().
 	 *
-	 * @covers ::get_seek_count
+	 * @covers ::get_cursor_move_count
 	 */
-	public function test_get_next_token_count(): void {
+	public function test_get_cursor_move_count(): void {
 		$processor = new OD_HTML_Tag_Processor(
 			trim(
 				'
@@ -612,20 +617,38 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 				'
 			)
 		);
-		$this->assertSame( 0, $processor->get_next_token_count() );
+		$this->assertSame( 0, $processor->get_cursor_move_count() );
 		$this->assertTrue( $processor->next_tag() );
 		$this->assertSame( 'HTML', $processor->get_tag() );
-		$this->assertSame( 1, $processor->get_next_token_count() );
+		$this->assertTrue( $processor->set_bookmark( 'document_root' ) );
+		$this->assertSame( 1, $processor->get_cursor_move_count() );
 		$this->assertTrue( $processor->next_tag() );
 		$this->assertSame( 'HEAD', $processor->get_tag() );
-		$this->assertSame( 3, $processor->get_next_token_count() ); // Note that next_token() call #2 was for the whitespace between <html> and <head>.
+		$this->assertSame( 3, $processor->get_cursor_move_count() ); // Note that next_token() call #2 was for the whitespace between <html> and <head>.
 		$this->assertTrue( $processor->next_tag() );
 		$this->assertSame( 'HEAD', $processor->get_tag() );
 		$this->assertTrue( $processor->is_tag_closer() );
-		$this->assertSame( 4, $processor->get_next_token_count() );
+		$this->assertSame( 4, $processor->get_cursor_move_count() );
 		$this->assertTrue( $processor->next_tag() );
 		$this->assertSame( 'BODY', $processor->get_tag() );
-		$this->assertSame( 6, $processor->get_next_token_count() ); // Note that next_token() call #5 was for the whitespace between </head> and <body>.
+		$this->assertSame( 6, $processor->get_cursor_move_count() ); // Note that next_token() call #5 was for the whitespace between </head> and <body>.
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'BODY', $processor->get_tag() );
+		$this->assertTrue( $processor->is_tag_closer() );
+		$this->assertSame( 7, $processor->get_cursor_move_count() );
+		$this->assertTrue( $processor->next_tag() );
+		$this->assertSame( 'HTML', $processor->get_tag() );
+		$this->assertTrue( $processor->is_tag_closer() );
+		$this->assertSame( 9, $processor->get_cursor_move_count() ); // Note that next_token() call #8 was for the whitespace between </body> and <html>.
+		$this->assertFalse( $processor->next_tag() );
+		$this->assertSame( 10, $processor->get_cursor_move_count() );
+		$this->assertFalse( $processor->next_tag() );
+		$this->assertSame( 11, $processor->get_cursor_move_count() );
+		$this->assertTrue( $processor->seek( 'document_root' ) );
+		$this->assertSame( 13, $processor->get_cursor_move_count() ); // Incremented by two because seek() was called in addition to next_token().
+		$this->setExpectedIncorrectUsage( 'WP_HTML_Tag_Processor::seek' );
+		$this->assertFalse( $processor->seek( 'does_not_exist' ) );
+		$this->assertSame( 13, $processor->get_cursor_move_count() ); // The bookmark does not exist so no change.
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -645,10 +645,10 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 		$this->assertFalse( $processor->next_tag() );
 		$this->assertSame( 11, $processor->get_cursor_move_count() );
 		$this->assertTrue( $processor->seek( 'document_root' ) );
-		$this->assertSame( 13, $processor->get_cursor_move_count() ); // Incremented by two because seek() was called in addition to next_token().
+		$this->assertSame( 12, $processor->get_cursor_move_count() );
 		$this->setExpectedIncorrectUsage( 'WP_HTML_Tag_Processor::seek' );
 		$this->assertFalse( $processor->seek( 'does_not_exist' ) );
-		$this->assertSame( 13, $processor->get_cursor_move_count() ); // The bookmark does not exist so no change.
+		$this->assertSame( 12, $processor->get_cursor_move_count() ); // The bookmark does not exist so no change.
 	}
 
 	/**


### PR DESCRIPTION
When explaining Optimization Detective's iteration over the tags in the document in https://github.com/WordPress/performance/pull/1476#discussion_r1720077867, I realized that the naming of the `OD_HTML_Tag_Processor::get_next_token_count()` method is poor. It's supposed to count the number of times that `next_token()` was called, but it looks like it gives you a count of the remaining tokens in the document. Also, in addition to this method there is `get_seek_count()` which returns the underlying protected `$seek_count` variable. We don't really need these two methods and can instead have a single `get_cursor_move_count()` that keeps track of the number of times that `next_token()` was called (which is what is called both by `seek()` and `next_tag()`). 