### PR TITLE
Capture userAgent in URL metric when debugging

### DIFF
--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -41,7 +41,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *                                url: string,
  *                                timestamp: float,
  *                                viewport: ViewportRect,
- *                                elements: ElementData[]
+ *                                elements: ElementData[],
+ *                                userAgent: string|null,
  *                            }
  *
  * @since 0.1.0
@@ -144,6 +145,7 @@ final class OD_URL_Metric implements JsonSerializable {
 					'readonly'    => true, // Omit from REST API.
 				),
 				'url'       => array(
+					// TODO: Should this not also be readonly?
 					'description' => __( 'The URL for which the metric was obtained.', 'optimization-detective' ),
 					'type'        => 'string',
 					'required'    => true,
@@ -167,6 +169,12 @@ final class OD_URL_Metric implements JsonSerializable {
 						),
 					),
 					'additionalProperties' => false,
+				),
+				'userAgent' => array(
+					'description' => __( 'The user agent responsible for the URL metric.', 'optimization-detective' ),
+					'type'        => 'string',
+					'required'    => false,
+					'readonly'    => true, // Omit from REST API.
 				),
 				'timestamp' => array(
 					'description' => __( 'Timestamp at which the URL metric was captured.', 'optimization-detective' ),

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -199,7 +199,9 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 	 */
 	protected function check_schema_subset( array $schema, string $path ): void {
 		$this->assertArrayHasKey( 'required', $schema, $path );
-		$this->assertTrue( $schema['required'], $path );
+		if ( 'root/userAgent' !== $path ) {
+			$this->assertTrue( $schema['required'], $path );
+		}
 		$this->assertArrayHasKey( 'type', $schema, $path );
 		if ( 'object' === $schema['type'] ) {
 			$this->assertArrayHasKey( 'properties', $schema, $path );


### PR DESCRIPTION
> [!IMPORTANT]
> This is a follow-up PR to #1489. Merge that PR before this one so that this PR will merge into `trunk`.

I discovered on my site when looking at URL metrics that there was a crazy tall viewport:

```json
"viewport": {
    "width": 1024,
    "height": 12140
}
```

Apparently this is because Googlebot is the crawler for the URL, as I found from https://www.seroundtable.com/googlebot-9000px-high-viewport-24727.html (although I need to confirm this). 

In any case, it isn't currently possible to determine the user agent responsible for a given URL metric. So I think it will be very helpful when debugging URL metrics data to have this information included.

_Separately, we'll need to compute the aspect ratio of the viewport and abort capturing the URL metric if it is not conceivably a regular device form factor!_