### PR TITLE
Introduce viewport aspect ratio validation for URL Metrics

### DIFF
--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -86,6 +86,25 @@ final class OD_URL_Metric implements JsonSerializable {
 		if ( is_wp_error( $valid ) ) {
 			throw new OD_Data_Validation_Exception( esc_html( $valid->get_error_message() ) );
 		}
+		$aspect_ratio     = $data['viewport']['width'] / $data['viewport']['height'];
+		$min_aspect_ratio = od_get_minimum_viewport_aspect_ratio();
+		$max_aspect_ratio = od_get_maximum_viewport_aspect_ratio();
+		if (
+			$aspect_ratio < $min_aspect_ratio ||
+			$aspect_ratio > $max_aspect_ratio
+		) {
+			throw new OD_Data_Validation_Exception(
+				esc_html(
+					sprintf(
+						/* translators: 1: current aspect ratio, 2: minimum aspect ratio, 3: maximum aspect ratio */
+						__( 'Viewport aspect ratio (%1$s) is in the accepted range of %2$s to %3$s.', 'optimization-detective' ),
+						$aspect_ratio,
+						$min_aspect_ratio,
+						$max_aspect_ratio
+					)
+				)
+			);
+		}
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -97,7 +97,7 @@ final class OD_URL_Metric implements JsonSerializable {
 				esc_html(
 					sprintf(
 						/* translators: 1: current aspect ratio, 2: minimum aspect ratio, 3: maximum aspect ratio */
-						__( 'Viewport aspect ratio (%1$s) is in the accepted range of %2$s to %3$s.', 'optimization-detective' ),
+						__( 'Viewport aspect ratio (%1$s) is not in the accepted range of %2$s to %3$s.', 'optimization-detective' ),
 						$aspect_ratio,
 						$min_aspect_ratio,
 						$max_aspect_ratio

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -202,7 +202,7 @@ export default async function detect( {
 	) {
 		if ( isDebug ) {
 			warn(
-				`Viewport aspect ratio (${ aspectRatio }) is in the accepted range of ${ minViewportAspectRatio } to ${ maxViewportAspectRatio }.`
+				`Viewport aspect ratio (${ aspectRatio }) is not in the accepted range of ${ minViewportAspectRatio } to ${ maxViewportAspectRatio }.`
 			);
 		}
 		return;

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -138,6 +138,8 @@ function getCurrentTime() {
  * @param {Object}                  args                             Args.
  * @param {number}                  args.serveTime                   The serve time of the page in milliseconds from PHP via `microtime( true ) * 1000`.
  * @param {number}                  args.detectionTimeWindow         The number of milliseconds between now and when the page was first generated in which detection should proceed.
+ * @param {number}                  args.minViewportAspectRatio      Minimum aspect ratio allowed for the viewport.
+ * @param {number}                  args.maxViewportAspectRatio      Maximum aspect ratio allowed for the viewport.
  * @param {boolean}                 args.isDebug                     Whether to show debug messages.
  * @param {string}                  args.restApiEndpoint             URL for where to send the detection data.
  * @param {string}                  args.restApiNonce                Nonce for writing to the REST API.
@@ -152,6 +154,8 @@ function getCurrentTime() {
 export default async function detect( {
 	serveTime,
 	detectionTimeWindow,
+	minViewportAspectRatio,
+	maxViewportAspectRatio,
 	isDebug,
 	restApiEndpoint,
 	restApiNonce,
@@ -186,6 +190,20 @@ export default async function detect( {
 	if ( ! isViewportNeeded( win.innerWidth, urlMetricsGroupStatuses ) ) {
 		if ( isDebug ) {
 			log( 'No need for URL metrics from the current viewport.' );
+		}
+		return;
+	}
+
+	// Abort if the viewport aspect ratio is not in a common range.
+	const aspectRatio = win.innerWidth / win.innerHeight;
+	if (
+		aspectRatio < minViewportAspectRatio ||
+		aspectRatio > maxViewportAspectRatio
+	) {
+		if ( isDebug ) {
+			warn(
+				`Viewport aspect ratio (${ aspectRatio }) is in the accepted range of ${ minViewportAspectRatio } to ${ maxViewportAspectRatio }.`
+			);
 		}
 		return;
 	}

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -42,6 +42,8 @@ function od_get_detection_script( string $slug, OD_URL_Metrics_Group_Collection 
 	$detect_args = array(
 		'serveTime'               => microtime( true ) * 1000, // In milliseconds for comparison with `Date.now()` in JavaScript.
 		'detectionTimeWindow'     => $detection_time_window,
+		'minViewportAspectRatio'  => od_get_minimum_viewport_aspect_ratio(),
+		'maxViewportAspectRatio'  => od_get_maximum_viewport_aspect_ratio(),
 		'isDebug'                 => WP_DEBUG,
 		'restApiEndpoint'         => rest_url( OD_REST_API_NAMESPACE . OD_URL_METRICS_ROUTE ),
 		'restApiNonce'            => wp_create_nonce( 'wp_rest' ),

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -96,6 +96,29 @@ add_filter( 'od_url_metric_freshness_ttl', '__return_zero' );
 
 Filters the time window between serve time and run time in which loading detection is allowed to run. This amount is the allowance between when the page was first generated (and perhaps cached) and when the detect function on the page is allowed to perform its detection logic and submit the request to store the results. This avoids situations in which there are missing URL Metrics in which case a site with page caching which also has a lot of traffic could result in a cache stampede.
 
+**Filter:** `od_minimum_viewport_aspect_ratio` (default: 0.4)
+
+Filters the minimum allowed viewport aspect ratio for URL metrics.
+
+The 0.4 value is intended to accommodate the phone with the greatest known aspect
+ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
+
+**Filter:** `od_maximum_viewport_aspect_ratio` (default: 2.0)
+
+Filters the maximum allowed viewport aspect ratio for URL metrics.
+
+The 2.5 value is intended to accommodate the phone with the greatest known aspect
+ratio at 21:9 (2.333).
+
+During development when you have the DevTools console open, for example, the viewport aspect ratio will be wider than normal. In this case, you may want to increase the maximum aspect ratio:
+
+`
+<?php
+add_filter( 'od_maximum_viewport_aspect_ratio', function () {
+	return 5;
+} );
+`
+
 **Filter:** `od_template_output_buffer` (default: the HTML response)
 
 Filters the template output buffer prior to sending to the client. This filter is added to implement [#43258](https://core.trac.wordpress.org/ticket/43258) in WordPress core.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -103,7 +103,7 @@ Filters the minimum allowed viewport aspect ratio for URL metrics.
 The 0.4 value is intended to accommodate the phone with the greatest known aspect
 ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
 
-**Filter:** `od_maximum_viewport_aspect_ratio` (default: 2.0)
+**Filter:** `od_maximum_viewport_aspect_ratio` (default: 2.5)
 
 Filters the maximum allowed viewport aspect ratio for URL metrics.
 

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -117,7 +117,7 @@ class OD_URL_Metrics_Post_Type {
 	 * @return OD_URL_Metric[] URL metrics.
 	 */
 	public static function get_url_metrics_from_post( WP_Post $post ): array {
-		$this_function   = __FUNCTION__;
+		$this_function   = __METHOD__;
 		$trigger_warning = static function ( string $message ) use ( $this_function ): void {
 			wp_trigger_error( $this_function, esc_html( $message ), E_USER_WARNING );
 		};
@@ -156,12 +156,17 @@ class OD_URL_Metrics_Post_Type {
 						try {
 							return new OD_URL_Metric( $url_metric_data );
 						} catch ( OD_Data_Validation_Exception $e ) {
+							$suffix = '';
+							if ( isset( $url_metric_data['uuid'] ) && is_string( $url_metric_data['uuid'] ) ) {
+								$suffix .= sprintf( ' (URL Metric UUID: %s)', $url_metric_data['uuid'] );
+							}
+
 							$trigger_warning(
 								sprintf(
 									/* translators: 1: Post type slug. 2: Exception message. */
 									__( 'Unexpected shape to JSON array in post_content of %1$s post type: %2$s', 'optimization-detective' ),
 									OD_URL_Metrics_Post_Type::SLUG,
-									$e->getMessage()
+									$e->getMessage() . $suffix
 								)
 							);
 

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -117,30 +117,32 @@ class OD_URL_Metrics_Post_Type {
 	 * @return OD_URL_Metric[] URL metrics.
 	 */
 	public static function get_url_metrics_from_post( WP_Post $post ): array {
-		$this_function   = __METHOD__;
-		$trigger_warning = static function ( string $message ) use ( $this_function ): void {
-			wp_trigger_error( $this_function, esc_html( $message ), E_USER_WARNING );
+		$this_function = __METHOD__;
+		$trigger_error = static function ( string $message, int $error_level = E_USER_NOTICE ) use ( $this_function ): void {
+			wp_trigger_error( $this_function, esc_html( $message ), $error_level );
 		};
 
 		$url_metrics_data = json_decode( $post->post_content, true );
 		if ( json_last_error() !== 0 ) {
-			$trigger_warning(
+			$trigger_error(
 				sprintf(
 					/* translators: 1: Post type slug, 2: Post ID, 3: JSON error message */
 					__( 'Contents of %1$s post type (ID: %2$s) not valid JSON: %3$s', 'optimization-detective' ),
 					self::SLUG,
 					$post->ID,
 					json_last_error_msg()
-				)
+				),
+				E_USER_WARNING
 			);
 			$url_metrics_data = array();
 		} elseif ( ! is_array( $url_metrics_data ) ) {
-			$trigger_warning(
+			$trigger_error(
 				sprintf(
 					/* translators: %s is post type slug */
 					__( 'Contents of %s post type was not a JSON array.', 'optimization-detective' ),
 					self::SLUG
-				)
+				),
+				E_USER_WARNING
 			);
 			$url_metrics_data = array();
 		}
@@ -148,7 +150,7 @@ class OD_URL_Metrics_Post_Type {
 		return array_values(
 			array_filter(
 				array_map(
-					static function ( $url_metric_data ) use ( $trigger_warning ) {
+					static function ( $url_metric_data ) use ( $trigger_error ) {
 						if ( ! is_array( $url_metric_data ) ) {
 							return null;
 						}
@@ -161,13 +163,16 @@ class OD_URL_Metrics_Post_Type {
 								$suffix .= sprintf( ' (URL Metric UUID: %s)', $url_metric_data['uuid'] );
 							}
 
-							$trigger_warning(
+							$trigger_error(
 								sprintf(
 									/* translators: 1: Post type slug. 2: Exception message. */
 									__( 'Unexpected shape to JSON array in post_content of %1$s post type: %2$s', 'optimization-detective' ),
 									OD_URL_Metrics_Post_Type::SLUG,
 									$e->getMessage() . $suffix
-								)
+								),
+								// This is not a warning because schema changes will happen, and so it is expected
+								// that this will result in existing URL metrics being invalidated.
+								E_USER_NOTICE
 							);
 
 							return null;

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -191,7 +191,7 @@ function od_get_minimum_viewport_aspect_ratio(): float {
 	/**
 	 * Filters the minimum allowed viewport aspect ratio for URL metrics.
 	 *
-	 * The 0.4 value is intended to accommodate the phone with the greatest known aspect
+	 * The 0.4 default value is intended to accommodate the phone with the greatest known aspect
 	 * ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
 	 *
 	 * @since n.e.x.t
@@ -213,7 +213,7 @@ function od_get_maximum_viewport_aspect_ratio(): float {
 	/**
 	 * Filters the maximum allowed viewport aspect ratio for URL metrics.
 	 *
-	 * The 2.5 value is intended to accommodate the phone with the greatest known aspect
+	 * The 2.5 default value is intended to accommodate the phone with the greatest known aspect
 	 * ratio at 21:9 (2.333).
 	 *
 	 * @since n.e.x.t

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -180,6 +180,50 @@ function od_verify_url_metrics_storage_nonce( string $nonce, string $slug, strin
 }
 
 /**
+ * Gets the minimum allowed viewport aspect ratio for URL metrics.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @return float Minimum viewport aspect ratio for URL metrics.
+ */
+function od_get_minimum_viewport_aspect_ratio(): float {
+	/**
+	 * Filters the minimum allowed viewport aspect ratio for URL metrics.
+	 *
+	 * The 0.4 value is intended to accommodate the phone with the greatest known aspect
+	 * ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param float $minimum_viewport_aspect_ratio Minimum viewport aspect ratio.
+	 */
+	return (float) apply_filters( 'od_minimum_viewport_aspect_ratio', 0.4 );
+}
+
+/**
+ * Gets the maximum allowed viewport aspect ratio for URL metrics.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @return float Maximum viewport aspect ratio for URL metrics.
+ */
+function od_get_maximum_viewport_aspect_ratio(): float {
+	/**
+	 * Filters the maximum allowed viewport aspect ratio for URL metrics.
+	 *
+	 * The 2.5 value is intended to accommodate the phone with the greatest known aspect
+	 * ratio at 21:9 (2.333).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param float $maximum_viewport_aspect_ratio Maximum viewport aspect ratio.
+	 */
+	return (float) apply_filters( 'od_maximum_viewport_aspect_ratio', 2.5 );
+}
+
+/**
  * Gets the breakpoint max widths to group URL metrics for various viewports.
  *
  * Each number represents the maximum width (inclusive) for a given breakpoint. So if there is one number, 480, then

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -143,12 +143,13 @@ function od_handle_rest_request( WP_REST_Request $request ) {
 		);
 	} catch ( OD_Data_Validation_Exception $e ) {
 		return new WP_Error(
-			'url_metric_exception',
+			'rest_invalid_param',
 			sprintf(
 				/* translators: %s is exception name */
 				__( 'Failed to validate URL metric: %s', 'optimization-detective' ),
 				$e->getMessage()
-			)
+			),
+			array( 'status' => 400 )
 		);
 	}
 

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -333,6 +333,42 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test od_get_minimum_viewport_aspect_ratio().
+	 *
+	 * @covers ::od_get_minimum_viewport_aspect_ratio
+	 */
+	public function test_od_get_minimum_viewport_aspect_ratio(): void {
+		$this->assertSame( 0.4, od_get_minimum_viewport_aspect_ratio() );
+
+		add_filter(
+			'od_minimum_viewport_aspect_ratio',
+			static function () {
+				return '0.6';
+			}
+		);
+
+		$this->assertSame( 0.6, od_get_minimum_viewport_aspect_ratio() );
+	}
+
+	/**
+	 * Test od_get_maximum_viewport_aspect_ratio().
+	 *
+	 * @covers ::od_get_maximum_viewport_aspect_ratio
+	 */
+	public function test_od_get_maximum_viewport_aspect_ratio(): void {
+		$this->assertSame( 2.5, od_get_maximum_viewport_aspect_ratio() );
+
+		add_filter(
+			'od_maximum_viewport_aspect_ratio',
+			static function () {
+				return 3;
+			}
+		);
+
+		$this->assertSame( 3.0, od_get_maximum_viewport_aspect_ratio() );
+	}
+
+	/**
 	 * Test od_get_breakpoint_max_widths().
 	 *
 	 * @covers ::od_get_breakpoint_max_widths

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -245,7 +245,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 					array(
 						'viewport' => array(
 							'width'  => $viewport_width,
-							'height' => $viewport_width / 2,
+							'height' => ceil( $viewport_width / 2 ),
 						),
 					)
 				)

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -85,6 +85,12 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 						'depth'   => 200,
 					),
 				),
+				'invalid_viewport_aspect_ratio'            => array(
+					'viewport' => array(
+						'width'  => 1024,
+						'height' => 12000,
+					),
+				),
 				'invalid_elements_type'                    => array(
 					'elements' => 'bad',
 				),
@@ -235,7 +241,14 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		foreach ( $viewport_widths as $viewport_width ) {
 			$this->populate_url_metrics(
 				$sample_size,
-				$this->get_valid_params( array( 'viewport' => array( 'width' => $viewport_width ) ) )
+				$this->get_valid_params(
+					array(
+						'viewport' => array(
+							'width'  => $viewport_width,
+							'height' => $viewport_width / 2,
+						),
+					)
+				)
 			);
 		}
 

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -29,7 +29,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 		);
 
 		return array(
-			'valid_minimal'          => array(
+			'valid_minimal'                   => array(
 				'data' => array(
 					'url'       => home_url( '/' ),
 					'viewport'  => $viewport,
@@ -37,7 +37,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 					'elements'  => array(),
 				),
 			),
-			'valid_with_element'     => array(
+			'valid_with_element'              => array(
 				'data' => array(
 					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
@@ -48,7 +48,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 					),
 				),
 			),
-			'bad_uuid'               => array(
+			'bad_uuid'                        => array(
 				'data'  => array(
 					'uuid'      => 'foo',
 					'url'       => home_url( '/' ),
@@ -58,7 +58,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'OD_URL_Metric[uuid] is not a valid UUID.',
 			),
-			'missing_viewport'       => array(
+			'missing_viewport'                => array(
 				'data'  => array(
 					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
@@ -67,7 +67,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'viewport is a required property of OD_URL_Metric.',
 			),
-			'missing_viewport_width' => array(
+			'missing_viewport_width'          => array(
 				'data'  => array(
 					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
@@ -77,7 +77,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'width is a required property of OD_URL_Metric[viewport].',
 			),
-			'bad_viewport'           => array(
+			'bad_viewport'                    => array(
 				'data'  => array(
 					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
@@ -90,7 +90,33 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'OD_URL_Metric[viewport][height] is not of type integer.',
 			),
-			'missing_timestamp'      => array(
+			'viewport_aspect_ratio_too_small' => array(
+				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
+					'url'       => home_url( '/' ),
+					'viewport'  => array(
+						'width'  => 1000,
+						'height' => 10000,
+					),
+					'timestamp' => microtime( true ),
+					'elements'  => array(),
+				),
+				'error' => 'Viewport aspect ratio (0.1) is in the accepted range of 0.4 to 2.5.',
+			),
+			'viewport_aspect_ratio_too_large' => array(
+				'data'  => array(
+					'uuid'      => wp_generate_uuid4(),
+					'url'       => home_url( '/' ),
+					'viewport'  => array(
+						'width'  => 10000,
+						'height' => 1000,
+					),
+					'timestamp' => microtime( true ),
+					'elements'  => array(),
+				),
+				'error' => 'Viewport aspect ratio (10) is in the accepted range of 0.4 to 2.5.',
+			),
+			'missing_timestamp'               => array(
 				'data'  => array(
 					'uuid'     => wp_generate_uuid4(),
 					'url'      => home_url( '/' ),
@@ -99,7 +125,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'timestamp is a required property of OD_URL_Metric.',
 			),
-			'missing_elements'       => array(
+			'missing_elements'                => array(
 				'data'  => array(
 					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
@@ -108,7 +134,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'elements is a required property of OD_URL_Metric.',
 			),
-			'missing_url'            => array(
+			'missing_url'                     => array(
 				'data'  => array(
 					'uuid'      => wp_generate_uuid4(),
 					'viewport'  => $viewport,
@@ -117,7 +143,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'url is a required property of OD_URL_Metric.',
 			),
-			'bad_elements'           => array(
+			'bad_elements'                    => array(
 				'data'  => array(
 					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),
@@ -131,7 +157,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				),
 				'error' => 'isLCP is a required property of OD_URL_Metric[elements][0].',
 			),
-			'bad_intersection_width' => array(
+			'bad_intersection_width'          => array(
 				'data'  => array(
 					'uuid'      => wp_generate_uuid4(),
 					'url'       => home_url( '/' ),

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -101,7 +101,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 					'timestamp' => microtime( true ),
 					'elements'  => array(),
 				),
-				'error' => 'Viewport aspect ratio (0.1) is in the accepted range of 0.4 to 2.5.',
+				'error' => 'Viewport aspect ratio (0.1) is not in the accepted range of 0.4 to 2.5.',
 			),
 			'viewport_aspect_ratio_too_large' => array(
 				'data'  => array(
@@ -114,7 +114,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 					'timestamp' => microtime( true ),
 					'elements'  => array(),
 				),
-				'error' => 'Viewport aspect ratio (10) is in the accepted range of 0.4 to 2.5.',
+				'error' => 'Viewport aspect ratio (10) is not in the accepted range of 0.4 to 2.5.',
 			),
 			'missing_timestamp'               => array(
 				'data'  => array(

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -208,7 +208,7 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 					'url'       => home_url( '/' ),
 					'viewport'  => array(
 						'width'  => $viewport_width,
-						'height' => $viewport_width / 2,
+						'height' => ceil( $viewport_width / 2 ),
 					),
 					'timestamp' => microtime( true ),
 					'elements'  => array(),

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -179,11 +179,11 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 	public function data_provider_test_add_url_metric(): array {
 		return array(
 			'out_of_range' => array(
-				'viewport_width' => 1,
+				'viewport_width' => 400,
 				'exception'      => InvalidArgumentException::class,
 			),
 			'within_range' => array(
-				'viewport_width' => 100,
+				'viewport_width' => 600,
 				'exception'      => '',
 			),
 		);
@@ -199,7 +199,7 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 		if ( '' !== $exception ) {
 			$this->expectException( $exception );
 		}
-		$group = new OD_URL_Metrics_Group( array(), 100, 200, 1, HOUR_IN_SECONDS );
+		$group = new OD_URL_Metrics_Group( array(), 480, 799, 1, HOUR_IN_SECONDS );
 
 		$this->assertFalse( $group->is_complete() );
 		$group->add_url_metric(
@@ -208,7 +208,7 @@ class Test_OD_URL_Metrics_Group extends WP_UnitTestCase {
 					'url'       => home_url( '/' ),
 					'viewport'  => array(
 						'width'  => $viewport_width,
-						'height' => 1000,
+						'height' => $viewport_width / 2,
 					),
 					'timestamp' => microtime( true ),
 					'elements'  => array(),

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -92,7 +92,7 @@ trait Optimization_Detective_Test_Helpers {
 				'url'       => home_url( '/' ),
 				'viewport'  => array(
 					'width'  => $params['viewport_width'],
-					'height' => 800,
+					'height' => $params['viewport_height'] ?? $params['viewport_width'],
 				),
 				'timestamp' => microtime( true ),
 				'elements'  => array_map(

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -92,7 +92,7 @@ trait Optimization_Detective_Test_Helpers {
 				'url'       => home_url( '/' ),
 				'viewport'  => array(
 					'width'  => $params['viewport_width'],
-					'height' => $params['viewport_height'] ?? $params['viewport_width'],
+					'height' => $params['viewport_height'] ?? ceil( $params['viewport_width'] / 2 ),
 				),
 				'timestamp' => microtime( true ),
 				'elements'  => array_map(


### PR DESCRIPTION
As mentioned in #1490, I was debugging URL Metrics on my own blog because I found that commenter avatars weren't getting `loading=lazy` even though they are far outside the initial viewport. When looking the URL Metrics for the URL, I was surprised to find a URL Metric with this viewport:

```json
"viewport": {
    "width": 1024,
    "height": 12140
}
```

This is an aspect ratio of `0.084` which seems incredibly unusual. It turns out that Googlebot actually crawls pages with a viewport set so extremely high like this (cf. [GoogleBot Crawls & Renders Tall, With 9000px High Viewport?](https://www.seroundtable.com/googlebot-9000px-high-viewport-24727.html)). The result is that when computing the `all_element_max_intersection_ratios`, since this URL Metric from Googlebot always has the entire page in the viewport, they will always be `1`. This means that `loading=lazy` would get removed from all images whenever there is a URL Metric stored from Googlebot for a page. Additionally, it could be that a large image outside of the viewport for normal visitors could end up getting identified as the LCP image due to it being in the viewport for Googlebot.

This is not just an issue related to Googlebot. It's also an issue with users visiting a site with unusual window sizes (e.g. split to the top half the monitor) which can skew the URL Metrics.

This PR introduces viewport aspect ratio validation when storing a URL Metric. The validation is also done at read time, so any existing URL Metrics with bad viewport aspect ratios will be immediately discarded.

The min/max aspect ratios I picked are to accommodate the device (Sony Xperia 1 ) with the most extreme aspect ratio I'm familiar with: 21:9. When in horizontal orientation, the aspect ratio is 2.33 and when in vertical orientation it is 0.43. So I picked 0.4 as the minimum and 2.5 as the maximum.

There are two new filters introduced to customize the aspect ratio range:

* `od_minimum_viewport_aspect_ratio`
* `od_maximum_viewport_aspect_ratio`

The `od_maximum_viewport_aspect_ratio` filter is particularly useful during development for example when you have DevTools open on the bottom of the screen.

When an error occurs when parsing URL Metrics out of the `od_url_metrics` post type, it now includes the UUID in the error message. Additionally, if the error is due to a JSON validation issue, the severity is now reduced from warning to notice, since JSON Schema changes are to be expected.