### PR TITLE
Support replacement of n.e.x.t in `_doing_it_wrong()` version strings

### DIFF
--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -79,7 +79,7 @@ exports.handler = async ( opt ) => {
 
 		const regexps = [
 			/(@since\s+)n\.e\.x\.t/g,
-			/('[^']+?)n\.e\.x\.t(?=')/g,
+			/('[^']*?)n\.e\.x\.t(?=')/g,
 		];
 
 		let replacementCount = 0;

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -77,21 +77,29 @@ exports.handler = async ( opt ) => {
 			ignore,
 		} );
 
-		const regexp = /(@since\s+)n\.e\.x\.t/g;
+		const regexps = [
+			/(@since\s+)n\.e\.x\.t/g,
+			/('[^']+?)n\.e\.x\.t(?=')/g,
+		];
 
 		let replacementCount = 0;
-		files.forEach( ( file ) => {
-			const content = fs.readFileSync( file, 'utf-8' );
-			if ( regexp.test( content ) ) {
-				fs.writeFileSync(
-					file,
-					content.replace( regexp, function ( matches, sinceTag ) {
-						replacementCount++;
-						return sinceTag + version;
-					} )
-				);
+		for ( const file of files ) {
+			for ( const regexp of regexps ) {
+				const content = fs.readFileSync( file, 'utf-8' );
+				if ( regexp.test( content ) ) {
+					fs.writeFileSync(
+						file,
+						content.replace(
+							regexp,
+							function ( matches, sinceTag ) {
+								replacementCount++;
+								return sinceTag + version;
+							}
+						)
+					);
+				}
 			}
-		} );
+		}
 
 		const commonMessage = `Using version ${ version } for ${ pluginSlug }: `;
 		if ( replacementCount > 0 ) {


### PR DESCRIPTION
See https://github.com/WordPress/performance/pull/1492/files#r1726503630

Given the following PHP code:

```php
		$doing_it_wrong = static function ( string $message ) use ( $filter_name ): void {
			_doing_it_wrong(
				esc_html( "add_filter({$filter_name},...)" ),
				esc_html( $message ),
				'Optimization Detective n.e.x.t'
			);
		};
```

The `n.e.x.t` should in this context be automatically replaced with the next version, in the same way that is done for `@since` tags. This is implemented in this PR.