### PR TITLE
Update watch command to only run tests after modifying a PHP file or a file in tests directory

### DIFF
--- a/bin/test-php-watch.sh
+++ b/bin/test-php-watch.sh
@@ -6,7 +6,7 @@ fi
 
 while true; do
 	echo "Waiting for a change in the plugins directory..."
-	output=$(inotifywait -e modify,create,delete -r ./plugins 2> /dev/null)
+	output=$(inotifywait -e modify,create,delete -r ./plugins  --include '.*(\.php$|/tests/.*)' 2> /dev/null)
 	plugin_slug=$(echo "$output" | awk -F/ '{print $3}')
 	sleep 1 # Give the user a chance to copy text from terminal before IDE auto-saves.
 	clear


### PR DESCRIPTION
I'm currently working on a JS file and it is unexpectedly causing `npm run test-php-watch` to trigger unit tests to start for the contained plugin whenever I make a change. In reality we should only be re-running tests for the plugin when a PHP file is modified or a file in the `tests` directory is changed (e.g. as when we have non-PHP files for snapshot testing per #1418). This PR implements that.