### PR TITLE
Include UUID with each URL metric

### DIFF
--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -66,7 +66,7 @@ final class OD_URL_Metric implements JsonSerializable {
 	 * @throws OD_Data_Validation_Exception When the input is invalid.
 	 */
 	public function __construct( array $data ) {
-		if ( ! array_key_exists( 'uuid', $data ) ) {
+		if ( ! isset( $data['uuid'] ) ) {
 			$data['uuid'] = wp_generate_uuid4();
 		}
 		$this->validate_data( $data );

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -37,6 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *                                boundingClientRect: DOMRect,
  *                            }
  * @phpstan-type Data         array{
+ *                                uuid: string,
  *                                url: string,
  *                                timestamp: float,
  *                                viewport: ViewportRect,
@@ -65,6 +66,9 @@ final class OD_URL_Metric implements JsonSerializable {
 	 * @throws OD_Data_Validation_Exception When the input is invalid.
 	 */
 	public function __construct( array $data ) {
+		if ( ! array_key_exists( 'uuid', $data ) ) {
+			$data['uuid'] = wp_generate_uuid4();
+		}
 		$this->validate_data( $data );
 		$this->data = $data;
 	}
@@ -86,6 +90,8 @@ final class OD_URL_Metric implements JsonSerializable {
 
 	/**
 	 * Gets JSON schema for URL Metric.
+	 *
+	 * @todo Cache the return value?
 	 *
 	 * @return array<string, mixed> Schema.
 	 */
@@ -130,6 +136,13 @@ final class OD_URL_Metric implements JsonSerializable {
 			'type'                 => 'object',
 			'required'             => true,
 			'properties'           => array(
+				'uuid'      => array(
+					'description' => __( 'The UUID for the URL metric.', 'optimization-detective' ),
+					'type'        => 'string',
+					'format'      => 'uuid',
+					'required'    => true,
+					'readonly'    => true, // Omit from REST API.
+				),
 				'url'       => array(
 					'description' => __( 'The URL for which the metric was obtained.', 'optimization-detective' ),
 					'type'        => 'string',
@@ -160,7 +173,6 @@ final class OD_URL_Metric implements JsonSerializable {
 					'type'        => 'number',
 					'required'    => true,
 					'readonly'    => true, // Omit from REST API.
-					'default'     => microtime( true ), // Value provided when instantiating OD_URL_Metric in REST API.
 					'minimum'     => 0,
 				),
 				'elements'  => array(
@@ -200,6 +212,15 @@ final class OD_URL_Metric implements JsonSerializable {
 			),
 			'additionalProperties' => false,
 		);
+	}
+
+	/**
+	 * Gets UUID.
+	 *
+	 * @return string UUID.
+	 */
+	public function get_uuid(): string {
+		return $this->data['uuid'];
 	}
 
 	/**

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -128,17 +128,16 @@ function od_handle_rest_request( WP_REST_Request $request ) {
 	OD_Storage_Lock::set_lock();
 
 	try {
-		$properties = OD_URL_Metric::get_json_schema()['properties'];
 		$url_metric = new OD_URL_Metric(
 			array_merge(
 				wp_array_slice_assoc(
 					$request->get_params(),
-					array_keys( $properties )
+					array_keys( OD_URL_Metric::get_json_schema()['properties'] )
 				),
 				array(
-					// Now supply the timestamp since it was omitted from the REST API params since it is `readonly`.
-					// Nevertheless, it is also `required`, so it must be set to instantiate an OD_URL_Metric.
-					'timestamp' => $properties['timestamp']['default'],
+					// Now supply the readonly args which were omitted from the REST API params due to being `readonly`.
+					'timestamp' => microtime( true ),
+					'uuid'      => wp_generate_uuid4(),
 				)
 			)
 		);

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -181,8 +181,9 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
 		$params  = $this->get_valid_params(
 			array(
-				// Timestamp should cause to be ignored.
+				// Both should be ignored since they are read-only.
 				'timestamp' => microtime( true ) - HOUR_IN_SECONDS,
+				'uuid'      => wp_generate_uuid4(),
 			)
 		);
 		$request->set_body_params( $params );
@@ -197,6 +198,8 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		$this->assertCount( 1, $url_metrics );
 		$url_metric = $url_metrics[0];
 		$this->assertNotEquals( $params['timestamp'], $url_metric->get_timestamp() );
+		$this->assertTrue( wp_is_uuid( $url_metric->get_uuid() ), $url_metric->get_uuid() );
+		$this->assertNotEquals( $params['uuid'], $url_metric->get_uuid() );
 		$this->assertGreaterThanOrEqual( $initial_microtime, $url_metric->get_timestamp() );
 	}
 

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -39,6 +39,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'valid_with_element'     => array(
 				'data' => array(
+					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
 					'viewport'  => $viewport,
 					'timestamp' => microtime( true ),
@@ -47,8 +48,19 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 					),
 				),
 			),
+			'bad_uuid'               => array(
+				'data'  => array(
+					'uuid'      => 'foo',
+					'url'       => home_url( '/' ),
+					'viewport'  => $viewport,
+					'timestamp' => microtime( true ),
+					'elements'  => array(),
+				),
+				'error' => 'OD_URL_Metric[uuid] is not a valid UUID.',
+			),
 			'missing_viewport'       => array(
 				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
 					'timestamp' => microtime( true ),
 					'elements'  => array(),
@@ -57,6 +69,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'missing_viewport_width' => array(
 				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
 					'viewport'  => array( 'height' => 640 ),
 					'timestamp' => microtime( true ),
@@ -66,6 +79,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'bad_viewport'           => array(
 				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
 					'viewport'  => array(
 						'height' => 'tall',
@@ -78,6 +92,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'missing_timestamp'      => array(
 				'data'  => array(
+					'uuid'     => wp_generate_uuid4(),
 					'url'      => home_url( '/' ),
 					'viewport' => $viewport,
 					'elements' => array(),
@@ -86,6 +101,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'missing_elements'       => array(
 				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
 					'viewport'  => $viewport,
 					'timestamp' => microtime( true ),
@@ -94,6 +110,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'missing_url'            => array(
 				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
 					'viewport'  => $viewport,
 					'timestamp' => microtime( true ),
 					'elements'  => array(),
@@ -102,6 +119,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'bad_elements'           => array(
 				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
 					'viewport'  => $viewport,
 					'timestamp' => microtime( true ),
@@ -115,6 +133,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			),
 			'bad_intersection_width' => array(
 				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
 					'viewport'  => $viewport,
 					'timestamp' => microtime( true ),
@@ -141,7 +160,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 	 *
 	 * @dataProvider data_provider
 	 *
-	 * @param array<string, mixed> $data Data.
+	 * @param array<string, mixed> $data  Data.
 	 * @param string               $error Error.
 	 */
 	public function test_constructor( array $data, string $error = '' ): void {
@@ -154,7 +173,13 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 		$this->assertSame( $data['viewport']['width'], $url_metric->get_viewport_width() );
 		$this->assertSame( $data['timestamp'], $url_metric->get_timestamp() );
 		$this->assertSame( $data['elements'], $url_metric->get_elements() );
-		$this->assertEquals( $data, $url_metric->jsonSerialize() );
+		$this->assertTrue( wp_is_uuid( $url_metric->get_uuid() ) );
+		$serialized = $url_metric->jsonSerialize();
+		if ( ! array_key_exists( 'uuid', $data ) ) {
+			$this->assertTrue( wp_is_uuid( $serialized['uuid'] ) );
+			unset( $serialized['uuid'] );
+		}
+		$this->assertEquals( $data, $serialized );
 	}
 
 	/**


### PR DESCRIPTION
When working with URL metrics, I found it difficult when debugging to not have a stable identifier as part of a given URL metric instance. This adds a `uuid` field to the URL metric to serve as this stable identifier.