### PR TITLE
Clarify docs around a tag visitor's boolean return value

### DIFF
--- a/plugins/auto-sizes/optimization-detective.php
+++ b/plugins/auto-sizes/optimization-detective.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.1.0
  *
  * @param OD_Tag_Visitor_Context $context Tag visitor context.
- * @return false Whether the tag should be recorded in URL metrics.
+ * @return false Whether the tag should be tracked in URL metrics.
  */
 function auto_sizes_visit_tag( OD_Tag_Visitor_Context $context ): bool {
 	if ( 'IMG' !== $context->processor->get_tag() ) {

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -32,7 +32,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	 * @since 0.2.0
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
-	 * @return bool Whether the visit or visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	public function __invoke( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;

--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -23,7 +23,7 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 	 * Visits a tag.
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
-	 * @return bool Whether the visitor visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	public function __invoke( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -24,7 +24,7 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
 	 *
-	 * @return bool Whether the visitor visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	public function __invoke( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;

--- a/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
@@ -23,7 +23,7 @@ abstract class Image_Prioritizer_Tag_Visitor {
 	 * Visits a tag.
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
-	 * @return bool Whether the visitor visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	abstract public function __invoke( OD_Tag_Visitor_Context $context ): bool;
 

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -215,12 +215,12 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	$current_tag_bookmark = 'optimization_detective_current_tag';
 	$visitors             = iterator_to_array( $tag_visitor_registry );
 	do {
-		$did_visit = false;
+		$tracked_in_url_metrics = false;
 		$processor->set_bookmark( $current_tag_bookmark ); // TODO: Should we break if this returns false?
 
 		foreach ( $visitors as $visitor ) {
-			$cursor_move_count = $processor->get_cursor_move_count();
-			$did_visit         = $visitor( $tag_visitor_context ) || $did_visit;
+			$cursor_move_count      = $processor->get_cursor_move_count();
+			$tracked_in_url_metrics = $visitor( $tag_visitor_context ) || $tracked_in_url_metrics;
 
 			// If the visitor traversed HTML tags, we need to go back to this tag so that in the next iteration any
 			// relevant tag visitors may apply, in addition to properly setting the data-od-xpath on this tag below.
@@ -230,7 +230,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 		}
 		$processor->release_bookmark( $current_tag_bookmark );
 
-		if ( $did_visit && $needs_detection ) {
+		if ( $tracked_in_url_metrics && $needs_detection ) {
 			$processor->set_meta_attribute( 'xpath', $processor->get_xpath() );
 		}
 	} while ( $processor->next_open_tag() );


### PR DESCRIPTION
> [!IMPORTANT]
> This is a follow-up PR to #1478. Merge that PR into `trunk` before merging this PR, since it is branched off of that PR's branch.

Fixes #1342

The terminology around a tag visitor "visiting" a tag is fuzzy. It's not clear what it means for a tag to be "visited". In reality, what this means is that the tag is tracked/recorded in URL metrics so that it appears among its `elements`, including the `intersectionRect` and `clientBoundingRect` among other aspects captured by `detect.js`. If a tag visitor does not need any of that information, then it can just always return `false`, even though it may have "visited" a tag by applying some optimization to it. For example. Enhanced Responsive Images (`auto-sizes`) has a tag visitor doesn't need that information to apply its optimizations as it just adds `auto` to the `sizes` attribute if it is lazy-loaded and doesn't have `auto` already. This is a case where the tag visitor always returns `false`.

As explained in #1342, instead of returning a boolean value for whether to track the tag in URL metrics, it could be more sophisticated by detecting whether the tag visitor tried to access information about that tag from the stored URL metrics. Or instead of returning a boolean there could be a method on the context object like `$context->track_in_url_metrics()` which would do the same. I could go either way. But these changes in the PR are a good iterative improvement at least and we can add such a method later.