### PR TITLE
Prepare 3.4.0 release

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -5,7 +5,7 @@
  * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.1.0' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.2.0' );
 
 require_once __DIR__ . '/hooks.php';
 

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -92,7 +92,7 @@ add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
  *
  * Per the HTML spec, if present it must be the first entry.
  *
- * @since n.e.x.t
+ * @since 1.2.0
  *
  * @param string $sizes_attr The 'sizes' attribute value.
  * @return bool True if the 'auto' keyword is present, false otherwise.

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   1.1.0
+Stable tag:   1.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, auto-sizes
@@ -51,6 +51,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.2.0 =
 
 = 1.1.0 =
 

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -54,6 +54,15 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.2.0 =
 
+**Enhancements**
+
+* Harden logic to add `auto` keyword to `sizes` attribute to prevent duplicate keyword. ([1445](https://github.com/WordPress/performance/pull/1445))
+* Use more robust HTML Tag Processor for auto sizes injection. ([1471](https://github.com/WordPress/performance/pull/1471))
+
+**Bug Fixes**
+
+* Remove sizes attribute when the responsive image disabled. ([1399](https://github.com/WordPress/performance/pull/1399))
+
 = 1.1.0 =
 
 **Features**

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -61,7 +61,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 **Bug Fixes**
 
-* Remove sizes attribute when the responsive image disabled. ([1399](https://github.com/WordPress/performance/pull/1399))
+* Remove sizes attribute when responsive images are disabled. ([1399](https://github.com/WordPress/performance/pull/1399))
 
 = 1.1.0 =
 

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.1.2
+ * Version: 0.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.1.2',
+	'0.2.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.2.0
+ * Version: 0.1.3
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.2.0',
+	'0.1.3',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.1.2
+Stable tag:   0.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -61,6 +61,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.2.0 =
 
 = 0.1.2 =
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.2.0
+Stable tag:   0.1.3
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -62,7 +62,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
-= 0.2.0 =
+= 0.1.3 =
 
 **Bug Fixes**
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -64,6 +64,10 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.2.0 =
 
+**Bug Fixes**
+
+* Fix handling of image prioritization when only some viewport groups are populated. ([1404](https://github.com/WordPress/performance/pull/1404))
+
 = 0.1.2 =
 
 * Update PHP logic to account for changes in Optimization Detective API. ([1302](https://github.com/WordPress/performance/pull/1302))

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.4.1
+ * Version: 0.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.4.1',
+	'0.5.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -136,6 +136,17 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.5.0 =
 
+**Enhancements**
+
+* Bump web-vitals from 4.2.1 to 4.2.2. ([1386](https://github.com/WordPress/performance/pull/1386))
+
+**Bug Fixes**
+
+* Disable Optimization Detective by default on the embed template. ([1472](https://github.com/WordPress/performance/pull/1472))
+* Ensure only HTML documents are processed by Optimization Detective. ([1442](https://github.com/WordPress/performance/pull/1442))
+* Ensure the entire template is passed to the output buffer callback for Optimization Detective to process. ([1317](https://github.com/WordPress/performance/pull/1317))
+* Implement full support for intersectionRect/boundingClientRect, fix viewportRect typing, and harden JSON schema. ([1411](https://github.com/WordPress/performance/pull/1411))
+
 = 0.4.1 =
 
 **Enhancements**

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.4.1
+Stable tag:   0.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -133,6 +133,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.5.0 =
 
 = 0.4.1 =
 

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
@@ -136,7 +136,7 @@ add_filter( 'site_status_autoloaded_options_limit_description', 'perflab_aao_ext
  * This filter modifies the 'option_perflab_aao_disabled_options' to ensure
  * that autoloaded options are not included in the disabled options list.
  *
- * @since n.e.x.t
+ * @since 3.4.0
  *
  * @param string[]|mixed $disabled_options Array of disabled options.
  * @return string[] Filtered array of disabled options excluding autoloaded options.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 3.3.1
+ * Version: 3.4.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.3.1' );
+define( 'PERFLAB_VERSION', '3.4.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.3.1
+Stable tag:   3.4.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -69,6 +69,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.4.0 =
 
 = 3.3.1 =
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -72,6 +72,16 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.4.0 =
 
+**Enhancements**
+
+* Remove Server-Timing metric for the autoloaded options query time. ([1456](https://github.com/WordPress/performance/pull/1456))
+
+**Bug Fixes**
+
+* Avoid sending Server-Timing header when buffer is being cleaned. ([1443](https://github.com/WordPress/performance/pull/1443))
+* Fix disabled options from reappearing in Site Health after external update. ([1374](https://github.com/WordPress/performance/pull/1374))
+* Improve Performance screen when external requests to WordPress.org fail. ([1474](https://github.com/WordPress/performance/pull/1474))
+
 = 3.3.1 =
 
 **Enhancements**

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -767,7 +767,7 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
 /**
  * Initializes custom functionality for handling image uploads and content filters.
  *
- * @since n.e.x.t
+ * @since 2.1.0
  */
 function webp_uploads_init(): void {
 	if ( webp_uploads_is_picture_element_enabled() ) {

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 2.0.2
+ * Version: 2.1.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.0.2' );
+define( 'WEBP_UPLOADS_VERSION', '2.1.0' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -62,7 +62,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	 * The original image will be used as the fallback image for browsers that don't support the picture element.
 	 *
 	 * @since 2.0.0
-	 * @since n.e.x.t The default value was updated, removing 'image/jpeg'.
+	 * @since 2.1.0 The default value was updated, removing 'image/jpeg'.
 	 *
 	 * @param string[] $mime_types    Mime types than can be used.
 	 * @param int      $attachment_id The id of the image being evaluated.

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -62,6 +62,22 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.1.0 =
 
+**Enhancements**
+
+* Improve disabling checkbox for Picture Element on Media settings screen. ([1470](https://github.com/WordPress/performance/pull/1470))
+
+**Bug Fixes**
+
+* Add missing full size image in PICTURE > SOURCE srcset. ([1437](https://github.com/WordPress/performance/pull/1437))
+* Correct the fallback image in PICTURE element. ([1408](https://github.com/WordPress/performance/pull/1408))
+* Don't wrap PICTURE element if JPEG fallback is not available. ([1450](https://github.com/WordPress/performance/pull/1450))
+* Fix setting sizes attribute on PICTURE > SOURCE elements. ([1354](https://github.com/WordPress/performance/pull/1354))
+* Remove string type hint from webp_uploads_sanitize_image_format() to prevent possible fatal error. ([1410](https://github.com/WordPress/performance/pull/1410))
+
+**Documentation**
+
+* Explain how to regenerate images in the Modern Image Formats readme. ([1348](https://github.com/WordPress/performance/pull/1348))
+
 = 2.0.2 =
 
 **Enhancements**

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   2.0.2
+Stable tag:   2.1.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -59,6 +59,8 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.1.0 =
 
 = 2.0.2 =
 


### PR DESCRIPTION
Previously https://github.com/WordPress/performance/pull/1345

- [x] Bump plugin versions
- [x] Run npm run since
- [x] Update readme changelogs

Fixes #1440

The following plugins are in scope for this release:

1. `auto-sizes`
1. `image-prioritizer`
1. `optimization-detective`
1. `performance-lab`
1. `webp-uploads`

# Pending Release Changes

## `auto-sizes`

> [!IMPORTANT]
> Stable tag change: 1.1.0 → **1.2.0**

`svn status`:
```
M       hooks.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: hooks.php
===================================================================
--- hooks.php	(revision 3137704)
+++ hooks.php	(working copy)
@@ -34,7 +34,7 @@
 	}
 
 	// Don't add 'auto' to the sizes attribute if it already exists.
-	if ( str_contains( $attr['sizes'], 'auto,' ) ) {
+	if ( auto_sizes_attribute_includes_valid_auto( $attr['sizes'] ) ) {
 		return $attr;
 	}
 
@@ -57,28 +57,52 @@
 		$html = '';
 	}
 
+	$processor = new WP_HTML_Tag_Processor( $html );
+
+	// Bail if there is no IMG tag.
+	if ( ! $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
+		return $html;
+	}
+
 	// Bail early if the image is not lazy-loaded.
-	if ( false === strpos( $html, 'loading="lazy"' ) ) {
+	$value = $processor->get_attribute( 'loading' );
+	if ( ! is_string( $value ) || 'lazy' !== strtolower( trim( $value, " \t\f\r\n" ) ) ) {
 		return $html;
 	}
 
+	$sizes = $processor->get_attribute( 'sizes' );
+
 	// Bail early if the image is not responsive.
-	if ( false === strpos( $html, 'sizes="' ) ) {
+	if ( ! is_string( $sizes ) ) {
 		return $html;
 	}
 
-	// Don't double process content images.
-	if ( false !== strpos( $html, 'sizes="auto,' ) ) {
+	// Don't add 'auto' to the sizes attribute if it already exists.
+	if ( auto_sizes_attribute_includes_valid_auto( $sizes ) ) {
 		return $html;
 	}
 
-	$html = str_replace( 'sizes="', 'sizes="auto, ', $html );
-
-	return $html;
+	$processor->set_attribute( 'sizes', "auto, $sizes" );
+	return $processor->get_updated_html();
 }
 add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
 
 /**
+ * Checks whether the given 'sizes' attribute includes the 'auto' keyword as the first item in the list.
+ *
+ * Per the HTML spec, if present it must be the first entry.
+ *
+ * @since 1.2.0
+ *
+ * @param string $sizes_attr The 'sizes' attribute value.
+ * @return bool True if the 'auto' keyword is present, false otherwise.
+ */
+function auto_sizes_attribute_includes_valid_auto( string $sizes_attr ): bool {
+	$token = strtok( strtolower( $sizes_attr ), ',' );
+	return false !== $token && 'auto' === trim( $token, " \t\f\r\n" );
+}
+
+/**
  * Displays the HTML generator tag for the plugin.
  *
  * See {@see 'wp_head'}.
@@ -115,8 +139,8 @@
  *
  * @since 1.1.0
  *
- * @param string               $content      The block content about to be rendered.
- * @param array<string, mixed> $parsed_block The parsed block.
+ * @param string                                                   $content      The block content about to be rendered.
+ * @param array{ attrs?: array{ align?: string, width?: string } } $parsed_block The parsed block.
  * @return string The updated block content.
  */
 function auto_sizes_filter_image_tag( string $content, array $parsed_block ): string {
@@ -126,15 +150,13 @@
 	// Only update the markup if an image is found.
 	if ( $has_image ) {
 		$processor->set_attribute( 'data-needs-sizes-update', true );
-		$align = $parsed_block['attrs']['align'] ?? '';
-		if ( $align ) {
-			$processor->set_attribute( 'data-align', $align );
+		if ( isset( $parsed_block['attrs']['align'] ) ) {
+			$processor->set_attribute( 'data-align', $parsed_block['attrs']['align'] );
 		}
 
 		// Resize image width.
-		$resize_image_width = $parsed_block['attrs']['width'] ?? '';
-		if ( $resize_image_width ) {
-			$processor->set_attribute( 'data-resize-width', $resize_image_width );
+		if ( isset( $parsed_block['attrs']['width'] ) ) {
+			$processor->set_attribute( 'data-resize-width', $parsed_block['attrs']['width'] );
 		}
 
 		$content = $processor->get_updated_html();
@@ -158,6 +180,18 @@
 		return $content;
 	}
 
+	$remove_data_attributes = static function () use ( $processor ): void {
+		$processor->remove_attribute( 'data-needs-sizes-update' );
+		$processor->remove_attribute( 'data-align' );
+		$processor->remove_attribute( 'data-resize-width' );
+	};
+
+	// Bail early if the responsive images are disabled.
+	if ( null === $processor->get_attribute( 'sizes' ) ) {
+		$remove_data_attributes();
+		return $processor->get_updated_html();
+	}
+
 	// Skips second time parsing if already processed.
 	if ( null === $processor->get_attribute( 'data-needs-sizes-update' ) ) {
 		return $content;
@@ -167,7 +201,7 @@
 
 	// Retrieve width from the image tag itself.
 	$image_width = $processor->get_attribute( 'width' );
-	if ( ! $image_width && ! in_array( $align, array( 'full', 'wide' ), true ) ) {
+	if ( ! is_string( $image_width ) && ! in_array( $align, array( 'full', 'wide' ), true ) ) {
 		return $content;
 	}
 
@@ -204,13 +238,11 @@
 			break;
 	}
 
-	if ( $sizes ) {
+	if ( is_string( $sizes ) ) {
 		$processor->set_attribute( 'sizes', $sizes );
 	}
 
-	$processor->remove_attribute( 'data-needs-sizes-update' );
-	$processor->remove_attribute( 'data-align' );
-	$processor->remove_attribute( 'data-resize-width' );
+	$remove_data_attributes();
 
 	return $processor->get_updated_html();
 }
Index: readme.txt
===================================================================
--- readme.txt	(revision 3137704)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   1.1.0
+Stable tag:   1.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, auto-sizes
@@ -52,6 +52,17 @@
 
 == Changelog ==
 
+= 1.2.0 =
+
+**Enhancements**
+
+* Harden logic to add `auto` keyword to `sizes` attribute to prevent duplicate keyword. ([1445](https://github.com/WordPress/performance/pull/1445))
+* Use more robust HTML Tag Processor for auto sizes injection. ([1471](https://github.com/WordPress/performance/pull/1471))
+
+**Bug Fixes**
+
+* Remove sizes attribute when responsive images are disabled. ([1399](https://github.com/WordPress/performance/pull/1399))
+
 = 1.1.0 =
 
 **Features**
```
</details>

## `dominant-color-images`

> [!WARNING]
> Stable tag is unchanged at 1.1.1, so no plugin release will occur.

`svn status`:
```
M       class-dominant-color-image-editor-gd.php
M       class-dominant-color-image-editor-imagick.php
M       helper.php
M       hooks.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-dominant-color-image-editor-gd.php
===================================================================
--- class-dominant-color-image-editor-gd.php	(revision 3137704)
+++ class-dominant-color-image-editor-gd.php	(working copy)
@@ -27,16 +27,20 @@
 	 */
 	public function get_dominant_color() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_dominant_color_error_no_image', __( 'Dominant color detection no image found.', 'dominant-color-images' ) );
 		}
 		// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 		$shorted_image = imagecreatetruecolor( 1, 1 );
-		$image_width   = imagesx( $this->image );
-		$image_height  = imagesy( $this->image );
-		if ( false === $shorted_image || false === $image_width || false === $image_height ) {
+		if ( false === $shorted_image ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
+		// Note: These two functions only return integers, but they used to return int|false in PHP<8. This was changed in the PHP documentation in
+		// <https://github.com/php/doc-en/commit/0462f49> and <https://github.com/php/doc-en/commit/37f858a>. However, PhpStorm's stubs still think
+		// they return int|false. However, from looking at <https://github.com/php/php-src/blob/5db847e/ext/gd/gd.stub.php#L716-L718> these functions
+		// apparently only ever returned integers. So the type casting is here for the possible sake PHP<8.
+		$image_width  = (int) imagesx( $this->image ); // @phpstan-ignore cast.useless
+		$image_height = (int) imagesy( $this->image ); // @phpstan-ignore cast.useless
 		imagecopyresampled( $shorted_image, $this->image, 0, 0, 0, 0, 1, 1, $image_width, $image_height );
 
 		$rgb = imagecolorat( $shorted_image, 0, 0 );
@@ -47,7 +51,7 @@
 		$g   = ( $rgb >> 8 ) & 0xFF;
 		$b   = $rgb & 0xFF;
 		$hex = dominant_color_rgb_to_hex( $r, $g, $b );
-		if ( ! $hex ) {
+		if ( null === $hex ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
 
@@ -64,7 +68,7 @@
 	 */
 	public function has_transparency() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_has_transparency_error_no_image', __( 'Transparency detection no image found.', 'dominant-color-images' ) );
 		}
 
@@ -77,7 +81,12 @@
 				if ( false === $rgb ) {
 					return new WP_Error( 'unable_to_obtain_rgb_via_imagecolorat' );
 				}
-				$rgba = imagecolorsforindex( $this->image, $rgb );
+				try {
+					// Note: In PHP<8, this returns false if the color is out of range. In PHP8, this throws a ValueError instead.
+					$rgba = imagecolorsforindex( $this->image, $rgb );
+				} catch ( ValueError $error ) {
+					$rgba = false;
+				}
 				if ( ! is_array( $rgba ) ) {
 					return new WP_Error( 'unable_to_obtain_rgba_via_imagecolorsforindex' );
 				}
Index: class-dominant-color-image-editor-imagick.php
===================================================================
--- class-dominant-color-image-editor-imagick.php	(revision 3137704)
+++ class-dominant-color-image-editor-imagick.php	(working copy)
@@ -27,18 +27,17 @@
 	 */
 	public function get_dominant_color() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_dominant_color_error_no_image', __( 'Dominant color detection no image found.', 'dominant-color-images' ) );
 		}
 
 		try {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 			$this->image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
 			$pixel = $this->image->getImagePixelColor( 0, 0 );
 			$color = $pixel->getColor();
 			$hex   = dominant_color_rgb_to_hex( $color['r'], $color['g'], $color['b'] );
-			if ( ! $hex ) {
+			if ( null === $hex ) {
 				return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 			}
 
@@ -59,7 +58,7 @@
 	 */
 	public function has_transparency() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_has_transparency_error_no_image', __( 'Transparency detection no image found.', 'dominant-color-images' ) );
 		}
 
Index: helper.php
===================================================================
--- helper.php	(revision 3137704)
+++ helper.php	(working copy)
@@ -54,10 +54,10 @@
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'dominant-color-images' ) );
 	}
 	$file = dominant_color_get_attachment_file_path( $attachment_id );
-	if ( ! $file ) {
+	if ( false === $file ) {
 		$file = get_attached_file( $attachment_id );
 	}
-	if ( ! $file ) {
+	if ( false === $file ) {
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'dominant-color-images' ) );
 	}
 	add_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
@@ -91,6 +91,8 @@
 	if ( is_wp_error( $has_transparency ) ) {
 		return $has_transparency;
 	}
+	$dominant_color_data = array();
+
 	$dominant_color_data['has_transparency'] = $has_transparency;
 
 	$dominant_color = $editor->get_dominant_color();
@@ -122,7 +124,7 @@
 	}
 
 	$file = get_attached_file( $attachment_id );
-	if ( ! $file ) {
+	if ( false === $file ) {
 		return false;
 	}
 
Index: hooks.php
===================================================================
--- hooks.php	(revision 3137704)
+++ hooks.php	(working copy)
@@ -153,11 +153,11 @@
 		$extra_class  = $image_meta['has_transparency'] ? 'has-transparency' : 'not-transparent';
 	}
 
-	if ( $data ) {
+	if ( '' !== $data ) {
 		$filtered_image = str_replace( '<img ', '<img ' . $data, $filtered_image );
 	}
 
-	if ( $extra_class ) {
+	if ( '' !== $extra_class ) {
 		$filtered_image = str_replace( ' class="', ' class="' . $extra_class . ' ', $filtered_image );
 	}
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3137704)
+++ readme.txt	(working copy)
@@ -1,13 +1,11 @@
 === Image Placeholders ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
-Requires PHP:      7.2
-Stable tag:        1.1.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, dominant color
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.1.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, images, dominant color
 
 Displays placeholders based on an image's dominant color while the image is loading.
 
```
</details>

## `embed-optimizer`

> [!WARNING]
> Stable tag is unchanged at 0.2.0, so no plugin release will occur.

`svn status`:
```
M       class-embed-optimizer-tag-visitor.php
M       hooks.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-embed-optimizer-tag-visitor.php
===================================================================
--- class-embed-optimizer-tag-visitor.php	(revision 3137704)
+++ class-embed-optimizer-tag-visitor.php	(working copy)
@@ -39,7 +39,7 @@
 		if ( ! (
 			'FIGURE' === $processor->get_tag()
 			&&
-			$processor->has_class( 'wp-block-embed' )
+			true === $processor->has_class( 'wp-block-embed' )
 		) ) {
 			return false;
 		}
@@ -60,44 +60,47 @@
 			 * for GET requests, as POST requests are not likely to be part of the critical rendering path.
 			 */
 			$preconnect_hrefs = array();
-			if ( $processor->has_class( 'wp-block-embed-youtube' ) ) {
+			$has_class        = static function ( string $wanted_class ) use ( $processor ): bool {
+				return true === $processor->has_class( $wanted_class );
+			};
+			if ( $has_class( 'wp-block-embed-youtube' ) ) {
 				$preconnect_hrefs[] = 'https://www.youtube.com';
 				$preconnect_hrefs[] = 'https://i.ytimg.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-twitter' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-twitter' ) ) {
 				$preconnect_hrefs[] = 'https://syndication.twitter.com';
 				$preconnect_hrefs[] = 'https://pbs.twimg.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-vimeo' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-vimeo' ) ) {
 				$preconnect_hrefs[] = 'https://player.vimeo.com';
 				$preconnect_hrefs[] = 'https://f.vimeocdn.com';
 				$preconnect_hrefs[] = 'https://i.vimeocdn.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-spotify' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-spotify' ) ) {
 				$preconnect_hrefs[] = 'https://apresolve.spotify.com';
 				$preconnect_hrefs[] = 'https://embed-cdn.spotifycdn.com';
 				$preconnect_hrefs[] = 'https://encore.scdn.co';
 				$preconnect_hrefs[] = 'https://i.scdn.co';
-			} elseif ( $processor->has_class( 'wp-block-embed-videopress' ) || $processor->has_class( 'wp-block-embed-wordpress-tv' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-videopress' ) || $has_class( 'wp-block-embed-wordpress-tv' ) ) {
 				$preconnect_hrefs[] = 'https://video.wordpress.com';
 				$preconnect_hrefs[] = 'https://public-api.wordpress.com';
 				$preconnect_hrefs[] = 'https://videos.files.wordpress.com';
 				$preconnect_hrefs[] = 'https://v0.wordpress.com'; // This does not appear to be a load-balanced domain since v1.wordpress.com is not valid.
-			} elseif ( $processor->has_class( 'wp-block-embed-instagram' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-instagram' ) ) {
 				$preconnect_hrefs[] = 'https://www.instagram.com';
 				$preconnect_hrefs[] = 'https://static.cdninstagram.com';
 				$preconnect_hrefs[] = 'https://scontent.cdninstagram.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-tiktok' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-tiktok' ) ) {
 				$preconnect_hrefs[] = 'https://www.tiktok.com';
 				// Note: The other domains used for TikTok embeds include https://lf16-tiktok-web.tiktokcdn-us.com,
 				// https://lf16-cdn-tos.tiktokcdn-us.com, and https://lf16-tiktok-common.tiktokcdn-us.com among others
 				// which either appear to be geo-targeted ('-us') _or_ load-balanced ('lf16'). So these are not added
 				// to the preconnected hosts.
-			} elseif ( $processor->has_class( 'wp-block-embed-amazon' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-amazon' ) ) {
 				$preconnect_hrefs[] = 'https://read.amazon.com';
 				$preconnect_hrefs[] = 'https://m.media-amazon.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-soundcloud' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-soundcloud' ) ) {
 				$preconnect_hrefs[] = 'https://w.soundcloud.com';
 				$preconnect_hrefs[] = 'https://widget.sndcdn.com';
 				// Note: There is also https://i1.sndcdn.com which is for the album art, but the '1' indicates it may be geotargeted/load-balanced.
-			} elseif ( $processor->has_class( 'wp-block-embed-pinterest' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-pinterest' ) ) {
 				$preconnect_hrefs[] = 'https://assets.pinterest.com';
 				$preconnect_hrefs[] = 'https://widgets.pinterest.com';
 				$preconnect_hrefs[] = 'https://i.pinimg.com';
Index: hooks.php
===================================================================
--- hooks.php	(revision 3137704)
+++ hooks.php	(working copy)
@@ -120,7 +120,8 @@
 
 			if ( 'IFRAME' === $html_processor->get_tag() ) {
 				$loading_value = $html_processor->get_attribute( 'loading' );
-				if ( empty( $loading_value ) ) {
+				// Per the HTML spec: "The attribute's missing value default and invalid value default are both the Eager state".
+				if ( 'lazy' !== $loading_value ) {
 					++$iframe_count;
 					if ( ! $html_processor->set_bookmark( $bookmark_names['iframe'] ) ) {
 						throw new Exception(
@@ -130,7 +131,7 @@
 					}
 				}
 			} elseif ( 'SCRIPT' === $html_processor->get_tag() ) {
-				if ( ! $html_processor->get_attribute( 'src' ) ) {
+				if ( null === $html_processor->get_attribute( 'src' ) ) {
 					$has_inline_script = true;
 				} else {
 					++$script_count;
@@ -147,7 +148,7 @@
 		if ( 1 === $script_count && ! $has_inline_script && $html_processor->has_bookmark( $bookmark_names['script'] ) ) {
 			$needs_lazy_script = true;
 			if ( $html_processor->seek( $bookmark_names['script'] ) ) {
-				if ( $html_processor->get_attribute( 'type' ) ) {
+				if ( is_string( $html_processor->get_attribute( 'type' ) ) ) {
 					$html_processor->set_attribute( 'data-original-type', $html_processor->get_attribute( 'type' ) );
 				}
 				$html_processor->set_attribute( 'type', 'application/vnd.embed-optimizer.javascript' );
@@ -166,7 +167,7 @@
 				// For post embeds, use visibility:hidden instead of clip since browsers will consistently load the
 				// lazy-loaded iframe (where Chromium is unreliably with clip) while at the same time improve accessibility
 				// by preventing links in the hidden iframe from receiving focus.
-				if ( $html_processor->has_class( 'wp-embedded-content' ) ) {
+				if ( true === $html_processor->has_class( 'wp-embedded-content' ) ) {
 					$style = $html_processor->get_attribute( 'style' );
 					if ( is_string( $style ) ) {
 						// WordPress core injects this clip CSS property:
```
</details>

## `image-prioritizer`

> [!IMPORTANT]
> Stable tag change: 0.1.2 → **0.1.3**

`svn status`:
```
M       class-image-prioritizer-background-image-styled-tag-visitor.php
M       class-image-prioritizer-img-tag-visitor.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-image-prioritizer-background-image-styled-tag-visitor.php
===================================================================
--- class-image-prioritizer-background-image-styled-tag-visitor.php	(revision 3137704)
+++ class-image-prioritizer-background-image-styled-tag-visitor.php	(working copy)
@@ -43,8 +43,6 @@
 			&&
 			1 === preg_match( '/background(?:-image)?\s*:[^;]*?url\(\s*[\'"]?\s*(?<background_image>.+?)\s*[\'"]?\s*\)/', $style, $matches )
 			&&
-			'' !== $matches['background_image'] // PHPStan should ideally know that this is a non-empty string based on the `.+?` regular expression. See <https://github.com/phpstan/phpstan/issues/11222>.
-			&&
 			! $this->is_data_url( $matches['background_image'] )
 		) {
 			$background_image_url = $matches['background_image'];
Index: class-image-prioritizer-img-tag-visitor.php
===================================================================
--- class-image-prioritizer-img-tag-visitor.php	(revision 3137704)
+++ class-image-prioritizer-img-tag-visitor.php	(working copy)
@@ -52,16 +52,23 @@
 			} else {
 				$processor->set_attribute( 'fetchpriority', 'high' );
 			}
-		} elseif ( is_string( $processor->get_attribute( 'fetchpriority' ) ) && $context->url_metrics_group_collection->is_every_group_populated() ) {
+		} elseif (
+			is_string( $processor->get_attribute( 'fetchpriority' ) )
+			&&
+			// Temporary condition in case someone updates Image Prioritizer without also updating Optimization Detective.
+			method_exists( $context->url_metrics_group_collection, 'is_any_group_populated' )
+			&&
+			$context->url_metrics_group_collection->is_any_group_populated()
+		) {
 			/*
-			 * At this point, the element is not the shared LCP across all viewport groups. It may not be an LCP element
-			 * in _any_ of the viewport groups. Nevertheless, server-side heuristics may have added the fetchpriority=high
-			 * attribute to the element for some reason. Because of server-side heuristics, we'll only go ahead and remove
-			 * the fetchpriority attribute if every viewport group (is_every_group_populated) has been populated with URL
-			 * metrics because only then do we know that in fact it is _not_ the LCP element in any of the viewport groups.
-			 * This allows for server-side heuristics to continue to apply while waiting for more URL metrics to be gathered.
-			 * Note also that if this is the LCP element for _some_ of the viewport groups, it will still get
-			 * fetchpriority=high by means of the preload link (with a media query) that is added further below.
+			 * At this point, the element is not the shared LCP across all viewport groups. Nevertheless, server-side
+			 * heuristics have added fetchpriority=high to the element, but this is not warranted either due to a lack
+			 * of data or because the LCP element is not common across all viewport groups. Since we have collected at
+			 * least some URL metrics (per is_any_group_populated), further below a fetchpriority=high preload link will
+			 * be added for the viewport(s) for which this is actually the LCP element. Some viewport groups may never
+			 * get populated due to a lack of traffic (e.g. from tablets or phablets), so it is important to remove
+			 * fetchpriority=high in such case to prevent server-side heuristics from prioritizing loading the image
+			 * which isn't actually the LCP element for actual visitors.
 			 */
 			$processor->remove_attribute( 'fetchpriority' );
 		}
Index: readme.txt
===================================================================
--- readme.txt	(revision 3137704)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.1.2
+Stable tag:   0.1.3
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -62,6 +62,12 @@
 
 == Changelog ==
 
+= 0.1.3 =
+
+**Bug Fixes**
+
+* Fix handling of image prioritization when only some viewport groups are populated. ([1404](https://github.com/WordPress/performance/pull/1404))
+
 = 0.1.2 =
 
 * Update PHP logic to account for changes in Optimization Detective API. ([1302](https://github.com/WordPress/performance/pull/1302))
```
</details>

## `optimization-detective`

> [!IMPORTANT]
> Stable tag change: 0.4.1 → **0.5.0**

`svn status`:
```
M       build/web-vitals.js
M       class-od-html-tag-processor.php
M       class-od-url-metric.php
M       class-od-url-metrics-group-collection.php
M       class-od-url-metrics-group.php
M       load.php
M       optimization.php
M       readme.txt
M       storage/class-od-url-metrics-post-type.php
M       storage/data.php
M       storage/rest-api.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: build/web-vitals.js
===================================================================
--- build/web-vitals.js	(revision 3137704)
+++ build/web-vitals.js	(working copy)
@@ -1 +1 @@
-var e,n,t,r,i,o=-1,a=function(e){addEventListener("pageshow",(function(n){n.persisted&&(o=n.timeStamp,e(n))}),!0)},c=function(){var e=self.performance&&performance.getEntriesByType&&performance.getEntriesByType("navigation")[0];if(e&&e.responseStart>0&&e.responseStart<performance.now())return e},u=function(){var e=c();return e&&e.activationStart||0},f=function(e,n){var t=c(),r="navigate";return o>=0?r="back-forward-cache":t&&(document.prerendering||u()>0?r="prerender":document.wasDiscarded?r="restore":t.type&&(r=t.type.replace(/_/g,"-"))),{name:e,value:void 0===n?-1:n,rating:"good",delta:0,entries:[],id:"v4-".concat(Date.now(),"-").concat(Math.floor(8999999999999*Math.random())+1e12),navigationType:r}},s=function(e,n,t){try{if(PerformanceObserver.supportedEntryTypes.includes(e)){var r=new PerformanceObserver((function(e){Promise.resolve().then((function(){n(e.getEntries())}))}));return r.observe(Object.assign({type:e,buffered:!0},t||{})),r}}catch(e){}},d=function(e,n,t,r){var i,a;return function(o){n.value>=0&&(o||r)&&((a=n.value-(i||0))||void 0===i)&&(i=n.value,n.delta=a,n.rating=function(e,n){return e>n[1]?"poor":e>n[0]?"needs-improvement":"good"}(n.value,t),e(n))}},l=function(e){requestAnimationFrame((function(){return requestAnimationFrame((function(){return e()}))}))},p=function(e){document.addEventListener("visibilitychange",(function(){"hidden"===document.visibilityState&&e()}))},v=function(e){var n=!1;return function(){n||(e(),n=!0)}},m=-1,h=function(){return"hidden"!==document.visibilityState||document.prerendering?1/0:0},g=function(e){"hidden"===document.visibilityState&&m>-1&&(m="visibilitychange"===e.type?e.timeStamp:0,T())},y=function(){addEventListener("visibilitychange",g,!0),addEventListener("prerenderingchange",g,!0)},T=function(){removeEventListener("visibilitychange",g,!0),removeEventListener("prerenderingchange",g,!0)},E=function(){return m<0&&(m=h(),y(),a((function(){setTimeout((function(){m=h(),y()}),0)}))),{get firstHiddenTime(){return m}}},C=function(e){document.prerendering?addEventListener("prerenderingchange",(function(){return e()}),!0):e()},b=[1800,3e3],S=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("FCP"),o=s("paint",(function(e){e.forEach((function(e){"first-contentful-paint"===e.name&&(o.disconnect(),e.startTime<r.firstHiddenTime&&(i.value=Math.max(e.startTime-u(),0),i.entries.push(e),t(!0)))}))}));o&&(t=d(e,i,b,n.reportAllChanges),a((function(r){i=f("FCP"),t=d(e,i,b,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,t(!0)}))})))}))},L=[.1,.25],w=function(e,n){n=n||{},S(v((function(){var t,r=f("CLS",0),i=0,o=[],c=function(e){e.forEach((function(e){if(!e.hadRecentInput){var n=o[0],t=o[o.length-1];i&&e.startTime-t.startTime<1e3&&e.startTime-n.startTime<5e3?(i+=e.value,o.push(e)):(i=e.value,o=[e])}})),i>r.value&&(r.value=i,r.entries=o,t())},u=s("layout-shift",c);u&&(t=d(e,r,L,n.reportAllChanges),p((function(){c(u.takeRecords()),t(!0)})),a((function(){i=0,r=f("CLS",0),t=d(e,r,L,n.reportAllChanges),l((function(){return t()}))})),setTimeout(t,0))})))},A=0,I=1/0,P=0,M=function(e){e.forEach((function(e){e.interactionId&&(I=Math.min(I,e.interactionId),P=Math.max(P,e.interactionId),A=P?(P-I)/7+1:0)}))},k=function(){"interactionCount"in performance||e||(e=s("event",M,{type:"event",buffered:!0,durationThreshold:0}))},F=[],D=new Map,x=0,R=function(){return(e?A:performance.interactionCount||0)-x},B=[],H=function(e){if(B.forEach((function(n){return n(e)})),e.interactionId||"first-input"===e.entryType){var n=F[F.length-1],t=D.get(e.interactionId);if(t||F.length<10||e.duration>n.latency){if(t)e.duration>t.latency?(t.entries=[e],t.latency=e.duration):e.duration===t.latency&&e.startTime===t.entries[0].startTime&&t.entries.push(e);else{var r={id:e.interactionId,latency:e.duration,entries:[e]};D.set(r.id,r),F.push(r)}F.sort((function(e,n){return n.latency-e.latency})),F.length>10&&F.splice(10).forEach((function(e){return D.delete(e.id)}))}}},q=function(e){var n=self.requestIdleCallback||self.setTimeout,t=-1;return e=v(e),"hidden"===document.visibilityState?e():(t=n(e),p(e)),t},O=[200,500],N=function(e,n){"PerformanceEventTiming"in self&&"interactionId"in PerformanceEventTiming.prototype&&(n=n||{},C((function(){var t;k();var r,i=f("INP"),o=function(e){q((function(){e.forEach(H);var n,t=(n=Math.min(F.length-1,Math.floor(R()/50)),F[n]);t&&t.latency!==i.value&&(i.value=t.latency,i.entries=t.entries,r())}))},c=s("event",o,{durationThreshold:null!==(t=n.durationThreshold)&&void 0!==t?t:40});r=d(e,i,O,n.reportAllChanges),c&&(c.observe({type:"first-input",buffered:!0}),p((function(){o(c.takeRecords()),r(!0)})),a((function(){x=0,F.length=0,D.clear(),i=f("INP"),r=d(e,i,O,n.reportAllChanges)})))})))},j=[2500,4e3],_={},z=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("LCP"),o=function(e){n.reportAllChanges||(e=e.slice(-1)),e.forEach((function(e){e.startTime<r.firstHiddenTime&&(i.value=Math.max(e.startTime-u(),0),i.entries=[e],t())}))},c=s("largest-contentful-paint",o);if(c){t=d(e,i,j,n.reportAllChanges);var m=v((function(){_[i.id]||(o(c.takeRecords()),c.disconnect(),_[i.id]=!0,t(!0))}));["keydown","click"].forEach((function(e){addEventListener(e,(function(){return q(m)}),!0)})),p(m),a((function(r){i=f("LCP"),t=d(e,i,j,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,_[i.id]=!0,t(!0)}))}))}}))},G=[800,1800],J=function e(n){document.prerendering?C((function(){return e(n)})):"complete"!==document.readyState?addEventListener("load",(function(){return e(n)}),!0):setTimeout(n,0)},K=function(e,n){n=n||{};var t=f("TTFB"),r=d(e,t,G,n.reportAllChanges);J((function(){var i=c();i&&(t.value=Math.max(i.responseStart-u(),0),t.entries=[i],r(!0),a((function(){t=f("TTFB",0),(r=d(e,t,G,n.reportAllChanges))(!0)})))}))},Q={passive:!0,capture:!0},U=new Date,V=function(e,i){n||(n=i,t=e,r=new Date,Y(removeEventListener),W())},W=function(){if(t>=0&&t<r-U){var e={entryType:"first-input",name:n.type,target:n.target,cancelable:n.cancelable,startTime:n.timeStamp,processingStart:n.timeStamp+t};i.forEach((function(n){n(e)})),i=[]}},X=function(e){if(e.cancelable){var n=(e.timeStamp>1e12?new Date:performance.now())-e.timeStamp;"pointerdown"==e.type?function(e,n){var t=function(){V(e,n),i()},r=function(){i()},i=function(){removeEventListener("pointerup",t,Q),removeEventListener("pointercancel",r,Q)};addEventListener("pointerup",t,Q),addEventListener("pointercancel",r,Q)}(n,e):V(n,e)}},Y=function(e){["mousedown","keydown","touchstart","pointerdown"].forEach((function(n){return e(n,X,Q)}))},Z=[100,300],$=function(e,r){r=r||{},C((function(){var o,c=E(),u=f("FID"),l=function(e){e.startTime<c.firstHiddenTime&&(u.value=e.processingStart-e.startTime,u.entries.push(e),o(!0))},m=function(e){e.forEach(l)},h=s("first-input",m);o=d(e,u,Z,r.reportAllChanges),h&&(p(v((function(){m(h.takeRecords()),h.disconnect()}))),a((function(){var a;u=f("FID"),o=d(e,u,Z,r.reportAllChanges),i=[],t=-1,n=null,Y(addEventListener),a=l,i.push(a),W()})))}))};export{L as CLSThresholds,b as FCPThresholds,Z as FIDThresholds,O as INPThresholds,j as LCPThresholds,G as TTFBThresholds,w as onCLS,S as onFCP,$ as onFID,N as onINP,z as onLCP,K as onTTFB};
\ No newline at end of file
+var e,n,t,r,i,o=-1,a=function(e){addEventListener("pageshow",(function(n){n.persisted&&(o=n.timeStamp,e(n))}),!0)},c=function(){var e=self.performance&&performance.getEntriesByType&&performance.getEntriesByType("navigation")[0];if(e&&e.responseStart>0&&e.responseStart<performance.now())return e},u=function(){var e=c();return e&&e.activationStart||0},f=function(e,n){var t=c(),r="navigate";return o>=0?r="back-forward-cache":t&&(document.prerendering||u()>0?r="prerender":document.wasDiscarded?r="restore":t.type&&(r=t.type.replace(/_/g,"-"))),{name:e,value:void 0===n?-1:n,rating:"good",delta:0,entries:[],id:"v4-".concat(Date.now(),"-").concat(Math.floor(8999999999999*Math.random())+1e12),navigationType:r}},s=function(e,n,t){try{if(PerformanceObserver.supportedEntryTypes.includes(e)){var r=new PerformanceObserver((function(e){Promise.resolve().then((function(){n(e.getEntries())}))}));return r.observe(Object.assign({type:e,buffered:!0},t||{})),r}}catch(e){}},d=function(e,n,t,r){var i,a;return function(o){n.value>=0&&(o||r)&&((a=n.value-(i||0))||void 0===i)&&(i=n.value,n.delta=a,n.rating=function(e,n){return e>n[1]?"poor":e>n[0]?"needs-improvement":"good"}(n.value,t),e(n))}},l=function(e){requestAnimationFrame((function(){return requestAnimationFrame((function(){return e()}))}))},p=function(e){document.addEventListener("visibilitychange",(function(){"hidden"===document.visibilityState&&e()}))},v=function(e){var n=!1;return function(){n||(e(),n=!0)}},m=-1,h=function(){return"hidden"!==document.visibilityState||document.prerendering?1/0:0},g=function(e){"hidden"===document.visibilityState&&m>-1&&(m="visibilitychange"===e.type?e.timeStamp:0,T())},y=function(){addEventListener("visibilitychange",g,!0),addEventListener("prerenderingchange",g,!0)},T=function(){removeEventListener("visibilitychange",g,!0),removeEventListener("prerenderingchange",g,!0)},E=function(){return m<0&&(m=h(),y(),a((function(){setTimeout((function(){m=h(),y()}),0)}))),{get firstHiddenTime(){return m}}},C=function(e){document.prerendering?addEventListener("prerenderingchange",(function(){return e()}),!0):e()},b=[1800,3e3],S=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("FCP"),o=s("paint",(function(e){e.forEach((function(e){"first-contentful-paint"===e.name&&(o.disconnect(),e.startTime<r.firstHiddenTime&&(i.value=Math.max(e.startTime-u(),0),i.entries.push(e),t(!0)))}))}));o&&(t=d(e,i,b,n.reportAllChanges),a((function(r){i=f("FCP"),t=d(e,i,b,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,t(!0)}))})))}))},L=[.1,.25],w=function(e,n){n=n||{},S(v((function(){var t,r=f("CLS",0),i=0,o=[],c=function(e){e.forEach((function(e){if(!e.hadRecentInput){var n=o[0],t=o[o.length-1];i&&e.startTime-t.startTime<1e3&&e.startTime-n.startTime<5e3?(i+=e.value,o.push(e)):(i=e.value,o=[e])}})),i>r.value&&(r.value=i,r.entries=o,t())},u=s("layout-shift",c);u&&(t=d(e,r,L,n.reportAllChanges),p((function(){c(u.takeRecords()),t(!0)})),a((function(){i=0,r=f("CLS",0),t=d(e,r,L,n.reportAllChanges),l((function(){return t()}))})),setTimeout(t,0))})))},A=0,I=1/0,P=0,M=function(e){e.forEach((function(e){e.interactionId&&(I=Math.min(I,e.interactionId),P=Math.max(P,e.interactionId),A=P?(P-I)/7+1:0)}))},k=function(){return e?A:performance.interactionCount||0},F=function(){"interactionCount"in performance||e||(e=s("event",M,{type:"event",buffered:!0,durationThreshold:0}))},D=[],x=new Map,R=0,B=function(){var e=Math.min(D.length-1,Math.floor((k()-R)/50));return D[e]},H=[],q=function(e){if(H.forEach((function(n){return n(e)})),e.interactionId||"first-input"===e.entryType){var n=D[D.length-1],t=x.get(e.interactionId);if(t||D.length<10||e.duration>n.latency){if(t)e.duration>t.latency?(t.entries=[e],t.latency=e.duration):e.duration===t.latency&&e.startTime===t.entries[0].startTime&&t.entries.push(e);else{var r={id:e.interactionId,latency:e.duration,entries:[e]};x.set(r.id,r),D.push(r)}D.sort((function(e,n){return n.latency-e.latency})),D.length>10&&D.splice(10).forEach((function(e){return x.delete(e.id)}))}}},O=function(e){var n=self.requestIdleCallback||self.setTimeout,t=-1;return e=v(e),"hidden"===document.visibilityState?e():(t=n(e),p(e)),t},N=[200,500],j=function(e,n){"PerformanceEventTiming"in self&&"interactionId"in PerformanceEventTiming.prototype&&(n=n||{},C((function(){var t;F();var r,i=f("INP"),o=function(e){O((function(){e.forEach(q);var n=B();n&&n.latency!==i.value&&(i.value=n.latency,i.entries=n.entries,r())}))},c=s("event",o,{durationThreshold:null!==(t=n.durationThreshold)&&void 0!==t?t:40});r=d(e,i,N,n.reportAllChanges),c&&(c.observe({type:"first-input",buffered:!0}),p((function(){o(c.takeRecords()),r(!0)})),a((function(){R=k(),D.length=0,x.clear(),i=f("INP"),r=d(e,i,N,n.reportAllChanges)})))})))},_=[2500,4e3],z={},G=function(e,n){n=n||{},C((function(){var t,r=E(),i=f("LCP"),o=function(e){n.reportAllChanges||(e=e.slice(-1)),e.forEach((function(e){e.startTime<r.firstHiddenTime&&(i.value=Math.max(e.startTime-u(),0),i.entries=[e],t())}))},c=s("largest-contentful-paint",o);if(c){t=d(e,i,_,n.reportAllChanges);var m=v((function(){z[i.id]||(o(c.takeRecords()),c.disconnect(),z[i.id]=!0,t(!0))}));["keydown","click"].forEach((function(e){addEventListener(e,(function(){return O(m)}),!0)})),p(m),a((function(r){i=f("LCP"),t=d(e,i,_,n.reportAllChanges),l((function(){i.value=performance.now()-r.timeStamp,z[i.id]=!0,t(!0)}))}))}}))},J=[800,1800],K=function e(n){document.prerendering?C((function(){return e(n)})):"complete"!==document.readyState?addEventListener("load",(function(){return e(n)}),!0):setTimeout(n,0)},Q=function(e,n){n=n||{};var t=f("TTFB"),r=d(e,t,J,n.reportAllChanges);K((function(){var i=c();i&&(t.value=Math.max(i.responseStart-u(),0),t.entries=[i],r(!0),a((function(){t=f("TTFB",0),(r=d(e,t,J,n.reportAllChanges))(!0)})))}))},U={passive:!0,capture:!0},V=new Date,W=function(e,i){n||(n=i,t=e,r=new Date,Z(removeEventListener),X())},X=function(){if(t>=0&&t<r-V){var e={entryType:"first-input",name:n.type,target:n.target,cancelable:n.cancelable,startTime:n.timeStamp,processingStart:n.timeStamp+t};i.forEach((function(n){n(e)})),i=[]}},Y=function(e){if(e.cancelable){var n=(e.timeStamp>1e12?new Date:performance.now())-e.timeStamp;"pointerdown"==e.type?function(e,n){var t=function(){W(e,n),i()},r=function(){i()},i=function(){removeEventListener("pointerup",t,U),removeEventListener("pointercancel",r,U)};addEventListener("pointerup",t,U),addEventListener("pointercancel",r,U)}(n,e):W(n,e)}},Z=function(e){["mousedown","keydown","touchstart","pointerdown"].forEach((function(n){return e(n,Y,U)}))},$=[100,300],ee=function(e,r){r=r||{},C((function(){var o,c=E(),u=f("FID"),l=function(e){e.startTime<c.firstHiddenTime&&(u.value=e.processingStart-e.startTime,u.entries.push(e),o(!0))},m=function(e){e.forEach(l)},h=s("first-input",m);o=d(e,u,$,r.reportAllChanges),h&&(p(v((function(){m(h.takeRecords()),h.disconnect()}))),a((function(){var a;u=f("FID"),o=d(e,u,$,r.reportAllChanges),i=[],t=-1,n=null,Z(addEventListener),a=l,i.push(a),X()})))}))};export{L as CLSThresholds,b as FCPThresholds,$ as FIDThresholds,N as INPThresholds,_ as LCPThresholds,J as TTFBThresholds,w as onCLS,S as onFCP,ee as onFID,j as onINP,G as onLCP,Q as onTTFB};
\ No newline at end of file
Index: class-od-html-tag-processor.php
===================================================================
--- class-od-html-tag-processor.php	(revision 3137704)
+++ class-od-html-tag-processor.php	(working copy)
@@ -196,7 +196,7 @@
 	 * @inheritDoc
 	 * @since 0.4.0
 	 *
-	 * @param null $query Query.
+	 * @param array{tag_name?: string|null, match_offset?: int|null, class_name?: string|null, tag_closers?: string|null}|null $query Query, but only null is accepted for this subclass.
 	 * @return bool Whether a tag was matched.
 	 *
 	 * @throws InvalidArgumentException If attempting to pass a query.
@@ -315,6 +315,7 @@
 			$popped_tag_name = array_pop( $this->open_stack_tags );
 			if ( $popped_tag_name !== $tag_name ) {
 				$this->warn(
+					__METHOD__,
 					sprintf(
 						/* translators: 1: Popped tag name, 2: Closing tag name */
 						__( 'Expected popped tag stack element %1$s to match the currently visited closing tag %2$s.', 'optimization-detective' ),
@@ -476,6 +477,7 @@
 	public function release_bookmark( $name ): bool {
 		if ( in_array( $name, array( self::END_OF_HEAD_BOOKMARK, self::END_OF_BODY_BOOKMARK ), true ) ) {
 			$this->warn(
+				__METHOD__,
 				/* translators: %s is the bookmark name */
 				sprintf( 'The %s bookmark is not allowed to be released.', 'optimization-detective' )
 			);
@@ -575,6 +577,7 @@
 			}
 			if ( ! $this->has_bookmark( $bookmark ) ) {
 				$this->warn(
+					__METHOD__,
 					sprintf(
 						/* translators: %s is the bookmark name */
 						__( 'Unable to append markup to %s since the bookmark no longer exists.', 'optimization-detective' ),
@@ -602,11 +605,12 @@
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param string $message Warning message.
+	 * @param string $function_name Function name.
+	 * @param string $message       Warning message.
 	 */
-	private function warn( string $message ): void {
+	private function warn( string $function_name, string $message ): void {
 		wp_trigger_error(
-			__CLASS__ . '::open_tags',
+			$function_name,
 			esc_html( $message )
 		);
 	}
Index: class-od-url-metric.php
===================================================================
--- class-od-url-metric.php	(revision 3137704)
+++ class-od-url-metric.php	(working copy)
@@ -14,21 +14,34 @@
 /**
  * Representation of the measurements taken from a single client's visit to a specific URL.
  *
- * @phpstan-type RectData    array{ width: int, height: int }
- * @phpstan-type ElementData array{
- *                               isLCP: bool,
- *                               isLCPCandidate: bool,
- *                               xpath: string,
- *                               intersectionRatio: float,
- *                               intersectionRect: RectData,
- *                               boundingClientRect: RectData,
- *                           }
- * @phpstan-type Data        array{
- *                               url: string,
- *                               timestamp: float,
- *                               viewport: RectData,
- *                               elements: ElementData[]
- *                           }
+ * @phpstan-type ViewportRect array{
+ *                                width: int,
+ *                                height: int
+ *                            }
+ * @phpstan-type DOMRect      array{
+ *                                width: float,
+ *                                height: float,
+ *                                x: float,
+ *                                y: float,
+ *                                top: float,
+ *                                right: float,
+ *                                bottom: float,
+ *                                left: float
+ *                            }
+ * @phpstan-type ElementData  array{
+ *                                isLCP: bool,
+ *                                isLCPCandidate: bool,
+ *                                xpath: string,
+ *                                intersectionRatio: float,
+ *                                intersectionRect: DOMRect,
+ *                                boundingClientRect: DOMRect,
+ *                            }
+ * @phpstan-type Data         array{
+ *                                url: string,
+ *                                timestamp: float,
+ *                                viewport: ViewportRect,
+ *                                elements: ElementData[]
+ *                            }
  *
  * @since 0.1.0
  * @access private
@@ -77,20 +90,38 @@
 	 * @return array<string, mixed> Schema.
 	 */
 	public static function get_json_schema(): array {
+		/*
+		 * The intersectionRect and clientBoundingRect are both instances of the DOMRectReadOnly, which
+		 * the following schema describes. See <https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly>.
+		 * Note that 'number' is used specifically instead of 'integer' because the values are all specified as
+		 * floats/doubles.
+		 */
+		$properties = array_fill_keys(
+			array(
+				'width',
+				'height',
+				'x',
+				'y',
+				'top',
+				'right',
+				'bottom',
+				'left',
+			),
+			array(
+				'type'     => 'number',
+				'required' => true,
+			)
+		);
+
+		// The spec allows these to be negative but this doesn't make sense in the context of intersectionRect and boundingClientRect.
+		$properties['width']['minimum']  = 0.0;
+		$properties['height']['minimum'] = 0.0;
+
 		$dom_rect_schema = array(
 			'type'                 => 'object',
-			'properties'           => array(
-				'width'  => array(
-					'type'    => 'number',
-					'minimum' => 0,
-				),
-				'height' => array(
-					'type'    => 'number',
-					'minimum' => 0,
-				),
-			),
-			// TODO: There are other properties to define if we need them: x, y, top, right, bottom, left.
-			'additionalProperties' => true,
+			'required'             => true,
+			'properties'           => $properties,
+			'additionalProperties' => false,
 		);
 
 		return array(
@@ -97,19 +128,20 @@
 			'$schema'              => 'http://json-schema.org/draft-04/schema#',
 			'title'                => 'od-url-metric',
 			'type'                 => 'object',
+			'required'             => true,
 			'properties'           => array(
 				'url'       => array(
+					'description' => __( 'The URL for which the metric was obtained.', 'optimization-detective' ),
 					'type'        => 'string',
-					'description' => __( 'The URL for which the metric was obtained.', 'optimization-detective' ),
 					'required'    => true,
 					'format'      => 'uri',
 					'pattern'     => '^https?://',
 				),
 				'viewport'  => array(
-					'description' => __( 'Viewport dimensions', 'optimization-detective' ),
-					'type'        => 'object',
-					'required'    => true,
-					'properties'  => array(
+					'description'          => __( 'Viewport dimensions', 'optimization-detective' ),
+					'type'                 => 'object',
+					'required'             => true,
+					'properties'           => array(
 						'width'  => array(
 							'type'     => 'integer',
 							'required' => true,
@@ -121,6 +153,7 @@
 							'minimum'  => 0,
 						),
 					),
+					'additionalProperties' => false,
 				),
 				'timestamp' => array(
 					'description' => __( 'Timestamp at which the URL metric was captured.', 'optimization-detective' ),
@@ -137,6 +170,7 @@
 					'items'       => array(
 						// See the ElementMetrics in detect.js.
 						'type'                 => 'object',
+						'required'             => true,
 						'properties'           => array(
 							'isLCP'              => array(
 								'type'     => 'boolean',
@@ -143,7 +177,8 @@
 								'required' => true,
 							),
 							'isLCPCandidate'     => array(
-								'type' => 'boolean',
+								'type'     => 'boolean',
+								'required' => true,
 							),
 							'xpath'              => array(
 								'type'     => 'string',
@@ -179,7 +214,7 @@
 	/**
 	 * Gets viewport data.
 	 *
-	 * @return RectData Viewport data.
+	 * @return ViewportRect Viewport data.
 	 */
 	public function get_viewport(): array {
 		return $this->data['viewport'];
Index: class-od-url-metrics-group-collection.php
===================================================================
--- class-od-url-metrics-group-collection.php	(revision 3137704)
+++ class-od-url-metrics-group-collection.php	(working copy)
@@ -21,7 +21,7 @@
  * @since 0.1.0
  * @access private
  */
-final class OD_URL_Metrics_Group_Collection implements Countable, IteratorAggregate, JSONSerializable {
+final class OD_URL_Metrics_Group_Collection implements Countable, IteratorAggregate, JsonSerializable {
 
 	/**
 	 * URL metrics groups.
@@ -76,6 +76,7 @@
 	 * @var array{
 	 *          get_group_for_viewport_width?: array<int, OD_URL_Metrics_Group>,
 	 *          is_every_group_populated?: bool,
+	 *          is_any_group_populated?: bool,
 	 *          is_every_group_complete?: bool,
 	 *          get_groups_by_lcp_element?: array<string, OD_URL_Metrics_Group[]>,
 	 *          get_common_lcp_element?: ElementData|null,
@@ -237,6 +238,29 @@
 	}
 
 	/**
+	 * Checks whether any group is populated with at least one URL metric.
+	 *
+	 * @return bool Whether at least one group has some URL metrics.
+	 */
+	public function is_any_group_populated(): bool {
+		if ( array_key_exists( __FUNCTION__, $this->result_cache ) ) {
+			return $this->result_cache[ __FUNCTION__ ];
+		}
+
+		$result = ( function () {
+			foreach ( $this->groups as $group ) {
+				if ( count( $group ) !== 0 ) {
+					return true;
+				}
+			}
+			return false;
+		} )();
+
+		$this->result_cache[ __FUNCTION__ ] = $result;
+		return $result;
+	}
+
+	/**
 	 * Checks whether every group is populated with at least one URL metric each.
 	 *
 	 * They aren't necessarily filled to the sample size, however.
Index: class-od-url-metrics-group.php
===================================================================
--- class-od-url-metrics-group.php	(revision 3137704)
+++ class-od-url-metrics-group.php	(working copy)
@@ -81,7 +81,7 @@
 	/**
 	 * Constructor.
 	 *
-	 * @throws InvalidArgumentException If arguments are valid.
+	 * @throws InvalidArgumentException If arguments are invalid.
 	 *
 	 * @param OD_URL_Metric[]                      $url_metrics            URL metrics to add to the group.
 	 * @param int                                  $minimum_viewport_width Minimum possible viewport width for the group. Must be zero or greater.
@@ -302,7 +302,7 @@
 			}
 
 			// Now sort by the breadcrumb counts in descending order, so the remaining first key is the most common breadcrumb.
-			if ( $seen_breadcrumbs ) {
+			if ( count( $seen_breadcrumbs ) > 0 ) {
 				arsort( $breadcrumb_counts );
 				$most_common_breadcrumb_index = key( $breadcrumb_counts );
 
Index: load.php
===================================================================
--- load.php	(revision 3137704)
+++ load.php	(working copy)
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.4.1
+ * Version: 0.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.4.1',
+	'0.5.0',
 	static function ( string $version ): void {
 
 		// Define the constant.
@@ -84,7 +84,7 @@
 						/* translators: 1: File path. 2: CLI command. */
 						'[Optimization Detective] ' . __( 'Unable to load %1$s. Please make sure you have run %2$s.', 'optimization-detective' ),
 						'build/web-vitals.asset.php',
-						'`npm install && npm run build:optimization-detective`'
+						'`npm install && npm run build:plugin:optimization-detective`'
 					)
 				),
 				E_USER_ERROR
Index: optimization.php
===================================================================
--- optimization.php	(revision 3137704)
+++ optimization.php	(working copy)
@@ -31,8 +31,30 @@
  * @return string Unmodified value of $passthrough.
  */
 function od_buffer_output( string $passthrough ): string {
+	/*
+	 * Instead of the default PHP_OUTPUT_HANDLER_STDFLAGS (cleanable, flushable, and removable) being used for flags,
+	 * we need to omit PHP_OUTPUT_HANDLER_FLUSHABLE. If the buffer were flushable, then each time that ob_flush() is
+	 * called, it would send a fragment of the output into the output buffer callback. When buffering the entire
+	 * response as an HTML document, this would result in broken HTML processing.
+	 *
+	 * If this ends up being problematic, then PHP_OUTPUT_HANDLER_FLUSHABLE could be added to the $flags and the
+	 * output buffer callback could check if the phase is PHP_OUTPUT_HANDLER_FLUSH and abort any subsequent
+	 * processing while also emitting a _doing_it_wrong().
+	 *
+	 * The output buffer needs to be removable because WordPress calls wp_ob_end_flush_all() and then calls
+	 * wp_cache_close(). If the buffers are not all flushed before wp_cache_close() is closed, then some output buffer
+	 * handlers (e.g. for caching plugins) may fail to be able to store the page output in the object cache.
+	 * See <https://github.com/WordPress/performance/pull/1317#issuecomment-2271955356>.
+	 */
+	$flags = PHP_OUTPUT_HANDLER_STDFLAGS ^ PHP_OUTPUT_HANDLER_FLUSHABLE;
+
 	ob_start(
-		static function ( string $output ): string {
+		static function ( string $output, ?int $phase ): string {
+			// When the output is being cleaned (e.g. pending template is replaced with error page), do not send it through the filter.
+			if ( ( $phase & PHP_OUTPUT_HANDLER_CLEAN ) !== 0 ) {
+				return $output;
+			}
+
 			/**
 			 * Filters the template output buffer prior to sending to the client.
 			 *
@@ -42,7 +64,9 @@
 			 * @return string Filtered output buffer.
 			 */
 			return (string) apply_filters( 'od_template_output_buffer', $output );
-		}
+		},
+		0, // Unlimited buffer size.
+		$flags
 	);
 	return $passthrough;
 }
@@ -83,6 +107,11 @@
 		// Since there is no predictability in whether posts in the loop will have featured images assigned or not. If a
 		// theme template for search results doesn't even show featured images, then this wouldn't be an issue.
 		is_search() ||
+		// Avoid optimizing embed responses because the Post Embed iframes include a sandbox attribute with the value of
+		// "allow-scripts" but without "allow-same-origin". This can result in an error in the console:
+		// > Access to script at '.../detect.js?ver=0.4.1' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
+		// So it's better to just avoid attempting to optimize Post Embed responses (which don't need optimization anyway).
+		is_embed() ||
 		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
 		is_customize_preview() ||
 		// Since the images detected in the response body of a POST request cannot, by definition, be cached.
@@ -137,19 +166,31 @@
  *
  * @param string $buffer Template output buffer.
  * @return string Filtered template output buffer.
- *
- * @throws Exception Except it won't really.
  */
 function od_optimize_template_output_buffer( string $buffer ): string {
-	if ( ! od_is_response_html_content_type() ) {
+	// If the content-type is not HTML or the output does not start with '<', then abort since the buffer is definitely not HTML.
+	if (
+		! od_is_response_html_content_type() ||
+		! str_starts_with( ltrim( $buffer ), '<' )
+	) {
 		return $buffer;
 	}
 
+	// If the initial tag is not an open HTML tag, then abort since the buffer is not a complete HTML document.
+	$processor = new OD_HTML_Tag_Processor( $buffer );
+	if ( ! (
+		$processor->next_tag() &&
+		! $processor->is_tag_closer() &&
+		'HTML' === $processor->get_tag()
+	) ) {
+		return $buffer;
+	}
+
 	$slug = od_get_url_metrics_slug( od_get_normalized_query_vars() );
 	$post = OD_URL_Metrics_Post_Type::get_post( $slug );
 
 	$group_collection = new OD_URL_Metrics_Group_Collection(
-		$post ? OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post ) : array(),
+		$post instanceof WP_Post ? OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post ) : array(),
 		od_get_breakpoint_max_widths(),
 		od_get_url_metrics_breakpoint_sample_size(),
 		od_get_url_metric_freshness_ttl()
@@ -170,11 +211,10 @@
 	do_action( 'od_register_tag_visitors', $tag_visitor_registry );
 
 	$link_collection      = new OD_Link_Collection();
-	$processor            = new OD_HTML_Tag_Processor( $buffer );
 	$tag_visitor_context  = new OD_Tag_Visitor_Context( $processor, $group_collection, $link_collection );
 	$current_tag_bookmark = 'optimization_detective_current_tag';
 	$visitors             = iterator_to_array( $tag_visitor_registry );
-	while ( $processor->next_open_tag() ) {
+	do {
 		$did_visit = false;
 		$processor->set_bookmark( $current_tag_bookmark ); // TODO: Should we break if this returns false?
 
@@ -194,7 +234,7 @@
 		if ( $did_visit && $needs_detection ) {
 			$processor->set_meta_attribute( 'xpath', $processor->get_xpath() );
 		}
-	}
+	} while ( $processor->next_open_tag() );
 
 	// Send any preload links in a Link response header and in a LINK tag injected at the end of the HEAD.
 	if ( count( $link_collection ) > 0 ) {
Index: readme.txt
===================================================================
--- readme.txt	(revision 3137704)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.4.1
+Stable tag:   0.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -48,10 +48,11 @@
 
 Filters whether the current response can be optimized. By default, detection and optimization are only performed when:
 
-1. It’s not a search template (i.e. `is_search()`).
-2. It’s not the Customizer preview.
-3. It’s not the response to a `POST` request.
-4. The user is not an administrator (i.e. the `customize` capability).
+1. It’s not a search template (`is_search()`).
+2. It’s not a post embed template (`is_embed()`).
+3. It’s not the Customizer preview (`is_customize_preview()`)
+4. It’s not the response to a `POST` request.
+5. The user is not an administrator (`current_user_can( 'customize' )`).
 
 During development, you may want to force this to always be enabled:
 
@@ -133,6 +134,19 @@
 
 == Changelog ==
 
+= 0.5.0 =
+
+**Enhancements**
+
+* Bump web-vitals from 4.2.1 to 4.2.2. ([1386](https://github.com/WordPress/performance/pull/1386))
+
+**Bug Fixes**
+
+* Disable Optimization Detective by default on the embed template. ([1472](https://github.com/WordPress/performance/pull/1472))
+* Ensure only HTML documents are processed by Optimization Detective. ([1442](https://github.com/WordPress/performance/pull/1442))
+* Ensure the entire template is passed to the output buffer callback for Optimization Detective to process. ([1317](https://github.com/WordPress/performance/pull/1317))
+* Implement full support for intersectionRect/boundingClientRect, fix viewportRect typing, and harden JSON schema. ([1411](https://github.com/WordPress/performance/pull/1411))
+
 = 0.4.1 =
 
 **Enhancements**
Index: storage/class-od-url-metrics-post-type.php
===================================================================
--- storage/class-od-url-metrics-post-type.php	(revision 3137704)
+++ storage/class-od-url-metrics-post-type.php	(working copy)
@@ -123,7 +123,7 @@
 		};
 
 		$url_metrics_data = json_decode( $post->post_content, true );
-		if ( json_last_error() ) {
+		if ( json_last_error() !== 0 ) {
 			$trigger_warning(
 				sprintf(
 					/* translators: 1: Post type slug, 2: Post ID, 3: JSON error message */
@@ -263,12 +263,12 @@
 
 		// Unschedule any existing event which had a differing recurrence.
 		$scheduled_event = wp_get_scheduled_event( self::GC_CRON_EVENT_NAME );
-		if ( $scheduled_event && self::GC_CRON_RECURRENCE !== $scheduled_event->schedule ) {
+		if ( is_object( $scheduled_event ) && self::GC_CRON_RECURRENCE !== $scheduled_event->schedule ) {
 			wp_unschedule_event( $scheduled_event->timestamp, self::GC_CRON_EVENT_NAME );
-			$scheduled_event = null;
+			$scheduled_event = false;
 		}
 
-		if ( ! $scheduled_event ) {
+		if ( false === $scheduled_event ) {
 			wp_schedule_event( time(), self::GC_CRON_RECURRENCE, self::GC_CRON_EVENT_NAME );
 		}
 	}
Index: storage/data.php
===================================================================
--- storage/data.php	(revision 3137704)
+++ storage/data.php	(working copy)
@@ -102,7 +102,7 @@
 		$parsed_url = array();
 	}
 
-	if ( empty( $parsed_url['scheme'] ) ) {
+	if ( ! isset( $parsed_url['scheme'] ) ) {
 		$parsed_url['scheme'] = is_ssl() ? 'https' : 'http';
 	}
 	if ( ! isset( $parsed_url['host'] ) ) {
@@ -210,7 +210,7 @@
 
 	$breakpoint_max_widths = array_map(
 		static function ( $original_breakpoint ) use ( $function_name ): int {
-			$breakpoint = (int) $original_breakpoint;
+			$breakpoint = $original_breakpoint;
 			if ( PHP_INT_MAX === $breakpoint ) {
 				$breakpoint = PHP_INT_MAX - 1;
 				_doing_it_wrong(
@@ -249,7 +249,7 @@
 		 *
 		 * @param int[] $breakpoint_max_widths Max widths for viewport breakpoints. Defaults to [480, 600, 782].
 		 */
-		(array) apply_filters( 'od_breakpoint_max_widths', array( 480, 600, 782 ) )
+		array_map( 'intval', (array) apply_filters( 'od_breakpoint_max_widths', array( 480, 600, 782 ) ) )
 	);
 
 	$breakpoint_max_widths = array_unique( $breakpoint_max_widths, SORT_NUMERIC );
Index: storage/rest-api.php
===================================================================
--- storage/rest-api.php	(revision 3137704)
+++ storage/rest-api.php	(working copy)
@@ -103,7 +103,7 @@
 	$post = OD_URL_Metrics_Post_Type::get_post( $request->get_param( 'slug' ) );
 
 	$group_collection = new OD_URL_Metrics_Group_Collection(
-		$post ? OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post ) : array(),
+		$post instanceof WP_Post ? OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post ) : array(),
 		od_get_breakpoint_max_widths(),
 		od_get_url_metrics_breakpoint_sample_size(),
 		od_get_url_metric_freshness_ttl()
```
</details>

## `performance-lab`

> [!IMPORTANT]
> Stable tag change: 3.3.1 → **3.4.0**

`svn status`:
```
M       includes/admin/plugins.php
M       includes/server-timing/class-perflab-server-timing.php
M       includes/server-timing/defaults.php
M       includes/site-health/audit-autoloaded-options/hooks.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: includes/admin/plugins.php
===================================================================
--- includes/admin/plugins.php	(revision 3137704)
+++ includes/admin/plugins.php	(working copy)
@@ -95,45 +95,95 @@
 	require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 	require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-	$plugins              = array();
-	$experimental_plugins = array();
+	$plugins = array();
+	$errors  = array();
 
-	foreach ( perflab_get_standalone_plugin_data() as $plugin_slug => $plugin_data ) {
+	$standalone_plugin_data = perflab_get_standalone_plugin_data();
+	foreach ( $standalone_plugin_data as $plugin_slug => $plugin_data ) {
 		$api_data = perflab_query_plugin_info( $plugin_slug ); // Data from wordpress.org.
 
 		// Skip if the plugin is not on WordPress.org or there was a network error.
 		if ( $api_data instanceof WP_Error ) {
-			wp_admin_notice(
-				esc_html(
-					sprintf(
-						/* translators: 1: plugin slug. 2: error message. */
-						__( 'Failed to query WordPress.org Plugin Directory for plugin "%1$s". %2$s', 'performance-lab' ),
-						$plugin_slug,
-						$api_data->get_error_message()
-					)
+			$errors[ $plugin_slug ] = $api_data;
+		} else {
+			$plugins[ $plugin_slug ] = array_merge(
+				array(
+					'experimental' => false,
 				),
-				array( 'type' => 'error' )
+				$plugin_data, // Data defined within Performance Lab.
+				$api_data
 			);
-			continue;
 		}
+	}
 
-		$plugin_data = array_merge(
-			array(
-				'experimental' => false,
-			),
-			$plugin_data, // Data defined within Performance Lab.
-			$api_data
+	if ( count( $errors ) > 0 ) {
+		$active_plugins = array_map(
+			static function ( string $file ) {
+				return strtok( $file, '/' );
+			},
+			array_keys( get_plugins() )
 		);
+		$plugin_list    = '<ul>';
+		$error_messages = array();
+		foreach ( $errors as $plugin_slug => $error ) {
+			if ( defined( $standalone_plugin_data[ $plugin_slug ]['constant'] ) ) {
+				$status = __( '(active)', 'performance-lab' );
+			} elseif ( in_array( $plugin_slug, $active_plugins, true ) ) {
+				$status = __( '(installed)', 'performance-lab' );
+			} else {
+				$status = '';
+			}
 
-		// Separate experimental plugins so that they're displayed after non-experimental plugins.
-		if ( $plugin_data['experimental'] ) {
-			$experimental_plugins[ $plugin_slug ] = $plugin_data;
-		} else {
-			$plugins[ $plugin_slug ] = $plugin_data;
+			$plugin_list     .= sprintf(
+				'<li><a target="_blank" href="%s"><code>%s</code></a> %s</li>',
+				esc_url( trailingslashit( __( 'https://wordpress.org/plugins/', 'default' ) . $plugin_slug ) ),
+				esc_html( $plugin_slug ),
+				esc_html( $status )
+			);
+			$error_messages[] = $error->get_error_message();
 		}
+		$plugin_list .= '</ul>';
+
+		$error_messages = array_unique( $error_messages );
+
+		wp_admin_notice(
+			'<p>' . esc_html(
+				_n( 'Failed to query WordPress.org Plugin Directory for the following plugin:', 'Failed to query WordPress.org Plugin Directory for the following plugins:', count( $errors ), 'performance-lab' )
+			) . '</p>' .
+			$plugin_list .
+			'<p>' . esc_html( _n( 'The following error occurred:', 'The following errors occurred:', count( $error_messages ), 'performance-lab' ) ) . '</p>' .
+			'<ul><li>' .
+			join(
+				'</li><li>',
+				array_map(
+					static function ( string $error_message ): string {
+						return wp_kses( $error_message, array( 'a' => array( 'href' => true ) ) );
+					},
+					$error_messages
+				)
+			)
+			. '</li></ul>' .
+			'<p>' . esc_html__( 'Please consider manual plugin installation and activation. You can then access each plugin\'s settings via its respective "Settings" link on the Plugins screen.', 'performance-lab' ) . '</p>',
+			array(
+				'type'           => 'error',
+				'paragraph_wrap' => false,
+			)
+		);
 	}
 
-	if ( count( $plugins ) === 0 && count( $experimental_plugins ) === 0 ) {
+	/*
+	 * Sort plugins alphabetically, with experimental ones coming last.
+	 * Even though `experimental` is a boolean flag, the underlying
+	 * algorithm (`usort` with `strcmp`) makes it possible to sort by it.
+	 */
+	$plugins = wp_list_sort(
+		$plugins,
+		array(
+			'experimental' => 'ASC',
+			'name'         => 'ASC',
+		)
+	);
+	if ( count( $plugins ) === 0 ) {
 		return;
 	}
 	?>
@@ -148,9 +198,6 @@
 						foreach ( $plugins as $plugin_data ) {
 							perflab_render_plugin_card( $plugin_data );
 						}
-						foreach ( $experimental_plugins as $plugin_data ) {
-							perflab_render_plugin_card( $plugin_data );
-						}
 						?>
 					</div>
 				</div>
Index: includes/server-timing/class-perflab-server-timing.php
===================================================================
--- includes/server-timing/class-perflab-server-timing.php	(revision 3137704)
+++ includes/server-timing/class-perflab-server-timing.php	(working copy)
@@ -61,7 +61,7 @@
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: metric slug */
-				sprintf( esc_html__( 'A metric with the slug %s is already registered.', 'performance-lab' ), esc_attr( $metric_slug ) ),
+				esc_html( sprintf( __( 'A metric with the slug %s is already registered.', 'performance-lab' ), $metric_slug ) ),
 				''
 			);
 			return;
@@ -71,7 +71,7 @@
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: WordPress action name */
-				sprintf( esc_html__( 'The method must be called before or during the %s action.', 'performance-lab' ), 'perflab_server_timing_send_header' ),
+				esc_html( sprintf( __( 'The method must be called before or during the %s action.', 'performance-lab' ), 'perflab_server_timing_send_header' ) ),
 				''
 			);
 			return;
@@ -88,7 +88,7 @@
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: PHP parameter name */
-				sprintf( esc_html__( 'The %s argument is required and must be a callable.', 'performance-lab' ), esc_attr( $args['measure_callback'] ) ),
+				esc_html( sprintf( __( 'The %s argument is required and must be a callable.', 'performance-lab' ), 'measure_callback' ) ),
 				''
 			);
 			return;
@@ -97,7 +97,7 @@
 			_doing_it_wrong(
 				__METHOD__,
 				/* translators: %s: PHP parameter name */
-				sprintf( esc_html__( 'The %s argument is required and must be a string.', 'performance-lab' ), esc_attr( $args['access_cap'] ) ),
+				esc_html( sprintf( __( 'The %s argument is required and must be a string.', 'performance-lab' ), 'access_cap' ) ),
 				''
 			);
 			return;
@@ -268,8 +268,11 @@
 	 */
 	public function start_output_buffer(): void {
 		ob_start(
-			function ( $output ) {
-				$this->send_header();
+			function ( string $output, ?int $phase ): string {
+				// Only send the header when the buffer is not being cleaned.
+				if ( ( $phase & PHP_OUTPUT_HANDLER_CLEAN ) === 0 ) {
+					$this->send_header();
+				}
 				return $output;
 			}
 		);
Index: includes/server-timing/defaults.php
===================================================================
--- includes/server-timing/defaults.php	(revision 3137704)
+++ includes/server-timing/defaults.php	(working copy)
@@ -87,42 +87,6 @@
 		},
 		PHP_INT_MAX
 	);
-
-	// Measure duration of autoloaded options query.
-	// Requires the Performance Lab object-cache.php drop-in to be present in order to work,
-	// which is why the constant is checked below.
-	if ( PERFLAB_OBJECT_CACHE_DROPIN_VERSION ) {
-		add_filter(
-			'query',
-			static function ( $query ) {
-				global $wpdb;
-				if ( "SELECT option_name, option_value FROM $wpdb->options WHERE autoload = 'yes'" !== $query ) {
-					return $query;
-				}
-				// In case the autoloaded options query is run again, prevent re-registering it and do not measure again.
-				if ( perflab_server_timing()->has_registered_metric( 'load-alloptions-query' ) ) {
-					return $query;
-				}
-				perflab_server_timing_register_metric(
-					'load-alloptions-query',
-					array(
-						'measure_callback' => static function ( $metric ): void {
-							$metric->measure_before();
-							add_filter(
-								'pre_cache_alloptions',
-								static function ( $passthrough ) use ( $metric ) {
-									$metric->measure_after();
-									return $passthrough;
-								}
-							);
-						},
-						'access_cap'       => 'exist',
-					)
-				);
-				return $query;
-			}
-		);
-	}
 }
 perflab_register_default_server_timing_before_template_metrics();
 
Index: includes/site-health/audit-autoloaded-options/hooks.php
===================================================================
--- includes/site-health/audit-autoloaded-options/hooks.php	(revision 3137704)
+++ includes/site-health/audit-autoloaded-options/hooks.php	(working copy)
@@ -129,3 +129,25 @@
 	return $description . perflab_aao_get_autoloaded_options_table() . perflab_aao_get_disabled_autoloaded_options_table();
 }
 add_filter( 'site_status_autoloaded_options_limit_description', 'perflab_aao_extend_core_check' );
+
+/**
+ * Filters the list of disabled options to exclude options that are autoloaded.
+ *
+ * This filter modifies the 'option_perflab_aao_disabled_options' to ensure
+ * that autoloaded options are not included in the disabled options list.
+ *
+ * @since 3.4.0
+ *
+ * @param string[]|mixed $disabled_options Array of disabled options.
+ * @return string[] Filtered array of disabled options excluding autoloaded options.
+ */
+function perflab_filter_option_perflab_aao_disabled_options( $disabled_options ): array {
+	$autoload_option_names = wp_list_pluck( perflab_aao_query_autoloaded_options(), 'option_name' );
+	return array_filter(
+		(array) $disabled_options,
+		static function ( $option ) use ( $autoload_option_names ): bool {
+			return ! in_array( $option, $autoload_option_names, true );
+		}
+	);
+}
+add_filter( 'option_perflab_aao_disabled_options', 'perflab_filter_option_perflab_aao_disabled_options' );
Index: readme.txt
===================================================================
--- readme.txt	(revision 3137704)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.3.1
+Stable tag:   3.4.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -11,8 +11,20 @@
 
 == Description ==
 
-The Performance Lab plugin is a collection of features focused on enhancing performance of your site, most of which should eventually be merged into WordPress core. The plugin allows to individually enable and test the features to get their benefits before they become available in WordPress core, and to provide feedback to further improve the solutions.
+The Performance Lab plugin is a collection of features focused on enhancing performance of your site, most of which should eventually be merged into WordPress core. The plugin facilitates the discovery and activation of the individual performance feature plugins which the performance team is developing. In this way you can test the features to get their benefits before they become available in WordPress core. You can also play an important role by providing feedback to further improve the solutions. 
 
+The feature plugins which are currently featured by this plugin are:
+
+* [Image Placeholders](https://wordpress.org/plugins/dominant-color-images/)
+* [Modern Image Formats](https://wordpress.org/plugins/webp-uploads/)
+* [Performant Translations](https://wordpress.org/plugins/performant-translations/)
+* [Speculative Loading](https://wordpress.org/plugins/speculation-rules/)
+* [Embed Optimizer](https://wordpress.org/plugins/embed-optimizer/) _(experimental)_
+* [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/) _(experimental)_
+* [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/) _(experimental)_
+
+These plugins can also be installed separately from installing Performance Lab, but having the Performance Lab plugin also active will ensure you find out about new performance features as they are developed.
+
 == Installation ==
 
 = Installation from within WordPress =
@@ -58,6 +70,18 @@
 
 == Changelog ==
 
+= 3.4.0 =
+
+**Enhancements**
+
+* Remove Server-Timing metric for the autoloaded options query time. ([1456](https://github.com/WordPress/performance/pull/1456))
+
+**Bug Fixes**
+
+* Avoid sending Server-Timing header when buffer is being cleaned. ([1443](https://github.com/WordPress/performance/pull/1443))
+* Fix disabled options from reappearing in Site Health after external update. ([1374](https://github.com/WordPress/performance/pull/1374))
+* Improve Performance screen when external requests to WordPress.org fail. ([1474](https://github.com/WordPress/performance/pull/1474))
+
 = 3.3.1 =
 
 **Enhancements**
```
</details>

## `speculation-rules`

> [!WARNING]
> Stable tag is unchanged at 1.3.1, so no plugin release will occur.

`svn status`:
```
M       class-plsr-url-pattern-prefixer.php
M       helper.php
M       hooks.php
M       readme.txt
M       settings.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-plsr-url-pattern-prefixer.php
===================================================================
--- class-plsr-url-pattern-prefixer.php	(revision 3137704)
+++ class-plsr-url-pattern-prefixer.php	(working copy)
@@ -35,7 +35,7 @@
 	 *                                        by the {@see PLSR_URL_Pattern_Prefixer::get_default_contexts()} method.
 	 */
 	public function __construct( array $contexts = array() ) {
-		if ( $contexts ) {
+		if ( count( $contexts ) > 0 ) {
 			$this->contexts = array_map(
 				static function ( string $str ): string {
 					return self::escape_pattern_string( trailingslashit( $str ) );
Index: helper.php
===================================================================
--- helper.php	(revision 3137704)
+++ helper.php	(working copy)
@@ -19,22 +19,11 @@
  *
  * @since 1.0.0
  *
- * @return array<string, array<int, array<string, mixed>>> Associative array of speculation rules by type.
+ * @return non-empty-array<string, array<int, array<string, mixed>>> Associative array of speculation rules by type.
  */
 function plsr_get_speculation_rules(): array {
-	$option = get_option( 'plsr_speculation_rules' );
-
-	/*
-	 * This logic is only relevant for edge-cases where the setting may not be registered,
-	 * a.k.a. defensive coding.
-	 */
-	if ( ! $option || ! is_array( $option ) ) {
-		$option = plsr_get_setting_default();
-	} else {
-		$option = array_merge( plsr_get_setting_default(), $option );
-	}
-
-	$mode      = (string) $option['mode'];
+	$option    = plsr_get_stored_setting_value();
+	$mode      = $option['mode'];
 	$eagerness = $option['eagerness'];
 
 	$prefixer = new PLSR_URL_Pattern_Prefixer();
Index: hooks.php
===================================================================
--- hooks.php	(revision 3137704)
+++ hooks.php	(working copy)
@@ -19,30 +19,10 @@
  * @since 1.0.0
  */
 function plsr_print_speculation_rules(): void {
-	$rules = plsr_get_speculation_rules();
-	if ( empty( $rules ) ) {
-		return;
-	}
-
-	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/60320>.
-	$needs_html5_workaround = (
-		! current_theme_supports( 'html5', 'script' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.4', '>=' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.5', '<' )
-	);
-	if ( $needs_html5_workaround ) {
-		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];
-		add_theme_support( 'html5', array( 'script' ) );
-	}
-
 	wp_print_inline_script_tag(
-		(string) wp_json_encode( $rules ),
+		(string) wp_json_encode( plsr_get_speculation_rules() ),
 		array( 'type' => 'speculationrules' )
 	);
-
-	if ( $needs_html5_workaround ) {
-		$GLOBALS['_wp_theme_features'] = $backup_wp_theme_features; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-	}
 }
 add_action( 'wp_footer', 'plsr_print_speculation_rules' );
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3137704)
+++ readme.txt	(working copy)
@@ -1,13 +1,11 @@
 === Speculative Loading ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
-Requires PHP:      7.2
-Stable tag:        1.3.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, javascript, speculation rules, prerender, prefetch
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.3.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, javascript, speculation rules, prerender, prefetch
 
 Enables browsers to speculatively prerender or prefetch pages when hovering over links.
 
Index: settings.php
===================================================================
--- settings.php	(revision 3137704)
+++ settings.php	(working copy)
@@ -16,7 +16,7 @@
  *
  * @since 1.0.0
  *
- * @return array<string, string> Associative array of `$mode => $label` pairs.
+ * @return array{ prefetch: string, prerender: string } Associative array of `$mode => $label` pairs.
  */
 function plsr_get_mode_labels(): array {
 	return array(
@@ -30,7 +30,7 @@
  *
  * @since 1.0.0
  *
- * @return array<string, string> Associative array of `$eagerness => $label` pairs.
+ * @return array{ conservative: string, moderate: string, eager: string } Associative array of `$eagerness => $label` pairs.
  */
 function plsr_get_eagerness_labels(): array {
 	return array(
@@ -45,7 +45,7 @@
  *
  * @since 1.0.0
  *
- * @return array<string, string> {
+ * @return array{ mode: 'prerender', eagerness: 'moderate' } {
  *     Default setting value.
  *
  *     @type string $mode      Mode.
@@ -60,12 +60,29 @@
 }
 
 /**
+ * Returns the stored setting value for Speculative Loading configuration.
+ *
+ * @since n.e.x.t
+ *
+ * @return array{ mode: 'prefetch'|'prerender', eagerness: 'conservative'|'moderate'|'eager' } {
+ *     Stored setting value.
+ *
+ *     @type string $mode      Mode.
+ *     @type string $eagerness Eagerness.
+ * }
+ */
+function plsr_get_stored_setting_value(): array {
+	return plsr_sanitize_setting( get_option( 'plsr_speculation_rules' ) );
+}
+
+/**
  * Sanitizes the setting for Speculative Loading configuration.
  *
  * @since 1.0.0
+ * @todo  Consider whether the JSON schema for the setting could be reused here.
  *
  * @param mixed $input Setting to sanitize.
- * @return array<string, string> {
+ * @return array{ mode: 'prefetch'|'prerender', eagerness: 'conservative'|'moderate'|'eager' } {
  *     Sanitized setting.
  *
  *     @type string $mode      Mode.
@@ -79,17 +96,14 @@
 		return $default_value;
 	}
 
-	$mode_labels      = plsr_get_mode_labels();
-	$eagerness_labels = plsr_get_eagerness_labels();
-
 	// Ensure only valid keys are present.
-	$value = array_intersect_key( $input, $default_value );
+	$value = array_intersect_key( array_merge( $default_value, $input ), $default_value );
 
-	// Set any missing or invalid values to their defaults.
-	if ( ! isset( $value['mode'] ) || ! isset( $mode_labels[ $value['mode'] ] ) ) {
+	// Constrain values to what is allowed.
+	if ( ! in_array( $value['mode'], array_keys( plsr_get_mode_labels() ), true ) ) {
 		$value['mode'] = $default_value['mode'];
 	}
-	if ( ! isset( $value['eagerness'] ) || ! isset( $eagerness_labels[ $value['eagerness'] ] ) ) {
+	if ( ! in_array( $value['eagerness'], array_keys( plsr_get_eagerness_labels() ), true ) ) {
 		$value['eagerness'] = $default_value['eagerness'];
 	}
 
@@ -113,7 +127,8 @@
 			'default'           => plsr_get_setting_default(),
 			'show_in_rest'      => array(
 				'schema' => array(
-					'properties' => array(
+					'type'                 => 'object',
+					'properties'           => array(
 						'mode'      => array(
 							'description' => __( 'Whether to prefetch or prerender URLs.', 'speculation-rules' ),
 							'type'        => 'string',
@@ -125,6 +140,7 @@
 							'enum'        => array_keys( plsr_get_eagerness_labels() ),
 						),
 					),
+					'additionalProperties' => false,
 				),
 			),
 		)
@@ -188,7 +204,7 @@
  * @since 1.0.0
  * @access private
  *
- * @param array<string, string> $args {
+ * @param array{ field: 'mode'|'eagerness', title: non-empty-string, description: non-empty-string } $args {
  *     Associative array of arguments.
  *
  *     @type string $field       The slug of the sub setting controlled by the field.
@@ -197,28 +213,24 @@
  * }
  */
 function plsr_render_settings_field( array $args ): void {
-	if ( empty( $args['field'] ) || empty( $args['title'] ) ) { // Invalid.
-		return;
-	}
+	$option = plsr_get_stored_setting_value();
 
-	$option = get_option( 'plsr_speculation_rules' );
-	if ( ! isset( $option[ $args['field'] ] ) ) { // Invalid.
-		return;
+	switch ( $args['field'] ) {
+		case 'mode':
+			$choices = plsr_get_mode_labels();
+			break;
+		case 'eagerness':
+			$choices = plsr_get_eagerness_labels();
+			break;
+		default:
+			return; // Invalid (and this case should never occur).
 	}
 
-	$value    = $option[ $args['field'] ];
-	$callback = "plsr_get_{$args['field']}_labels";
-	if ( ! is_callable( $callback ) ) {
-		return;
-	}
-	$choices = call_user_func( $callback );
-
+	$value = $option[ $args['field'] ];
 	?>
 	<fieldset>
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
-		<?php
-		foreach ( $choices as $slug => $label ) {
-			?>
+		<?php foreach ( $choices as $slug => $label ) : ?>
 			<p>
 				<label>
 					<input
@@ -230,17 +242,11 @@
 					<?php echo esc_html( $label ); ?>
 				</label>
 			</p>
-			<?php
-		}
+		<?php endforeach; ?>
 
-		if ( ! empty( $args['description'] ) ) {
-			?>
-			<p class="description" style="max-width: 800px;">
-				<?php echo esc_html( $args['description'] ); ?>
-			</p>
-			<?php
-		}
-		?>
+		<p class="description" style="max-width: 800px;">
+			<?php echo esc_html( $args['description'] ); ?>
+		</p>
 	</fieldset>
 	<?php
 }
```
</details>

## `webp-uploads`

> [!IMPORTANT]
> Stable tag change: 2.0.2 → **2.1.0**

`svn status`:
```
M       helper.php
M       hooks.php
M       picture-element.php
M       readme.txt
M       settings.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: helper.php
===================================================================
--- helper.php	(revision 3137704)
+++ helper.php	(working copy)
@@ -140,7 +140,7 @@
 	}
 
 	$image_path = wp_get_original_image_path( $attachment_id );
-	if ( ! $image_path || ! file_exists( $image_path ) ) {
+	if ( false === $image_path || ! file_exists( $image_path ) ) {
 		return new WP_Error( 'original_image_file_not_found', __( 'The original image file does not exists, subsizes are created out of the original image.', 'webp-uploads' ) );
 	}
 
@@ -290,7 +290,7 @@
 	}
 
 	// Check if we're anywhere before 'template_redirect' or within the 'wp_head' action.
-	if ( ! did_action( 'template_redirect' ) || doing_action( 'wp_head' ) ) {
+	if ( 0 === did_action( 'template_redirect' ) || doing_action( 'wp_head' ) ) {
 		return false;
 	}
 
@@ -378,10 +378,10 @@
  *
  * @since 2.0.0
  *
- * @param string $image_format The image format to check.
+ * @param string|mixed $image_format The image format to check.
  * @return string Supported image format.
  */
-function webp_uploads_sanitize_image_format( string $image_format ): string {
+function webp_uploads_sanitize_image_format( $image_format ): string {
 	return in_array( $image_format, array( 'webp', 'avif' ), true ) ? $image_format : 'webp';
 }
 
@@ -393,7 +393,7 @@
  * @return bool True if the option is enabled, false otherwise.
  */
 function webp_uploads_is_picture_element_enabled(): bool {
-	return (bool) get_option( 'webp_uploads_use_picture_element', false );
+	return webp_uploads_is_jpeg_fallback_enabled() && (bool) get_option( 'webp_uploads_use_picture_element', false );
 }
 
 /**
Index: hooks.php
===================================================================
--- hooks.php	(revision 3137704)
+++ hooks.php	(working copy)
@@ -63,7 +63,7 @@
 
 	$file = get_attached_file( $attachment_id, true );
 	// File does not exist.
-	if ( ! $file || ! file_exists( $file ) ) {
+	if ( false === $file || ! file_exists( $file ) ) {
 		return $metadata;
 	}
 
@@ -148,13 +148,13 @@
 			if ( ! empty( $metadata['original_image'] ) ) {
 				$uploadpath    = wp_get_upload_dir();
 				$attached_file = get_attached_file( $attachment_id );
-				if ( $attached_file ) {
+				if ( false !== $attached_file ) {
 					wp_delete_file_from_directory( $attached_file, $uploadpath['basedir'] );
 				}
 			}
 
 			// Replace the attached file with the custom MIME type version.
-			if ( $original_image ) {
+			if ( false !== $original_image ) {
 				$metadata = _wp_image_meta_replace_original( $saved_data, $original_image, $metadata, $attachment_id );
 			}
 
@@ -397,7 +397,7 @@
 			}
 
 			$intermediate_file = str_replace( $basename, $properties['file'], $file );
-			if ( ! $intermediate_file ) {
+			if ( '' === $intermediate_file ) {
 				continue;
 			}
 
@@ -429,7 +429,7 @@
 		}
 
 		$full_size = str_replace( $basename, $properties['file'], $file );
-		if ( ! $full_size ) {
+		if ( '' === $full_size ) {
 			continue;
 		}
 
@@ -534,7 +534,7 @@
 
 	// This content does not have any tag on it, move forward.
 	// TODO: Eventually this should use the HTML API to parse out the image tags and then update them.
-	if ( ! preg_match_all( '/<(img)\s[^>]+>/', $content, $img_tags, PREG_SET_ORDER ) ) {
+	if ( 0 === (int) preg_match_all( '/<(img)\s[^>]+>/', $content, $img_tags, PREG_SET_ORDER ) ) {
 		return $content;
 	}
 
@@ -549,7 +549,11 @@
 		// Find the ID of each image by the class.
 		// TODO: It would be preferable to use the $processor->class_list() method but there seems to be some typing issues with PHPStan.
 		$class_name = $processor->get_attribute( 'class' );
-		if ( ! is_string( $class_name ) || ! preg_match( '/(?:^|\s)wp-image-([1-9]\d*)(?:\s|$)/i', $class_name, $matches ) ) {
+		if (
+			! is_string( $class_name )
+			||
+			1 !== preg_match( '/(?:^|\s)wp-image-([1-9]\d*)(?:\s|$)/i', $class_name, $matches )
+		) {
 			continue;
 		}
 
@@ -572,7 +576,6 @@
 
 	return $content;
 }
-add_filter( 'the_content', 'webp_uploads_update_image_references', 13 ); // Run after wp_filter_content_tags.
 
 /**
  * Finds all the urls with *.jpg and *.jpeg extension and updates with *.webp version for the provided image
@@ -761,6 +764,16 @@
 }
 add_action( 'wp_head', 'webp_uploads_render_generator' );
 
-if ( webp_uploads_is_picture_element_enabled() ) {
-	add_filter( 'wp_content_img_tag', 'webp_uploads_wrap_image_in_picture', 10, 3 );
+/**
+ * Initializes custom functionality for handling image uploads and content filters.
+ *
+ * @since 2.1.0
+ */
+function webp_uploads_init(): void {
+	if ( webp_uploads_is_picture_element_enabled() ) {
+		add_filter( 'wp_content_img_tag', 'webp_uploads_wrap_image_in_picture', 10, 3 );
+	} else {
+		add_filter( 'the_content', 'webp_uploads_update_image_references', 13 ); // Run after wp_filter_content_tags.
+	}
 }
+add_action( 'init', 'webp_uploads_init' );
Index: picture-element.php
===================================================================
--- picture-element.php	(revision 3137704)
+++ picture-element.php	(working copy)
@@ -28,9 +28,16 @@
 		return $image;
 	}
 
+	$image_sizes = $image_meta['sizes'];
+
+	// Append missing full size image in $image_sizes array for srcset.
+	if ( isset( $image_meta['sources'], $image_meta['width'], $image_meta['height'] ) ) {
+		array_unshift( $image_sizes, $image_meta );
+	}
+
 	// Collect all the sub size image mime types.
 	$mime_type_data = array();
-	foreach ( $image_meta['sizes'] as $size ) {
+	foreach ( $image_sizes as $size ) {
 		if ( isset( $size['sources'] ) && isset( $size['width'] ) && isset( $size['height'] ) ) {
 			foreach ( $size['sources'] as $mime_type => $data ) {
 				$mime_type_data[ $mime_type ]                         = $mime_type_data[ $mime_type ] ?? array();
@@ -41,15 +48,22 @@
 	}
 	$sub_size_mime_types = array_keys( $mime_type_data );
 
+	// If original image type fallback is not available, don't wrap in picture element.
+	if ( ! in_array( $original_file_mime_type, $sub_size_mime_types, true ) ) {
+		return $image;
+	}
+
 	/**
 	 * Filter the image mime types that can be used for the <picture> element.
 	 *
-	 * Default is: ['image/avif', 'image/webp', 'image/jpeg']. Returning an empty array will skip using the `picture` element.
+	 * Default is: ['image/avif', 'image/webp']. Returning an empty array will skip using the `picture` element.
 	 *
 	 * The mime types will output in the picture element in the order they are provided.
 	 * The original image will be used as the fallback image for browsers that don't support the picture element.
 	 *
 	 * @since 2.0.0
+	 * @since 2.1.0 The default value was updated, removing 'image/jpeg'.
+	 *
 	 * @param string[] $mime_types    Mime types than can be used.
 	 * @param int      $attachment_id The id of the image being evaluated.
 	 */
@@ -58,7 +72,6 @@
 		array(
 			'image/avif',
 			'image/webp',
-			'image/jpeg',
 		),
 		$attachment_id
 	);
@@ -95,12 +108,10 @@
 	list( $src, $width, $height ) = $image_src;
 	$size_array                   = array( absint( $width ), absint( $height ) );
 
+	// Get the sizes from the IMG tag.
+	$sizes = $processor->get_attribute( 'sizes' );
+
 	foreach ( $mime_types as $image_mime_type ) {
-		$sizes = wp_calculate_image_sizes( $size_array, $src, $image_meta, $attachment_id );
-		if ( false === $sizes ) {
-			continue;
-		}
-
 		// Filter core's wp_get_attachment_image_srcset to return the sources for the current mime type.
 		$filter = static function ( $sources ) use ( $mime_type_data, $image_mime_type ): array {
 			$filtered_sources = array();
@@ -124,10 +135,10 @@
 			continue;
 		}
 		$picture_sources .= sprintf(
-			'<source type="%s" srcset="%s" sizes="%s">',
+			'<source type="%s"%s%s>',
 			esc_attr( $image_mime_type ),
-			esc_attr( $image_srcset ),
-			esc_attr( $sizes )
+			is_string( $image_srcset ) ? sprintf( ' srcset="%s"', esc_attr( $image_srcset ) ) : '',
+			is_string( $sizes ) ? sprintf( ' sizes="%s"', esc_attr( $sizes ) ) : ''
 		);
 	}
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3137704)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   2.0.2
+Stable tag:   2.1.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -11,7 +11,7 @@
 
 == Description ==
 
-This plugin adds WebP and AVIF support for media uploads within the WordPress application. By default, AVIF images will be generated if supported on the hosting server, otherwise WebP will be used as the output format. When both formats are available, the output format can be selected under `Settings > Media`. Modern images will be generated only for new uploads, pre-existing images will only converted to a modern format if images are "Regenerated".
+This plugin adds WebP and AVIF support for media uploads within the WordPress application. By default, AVIF images will be generated if supported on the hosting server, otherwise WebP will be used as the output format. When both formats are available, the output format can be selected under `Settings > Media`. Modern images will be generated only for new uploads, pre-existing images will only converted to a modern format if images are regenerated. Images can be regenerated with a plugin like [Regenerate Thumbnails](https://wordpress.org/plugins/regenerate-thumbnails/) or via WP-CLI with the `wp media regenerate` [command](https://developer.wordpress.org/cli/commands/media/regenerate/).
 
 By default, only modern image format sub-sizes will be generated for JPEG uploads - only the original uploaded file will still exist as a JPEG image, generated image sizes use be WebP or AVIF files. To change this behavior, there is a checkbox in `Settings > Media` "Also output JPEG" that - when checked - will result in the plugin generating both JPEG and WebP or AVIF images for every sub-size (noting again that this will only affect newly uploaded images, i.e. after making said change).
 
@@ -60,6 +60,24 @@
 
 == Changelog ==
 
+= 2.1.0 =
+
+**Enhancements**
+
+* Improve disabling checkbox for Picture Element on Media settings screen. ([1470](https://github.com/WordPress/performance/pull/1470))
+
+**Bug Fixes**
+
+* Add missing full size image in PICTURE > SOURCE srcset. ([1437](https://github.com/WordPress/performance/pull/1437))
+* Correct the fallback image in PICTURE element. ([1408](https://github.com/WordPress/performance/pull/1408))
+* Don't wrap PICTURE element if JPEG fallback is not available. ([1450](https://github.com/WordPress/performance/pull/1450))
+* Fix setting sizes attribute on PICTURE > SOURCE elements. ([1354](https://github.com/WordPress/performance/pull/1354))
+* Remove string type hint from webp_uploads_sanitize_image_format() to prevent possible fatal error. ([1410](https://github.com/WordPress/performance/pull/1410))
+
+**Documentation**
+
+* Explain how to regenerate images in the Modern Image Formats readme. ([1348](https://github.com/WordPress/performance/pull/1348))
+
 = 2.0.2 =
 
 **Enhancements**
Index: settings.php
===================================================================
--- settings.php	(revision 3137704)
+++ settings.php	(working copy)
@@ -26,7 +26,7 @@
 		array(
 			'sanitize_callback' => 'webp_uploads_sanitize_image_format',
 			'type'              => 'string',
-			'default'           => 'avif',                                                                                                                                    // AVIF is the default if the editor supports it.
+			'default'           => 'avif', // AVIF is the default if the editor supports it.
 			'show_in_rest'      => false,
 		)
 	);
@@ -169,7 +169,6 @@
  * @since 1.0.0
  */
 function webp_uploads_generate_webp_jpeg_setting_callback(): void {
-
 	?>
 		<label for="perflab_generate_webp_and_jpeg">
 			<input name="perflab_generate_webp_and_jpeg" type="checkbox" id="perflab_generate_webp_and_jpeg" aria-describedby="perflab_generate_webp_and_jpeg_description" value="1"<?php checked( '1', get_option( 'perflab_generate_webp_and_jpeg' ) ); ?> />
@@ -176,16 +175,6 @@
 			<?php esc_html_e( 'Output JPEG images in addition to the modern format', 'webp-uploads' ); ?>
 		</label>
 		<p class="description" id="perflab_generate_webp_and_jpeg_description"><?php esc_html_e( 'Enabling JPEG output can improve compatibility, but will increase the filesystem storage use of your images.', 'webp-uploads' ); ?></p>
-		<script>
-			// Listen for clicks on the JPEG output checkbox, enabling/disabling the
-			// picture element checkbox accordingly.
-			document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
-				document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
-				document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
-				document.getElementById( 'webp_uploads_use_picture_element' ).classList.toggle( 'disabled', ! this.checked );
-				document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
-			} );
-		</script>
 	<?php
 }
 
@@ -196,7 +185,9 @@
  */
 function webp_uploads_use_picture_element_callback(): void {
 	// Picture element support requires the JPEG output to be enabled.
-	$jpeg_fallback_enabled = webp_uploads_is_jpeg_fallback_enabled();
+	$picture_element_option    = 1 === (int) get_option( 'webp_uploads_use_picture_element', 0 );
+	$jpeg_fallback_enabled     = webp_uploads_is_jpeg_fallback_enabled();
+	$picture_element_hidden_id = 'webp_uploads_use_picture_element_hidden';
 	?>
 	<style>
 		#webp_uploads_picture_element_fieldset.disabled label,
@@ -209,12 +200,73 @@
 	</div>
 	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
-			<input name="webp_uploads_use_picture_element" type="checkbox" id="webp_uploads_use_picture_element" aria-describedby="webp_uploads_use_picture_element_description" value="1"<?php checked( webp_uploads_is_picture_element_enabled() ); ?> class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>" >
-			<?php esc_html_e( 'Use <picture> Element', 'webp-uploads' ); ?>
+			<input
+				type="checkbox"
+				id="webp_uploads_use_picture_element"
+				name="webp_uploads_use_picture_element"
+				aria-describedby="webp_uploads_use_picture_element_description"
+				value="1"
+				<?php checked( $picture_element_option ); // Option intentionally used instead of webp_uploads_is_picture_element_enabled() to persist when perflab_generate_webp_and_jpeg is updated. ?>
+				<?php disabled( ! $jpeg_fallback_enabled ); ?>
+			>
+			<?php
+			/*
+			 * If the checkbox is disabled, but the option is enabled, include a hidden input to continue sending the
+			 * same value upon form submission.
+			 */
+			if ( ! $jpeg_fallback_enabled && $picture_element_option ) {
+				?>
+				<input
+					type="hidden"
+					id="<?php echo esc_attr( $picture_element_hidden_id ); ?>"
+					name="webp_uploads_use_picture_element"
+					value="1"
+				>
+				<?php
+			}
+			esc_html_e( 'Use <picture> Element', 'webp-uploads' );
+			?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>
 		<p class="description" id="webp_uploads_use_picture_element_description"><?php esc_html_e( 'The picture element serves a modern image format with a fallback to JPEG. Warning: Make sure you test your theme and plugins for compatibility. In particular, CSS selectors will not match images when using the child combinator (e.g. figure > img).', 'webp-uploads' ); ?></p>
+		<div id="webp_uploads_jpeg_fallback_notice" class="notice notice-info inline" <?php echo $picture_element_option ? '' : 'hidden'; ?>>
+			<p><?php esc_html_e( 'Picture elements will only be used when JPEG fallback images are available. So this will not apply to any images you may have uploaded while the "Also generate JPEG" setting was disabled.', 'webp-uploads' ); ?></p>
+		</div>
 	</div>
+	<script>
+	( function ( pictureElementHiddenId ) {
+		document.getElementById( 'webp_uploads_use_picture_element' ).addEventListener( 'change', function () {
+			document.getElementById( 'webp_uploads_jpeg_fallback_notice' ).hidden = ! this.checked;
+		} );
+
+		// Listen for clicks on the JPEG output checkbox, enabling/disabling the
+		// picture element checkbox accordingly.
+		document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
+			document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
+			document.getElementById( 'webp_uploads_picture_element_notice' ).hidden = this.checked;
+			document.getElementById( 'webp_uploads_picture_element_fieldset' ).classList.toggle( 'disabled', ! this.checked );
+
+			const checkbox = document.getElementById( 'webp_uploads_use_picture_element' );
+			checkbox.disabled = ! this.checked;
+
+			// Remove or inject hidden input to preserve original setting value as needed.
+			if ( this.checked ) {
+				const hiddenInput = document.getElementById( pictureElementHiddenId );
+				if ( hiddenInput ) {
+					hiddenInput.parentElement.removeChild( hiddenInput );
+				}
+			} else if ( checkbox.checked && ! document.getElementById( pictureElementHiddenId ) ) {
+				// The hidden input is only needed if the value was originally set (i.e. the checkbox enabled).
+				const hiddenInput = document.createElement( 'input' );
+				hiddenInput.type = 'hidden';
+				hiddenInput.id = pictureElementHiddenId;
+				hiddenInput.name = checkbox.name;
+				hiddenInput.value = checkbox.value;
+				checkbox.parentElement.insertBefore( hiddenInput, checkbox.nextSibling );
+			}
+		} );
+	} )( <?php echo wp_json_encode( $picture_element_hidden_id ); ?> );
+	</script>
 	<?php
 }
 
```
</details>

