### PR TITLE
Update auto sizes logic in Enhanced Responsive Images plugin to no longer load if already in Core

### DIFF
--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -42,7 +42,6 @@ function auto_sizes_update_image_attributes( $attr ): array {
 
 	return $attr;
 }
-add_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' );
 
 /**
  * Adds auto to the sizes attribute to the image, if applicable.
@@ -85,7 +84,12 @@ function auto_sizes_update_content_img_tag( $html ): string {
 	$processor->set_attribute( 'sizes', "auto, $sizes" );
 	return $processor->get_updated_html();
 }
-add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
+
+// Skip loading plugin filters if the WordPress core is already loaded auto sizes.
+if ( ! function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ) {
+	add_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' );
+	add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
+}
 
 /**
  * Checks whether the given 'sizes' attribute includes the 'auto' keyword as the first item in the list.

--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -85,7 +85,7 @@ function auto_sizes_update_content_img_tag( $html ): string {
 	return $processor->get_updated_html();
 }
 
-// Skip loading plugin filters if the WordPress core is already loaded auto sizes.
+// Skip loading plugin filters if WordPress Core already loaded the functionality.
 if ( ! function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ) {
 	add_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' );
 	add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -32,6 +32,12 @@ class Test_AutoSizes extends WP_UnitTestCase {
 		return get_image_tag( $attachment_id, '', '', '', 'large' );
 	}
 
+	public function test_hooks(): void {
+		$this->assertSame( function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ? false : 10, has_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' ) );
+		$this->assertSame( function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ? false : 10, has_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' ) );
+		$this->assertSame( 10, has_action( 'wp_head', 'auto_sizes_render_generator' ) );
+	}
+
 	/**
 	 * Test generated markup for an image with lazy loading gets auto-sizes.
 	 *

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -206,11 +206,13 @@ class Test_AutoSizes extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test auto-sizes meta tag present in wp_head hook.
+	 * Test printing the meta generator tag.
+	 *
+	 * @covers ::auto_sizes_render_generator
 	 */
-	public function test_auto_sizes_meta_tag_present_in_wp_head_hook(): void {
-		$tag = get_echo( 'wp_head' );
-		$this->assertStringContainsString( '<meta', $tag );
+	public function test_auto_sizes_render_generator(): void {
+		$tag = get_echo( 'auto_sizes_render_generator' );
+		$this->assertStringStartsWith( '<meta', $tag );
 		$this->assertStringContainsString( 'generator', $tag );
 		$this->assertStringContainsString( 'auto-sizes ' . IMAGE_AUTO_SIZES_VERSION, $tag );
 	}

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -33,8 +33,11 @@ class Test_AutoSizes extends WP_UnitTestCase {
 	}
 
 	public function test_hooks(): void {
-		$this->assertSame( 10, has_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' ) );
-		$this->assertSame( 10, has_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' ) );
+		// Skip loading plugin filters if the WordPress core is already loaded auto sizes.
+		if ( ! function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ) {
+			$this->assertSame( 10, has_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' ) );
+			$this->assertSame( 10, has_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' ) );
+		}
 		$this->assertSame( 10, has_action( 'wp_head', 'auto_sizes_render_generator' ) );
 	}
 

--- a/plugins/auto-sizes/tests/test-auto-sizes.php
+++ b/plugins/auto-sizes/tests/test-auto-sizes.php
@@ -32,15 +32,6 @@ class Test_AutoSizes extends WP_UnitTestCase {
 		return get_image_tag( $attachment_id, '', '', '', 'large' );
 	}
 
-	public function test_hooks(): void {
-		// Skip loading plugin filters if the WordPress core is already loaded auto sizes.
-		if ( ! function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ) {
-			$this->assertSame( 10, has_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' ) );
-			$this->assertSame( 10, has_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' ) );
-		}
-		$this->assertSame( 10, has_action( 'wp_head', 'auto_sizes_render_generator' ) );
-	}
-
 	/**
 	 * Test generated markup for an image with lazy loading gets auto-sizes.
 	 *
@@ -209,13 +200,11 @@ class Test_AutoSizes extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test printing the meta generator tag.
-	 *
-	 * @covers ::auto_sizes_render_generator
+	 * Test auto-sizes meta tag present in wp_head hook.
 	 */
-	public function test_auto_sizes_render_generator(): void {
-		$tag = get_echo( 'auto_sizes_render_generator' );
-		$this->assertStringStartsWith( '<meta', $tag );
+	public function test_auto_sizes_meta_tag_present_in_wp_head_hook(): void {
+		$tag = get_echo( 'wp_head' );
+		$this->assertStringContainsString( '<meta', $tag );
 		$this->assertStringContainsString( 'generator', $tag );
 		$this->assertStringContainsString( 'auto-sizes ' . IMAGE_AUTO_SIZES_VERSION, $tag );
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1531


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
