### PR TITLE
Automatically populate wp-cli.local.yml for cli container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,11 +43,12 @@ vendor/
 .DS_store?
 
 ############
-## Config overrides for CS tools
+## Config overrides for tools
 ############
 phpcs.xml
 phpunit.xml
 phpstan.neon
+wp-cli.local.yml
 
 ############
 ## Misc

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -11,6 +11,9 @@
     "./plugins/web-worker-offloading",
     "./plugins/webp-uploads"
   ],
+  "lifecycleScripts": {
+    "afterStart": "bin/update-wp-cli-local-ssh.sh"
+  },
   "env": {
     "tests": {
       "config": {

--- a/bin/update-wp-cli-local-ssh.sh
+++ b/bin/update-wp-cli-local-ssh.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# This script is intended to be run as the lifecycleScripts.afterStart script.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+wp_cli_config_file="wp-cli.local.yml"
+
+if [ ! -e "$wp_cli_config_file" ]; then
+	echo "path: /var/www/html" >> "$wp_cli_config_file"
+fi
+
+hash=$(basename "$(npm run --silent wp-env install-path 2>/dev/null)")
+container_id=$(docker ps --format "{{.ID}} {{.Names}}" | grep "$hash-cli" | awk '{print $1}')
+
+grep -v 'ssh:' < "$wp_cli_config_file" > "$wp_cli_config_file-next"
+
+echo "ssh: docker:$container_id" >> "$wp_cli_config_file-next"
+mv "$wp_cli_config_file-next" "$wp_cli_config_file"
+
+echo "Container ID for cli: $container_id"


### PR DESCRIPTION
This is inspired by @swissspidy's [reply](https://x.com/swissspidy/status/1831090473810993601) to my [Tweet](https://x.com/westonruter/status/1831086471576703433) (and [blog post](https://weston.ruter.net/2024/09/03/ergonomically-running-wp-cli-in-wp-env/)) about making it easier to run WP-CLI commands in wp-env. He suggests that we could use SSH as the mechanism to connect WP-CLI to the `cli` Docker container. After some digging, I found this is possible. However, it is complicated by the fact that the container IDs change every time that `wp-env start` runs. So this PR adds a lifecycle script to automatically populate the `wp-cli.local.yml` with the proper [`ssh` config value](https://make.wordpress.org/cli/handbook/references/config/#remote-ssh-configuration).

When this is done, a globally installed WP-CLI will just work when inside when wp-env is started and the user is inside the repo subdirectory.

It is indeed faster than using `npm run wp-env run cli wp` (about twice as fast), however I'm seeing some strange behavior where the pager isn't working. For example, if I do `wp --help`, I can't scroll down in the text. I have to <kbd>Ctrl+C</kbd> to quit the pager (and then the scroll wheel in my Terminal is messed up where it starts scrolling back through my command history instead of scrolling the terminal output).