### PR TITLE
Post 3.4.0 release merge

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -5,7 +5,7 @@
  * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.1.0' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.2.0' );
 
 require_once __DIR__ . '/hooks.php';
 

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -92,7 +92,7 @@ add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
  *
  * Per the HTML spec, if present it must be the first entry.
  *
- * @since n.e.x.t
+ * @since 1.2.0
  *
  * @param string $sizes_attr The 'sizes' attribute value.
  * @return bool True if the 'auto' keyword is present, false otherwise.

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   1.1.0
+Stable tag:   1.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, auto-sizes
@@ -51,6 +51,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.2.0 =
 
 = 1.1.0 =
 

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -54,6 +54,15 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.2.0 =
 
+**Enhancements**
+
+* Harden logic to add `auto` keyword to `sizes` attribute to prevent duplicate keyword. ([1445](https://github.com/WordPress/performance/pull/1445))
+* Use more robust HTML Tag Processor for auto sizes injection. ([1471](https://github.com/WordPress/performance/pull/1471))
+
+**Bug Fixes**
+
+* Remove sizes attribute when the responsive image disabled. ([1399](https://github.com/WordPress/performance/pull/1399))
+
 = 1.1.0 =
 
 **Features**

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -61,7 +61,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 **Bug Fixes**
 
-* Remove sizes attribute when the responsive image disabled. ([1399](https://github.com/WordPress/performance/pull/1399))
+* Remove sizes attribute when responsive images are disabled. ([1399](https://github.com/WordPress/performance/pull/1399))
 
 = 1.1.0 =
 

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.1.2
+ * Version: 0.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.1.2',
+	'0.2.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.2.0
+ * Version: 0.1.3
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.2.0',
+	'0.1.3',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.1.2
+Stable tag:   0.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -61,6 +61,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.2.0 =
 
 = 0.1.2 =
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.2.0
+Stable tag:   0.1.3
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -62,7 +62,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
-= 0.2.0 =
+= 0.1.3 =
 
 **Bug Fixes**
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -64,6 +64,10 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.2.0 =
 
+**Bug Fixes**
+
+* Fix handling of image prioritization when only some viewport groups are populated. ([1404](https://github.com/WordPress/performance/pull/1404))
+
 = 0.1.2 =
 
 * Update PHP logic to account for changes in Optimization Detective API. ([1302](https://github.com/WordPress/performance/pull/1302))

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.4.1
+ * Version: 0.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.4.1',
+	'0.5.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -136,6 +136,17 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.5.0 =
 
+**Enhancements**
+
+* Bump web-vitals from 4.2.1 to 4.2.2. ([1386](https://github.com/WordPress/performance/pull/1386))
+
+**Bug Fixes**
+
+* Disable Optimization Detective by default on the embed template. ([1472](https://github.com/WordPress/performance/pull/1472))
+* Ensure only HTML documents are processed by Optimization Detective. ([1442](https://github.com/WordPress/performance/pull/1442))
+* Ensure the entire template is passed to the output buffer callback for Optimization Detective to process. ([1317](https://github.com/WordPress/performance/pull/1317))
+* Implement full support for intersectionRect/boundingClientRect, fix viewportRect typing, and harden JSON schema. ([1411](https://github.com/WordPress/performance/pull/1411))
+
 = 0.4.1 =
 
 **Enhancements**

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.4.1
+Stable tag:   0.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -133,6 +133,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.5.0 =
 
 = 0.4.1 =
 

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/hooks.php
@@ -136,7 +136,7 @@ add_filter( 'site_status_autoloaded_options_limit_description', 'perflab_aao_ext
  * This filter modifies the 'option_perflab_aao_disabled_options' to ensure
  * that autoloaded options are not included in the disabled options list.
  *
- * @since n.e.x.t
+ * @since 3.4.0
  *
  * @param string[]|mixed $disabled_options Array of disabled options.
  * @return string[] Filtered array of disabled options excluding autoloaded options.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 3.3.1
+ * Version: 3.4.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.3.1' );
+define( 'PERFLAB_VERSION', '3.4.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.3.1
+Stable tag:   3.4.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -69,6 +69,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.4.0 =
 
 = 3.3.1 =
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -72,6 +72,16 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.4.0 =
 
+**Enhancements**
+
+* Remove Server-Timing metric for the autoloaded options query time. ([1456](https://github.com/WordPress/performance/pull/1456))
+
+**Bug Fixes**
+
+* Avoid sending Server-Timing header when buffer is being cleaned. ([1443](https://github.com/WordPress/performance/pull/1443))
+* Fix disabled options from reappearing in Site Health after external update. ([1374](https://github.com/WordPress/performance/pull/1374))
+* Improve Performance screen when external requests to WordPress.org fail. ([1474](https://github.com/WordPress/performance/pull/1474))
+
 = 3.3.1 =
 
 **Enhancements**

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -767,7 +767,7 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
 /**
  * Initializes custom functionality for handling image uploads and content filters.
  *
- * @since n.e.x.t
+ * @since 2.1.0
  */
 function webp_uploads_init(): void {
 	if ( webp_uploads_is_picture_element_enabled() ) {

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 2.0.2
+ * Version: 2.1.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.0.2' );
+define( 'WEBP_UPLOADS_VERSION', '2.1.0' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -62,7 +62,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	 * The original image will be used as the fallback image for browsers that don't support the picture element.
 	 *
 	 * @since 2.0.0
-	 * @since n.e.x.t The default value was updated, removing 'image/jpeg'.
+	 * @since 2.1.0 The default value was updated, removing 'image/jpeg'.
 	 *
 	 * @param string[] $mime_types    Mime types than can be used.
 	 * @param int      $attachment_id The id of the image being evaluated.

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -62,6 +62,22 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.1.0 =
 
+**Enhancements**
+
+* Improve disabling checkbox for Picture Element on Media settings screen. ([1470](https://github.com/WordPress/performance/pull/1470))
+
+**Bug Fixes**
+
+* Add missing full size image in PICTURE > SOURCE srcset. ([1437](https://github.com/WordPress/performance/pull/1437))
+* Correct the fallback image in PICTURE element. ([1408](https://github.com/WordPress/performance/pull/1408))
+* Don't wrap PICTURE element if JPEG fallback is not available. ([1450](https://github.com/WordPress/performance/pull/1450))
+* Fix setting sizes attribute on PICTURE > SOURCE elements. ([1354](https://github.com/WordPress/performance/pull/1354))
+* Remove string type hint from webp_uploads_sanitize_image_format() to prevent possible fatal error. ([1410](https://github.com/WordPress/performance/pull/1410))
+
+**Documentation**
+
+* Explain how to regenerate images in the Modern Image Formats readme. ([1348](https://github.com/WordPress/performance/pull/1348))
+
 = 2.0.2 =
 
 **Enhancements**

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   2.0.2
+Stable tag:   2.1.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -59,6 +59,8 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.1.0 =
 
 = 2.0.2 =
 


### PR DESCRIPTION
Previously https://github.com/WordPress/performance/pull/1346

- **Bump versions**
- **Do npm run since, omitting speculation-rules change**
- **Do npm run readme for 5 pending plugin releases**
- **Use 0.1.3 as image-prioritizer version instead of 0.2.0**
- **Fix auto-sizes readme entry**
