### PR TITLE
Add missing global documentation for `delete_all_posts()`

### DIFF
--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -315,6 +315,8 @@ class OD_URL_Metrics_Post_Type {
 	 * This is used during uninstallation.
 	 *
 	 * @since 0.1.0
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
 	 */
 	public static function delete_all_posts(): void {
 		global $wpdb;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/performance/issues/1521