### PR TITLE
Prepare 3.4.1 release

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -5,7 +5,7 @@
  * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,6 +25,6 @@ if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.2.0' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.3.0' );
 
 require_once __DIR__ . '/hooks.php';

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   1.2.0
+Stable tag:   1.3.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, auto-sizes
@@ -51,6 +51,13 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.3.0 =
+
+**Enhancements**
+
+* Move Auto Sizes logic from Enhanced Responsive Images to Image Prioritizer. ([1476](https://github.com/WordPress/performance/pull/1476))
+* Update auto sizes logic in Enhanced Responsive Images plugin to no longer load if already in Core. ([1547](https://github.com/WordPress/performance/pull/1547))
 
 = 1.2.0 =
 

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -5,7 +5,7 @@
  * Description: Displays placeholders based on an image's dominant color while the image is loading.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'DOMINANT_COLOR_IMAGES_VERSION' ) ) {
 	return;
 }
 
-define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.1.1' );
+define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.1.2' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   1.1.1
+Stable tag:   1.1.2
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, dominant color
@@ -46,6 +46,17 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.1.2 =
+
+**Enhancements**
+
+* Use more robust HTML Tag Processor for Image Placeholders. ([1477](https://github.com/WordPress/performance/pull/1477))
+
+**Bug Fixes**
+
+* Re-remove unneeded phpcs:ignore. ([1231](https://github.com/WordPress/performance/pull/1231))
+* Update PHPStan to 1.11.5. ([1318](https://github.com/WordPress/performance/pull/1318))
 
 = 1.1.1 =
 

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -163,7 +163,7 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 	 *
 	 * Per the HTML spec, if present it must be the first entry.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.1.4
 	 *
 	 * @param string $sizes_attr The 'sizes' attribute value.
 	 * @return bool True if the 'auto' keyword is present, false otherwise.

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.1.3
+ * Version: 0.1.4
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.1.3',
+	'0.1.4',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.1.3
+Stable tag:   0.1.4
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -61,6 +61,12 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.1.4 =
+
+**Enhancements**
+
+* Move Auto Sizes logic from Enhanced Responsive Images to Image Prioritizer. ([1476](https://github.com/WordPress/performance/pull/1476))
 
 = 0.1.3 =
 

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -181,7 +181,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Count for the number of times that the cursor was moved.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 * @var int
 	 * @see self::next_token()
 	 * @see self::seek()
@@ -342,7 +342,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Gets the number of times the cursor has moved.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 * @see self::next_token()
 	 * @see self::seek()
 	 *

--- a/plugins/optimization-detective/class-od-strict-url-metric.php
+++ b/plugins/optimization-detective/class-od-strict-url-metric.php
@@ -3,7 +3,7 @@
  * Optimization Detective: OD_Strict_URL_Metric class
  *
  * @package optimization-detective
- * @since n.e.x.t
+ * @since 0.6.0
  */
 
 // Exit if accessed directly.
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This is used exclusively in the REST API endpoint for capturing new URL metrics to prevent invalid additional data from being
  * submitted in the request. For URL metrics which have been stored the looser OD_URL_Metric class is used instead.
  *
- * @since n.e.x.t
+ * @since 0.6.0
  * @access private
  */
 final class OD_Strict_URL_Metric extends OD_URL_Metric {
@@ -25,7 +25,7 @@ final class OD_Strict_URL_Metric extends OD_URL_Metric {
 	/**
 	 * Gets JSON schema for URL Metric without additionalProperties.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @return array<string, mixed> Schema.
 	 */
@@ -39,7 +39,7 @@ final class OD_Strict_URL_Metric extends OD_URL_Metric {
 	 * This is a forked version of `rest_default_additional_properties_to_false()` which isn't being used itself because
 	 * it does not override `additionalProperties` to be false, but rather only sets it when it is empty.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 * @see rest_default_additional_properties_to_false()
 	 *
 	 * @param mixed $schema Schema.

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -243,7 +243,7 @@ class OD_URL_Metric implements JsonSerializable {
 		/**
 		 * Filters additional schema properties which should be allowed at the root of a URL metric.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.6.0
 		 *
 		 * @param array<string, array{type: string}> $additional_properties Additional properties.
 		 */
@@ -255,7 +255,7 @@ class OD_URL_Metric implements JsonSerializable {
 		/**
 		 * Filters additional schema properties which should be allowed for an elements item in a URL metric.
 		 *
-		 * @since n.e.x.t
+		 * @since 0.6.0
 		 *
 		 * @param array<string, array{type: string}> $additional_properties Additional properties.
 		 */
@@ -274,7 +274,7 @@ class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Extends a schema with additional optional properties.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param array<string, mixed> $properties_schema     Properties schema to extend.
 	 * @param array<string, mixed> $additional_properties Additional properties.
@@ -287,7 +287,7 @@ class OD_URL_Metric implements JsonSerializable {
 			_doing_it_wrong(
 				esc_html( "Filter: '{$filter_name}'" ),
 				esc_html( $message ),
-				'Optimization Detective n.e.x.t'
+				'Optimization Detective 0.6.0'
 			);
 		};
 		foreach ( $additional_properties as $property_key => $property_schema ) {
@@ -349,7 +349,7 @@ class OD_URL_Metric implements JsonSerializable {
 	 *
 	 * This is particularly useful in conjunction with the `od_url_metric_schema_root_additional_properties` filter.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param string $key Property.
 	 * @return mixed|null The property value, or null if not set.

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.5.0
+ * Version: 0.6.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.5.0',
+	'0.6.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.5.0
+Stable tag:   0.6.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -156,6 +156,20 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.6.0 =
+
+**Enhancements**
+
+* Allow URL metric schema to be extended. ([1492](https://github.com/WordPress/performance/pull/1492))
+* Clarify docs around a tag visitor's boolean return value. ([1479](https://github.com/WordPress/performance/pull/1479))
+* Include UUID with each URL metric. ([1489](https://github.com/WordPress/performance/pull/1489))
+* Introduce get_cursor_move_count() to use instead of get_seek_count() and get_next_token_count(). ([1478](https://github.com/WordPress/performance/pull/1478))
+
+**Bug Fixes**
+
+* Add missing global documentation for `delete_all_posts()`. ([1522](https://github.com/WordPress/performance/pull/1522))
+* Introduce viewport aspect ratio validation for URL Metrics. ([1494](https://github.com/WordPress/performance/pull/1494))
 
 = 0.5.0 =
 

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -182,7 +182,7 @@ function od_verify_url_metrics_storage_nonce( string $nonce, string $slug, strin
 /**
  * Gets the minimum allowed viewport aspect ratio for URL metrics.
  *
- * @since n.e.x.t
+ * @since 0.6.0
  * @access private
  *
  * @return float Minimum viewport aspect ratio for URL metrics.
@@ -194,7 +194,7 @@ function od_get_minimum_viewport_aspect_ratio(): float {
 	 * The 0.4 default value is intended to accommodate the phone with the greatest known aspect
 	 * ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param float $minimum_viewport_aspect_ratio Minimum viewport aspect ratio.
 	 */
@@ -204,7 +204,7 @@ function od_get_minimum_viewport_aspect_ratio(): float {
 /**
  * Gets the maximum allowed viewport aspect ratio for URL metrics.
  *
- * @since n.e.x.t
+ * @since 0.6.0
  * @access private
  *
  * @return float Maximum viewport aspect ratio for URL metrics.
@@ -216,7 +216,7 @@ function od_get_maximum_viewport_aspect_ratio(): float {
 	 * The 2.5 default value is intended to accommodate the phone with the greatest known aspect
 	 * ratio at 21:9 (2.333).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param float $maximum_viewport_aspect_ratio Maximum viewport aspect ratio.
 	 */

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -171,7 +171,7 @@ function od_handle_rest_request( WP_REST_Request $request ) {
 	/**
 	 * Fires whenever a URL Metric was successfully collected.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.6.0
 	 *
 	 * @param array $context {
 	 *     Context about the successful URL Metric collection.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 3.4.0
+ * Version: 3.4.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.4.0' );
+define( 'PERFLAB_VERSION', '3.4.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.4.0
+Stable tag:   3.4.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -69,6 +69,12 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.4.1 =
+
+**Bug Fixes**
+
+* Fix Incorrect use of _n(). ([1491](https://github.com/WordPress/performance/pull/1491))
 
 = 3.4.0 =
 

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.0.0
  * @since 2.0.0 Added support for AVIF.
- * @since n.e.x.t Added support for PNG.
+ * @since 2.2.0 Added support for PNG.
  *
  * @return array<string, array<string>> An array of valid mime types, where the key is the mime type and the value is the extension type.
  */
@@ -403,7 +403,7 @@ function webp_uploads_is_picture_element_enabled(): bool {
  * Checks if the `perflab_generate_webp_and_jpeg` option is enabled.
  *
  * @since 2.0.0
- * @since n.e.x.t Renamed to webp_uploads_is_fallback_enabled().
+ * @since 2.2.0 Renamed to webp_uploads_is_fallback_enabled().
  *
  * @return bool True if the option is enabled, false otherwise.
  */
@@ -417,7 +417,7 @@ function webp_uploads_is_fallback_enabled(): bool {
  * This function attempts to locate an alternate image source URL in the
  * attachment's metadata that matches the provided MIME type.
  *
- * @since n.e.x.t
+ * @since 2.2.0
  *
  * @param int    $attachment_id The ID of the attachment.
  * @param string $src           The original image src url.

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 2.1.0
+ * Version: 2.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.1.0' );
+define( 'WEBP_UPLOADS_VERSION', '2.2.0' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   2.1.0
+Stable tag:   2.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -59,6 +59,16 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.2.0 =
+
+**Enhancements**
+
+* Convert uploaded PNG files to AVIF or WebP. ([1421](https://github.com/WordPress/performance/pull/1421))
+
+**Bug Fixes**
+
+* Account for responsive images being disabled when generating a PICTURE element. ([1449](https://github.com/WordPress/performance/pull/1449))
 
 = 2.1.0 =
 


### PR DESCRIPTION
Fixes #1534

- Bump versions
- Add changelogs
- Run `npm run since`

Plugins being released:

1. auto-sizes
1. dominant-color-images
1. image-prioritizer
1. optimization-detective
1. performance-lab
1. webp-uploads

# Pending Release Diffs


> generate-pending-release-diffs
> bin/generate-pending-release-diffs.sh

## `auto-sizes`

> [!IMPORTANT]
> Stable tag change: 1.2.0 → **1.3.0**

`svn status`:
```
M       auto-sizes.php
M       hooks.php
!       optimization-detective.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: auto-sizes.php
===================================================================
--- auto-sizes.php	(revision 3156461)
+++ auto-sizes.php	(working copy)
@@ -5,7 +5,7 @@
  * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 1.2.0
+ * Version: 1.3.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,8 +25,6 @@
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.2.0' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.3.0' );
 
 require_once __DIR__ . '/hooks.php';
-
-require_once __DIR__ . '/optimization-detective.php';
Index: hooks.php
===================================================================
--- hooks.php	(revision 3156461)
+++ hooks.php	(working copy)
@@ -42,7 +42,6 @@
 
 	return $attr;
 }
-add_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' );
 
 /**
  * Adds auto to the sizes attribute to the image, if applicable.
@@ -85,8 +84,13 @@
 	$processor->set_attribute( 'sizes', "auto, $sizes" );
 	return $processor->get_updated_html();
 }
-add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
 
+// Skip loading plugin filters if WordPress Core already loaded the functionality.
+if ( ! function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ) {
+	add_filter( 'wp_get_attachment_image_attributes', 'auto_sizes_update_image_attributes' );
+	add_filter( 'wp_content_img_tag', 'auto_sizes_update_content_img_tag' );
+}
+
 /**
  * Checks whether the given 'sizes' attribute includes the 'auto' keyword as the first item in the list.
  *
@@ -98,8 +102,8 @@
  * @return bool True if the 'auto' keyword is present, false otherwise.
  */
 function auto_sizes_attribute_includes_valid_auto( string $sizes_attr ): bool {
-	$token = strtok( strtolower( $sizes_attr ), ',' );
-	return false !== $token && 'auto' === trim( $token, " \t\f\r\n" );
+	list( $first_size ) = explode( ',', $sizes_attr, 2 );
+	return 'auto' === strtolower( trim( $first_size, " \t\f\r\n" ) );
 }
 
 /**
Index: readme.txt
===================================================================
--- readme.txt	(revision 3156461)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   1.2.0
+Stable tag:   1.3.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, auto-sizes
@@ -52,6 +52,13 @@
 
 == Changelog ==
 
+= 1.3.0 =
+
+**Enhancements**
+
+* Move Auto Sizes logic from Enhanced Responsive Images to Image Prioritizer. ([1476](https://github.com/WordPress/performance/pull/1476))
+* Update auto sizes logic in Enhanced Responsive Images plugin to no longer load if already in Core. ([1547](https://github.com/WordPress/performance/pull/1547))
+
 = 1.2.0 =
 
 **Enhancements**
```
</details>

## `dominant-color-images`

> [!IMPORTANT]
> Stable tag change: 1.1.1 → **1.1.2**

`svn status`:
```
M       class-dominant-color-image-editor-gd.php
M       class-dominant-color-image-editor-imagick.php
M       helper.php
M       hooks.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-dominant-color-image-editor-gd.php
===================================================================
--- class-dominant-color-image-editor-gd.php	(revision 3156461)
+++ class-dominant-color-image-editor-gd.php	(working copy)
@@ -27,16 +27,20 @@
 	 */
 	public function get_dominant_color() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_dominant_color_error_no_image', __( 'Dominant color detection no image found.', 'dominant-color-images' ) );
 		}
 		// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 		$shorted_image = imagecreatetruecolor( 1, 1 );
-		$image_width   = imagesx( $this->image );
-		$image_height  = imagesy( $this->image );
-		if ( false === $shorted_image || false === $image_width || false === $image_height ) {
+		if ( false === $shorted_image ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
+		// Note: These two functions only return integers, but they used to return int|false in PHP<8. This was changed in the PHP documentation in
+		// <https://github.com/php/doc-en/commit/0462f49> and <https://github.com/php/doc-en/commit/37f858a>. However, PhpStorm's stubs still think
+		// they return int|false. However, from looking at <https://github.com/php/php-src/blob/5db847e/ext/gd/gd.stub.php#L716-L718> these functions
+		// apparently only ever returned integers. So the type casting is here for the possible sake PHP<8.
+		$image_width  = (int) imagesx( $this->image ); // @phpstan-ignore cast.useless
+		$image_height = (int) imagesy( $this->image ); // @phpstan-ignore cast.useless
 		imagecopyresampled( $shorted_image, $this->image, 0, 0, 0, 0, 1, 1, $image_width, $image_height );
 
 		$rgb = imagecolorat( $shorted_image, 0, 0 );
@@ -47,7 +51,7 @@
 		$g   = ( $rgb >> 8 ) & 0xFF;
 		$b   = $rgb & 0xFF;
 		$hex = dominant_color_rgb_to_hex( $r, $g, $b );
-		if ( ! $hex ) {
+		if ( null === $hex ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
 
@@ -64,7 +68,7 @@
 	 */
 	public function has_transparency() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_has_transparency_error_no_image', __( 'Transparency detection no image found.', 'dominant-color-images' ) );
 		}
 
@@ -77,7 +81,12 @@
 				if ( false === $rgb ) {
 					return new WP_Error( 'unable_to_obtain_rgb_via_imagecolorat' );
 				}
-				$rgba = imagecolorsforindex( $this->image, $rgb );
+				try {
+					// Note: In PHP<8, this returns false if the color is out of range. In PHP8, this throws a ValueError instead.
+					$rgba = imagecolorsforindex( $this->image, $rgb );
+				} catch ( ValueError $error ) {
+					$rgba = false;
+				}
 				if ( ! is_array( $rgba ) ) {
 					return new WP_Error( 'unable_to_obtain_rgba_via_imagecolorsforindex' );
 				}
Index: class-dominant-color-image-editor-imagick.php
===================================================================
--- class-dominant-color-image-editor-imagick.php	(revision 3156461)
+++ class-dominant-color-image-editor-imagick.php	(working copy)
@@ -27,18 +27,17 @@
 	 */
 	public function get_dominant_color() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_dominant_color_error_no_image', __( 'Dominant color detection no image found.', 'dominant-color-images' ) );
 		}
 
 		try {
-			// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			// The logic here is resize the image to 1x1 pixel, then get the color of that pixel.
 			$this->image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
 			$pixel = $this->image->getImagePixelColor( 0, 0 );
 			$color = $pixel->getColor();
 			$hex   = dominant_color_rgb_to_hex( $color['r'], $color['g'], $color['b'] );
-			if ( ! $hex ) {
+			if ( null === $hex ) {
 				return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 			}
 
@@ -59,7 +58,7 @@
 	 */
 	public function has_transparency() {
 
-		if ( ! $this->image ) {
+		if ( ! (bool) $this->image ) {
 			return new WP_Error( 'image_editor_has_transparency_error_no_image', __( 'Transparency detection no image found.', 'dominant-color-images' ) );
 		}
 
Index: helper.php
===================================================================
--- helper.php	(revision 3156461)
+++ helper.php	(working copy)
@@ -54,10 +54,10 @@
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'dominant-color-images' ) );
 	}
 	$file = dominant_color_get_attachment_file_path( $attachment_id );
-	if ( ! $file ) {
+	if ( false === $file ) {
 		$file = get_attached_file( $attachment_id );
 	}
-	if ( ! $file ) {
+	if ( false === $file ) {
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'dominant-color-images' ) );
 	}
 	add_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
@@ -91,6 +91,8 @@
 	if ( is_wp_error( $has_transparency ) ) {
 		return $has_transparency;
 	}
+	$dominant_color_data = array();
+
 	$dominant_color_data['has_transparency'] = $has_transparency;
 
 	$dominant_color = $editor->get_dominant_color();
@@ -122,7 +124,7 @@
 	}
 
 	$file = get_attached_file( $attachment_id );
-	if ( ! $file ) {
+	if ( false === $file ) {
 		return false;
 	}
 
Index: hooks.php
===================================================================
--- hooks.php	(revision 3156461)
+++ hooks.php	(working copy)
@@ -100,14 +100,18 @@
 		return $filtered_image;
 	}
 
-	// Only apply the dominant color to images that have a src attribute that
-	// starts with a double quote, ensuring escaped JSON is also excluded.
-	if ( ! str_contains( $filtered_image, ' src="' ) ) {
+	$processor = new WP_HTML_Tag_Processor( $filtered_image );
+	if ( ! $processor->next_tag( array( 'tag_name' => 'IMG' ) ) ) {
 		return $filtered_image;
 	}
 
+	// Only apply the dominant color to images that have a src attribute.
+	if ( ! is_string( $processor->get_attribute( 'src' ) ) ) {
+		return $filtered_image;
+	}
+
 	// Ensure to not run the logic below in case relevant attributes are already present.
-	if ( str_contains( $filtered_image, ' data-dominant-color="' ) || str_contains( $filtered_image, ' data-has-transparency="' ) ) {
+	if ( null !== $processor->get_attribute( 'data-dominant-color' ) || null !== $processor->get_attribute( 'data-has-transparency' ) ) {
 		return $filtered_image;
 	}
 
@@ -134,34 +138,23 @@
 		return $filtered_image;
 	}
 
-	$data        = '';
-	$extra_class = '';
-
 	if ( ! empty( $image_meta['dominant_color'] ) ) {
-		$data .= sprintf( 'data-dominant-color="%s" ', esc_attr( $image_meta['dominant_color'] ) );
+		$processor->set_attribute( 'data-dominant-color', $image_meta['dominant_color'] );
 
-		if ( str_contains( $filtered_image, ' style="' ) ) {
-			$filtered_image = str_replace( ' style="', ' style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . '; ', $filtered_image );
-		} else {
-			$filtered_image = str_replace( '<img ', '<img style="--dominant-color: #' . esc_attr( $image_meta['dominant_color'] ) . ';" ', $filtered_image );
+		$style_attribute = '--dominant-color: #' . $image_meta['dominant_color'] . '; ';
+		if ( null !== $processor->get_attribute( 'style' ) ) {
+			$style_attribute .= $processor->get_attribute( 'style' );
 		}
+		$processor->set_attribute( 'style', trim( $style_attribute ) );
 	}
 
 	if ( isset( $image_meta['has_transparency'] ) ) {
 		$transparency = $image_meta['has_transparency'] ? 'true' : 'false';
-		$data        .= sprintf( 'data-has-transparency="%s" ', $transparency );
-		$extra_class  = $image_meta['has_transparency'] ? 'has-transparency' : 'not-transparent';
+		$processor->set_attribute( 'data-has-transparency', $transparency );
+		$processor->add_class( $image_meta['has_transparency'] ? 'has-transparency' : 'not-transparent' );
 	}
 
-	if ( $data ) {
-		$filtered_image = str_replace( '<img ', '<img ' . $data, $filtered_image );
-	}
-
-	if ( $extra_class ) {
-		$filtered_image = str_replace( ' class="', ' class="' . $extra_class . ' ', $filtered_image );
-	}
-
-	return $filtered_image;
+	return $processor->get_updated_html();
 }
 add_filter( 'wp_content_img_tag', 'dominant_color_img_tag_add_dominant_color', 20, 3 );
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3156461)
+++ readme.txt	(working copy)
@@ -1,13 +1,11 @@
 === Image Placeholders ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
-Requires PHP:      7.2
-Stable tag:        1.1.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, images, dominant color
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.1.2
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, images, dominant color
 
 Displays placeholders based on an image's dominant color while the image is loading.
 
@@ -49,6 +47,17 @@
 
 == Changelog ==
 
+= 1.1.2 =
+
+**Enhancements**
+
+* Use more robust HTML Tag Processor for Image Placeholders. ([1477](https://github.com/WordPress/performance/pull/1477))
+
+**Bug Fixes**
+
+* Re-remove unneeded phpcs:ignore. ([1231](https://github.com/WordPress/performance/pull/1231))
+* Update PHPStan to 1.11.5. ([1318](https://github.com/WordPress/performance/pull/1318))
+
 = 1.1.1 =
 
 **Enhancements**
```
</details>

## `embed-optimizer`

> [!WARNING]
> Stable tag is unchanged at 0.2.0, so no plugin release will occur.

`svn status`:
```
M       class-embed-optimizer-tag-visitor.php
M       hooks.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-embed-optimizer-tag-visitor.php
===================================================================
--- class-embed-optimizer-tag-visitor.php	(revision 3156461)
+++ class-embed-optimizer-tag-visitor.php	(working copy)
@@ -32,7 +32,7 @@
 	 * @since 0.2.0
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
-	 * @return bool Whether the visit or visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	public function __invoke( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
@@ -39,7 +39,7 @@
 		if ( ! (
 			'FIGURE' === $processor->get_tag()
 			&&
-			$processor->has_class( 'wp-block-embed' )
+			true === $processor->has_class( 'wp-block-embed' )
 		) ) {
 			return false;
 		}
@@ -60,44 +60,47 @@
 			 * for GET requests, as POST requests are not likely to be part of the critical rendering path.
 			 */
 			$preconnect_hrefs = array();
-			if ( $processor->has_class( 'wp-block-embed-youtube' ) ) {
+			$has_class        = static function ( string $wanted_class ) use ( $processor ): bool {
+				return true === $processor->has_class( $wanted_class );
+			};
+			if ( $has_class( 'wp-block-embed-youtube' ) ) {
 				$preconnect_hrefs[] = 'https://www.youtube.com';
 				$preconnect_hrefs[] = 'https://i.ytimg.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-twitter' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-twitter' ) ) {
 				$preconnect_hrefs[] = 'https://syndication.twitter.com';
 				$preconnect_hrefs[] = 'https://pbs.twimg.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-vimeo' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-vimeo' ) ) {
 				$preconnect_hrefs[] = 'https://player.vimeo.com';
 				$preconnect_hrefs[] = 'https://f.vimeocdn.com';
 				$preconnect_hrefs[] = 'https://i.vimeocdn.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-spotify' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-spotify' ) ) {
 				$preconnect_hrefs[] = 'https://apresolve.spotify.com';
 				$preconnect_hrefs[] = 'https://embed-cdn.spotifycdn.com';
 				$preconnect_hrefs[] = 'https://encore.scdn.co';
 				$preconnect_hrefs[] = 'https://i.scdn.co';
-			} elseif ( $processor->has_class( 'wp-block-embed-videopress' ) || $processor->has_class( 'wp-block-embed-wordpress-tv' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-videopress' ) || $has_class( 'wp-block-embed-wordpress-tv' ) ) {
 				$preconnect_hrefs[] = 'https://video.wordpress.com';
 				$preconnect_hrefs[] = 'https://public-api.wordpress.com';
 				$preconnect_hrefs[] = 'https://videos.files.wordpress.com';
 				$preconnect_hrefs[] = 'https://v0.wordpress.com'; // This does not appear to be a load-balanced domain since v1.wordpress.com is not valid.
-			} elseif ( $processor->has_class( 'wp-block-embed-instagram' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-instagram' ) ) {
 				$preconnect_hrefs[] = 'https://www.instagram.com';
 				$preconnect_hrefs[] = 'https://static.cdninstagram.com';
 				$preconnect_hrefs[] = 'https://scontent.cdninstagram.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-tiktok' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-tiktok' ) ) {
 				$preconnect_hrefs[] = 'https://www.tiktok.com';
 				// Note: The other domains used for TikTok embeds include https://lf16-tiktok-web.tiktokcdn-us.com,
 				// https://lf16-cdn-tos.tiktokcdn-us.com, and https://lf16-tiktok-common.tiktokcdn-us.com among others
 				// which either appear to be geo-targeted ('-us') _or_ load-balanced ('lf16'). So these are not added
 				// to the preconnected hosts.
-			} elseif ( $processor->has_class( 'wp-block-embed-amazon' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-amazon' ) ) {
 				$preconnect_hrefs[] = 'https://read.amazon.com';
 				$preconnect_hrefs[] = 'https://m.media-amazon.com';
-			} elseif ( $processor->has_class( 'wp-block-embed-soundcloud' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-soundcloud' ) ) {
 				$preconnect_hrefs[] = 'https://w.soundcloud.com';
 				$preconnect_hrefs[] = 'https://widget.sndcdn.com';
 				// Note: There is also https://i1.sndcdn.com which is for the album art, but the '1' indicates it may be geotargeted/load-balanced.
-			} elseif ( $processor->has_class( 'wp-block-embed-pinterest' ) ) {
+			} elseif ( $has_class( 'wp-block-embed-pinterest' ) ) {
 				$preconnect_hrefs[] = 'https://assets.pinterest.com';
 				$preconnect_hrefs[] = 'https://widgets.pinterest.com';
 				$preconnect_hrefs[] = 'https://i.pinimg.com';
Index: hooks.php
===================================================================
--- hooks.php	(revision 3156461)
+++ hooks.php	(working copy)
@@ -120,7 +120,8 @@
 
 			if ( 'IFRAME' === $html_processor->get_tag() ) {
 				$loading_value = $html_processor->get_attribute( 'loading' );
-				if ( empty( $loading_value ) ) {
+				// Per the HTML spec: "The attribute's missing value default and invalid value default are both the Eager state".
+				if ( 'lazy' !== $loading_value ) {
 					++$iframe_count;
 					if ( ! $html_processor->set_bookmark( $bookmark_names['iframe'] ) ) {
 						throw new Exception(
@@ -130,7 +131,7 @@
 					}
 				}
 			} elseif ( 'SCRIPT' === $html_processor->get_tag() ) {
-				if ( ! $html_processor->get_attribute( 'src' ) ) {
+				if ( null === $html_processor->get_attribute( 'src' ) ) {
 					$has_inline_script = true;
 				} else {
 					++$script_count;
@@ -147,7 +148,7 @@
 		if ( 1 === $script_count && ! $has_inline_script && $html_processor->has_bookmark( $bookmark_names['script'] ) ) {
 			$needs_lazy_script = true;
 			if ( $html_processor->seek( $bookmark_names['script'] ) ) {
-				if ( $html_processor->get_attribute( 'type' ) ) {
+				if ( is_string( $html_processor->get_attribute( 'type' ) ) ) {
 					$html_processor->set_attribute( 'data-original-type', $html_processor->get_attribute( 'type' ) );
 				}
 				$html_processor->set_attribute( 'type', 'application/vnd.embed-optimizer.javascript' );
@@ -166,7 +167,7 @@
 				// For post embeds, use visibility:hidden instead of clip since browsers will consistently load the
 				// lazy-loaded iframe (where Chromium is unreliably with clip) while at the same time improve accessibility
 				// by preventing links in the hidden iframe from receiving focus.
-				if ( $html_processor->has_class( 'wp-embedded-content' ) ) {
+				if ( true === $html_processor->has_class( 'wp-embedded-content' ) ) {
 					$style = $html_processor->get_attribute( 'style' );
 					if ( is_string( $style ) ) {
 						// WordPress core injects this clip CSS property:
```
</details>

## `image-prioritizer`

> [!IMPORTANT]
> Stable tag change: 0.1.3 → **0.1.4**

`svn status`:
```
M       class-image-prioritizer-background-image-styled-tag-visitor.php
M       class-image-prioritizer-img-tag-visitor.php
M       class-image-prioritizer-tag-visitor.php
M       load.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-image-prioritizer-background-image-styled-tag-visitor.php
===================================================================
--- class-image-prioritizer-background-image-styled-tag-visitor.php	(revision 3156461)
+++ class-image-prioritizer-background-image-styled-tag-visitor.php	(working copy)
@@ -23,7 +23,7 @@
 	 * Visits a tag.
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
-	 * @return bool Whether the visitor visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	public function __invoke( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
Index: class-image-prioritizer-img-tag-visitor.php
===================================================================
--- class-image-prioritizer-img-tag-visitor.php	(revision 3156461)
+++ class-image-prioritizer-img-tag-visitor.php	(working copy)
@@ -24,7 +24,7 @@
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
 	 *
-	 * @return bool Whether the visitor visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	public function __invoke( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
@@ -40,6 +40,20 @@
 
 		$xpath = $processor->get_xpath();
 
+		/**
+		 * Gets attribute value.
+		 *
+		 * @param string $attribute_name Attribute name.
+		 * @return string|true|null Normalized attribute value.
+		 */
+		$get_attribute_value = static function ( string $attribute_name ) use ( $processor ) {
+			$value = $processor->get_attribute( $attribute_name );
+			if ( is_string( $value ) ) {
+				$value = strtolower( trim( $value, " \t\f\r\n" ) );
+			}
+			return $value;
+		};
+
 		/*
 		 * When the same LCP element is common/shared among all viewport groups, make sure that the element has
 		 * fetchpriority=high, even though it won't really be needed because a preload link with fetchpriority=high
@@ -47,7 +61,7 @@
 		 */
 		$common_lcp_element = $context->url_metrics_group_collection->get_common_lcp_element();
 		if ( ! is_null( $common_lcp_element ) && $xpath === $common_lcp_element['xpath'] ) {
-			if ( 'high' === $processor->get_attribute( 'fetchpriority' ) ) {
+			if ( 'high' === $get_attribute_value( 'fetchpriority' ) ) {
 				$processor->set_meta_attribute( 'fetchpriority-already-added', true );
 			} else {
 				$processor->set_attribute( 'fetchpriority', 'high' );
@@ -81,7 +95,7 @@
 		} else {
 			// Otherwise, make sure visible elements omit the loading attribute, and hidden elements include loading=lazy.
 			$is_visible = $element_max_intersection_ratio > 0.0;
-			$loading    = (string) $processor->get_attribute( 'loading' );
+			$loading    = $get_attribute_value( 'loading' );
 			if ( $is_visible && 'lazy' === $loading ) {
 				$processor->remove_attribute( 'loading' );
 			} elseif ( ! $is_visible && 'lazy' !== $loading ) {
@@ -90,6 +104,23 @@
 		}
 		// TODO: If an image is visible in one breakpoint but not another, add loading=lazy AND add a regular-priority preload link with media queries (unless LCP in which case it should already have a fetchpriority=high link) so that the image won't be eagerly-loaded for viewports on which it is not shown.
 
+		// Ensure that sizes=auto is set properly.
+		$sizes = $processor->get_attribute( 'sizes' );
+		if ( is_string( $sizes ) ) {
+			$is_lazy  = 'lazy' === $get_attribute_value( 'loading' );
+			$has_auto = $this->sizes_attribute_includes_valid_auto( $sizes );
+
+			if ( $is_lazy && ! $has_auto ) {
+				$processor->set_attribute( 'sizes', "auto, $sizes" );
+			} elseif ( ! $is_lazy && $has_auto ) {
+				// Remove auto from the beginning of the list.
+				$processor->set_attribute(
+					'sizes',
+					(string) preg_replace( '/^[ \t\f\r\n]*auto[ \t\f\r\n]*(,[ \t\f\r\n]*)?/i', '', $sizes )
+				);
+			}
+		}
+
 		// If this element is the LCP (for a breakpoint group), add a preload link for it.
 		foreach ( $context->url_metrics_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
 			$link_attributes = array_merge(
@@ -110,8 +141,8 @@
 				)
 			);
 
-			$crossorigin = $processor->get_attribute( 'crossorigin' );
-			if ( is_string( $crossorigin ) ) {
+			$crossorigin = $get_attribute_value( 'crossorigin' );
+			if ( null !== $crossorigin ) {
 				$link_attributes['crossorigin'] = 'use-credentials' === $crossorigin ? 'use-credentials' : 'anonymous';
 			}
 
@@ -126,4 +157,24 @@
 
 		return true;
 	}
+
+	/**
+	 * Checks whether the given 'sizes' attribute includes the 'auto' keyword as the first item in the list.
+	 *
+	 * Per the HTML spec, if present it must be the first entry.
+	 *
+	 * @since 0.1.4
+	 *
+	 * @param string $sizes_attr The 'sizes' attribute value.
+	 * @return bool True if the 'auto' keyword is present, false otherwise.
+	 */
+	private function sizes_attribute_includes_valid_auto( string $sizes_attr ): bool {
+		if ( function_exists( 'wp_sizes_attribute_includes_valid_auto' ) ) {
+			return wp_sizes_attribute_includes_valid_auto( $sizes_attr );
+		} elseif ( function_exists( 'auto_sizes_attribute_includes_valid_auto' ) ) {
+			return auto_sizes_attribute_includes_valid_auto( $sizes_attr );
+		} else {
+			return 'auto' === $sizes_attr || str_starts_with( $sizes_attr, 'auto,' );
+		}
+	}
 }
Index: class-image-prioritizer-tag-visitor.php
===================================================================
--- class-image-prioritizer-tag-visitor.php	(revision 3156461)
+++ class-image-prioritizer-tag-visitor.php	(working copy)
@@ -23,7 +23,7 @@
 	 * Visits a tag.
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
-	 * @return bool Whether the visitor visited the tag.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	abstract public function __invoke( OD_Tag_Visitor_Context $context ): bool;
 
Index: load.php
===================================================================
--- load.php	(revision 3156461)
+++ load.php	(working copy)
@@ -6,7 +6,7 @@
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.1.3
+ * Version: 0.1.4
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.1.3',
+	'0.1.4',
 	static function ( string $version ): void {
 
 		// Define the constant.
Index: readme.txt
===================================================================
--- readme.txt	(revision 3156461)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.1.3
+Stable tag:   0.1.4
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -62,6 +62,12 @@
 
 == Changelog ==
 
+= 0.1.4 =
+
+**Enhancements**
+
+* Move Auto Sizes logic from Enhanced Responsive Images to Image Prioritizer. ([1476](https://github.com/WordPress/performance/pull/1476))
+
 = 0.1.3 =
 
 **Bug Fixes**
```
</details>

## `optimization-detective`

> [!IMPORTANT]
> Stable tag change: 0.5.0 → **0.6.0**

`svn status`:
```
M       class-od-html-tag-processor.php
M       class-od-link-collection.php
?       class-od-strict-url-metric.php
M       class-od-url-metric.php
M       detect.js
M       detection.php
M       load.php
M       optimization.php
M       readme.txt
M       storage/class-od-url-metrics-post-type.php
M       storage/data.php
M       storage/rest-api.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-od-html-tag-processor.php
===================================================================
--- class-od-html-tag-processor.php	(revision 3156461)
+++ class-od-html-tag-processor.php	(working copy)
@@ -179,13 +179,14 @@
 	private $buffered_text_replacements = array();
 
 	/**
-	 * Count for the number of times next_token() was called
+	 * Count for the number of times that the cursor was moved.
 	 *
-	 * @since 0.4.1
+	 * @since 0.6.0
 	 * @var int
 	 * @see self::next_token()
+	 * @see self::seek()
 	 */
-	private $next_token_count = 0;
+	private $cursor_move_count = 0;
 
 	/**
 	 * Finds the next tag.
@@ -258,7 +259,7 @@
 	 */
 	public function next_token(): bool {
 		$this->current_xpath = null; // Clear cache.
-		++$this->next_token_count;
+		++$this->cursor_move_count;
 		if ( ! parent::next_token() ) {
 			$this->open_stack_tags    = array();
 			$this->open_stack_indices = array();
@@ -339,15 +340,16 @@
 	}
 
 	/**
-	 * Gets the number of times next_token() was called.
+	 * Gets the number of times the cursor has moved.
 	 *
-	 * @since 0.4.1
+	 * @since 0.6.0
 	 * @see self::next_token()
+	 * @see self::seek()
 	 *
-	 * @return int Count of next_token() calls.
+	 * @return int Count of times the cursor has moved.
 	 */
-	public function get_next_token_count(): int {
-		return $this->next_token_count;
+	public function get_cursor_move_count(): int {
+		return $this->cursor_move_count;
 	}
 
 	/**
@@ -376,8 +378,10 @@
 	/**
 	 * Sets a meta attribute.
 	 *
-	 * All meta attributes are prefixed with 'data-od-'.
+	 * All meta attributes are prefixed with data-od-.
 	 *
+	 * @since 0.4.0
+	 *
 	 * @param string      $name  Meta attribute name.
 	 * @param string|true $value Value.
 	 * @return bool Whether an attribute was set.
@@ -434,18 +438,6 @@
 	}
 
 	/**
-	 * Gets the number of times seek() was called.
-	 *
-	 * @since 0.4.1
-	 * @see self::seek()
-	 *
-	 * @return int Count of seek() calls.
-	 */
-	public function get_seek_count(): int {
-		return $this->seek_count;
-	}
-
-	/**
 	 * Sets a bookmark in the HTML document.
 	 *
 	 * @inheritDoc
@@ -567,6 +559,8 @@
 	/**
 	 * Returns the string representation of the HTML Tag Processor.
 	 *
+	 * @since 0.4.0
+	 *
 	 * @return string The processed HTML.
 	 */
 	public function get_updated_html(): string {
Index: class-od-link-collection.php
===================================================================
--- class-od-link-collection.php	(revision 3156461)
+++ class-od-link-collection.php	(working copy)
@@ -25,7 +25,7 @@
  *                   href?: non-empty-string,
  *                   imagesrcset?: non-empty-string,
  *                   imagesizes?: non-empty-string,
- *                   crossorigin?: ''|'anonymous'|'use-credentials',
+ *                   crossorigin?: 'anonymous'|'use-credentials',
  *                   fetchpriority?: 'high'|'low'|'auto',
  *                   as?: 'audio'|'document'|'embed'|'fetch'|'font'|'image'|'object'|'script'|'style'|'track'|'video'|'worker',
  *                   media?: non-empty-string,
Index: class-od-url-metric.php
===================================================================
--- class-od-url-metric.php	(revision 3156461)
+++ class-od-url-metric.php	(working copy)
@@ -37,6 +37,7 @@
  *                                boundingClientRect: DOMRect,
  *                            }
  * @phpstan-type Data         array{
+ *                                uuid: string,
  *                                url: string,
  *                                timestamp: float,
  *                                viewport: ViewportRect,
@@ -46,7 +47,7 @@
  * @since 0.1.0
  * @access private
  */
-final class OD_URL_Metric implements JsonSerializable {
+class OD_URL_Metric implements JsonSerializable {
 
 	/**
 	 * Data.
@@ -53,7 +54,7 @@
 	 *
 	 * @var Data
 	 */
-	private $data;
+	protected $data;
 
 	/**
 	 * Constructor.
@@ -60,43 +61,68 @@
 	 *
 	 * @phpstan-param Data|array<string, mixed> $data Valid data or invalid data (in which case an exception is thrown).
 	 *
+	 * @throws OD_Data_Validation_Exception When the input is invalid.
+	 *
 	 * @param array<string, mixed> $data URL metric data.
-	 *
-	 * @throws OD_Data_Validation_Exception When the input is invalid.
 	 */
 	public function __construct( array $data ) {
-		$this->validate_data( $data );
-		$this->data = $data;
+		if ( ! isset( $data['uuid'] ) ) {
+			$data['uuid'] = wp_generate_uuid4();
+		}
+		$this->data = $this->prepare_data( $data );
 	}
 
 	/**
-	 * Validate data.
+	 * Prepares data with validation and sanitization.
 	 *
-	 * @phpstan-assert Data $data
+	 * @throws OD_Data_Validation_Exception When the input is invalid.
 	 *
 	 * @param array<string, mixed> $data Data to validate.
-	 * @throws OD_Data_Validation_Exception When the input is invalid.
+	 * @return Data Validated and sanitized data.
 	 */
-	private function validate_data( array $data ): void {
-		$valid = rest_validate_object_value_from_schema( $data, self::get_json_schema(), self::class );
+	private function prepare_data( array $data ): array {
+		$schema = static::get_json_schema();
+		$valid  = rest_validate_object_value_from_schema( $data, $schema, self::class );
 		if ( is_wp_error( $valid ) ) {
 			throw new OD_Data_Validation_Exception( esc_html( $valid->get_error_message() ) );
 		}
+		$aspect_ratio     = $data['viewport']['width'] / $data['viewport']['height'];
+		$min_aspect_ratio = od_get_minimum_viewport_aspect_ratio();
+		$max_aspect_ratio = od_get_maximum_viewport_aspect_ratio();
+		if (
+			$aspect_ratio < $min_aspect_ratio ||
+			$aspect_ratio > $max_aspect_ratio
+		) {
+			throw new OD_Data_Validation_Exception(
+				esc_html(
+					sprintf(
+						/* translators: 1: current aspect ratio, 2: minimum aspect ratio, 3: maximum aspect ratio */
+						__( 'Viewport aspect ratio (%1$s) is not in the accepted range of %2$s to %3$s.', 'optimization-detective' ),
+						$aspect_ratio,
+						$min_aspect_ratio,
+						$max_aspect_ratio
+					)
+				)
+			);
+		}
+		return rest_sanitize_value_from_schema( $data, $schema, self::class );
 	}
 
 	/**
 	 * Gets JSON schema for URL Metric.
 	 *
+	 * @todo Cache the return value?
+	 *
 	 * @return array<string, mixed> Schema.
 	 */
 	public static function get_json_schema(): array {
 		/*
-		 * The intersectionRect and clientBoundingRect are both instances of the DOMRectReadOnly, which
+		 * The intersectionRect and boundingClientRect are both instances of the DOMRectReadOnly, which
 		 * the following schema describes. See <https://developer.mozilla.org/en-US/docs/Web/API/DOMRectReadOnly>.
 		 * Note that 'number' is used specifically instead of 'integer' because the values are all specified as
 		 * floats/doubles.
 		 */
-		$properties = array_fill_keys(
+		$dom_rect_properties = array_fill_keys(
 			array(
 				'width',
 				'height',
@@ -114,22 +140,29 @@
 		);
 
 		// The spec allows these to be negative but this doesn't make sense in the context of intersectionRect and boundingClientRect.
-		$properties['width']['minimum']  = 0.0;
-		$properties['height']['minimum'] = 0.0;
+		$dom_rect_properties['width']['minimum']  = 0.0;
+		$dom_rect_properties['height']['minimum'] = 0.0;
 
 		$dom_rect_schema = array(
 			'type'                 => 'object',
 			'required'             => true,
-			'properties'           => $properties,
+			'properties'           => $dom_rect_properties,
 			'additionalProperties' => false,
 		);
 
-		return array(
+		$schema = array(
 			'$schema'              => 'http://json-schema.org/draft-04/schema#',
 			'title'                => 'od-url-metric',
 			'type'                 => 'object',
 			'required'             => true,
 			'properties'           => array(
+				'uuid'      => array(
+					'description' => __( 'The UUID for the URL metric.', 'optimization-detective' ),
+					'type'        => 'string',
+					'format'      => 'uuid',
+					'required'    => true,
+					'readonly'    => true, // Omit from REST API.
+				),
 				'url'       => array(
 					'description' => __( 'The URL for which the metric was obtained.', 'optimization-detective' ),
 					'type'        => 'string',
@@ -160,7 +193,6 @@
 					'type'        => 'number',
 					'required'    => true,
 					'readonly'    => true, // Omit from REST API.
-					'default'     => microtime( true ), // Value provided when instantiating OD_URL_Metric in REST API.
 					'minimum'     => 0,
 				),
 				'elements'  => array(
@@ -194,15 +226,148 @@
 							'intersectionRect'   => $dom_rect_schema,
 							'boundingClientRect' => $dom_rect_schema,
 						),
-						'additionalProperties' => false,
+
+						// Additional properties may be added to the schema for items of elements via the od_url_metric_schema_element_item_additional_properties filter.
+						// See further explanation below.
+						'additionalProperties' => true,
 					),
 				),
 			),
-			'additionalProperties' => false,
+			// Additional root properties may be added to the schema via the od_url_metric_schema_root_additional_properties filter.
+			// Therefore, additionalProperties is set to true so that additional properties defined in the extended schema may persist
+			// in a stored URL Metric even when the extension is deactivated. For REST API requests, the OD_Strict_URL_Metric
+			// which sets this to false so that newly-submitted URL Metrics only ever include the known properties.
+			'additionalProperties' => true,
 		);
+
+		/**
+		 * Filters additional schema properties which should be allowed at the root of a URL metric.
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param array<string, array{type: string}> $additional_properties Additional properties.
+		 */
+		$additional_properties = (array) apply_filters( 'od_url_metric_schema_root_additional_properties', array() );
+		if ( count( $additional_properties ) > 0 ) {
+			$schema['properties'] = self::extend_schema_with_optional_properties( $schema['properties'], $additional_properties, 'od_url_metric_schema_root_additional_properties' );
+		}
+
+		/**
+		 * Filters additional schema properties which should be allowed for an elements item in a URL metric.
+		 *
+		 * @since 0.6.0
+		 *
+		 * @param array<string, array{type: string}> $additional_properties Additional properties.
+		 */
+		$additional_properties = (array) apply_filters( 'od_url_metric_schema_element_item_additional_properties', array() );
+		if ( count( $additional_properties ) > 0 ) {
+			$schema['properties']['elements']['items']['properties'] = self::extend_schema_with_optional_properties(
+				$schema['properties']['elements']['items']['properties'],
+				$additional_properties,
+				'od_url_metric_schema_root_additional_properties'
+			);
+		}
+
+		return $schema;
 	}
 
 	/**
+	 * Extends a schema with additional optional properties.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param array<string, mixed> $properties_schema     Properties schema to extend.
+	 * @param array<string, mixed> $additional_properties Additional properties.
+	 * @param string               $filter_name           Filter name used to extend.
+	 *
+	 * @return array<string, mixed> Extended schema.
+	 */
+	protected static function extend_schema_with_optional_properties( array $properties_schema, array $additional_properties, string $filter_name ): array {
+		$doing_it_wrong = static function ( string $message ) use ( $filter_name ): void {
+			_doing_it_wrong(
+				esc_html( "Filter: '{$filter_name}'" ),
+				esc_html( $message ),
+				'Optimization Detective 0.6.0'
+			);
+		};
+		foreach ( $additional_properties as $property_key => $property_schema ) {
+			if ( ! is_array( $property_schema ) ) {
+				continue;
+			}
+			if ( isset( $properties_schema[ $property_key ] ) ) {
+				$doing_it_wrong(
+					sprintf(
+						/* translators: property name */
+						__( 'Disallowed override of existing schema property "%s".', 'optimization-detective' ),
+						$property_key
+					)
+				);
+				continue;
+			}
+			if ( ! isset( $property_schema['type'] ) || ! ( is_string( $property_schema['type'] ) || is_array( $property_schema['type'] ) ) ) {
+				$doing_it_wrong(
+					sprintf(
+						/* translators: 1: property name, 2: 'type' */
+						__( 'Supplied schema property "%1$s" with missing "%2$s" key.', 'optimization-detective' ),
+						'type',
+						$property_key
+					)
+				);
+				continue;
+			}
+			if ( isset( $property_schema['required'] ) && false !== $property_schema['required'] ) {
+				$doing_it_wrong(
+					sprintf(
+						/* translators: 1: property name, 2: 'required' */
+						__( 'Supplied schema property "%1$s" has a truthy value for "%2$s". All extended properties must be optional so that URL Metrics are not all immediately invalidated once an extension is deactivated.', 'optimization-detective' ),
+						$property_key,
+						'required'
+					)
+				);
+			}
+			$property_schema['required'] = false;
+
+			if ( isset( $property_schema['default'] ) ) {
+				$doing_it_wrong(
+					sprintf(
+						/* translators: 1: property name, 2: 'default' */
+						__( 'Supplied schema property "%1$s" has disallowed "%2$s" specified.', 'optimization-detective' ),
+						$property_key,
+						'default'
+					)
+				);
+				unset( $property_schema['default'] );
+			}
+
+			$properties_schema[ $property_key ] = $property_schema;
+		}
+		return $properties_schema;
+	}
+
+	/**
+	 * Gets property value for an arbitrary key.
+	 *
+	 * This is particularly useful in conjunction with the `od_url_metric_schema_root_additional_properties` filter.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param string $key Property.
+	 * @return mixed|null The property value, or null if not set.
+	 */
+	public function get( string $key ) {
+		return $this->data[ $key ] ?? null;
+	}
+
+	/**
+	 * Gets UUID.
+	 *
+	 * @return string UUID.
+	 */
+	public function get_uuid(): string {
+		return $this->data['uuid'];
+	}
+
+	/**
 	 * Gets URL.
 	 *
 	 * @return string URL.
Index: detect.js
===================================================================
--- detect.js	(revision 3156461)
+++ detect.js	(working copy)
@@ -1 +1 @@
-const win=window,doc=win.document,consoleLogPrefix="[Optimization Detective]",storageLockTimeSessionKey="odStorageLockTime";function isStorageLocked(e,t){if(0===t)return!1;try{const o=parseInt(sessionStorage.getItem(storageLockTimeSessionKey));return!isNaN(o)&&e<o+1e3*t}catch(e){return!1}}function setStorageLock(e){try{sessionStorage.setItem(storageLockTimeSessionKey,String(e))}catch(e){}}function log(...e){console.log(consoleLogPrefix,...e)}function warn(...e){console.warn(consoleLogPrefix,...e)}function error(...e){console.error(consoleLogPrefix,...e)}function isViewportNeeded(e,t){let o=!1;for(const{minimumViewportWidth:n,complete:i}of t){if(!(e>=n))break;o=!i}return o}function getCurrentTime(){return Date.now()}export default async function detect({serveTime:e,detectionTimeWindow:t,isDebug:o,restApiEndpoint:n,restApiNonce:i,currentUrl:r,urlMetricsSlug:s,urlMetricsNonce:c,urlMetricsGroupStatuses:a,storageLockTTL:d,webVitalsLibrarySrc:l,urlMetricsGroupCollection:u}){const g=getCurrentTime();if(o&&log("Stored URL metrics group collection:",u),g-e>t)return void(o&&warn("Aborted detection due to being outside detection time window."));if(!isViewportNeeded(win.innerWidth,a))return void(o&&log("No need for URL metrics from the current viewport."));if(await new Promise((e=>{"loading"!==doc.readyState?e():doc.addEventListener("DOMContentLoaded",e,{once:!0})})),await new Promise((e=>{"complete"===doc.readyState?e():win.addEventListener("load",e,{once:!0})})),"function"==typeof requestIdleCallback&&await new Promise((e=>{requestIdleCallback(e)})),isStorageLocked(g,d))return void(o&&warn("Aborted detection due to storage being locked."));if(doc.documentElement.scrollTop>0)return void(o&&warn("Aborted detection since initial scroll position of page is not at the top."));o&&log("Proceeding with detection");const w=doc.body.querySelectorAll("[data-od-xpath]"),m=new Map([...w].map((e=>[e,e.dataset.odXpath]))),f=[];let p;function h(){p instanceof IntersectionObserver&&(p.disconnect(),win.removeEventListener("scroll",h))}m.size>0&&(await new Promise((e=>{p=new IntersectionObserver((t=>{for(const e of t)f.push(e);e()}),{root:null,threshold:0});for(const e of m.keys())p.observe(e)})),win.addEventListener("scroll",h,{once:!0,passive:!0}));const{onLCP:L}=await import(l),S=[];await new Promise((e=>{L((t=>{S.push(t),e()}),{reportAllChanges:!0})})),h(),o&&log("Detection is stopping.");const b={url:r,slug:s,nonce:c,viewport:{width:win.innerWidth,height:win.innerHeight},elements:[]},v=S.at(-1);for(const e of f){const t=m.get(e.target);if(!t){o&&error("Unable to look up XPath for element");continue}const n={isLCP:e.target===v?.entries[0]?.element,isLCPCandidate:!!S.find((t=>t.entries[0]?.element===e.target)),xpath:t,intersectionRatio:e.intersectionRatio,intersectionRect:e.intersectionRect,boundingClientRect:e.boundingClientRect};b.elements.push(n)}o&&log("Current URL metrics:",b),await new Promise((e=>{setTimeout(e,0)}));try{const e=await fetch(n,{method:"POST",headers:{"Content-Type":"application/json","X-WP-Nonce":i},body:JSON.stringify(b)});if(200===e.status&&setStorageLock(getCurrentTime()),o){const t=await e.json();200===e.status?log("Response:",t):error("Failure:",t)}}catch(e){o&&error(e)}m.clear()}
\ No newline at end of file
+const win=window,doc=win.document,consoleLogPrefix="[Optimization Detective]",storageLockTimeSessionKey="odStorageLockTime";function isStorageLocked(e,t){if(0===t)return!1;try{const o=parseInt(sessionStorage.getItem(storageLockTimeSessionKey));return!isNaN(o)&&e<o+1e3*t}catch(e){return!1}}function setStorageLock(e){try{sessionStorage.setItem(storageLockTimeSessionKey,String(e))}catch(e){}}function log(...e){console.log(consoleLogPrefix,...e)}function warn(...e){console.warn(consoleLogPrefix,...e)}function error(...e){console.error(consoleLogPrefix,...e)}function isViewportNeeded(e,t){let o=!1;for(const{minimumViewportWidth:n,complete:i}of t){if(!(e>=n))break;o=!i}return o}function getCurrentTime(){return Date.now()}export default async function detect({serveTime:e,detectionTimeWindow:t,minViewportAspectRatio:o,maxViewportAspectRatio:n,isDebug:i,restApiEndpoint:r,restApiNonce:s,currentUrl:c,urlMetricsSlug:a,urlMetricsNonce:d,urlMetricsGroupStatuses:l,storageLockTTL:u,webVitalsLibrarySrc:g,urlMetricsGroupCollection:w}){const p=getCurrentTime();if(i&&log("Stored URL metrics group collection:",w),p-e>t)return void(i&&warn("Aborted detection due to being outside detection time window."));if(!isViewportNeeded(win.innerWidth,l))return void(i&&log("No need for URL metrics from the current viewport."));const m=win.innerWidth/win.innerHeight;if(m<o||m>n)return void(i&&warn(`Viewport aspect ratio (${m}) is not in the accepted range of ${o} to ${n}.`));if(await new Promise((e=>{"loading"!==doc.readyState?e():doc.addEventListener("DOMContentLoaded",e,{once:!0})})),await new Promise((e=>{"complete"===doc.readyState?e():win.addEventListener("load",e,{once:!0})})),"function"==typeof requestIdleCallback&&await new Promise((e=>{requestIdleCallback(e)})),isStorageLocked(p,u))return void(i&&warn("Aborted detection due to storage being locked."));if(doc.documentElement.scrollTop>0)return void(i&&warn("Aborted detection since initial scroll position of page is not at the top."));i&&log("Proceeding with detection");const f=doc.body.querySelectorAll("[data-od-xpath]"),h=new Map([...f].map((e=>[e,e.dataset.odXpath]))),L=[];let S;function b(){S instanceof IntersectionObserver&&(S.disconnect(),win.removeEventListener("scroll",b))}h.size>0&&(await new Promise((e=>{S=new IntersectionObserver((t=>{for(const e of t)L.push(e);e()}),{root:null,threshold:0});for(const e of h.keys())S.observe(e)})),win.addEventListener("scroll",b,{once:!0,passive:!0}));const{onLCP:v}=await import(g),y=[];await new Promise((e=>{v((t=>{y.push(t),e()}),{reportAllChanges:!0})})),b(),i&&log("Detection is stopping.");const P={url:c,slug:a,nonce:d,viewport:{width:win.innerWidth,height:win.innerHeight},elements:[]},C=y.at(-1);for(const e of L){const t=h.get(e.target);if(!t){i&&error("Unable to look up XPath for element");continue}const o={isLCP:e.target===C?.entries[0]?.element,isLCPCandidate:!!y.find((t=>t.entries[0]?.element===e.target)),xpath:t,intersectionRatio:e.intersectionRatio,intersectionRect:e.intersectionRect,boundingClientRect:e.boundingClientRect};P.elements.push(o)}i&&log("Current URL metrics:",P),await new Promise((e=>{setTimeout(e,0)}));try{const e=await fetch(r,{method:"POST",headers:{"Content-Type":"application/json","X-WP-Nonce":s},body:JSON.stringify(P)});if(200===e.status&&setStorageLock(getCurrentTime()),i){const t=await e.json();200===e.status?log("Response:",t):error("Failure:",t)}}catch(e){i&&error(e)}h.clear()}
\ No newline at end of file
Index: detection.php
===================================================================
--- detection.php	(revision 3156461)
+++ detection.php	(working copy)
@@ -42,6 +42,8 @@
 	$detect_args = array(
 		'serveTime'               => microtime( true ) * 1000, // In milliseconds for comparison with `Date.now()` in JavaScript.
 		'detectionTimeWindow'     => $detection_time_window,
+		'minViewportAspectRatio'  => od_get_minimum_viewport_aspect_ratio(),
+		'maxViewportAspectRatio'  => od_get_maximum_viewport_aspect_ratio(),
 		'isDebug'                 => WP_DEBUG,
 		'restApiEndpoint'         => rest_url( OD_REST_API_NAMESPACE . OD_URL_METRICS_ROUTE ),
 		'restApiNonce'            => wp_create_nonce( 'wp_rest' ),
Index: load.php
===================================================================
--- load.php	(revision 3156461)
+++ load.php	(working copy)
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.5.0
+ * Version: 0.6.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -65,7 +65,7 @@
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.5.0',
+	'0.6.0',
 	static function ( string $version ): void {
 
 		// Define the constant.
@@ -99,6 +99,7 @@
 		require_once __DIR__ . '/class-od-data-validation-exception.php';
 		require_once __DIR__ . '/class-od-html-tag-processor.php';
 		require_once __DIR__ . '/class-od-url-metric.php';
+		require_once __DIR__ . '/class-od-strict-url-metric.php';
 		require_once __DIR__ . '/class-od-url-metrics-group.php';
 		require_once __DIR__ . '/class-od-url-metrics-group-collection.php';
 
Index: optimization.php
===================================================================
--- optimization.php	(revision 3156461)
+++ optimization.php	(working copy)
@@ -215,23 +215,22 @@
 	$current_tag_bookmark = 'optimization_detective_current_tag';
 	$visitors             = iterator_to_array( $tag_visitor_registry );
 	do {
-		$did_visit = false;
+		$tracked_in_url_metrics = false;
 		$processor->set_bookmark( $current_tag_bookmark ); // TODO: Should we break if this returns false?
 
 		foreach ( $visitors as $visitor ) {
-			$seek_count       = $processor->get_seek_count();
-			$next_token_count = $processor->get_next_token_count();
-			$did_visit        = $visitor( $tag_visitor_context ) || $did_visit;
+			$cursor_move_count      = $processor->get_cursor_move_count();
+			$tracked_in_url_metrics = $visitor( $tag_visitor_context ) || $tracked_in_url_metrics;
 
 			// If the visitor traversed HTML tags, we need to go back to this tag so that in the next iteration any
 			// relevant tag visitors may apply, in addition to properly setting the data-od-xpath on this tag below.
-			if ( $seek_count !== $processor->get_seek_count() || $next_token_count !== $processor->get_next_token_count() ) {
+			if ( $cursor_move_count !== $processor->get_cursor_move_count() ) {
 				$processor->seek( $current_tag_bookmark ); // TODO: Should this break out of the optimization loop if it returns false?
 			}
 		}
 		$processor->release_bookmark( $current_tag_bookmark );
 
-		if ( $did_visit && $needs_detection ) {
+		if ( $tracked_in_url_metrics && $needs_detection ) {
 			$processor->set_meta_attribute( 'xpath', $processor->get_xpath() );
 		}
 	} while ( $processor->next_open_tag() );
Index: readme.txt
===================================================================
--- readme.txt	(revision 3156461)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.5.0
+Stable tag:   0.6.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -96,6 +96,29 @@
 
 Filters the time window between serve time and run time in which loading detection is allowed to run. This amount is the allowance between when the page was first generated (and perhaps cached) and when the detect function on the page is allowed to perform its detection logic and submit the request to store the results. This avoids situations in which there are missing URL Metrics in which case a site with page caching which also has a lot of traffic could result in a cache stampede.
 
+**Filter:** `od_minimum_viewport_aspect_ratio` (default: 0.4)
+
+Filters the minimum allowed viewport aspect ratio for URL metrics.
+
+The 0.4 value is intended to accommodate the phone with the greatest known aspect
+ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
+
+**Filter:** `od_maximum_viewport_aspect_ratio` (default: 2.5)
+
+Filters the maximum allowed viewport aspect ratio for URL metrics.
+
+The 2.5 value is intended to accommodate the phone with the greatest known aspect
+ratio at 21:9 (2.333).
+
+During development when you have the DevTools console open, for example, the viewport aspect ratio will be wider than normal. In this case, you may want to increase the maximum aspect ratio:
+
+`
+<?php
+add_filter( 'od_maximum_viewport_aspect_ratio', function () {
+	return 5;
+} );
+`
+
 **Filter:** `od_template_output_buffer` (default: the HTML response)
 
 Filters the template output buffer prior to sending to the client. This filter is added to implement [#43258](https://core.trac.wordpress.org/ticket/43258) in WordPress core.
@@ -134,6 +157,20 @@
 
 == Changelog ==
 
+= 0.6.0 =
+
+**Enhancements**
+
+* Allow URL metric schema to be extended. ([1492](https://github.com/WordPress/performance/pull/1492))
+* Clarify docs around a tag visitor's boolean return value. ([1479](https://github.com/WordPress/performance/pull/1479))
+* Include UUID with each URL metric. ([1489](https://github.com/WordPress/performance/pull/1489))
+* Introduce get_cursor_move_count() to use instead of get_seek_count() and get_next_token_count(). ([1478](https://github.com/WordPress/performance/pull/1478))
+
+**Bug Fixes**
+
+* Add missing global documentation for `delete_all_posts()`. ([1522](https://github.com/WordPress/performance/pull/1522))
+* Introduce viewport aspect ratio validation for URL Metrics. ([1494](https://github.com/WordPress/performance/pull/1494))
+
 = 0.5.0 =
 
 **Enhancements**
Index: storage/class-od-url-metrics-post-type.php
===================================================================
--- storage/class-od-url-metrics-post-type.php	(revision 3156461)
+++ storage/class-od-url-metrics-post-type.php	(working copy)
@@ -117,14 +117,14 @@
 	 * @return OD_URL_Metric[] URL metrics.
 	 */
 	public static function get_url_metrics_from_post( WP_Post $post ): array {
-		$this_function   = __FUNCTION__;
-		$trigger_warning = static function ( string $message ) use ( $this_function ): void {
-			wp_trigger_error( $this_function, esc_html( $message ), E_USER_WARNING );
+		$this_function = __METHOD__;
+		$trigger_error = static function ( string $message, int $error_level = E_USER_NOTICE ) use ( $this_function ): void {
+			wp_trigger_error( $this_function, esc_html( $message ), $error_level );
 		};
 
 		$url_metrics_data = json_decode( $post->post_content, true );
 		if ( json_last_error() !== 0 ) {
-			$trigger_warning(
+			$trigger_error(
 				sprintf(
 					/* translators: 1: Post type slug, 2: Post ID, 3: JSON error message */
 					__( 'Contents of %1$s post type (ID: %2$s) not valid JSON: %3$s', 'optimization-detective' ),
@@ -131,16 +131,18 @@
 					self::SLUG,
 					$post->ID,
 					json_last_error_msg()
-				)
+				),
+				E_USER_WARNING
 			);
 			$url_metrics_data = array();
 		} elseif ( ! is_array( $url_metrics_data ) ) {
-			$trigger_warning(
+			$trigger_error(
 				sprintf(
 					/* translators: %s is post type slug */
 					__( 'Contents of %s post type was not a JSON array.', 'optimization-detective' ),
 					self::SLUG
-				)
+				),
+				E_USER_WARNING
 			);
 			$url_metrics_data = array();
 		}
@@ -148,7 +150,7 @@
 		return array_values(
 			array_filter(
 				array_map(
-					static function ( $url_metric_data ) use ( $trigger_warning ) {
+					static function ( $url_metric_data ) use ( $trigger_error ) {
 						if ( ! is_array( $url_metric_data ) ) {
 							return null;
 						}
@@ -156,13 +158,21 @@
 						try {
 							return new OD_URL_Metric( $url_metric_data );
 						} catch ( OD_Data_Validation_Exception $e ) {
-							$trigger_warning(
+							$suffix = '';
+							if ( isset( $url_metric_data['uuid'] ) && is_string( $url_metric_data['uuid'] ) ) {
+								$suffix .= sprintf( ' (URL Metric UUID: %s)', $url_metric_data['uuid'] );
+							}
+
+							$trigger_error(
 								sprintf(
 									/* translators: 1: Post type slug. 2: Exception message. */
 									__( 'Unexpected shape to JSON array in post_content of %1$s post type: %2$s', 'optimization-detective' ),
 									OD_URL_Metrics_Post_Type::SLUG,
-									$e->getMessage()
-								)
+									$e->getMessage() . $suffix
+								),
+								// This is not a warning because schema changes will happen, and so it is expected
+								// that this will result in existing URL metrics being invalidated.
+								E_USER_NOTICE
 							);
 
 							return null;
@@ -178,6 +188,7 @@
 	 * Stores URL metric by merging it with the other URL metrics which share the same normalized query vars.
 	 *
 	 * @since 0.1.0
+	 * @todo There is duplicate logic here with od_handle_rest_request().
 	 *
 	 * @param string        $slug           Slug (hash of normalized query vars).
 	 * @param OD_URL_Metric $new_url_metric New URL metric.
@@ -305,6 +316,8 @@
 	 * This is used during uninstallation.
 	 *
 	 * @since 0.1.0
+	 *
+	 * @global wpdb $wpdb WordPress database abstraction object.
 	 */
 	public static function delete_all_posts(): void {
 		global $wpdb;
Index: storage/data.php
===================================================================
--- storage/data.php	(revision 3156461)
+++ storage/data.php	(working copy)
@@ -180,6 +180,50 @@
 }
 
 /**
+ * Gets the minimum allowed viewport aspect ratio for URL metrics.
+ *
+ * @since 0.6.0
+ * @access private
+ *
+ * @return float Minimum viewport aspect ratio for URL metrics.
+ */
+function od_get_minimum_viewport_aspect_ratio(): float {
+	/**
+	 * Filters the minimum allowed viewport aspect ratio for URL metrics.
+	 *
+	 * The 0.4 default value is intended to accommodate the phone with the greatest known aspect
+	 * ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param float $minimum_viewport_aspect_ratio Minimum viewport aspect ratio.
+	 */
+	return (float) apply_filters( 'od_minimum_viewport_aspect_ratio', 0.4 );
+}
+
+/**
+ * Gets the maximum allowed viewport aspect ratio for URL metrics.
+ *
+ * @since 0.6.0
+ * @access private
+ *
+ * @return float Maximum viewport aspect ratio for URL metrics.
+ */
+function od_get_maximum_viewport_aspect_ratio(): float {
+	/**
+	 * Filters the maximum allowed viewport aspect ratio for URL metrics.
+	 *
+	 * The 2.5 default value is intended to accommodate the phone with the greatest known aspect
+	 * ratio at 21:9 (2.333).
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param float $maximum_viewport_aspect_ratio Maximum viewport aspect ratio.
+	 */
+	return (float) apply_filters( 'od_maximum_viewport_aspect_ratio', 2.5 );
+}
+
+/**
  * Gets the breakpoint max widths to group URL metrics for various viewports.
  *
  * Each number represents the maximum width (inclusive) for a given breakpoint. So if there is one number, 480, then
Index: storage/rest-api.php
===================================================================
--- storage/rest-api.php	(revision 3156461)
+++ storage/rest-api.php	(working copy)
@@ -67,7 +67,7 @@
 			'methods'             => 'POST',
 			'args'                => array_merge(
 				$args,
-				rest_get_endpoint_args_for_schema( OD_URL_Metric::get_json_schema() )
+				rest_get_endpoint_args_for_schema( OD_Strict_URL_Metric::get_json_schema() )
 			),
 			'callback'            => static function ( WP_REST_Request $request ) {
 				return od_handle_rest_request( $request );
@@ -128,31 +128,36 @@
 	OD_Storage_Lock::set_lock();
 
 	try {
-		$properties = OD_URL_Metric::get_json_schema()['properties'];
-		$url_metric = new OD_URL_Metric(
-			array_merge(
-				wp_array_slice_assoc(
-					$request->get_params(),
-					array_keys( $properties )
-				),
-				array(
-					// Now supply the timestamp since it was omitted from the REST API params since it is `readonly`.
-					// Nevertheless, it is also `required`, so it must be set to instantiate an OD_URL_Metric.
-					'timestamp' => $properties['timestamp']['default'],
-				)
+		$data = $request->get_params();
+		// Remove params which are only used for the REST API request and which are not part of a URL Metric.
+		unset(
+			$data['slug'],
+			$data['nonce']
+		);
+		$data = array_merge(
+			$data,
+			array(
+				// Now supply the readonly args which were omitted from the REST API params due to being `readonly`.
+				'timestamp' => microtime( true ),
+				'uuid'      => wp_generate_uuid4(),
 			)
 		);
+
+		// The "strict" URL Metric class is being used here to ensure additionalProperties of all objects are disallowed.
+		$url_metric = new OD_Strict_URL_Metric( $data );
 	} catch ( OD_Data_Validation_Exception $e ) {
 		return new WP_Error(
-			'url_metric_exception',
+			'rest_invalid_param',
 			sprintf(
 				/* translators: %s is exception name */
 				__( 'Failed to validate URL metric: %s', 'optimization-detective' ),
 				$e->getMessage()
-			)
+			),
+			array( 'status' => 400 )
 		);
 	}
 
+	// TODO: This should be changed from store_url_metric($slug, $url_metric) instead be update_post( $slug, $group_collection ). As it stands, store_url_metric() is duplicating logic here.
 	$result = OD_URL_Metrics_Post_Type::store_url_metric(
 		$request->get_param( 'slug' ),
 		$url_metric
@@ -161,7 +166,34 @@
 	if ( $result instanceof WP_Error ) {
 		return $result;
 	}
+	$post_id = $result;
 
+	/**
+	 * Fires whenever a URL Metric was successfully collected.
+	 *
+	 * @since 0.6.0
+	 *
+	 * @param array $context {
+	 *     Context about the successful URL Metric collection.
+	 *
+	 *     @var int                                   $post_id
+	 *     @var WP_REST_Request<array<string, mixed>> $request
+	 *     @var OD_Strict_URL_Metric                  $url_metric
+	 *     @var OD_URL_Metrics_Group                  $group
+	 *     @var OD_URL_Metrics_Group_Collection       $group_collection
+	 * }
+	 */
+	do_action(
+		'od_url_metric_collected',
+		array(
+			'post_id'                      => $post_id,
+			'request'                      => $request,
+			'url_metric'                   => $url_metric,
+			'url_metrics_group'            => $group,
+			'url_metrics_group_collection' => $group_collection,
+		)
+	);
+
 	return new WP_REST_Response(
 		array(
 			'success' => true,
```
</details>

## `performance-lab`

> [!IMPORTANT]
> Stable tag change: 3.4.0 → **3.4.1**

`svn status`:
```
M       includes/admin/plugins.php
M       readme.txt
```

<details><summary><code>svn diff</code></summary>

```diff
Index: includes/admin/plugins.php
===================================================================
--- includes/admin/plugins.php	(revision 3156461)
+++ includes/admin/plugins.php	(working copy)
@@ -146,12 +146,18 @@
 
 		$error_messages = array_unique( $error_messages );
 
+		if ( count( $error_messages ) === 1 ) {
+			$error_text          = __( 'Failed to query WordPress.org Plugin Directory for the following plugin:', 'performance-lab' );
+			$error_occurred_text = __( 'The following error occurred:', 'performance-lab' );
+		} else {
+			$error_text          = __( 'Failed to query WordPress.org Plugin Directory for the following plugins:', 'performance-lab' );
+			$error_occurred_text = __( 'The following errors occurred:', 'performance-lab' );
+		}
+
 		wp_admin_notice(
-			'<p>' . esc_html(
-				_n( 'Failed to query WordPress.org Plugin Directory for the following plugin:', 'Failed to query WordPress.org Plugin Directory for the following plugins:', count( $errors ), 'performance-lab' )
-			) . '</p>' .
+			'<p>' . esc_html( $error_text ) . '</p>' .
 			$plugin_list .
-			'<p>' . esc_html( _n( 'The following error occurred:', 'The following errors occurred:', count( $error_messages ), 'performance-lab' ) ) . '</p>' .
+			'<p>' . esc_html( $error_occurred_text ) . '</p>' .
 			'<ul><li>' .
 			join(
 				'</li><li>',
Index: readme.txt
===================================================================
--- readme.txt	(revision 3156461)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.4.0
+Stable tag:   3.4.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -70,6 +70,12 @@
 
 == Changelog ==
 
+= 3.4.1 =
+
+**Bug Fixes**
+
+* Fix Incorrect use of _n(). ([1491](https://github.com/WordPress/performance/pull/1491))
+
 = 3.4.0 =
 
 **Enhancements**
```
</details>

## `speculation-rules`

> [!WARNING]
> Stable tag is unchanged at 1.3.1, so no plugin release will occur.

`svn status`:
```
M       class-plsr-url-pattern-prefixer.php
M       helper.php
M       hooks.php
M       readme.txt
M       settings.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: class-plsr-url-pattern-prefixer.php
===================================================================
--- class-plsr-url-pattern-prefixer.php	(revision 3156461)
+++ class-plsr-url-pattern-prefixer.php	(working copy)
@@ -35,7 +35,7 @@
 	 *                                        by the {@see PLSR_URL_Pattern_Prefixer::get_default_contexts()} method.
 	 */
 	public function __construct( array $contexts = array() ) {
-		if ( $contexts ) {
+		if ( count( $contexts ) > 0 ) {
 			$this->contexts = array_map(
 				static function ( string $str ): string {
 					return self::escape_pattern_string( trailingslashit( $str ) );
Index: helper.php
===================================================================
--- helper.php	(revision 3156461)
+++ helper.php	(working copy)
@@ -19,22 +19,11 @@
  *
  * @since 1.0.0
  *
- * @return array<string, array<int, array<string, mixed>>> Associative array of speculation rules by type.
+ * @return non-empty-array<string, array<int, array<string, mixed>>> Associative array of speculation rules by type.
  */
 function plsr_get_speculation_rules(): array {
-	$option = get_option( 'plsr_speculation_rules' );
-
-	/*
-	 * This logic is only relevant for edge-cases where the setting may not be registered,
-	 * a.k.a. defensive coding.
-	 */
-	if ( ! $option || ! is_array( $option ) ) {
-		$option = plsr_get_setting_default();
-	} else {
-		$option = array_merge( plsr_get_setting_default(), $option );
-	}
-
-	$mode      = (string) $option['mode'];
+	$option    = plsr_get_stored_setting_value();
+	$mode      = $option['mode'];
 	$eagerness = $option['eagerness'];
 
 	$prefixer = new PLSR_URL_Pattern_Prefixer();
Index: hooks.php
===================================================================
--- hooks.php	(revision 3156461)
+++ hooks.php	(working copy)
@@ -19,30 +19,10 @@
  * @since 1.0.0
  */
 function plsr_print_speculation_rules(): void {
-	$rules = plsr_get_speculation_rules();
-	if ( empty( $rules ) ) {
-		return;
-	}
-
-	// This workaround is needed for WP 6.4. See <https://core.trac.wordpress.org/ticket/60320>.
-	$needs_html5_workaround = (
-		! current_theme_supports( 'html5', 'script' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.4', '>=' ) &&
-		version_compare( (string) strtok( (string) get_bloginfo( 'version' ), '-' ), '6.5', '<' )
-	);
-	if ( $needs_html5_workaround ) {
-		$backup_wp_theme_features = $GLOBALS['_wp_theme_features'];
-		add_theme_support( 'html5', array( 'script' ) );
-	}
-
 	wp_print_inline_script_tag(
-		(string) wp_json_encode( $rules ),
+		(string) wp_json_encode( plsr_get_speculation_rules() ),
 		array( 'type' => 'speculationrules' )
 	);
-
-	if ( $needs_html5_workaround ) {
-		$GLOBALS['_wp_theme_features'] = $backup_wp_theme_features; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-	}
 }
 add_action( 'wp_footer', 'plsr_print_speculation_rules' );
 
Index: readme.txt
===================================================================
--- readme.txt	(revision 3156461)
+++ readme.txt	(working copy)
@@ -1,13 +1,11 @@
 === Speculative Loading ===
 
-Contributors:      wordpressdotorg
-Requires at least: 6.4
-Tested up to:      6.5
-Requires PHP:      7.2
-Stable tag:        1.3.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, javascript, speculation rules, prerender, prefetch
+Contributors: wordpressdotorg
+Tested up to: 6.6
+Stable tag:   1.3.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, javascript, speculation rules, prerender, prefetch
 
 Enables browsers to speculatively prerender or prefetch pages when hovering over links.
 
Index: settings.php
===================================================================
--- settings.php	(revision 3156461)
+++ settings.php	(working copy)
@@ -16,7 +16,7 @@
  *
  * @since 1.0.0
  *
- * @return array<string, string> Associative array of `$mode => $label` pairs.
+ * @return array{ prefetch: string, prerender: string } Associative array of `$mode => $label` pairs.
  */
 function plsr_get_mode_labels(): array {
 	return array(
@@ -30,7 +30,7 @@
  *
  * @since 1.0.0
  *
- * @return array<string, string> Associative array of `$eagerness => $label` pairs.
+ * @return array{ conservative: string, moderate: string, eager: string } Associative array of `$eagerness => $label` pairs.
  */
 function plsr_get_eagerness_labels(): array {
 	return array(
@@ -45,7 +45,7 @@
  *
  * @since 1.0.0
  *
- * @return array<string, string> {
+ * @return array{ mode: 'prerender', eagerness: 'moderate' } {
  *     Default setting value.
  *
  *     @type string $mode      Mode.
@@ -60,12 +60,29 @@
 }
 
 /**
+ * Returns the stored setting value for Speculative Loading configuration.
+ *
+ * @since n.e.x.t
+ *
+ * @return array{ mode: 'prefetch'|'prerender', eagerness: 'conservative'|'moderate'|'eager' } {
+ *     Stored setting value.
+ *
+ *     @type string $mode      Mode.
+ *     @type string $eagerness Eagerness.
+ * }
+ */
+function plsr_get_stored_setting_value(): array {
+	return plsr_sanitize_setting( get_option( 'plsr_speculation_rules' ) );
+}
+
+/**
  * Sanitizes the setting for Speculative Loading configuration.
  *
  * @since 1.0.0
+ * @todo  Consider whether the JSON schema for the setting could be reused here.
  *
  * @param mixed $input Setting to sanitize.
- * @return array<string, string> {
+ * @return array{ mode: 'prefetch'|'prerender', eagerness: 'conservative'|'moderate'|'eager' } {
  *     Sanitized setting.
  *
  *     @type string $mode      Mode.
@@ -79,17 +96,14 @@
 		return $default_value;
 	}
 
-	$mode_labels      = plsr_get_mode_labels();
-	$eagerness_labels = plsr_get_eagerness_labels();
-
 	// Ensure only valid keys are present.
-	$value = array_intersect_key( $input, $default_value );
+	$value = array_intersect_key( array_merge( $default_value, $input ), $default_value );
 
-	// Set any missing or invalid values to their defaults.
-	if ( ! isset( $value['mode'] ) || ! isset( $mode_labels[ $value['mode'] ] ) ) {
+	// Constrain values to what is allowed.
+	if ( ! in_array( $value['mode'], array_keys( plsr_get_mode_labels() ), true ) ) {
 		$value['mode'] = $default_value['mode'];
 	}
-	if ( ! isset( $value['eagerness'] ) || ! isset( $eagerness_labels[ $value['eagerness'] ] ) ) {
+	if ( ! in_array( $value['eagerness'], array_keys( plsr_get_eagerness_labels() ), true ) ) {
 		$value['eagerness'] = $default_value['eagerness'];
 	}
 
@@ -113,7 +127,8 @@
 			'default'           => plsr_get_setting_default(),
 			'show_in_rest'      => array(
 				'schema' => array(
-					'properties' => array(
+					'type'                 => 'object',
+					'properties'           => array(
 						'mode'      => array(
 							'description' => __( 'Whether to prefetch or prerender URLs.', 'speculation-rules' ),
 							'type'        => 'string',
@@ -125,6 +140,7 @@
 							'enum'        => array_keys( plsr_get_eagerness_labels() ),
 						),
 					),
+					'additionalProperties' => false,
 				),
 			),
 		)
@@ -188,7 +204,7 @@
  * @since 1.0.0
  * @access private
  *
- * @param array<string, string> $args {
+ * @param array{ field: 'mode'|'eagerness', title: non-empty-string, description: non-empty-string } $args {
  *     Associative array of arguments.
  *
  *     @type string $field       The slug of the sub setting controlled by the field.
@@ -197,28 +213,24 @@
  * }
  */
 function plsr_render_settings_field( array $args ): void {
-	if ( empty( $args['field'] ) || empty( $args['title'] ) ) { // Invalid.
-		return;
-	}
+	$option = plsr_get_stored_setting_value();
 
-	$option = get_option( 'plsr_speculation_rules' );
-	if ( ! isset( $option[ $args['field'] ] ) ) { // Invalid.
-		return;
+	switch ( $args['field'] ) {
+		case 'mode':
+			$choices = plsr_get_mode_labels();
+			break;
+		case 'eagerness':
+			$choices = plsr_get_eagerness_labels();
+			break;
+		default:
+			return; // Invalid (and this case should never occur).
 	}
 
-	$value    = $option[ $args['field'] ];
-	$callback = "plsr_get_{$args['field']}_labels";
-	if ( ! is_callable( $callback ) ) {
-		return;
-	}
-	$choices = call_user_func( $callback );
-
+	$value = $option[ $args['field'] ];
 	?>
 	<fieldset>
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
-		<?php
-		foreach ( $choices as $slug => $label ) {
-			?>
+		<?php foreach ( $choices as $slug => $label ) : ?>
 			<p>
 				<label>
 					<input
@@ -230,17 +242,11 @@
 					<?php echo esc_html( $label ); ?>
 				</label>
 			</p>
-			<?php
-		}
+		<?php endforeach; ?>
 
-		if ( ! empty( $args['description'] ) ) {
-			?>
-			<p class="description" style="max-width: 800px;">
-				<?php echo esc_html( $args['description'] ); ?>
-			</p>
-			<?php
-		}
-		?>
+		<p class="description" style="max-width: 800px;">
+			<?php echo esc_html( $args['description'] ); ?>
+		</p>
 	</fieldset>
 	<?php
 }
```
</details>

## `webp-uploads`

> [!IMPORTANT]
> Stable tag change: 2.1.0 → **2.2.0**

`svn status`:
```
M       helper.php
M       picture-element.php
M       readme.txt
M       settings.php
```

<details><summary><code>svn diff</code></summary>

```diff
Index: helper.php
===================================================================
--- helper.php	(revision 3156461)
+++ helper.php	(working copy)
@@ -17,6 +17,7 @@
  *
  * @since 1.0.0
  * @since 2.0.0 Added support for AVIF.
+ * @since 2.2.0 Added support for PNG.
  *
  * @return array<string, array<string>> An array of valid mime types, where the key is the mime type and the value is the extension type.
  */
@@ -29,12 +30,14 @@
 		'image/jpeg' => array( 'image/' . $output_format ),
 		'image/webp' => array( 'image/webp' ),
 		'image/avif' => array( 'image/avif' ),
+		'image/png'  => array( 'image/' . $output_format ),
 	);
 
 	// Check setting for whether to generate both JPEG and the modern output format.
-	if ( webp_uploads_is_jpeg_fallback_enabled() ) {
+	if ( webp_uploads_is_fallback_enabled() ) {
 		$default_transforms = array(
 			'image/jpeg'              => array( 'image/jpeg', 'image/' . $output_format ),
+			'image/png'               => array( 'image/png', 'image/' . $output_format ),
 			'image/' . $output_format => array( 'image/' . $output_format, 'image/jpeg' ),
 		);
 	}
@@ -393,7 +396,7 @@
  * @return bool True if the option is enabled, false otherwise.
  */
 function webp_uploads_is_picture_element_enabled(): bool {
-	return webp_uploads_is_jpeg_fallback_enabled() && (bool) get_option( 'webp_uploads_use_picture_element', false );
+	return webp_uploads_is_fallback_enabled() && (bool) get_option( 'webp_uploads_use_picture_element', false );
 }
 
 /**
@@ -400,9 +403,68 @@
  * Checks if the `perflab_generate_webp_and_jpeg` option is enabled.
  *
  * @since 2.0.0
+ * @since 2.2.0 Renamed to webp_uploads_is_fallback_enabled().
  *
  * @return bool True if the option is enabled, false otherwise.
  */
-function webp_uploads_is_jpeg_fallback_enabled(): bool {
+function webp_uploads_is_fallback_enabled(): bool {
 	return (bool) get_option( 'perflab_generate_webp_and_jpeg' );
 }
+
+/**
+ * Retrieves the image URL for a specified MIME type from the attachment metadata.
+ *
+ * This function attempts to locate an alternate image source URL in the
+ * attachment's metadata that matches the provided MIME type.
+ *
+ * @since 2.2.0
+ *
+ * @param int    $attachment_id The ID of the attachment.
+ * @param string $src           The original image src url.
+ * @param string $mime          A mime type we are looking to get image url.
+ * @return string|null Returns mime type image if available.
+ */
+function webp_uploads_get_mime_type_image( int $attachment_id, string $src, string $mime ): ?string {
+	$metadata     = wp_get_attachment_metadata( $attachment_id );
+	$src_basename = wp_basename( $src );
+	if ( isset( $metadata['sources'][ $mime ]['file'] ) ) {
+		$basename = wp_basename( $metadata['file'] );
+
+		if ( $src_basename === $basename ) {
+			return str_replace(
+				$basename,
+				$metadata['sources'][ $mime ]['file'],
+				$src
+			);
+		}
+	}
+
+	if ( isset( $metadata['sizes'] ) && is_array( $metadata['sizes'] ) ) {
+		foreach ( $metadata['sizes'] as $size => $size_data ) {
+
+			if ( ! isset( $size_data['file'] ) ) {
+				continue;
+			}
+
+			if ( ! isset( $size_data['sources'][ $mime ]['file'] ) ) {
+				continue;
+			}
+
+			if ( $size_data['file'] === $size_data['sources'][ $mime ]['file'] ) {
+				continue;
+			}
+
+			if ( $src_basename !== $size_data['file'] ) {
+				continue;
+			}
+
+			return str_replace(
+				$size_data['file'],
+				$size_data['sources'][ $mime ]['file'],
+				$src
+			);
+		}
+	}
+
+	return null;
+}
Index: picture-element.php
===================================================================
--- picture-element.php	(revision 3156461)
+++ picture-element.php	(working copy)
@@ -108,38 +108,51 @@
 	list( $src, $width, $height ) = $image_src;
 	$size_array                   = array( absint( $width ), absint( $height ) );
 
-	// Get the sizes from the IMG tag.
-	$sizes = $processor->get_attribute( 'sizes' );
+	// Gets the srcset and sizes from the IMG tag.
+	$sizes  = $processor->get_attribute( 'sizes' );
+	$srcset = $processor->get_attribute( 'srcset' );
 
-	foreach ( $mime_types as $image_mime_type ) {
-		// Filter core's wp_get_attachment_image_srcset to return the sources for the current mime type.
-		$filter = static function ( $sources ) use ( $mime_type_data, $image_mime_type ): array {
-			$filtered_sources = array();
-			foreach ( $sources as $source ) {
-				// Swap the URL for the current mime type.
-				if ( isset( $mime_type_data[ $image_mime_type ][ $source['descriptor'] ][ $source['value'] ] ) ) {
-					$filename           = $mime_type_data[ $image_mime_type ][ $source['descriptor'] ][ $source['value'] ]['file'];
-					$filtered_sources[] = array(
-						'url'        => dirname( $source['url'] ) . '/' . $filename,
-						'descriptor' => $source['descriptor'],
-						'value'      => $source['value'],
-					);
+	if ( null !== $srcset && null !== $sizes ) {
+		foreach ( $mime_types as $image_mime_type ) {
+			// Filter core's wp_get_attachment_image_srcset to return the sources for the current mime type.
+			$filter = static function ( $sources ) use ( $mime_type_data, $image_mime_type ): array {
+				$filtered_sources = array();
+				foreach ( $sources as $source ) {
+					// Swap the URL for the current mime type.
+					if ( isset( $mime_type_data[ $image_mime_type ][ $source['descriptor'] ][ $source['value'] ] ) ) {
+						$filename           = $mime_type_data[ $image_mime_type ][ $source['descriptor'] ][ $source['value'] ]['file'];
+						$filtered_sources[] = array(
+							'url'        => dirname( $source['url'] ) . '/' . $filename,
+							'descriptor' => $source['descriptor'],
+							'value'      => $source['value'],
+						);
+					}
 				}
+				return $filtered_sources;
+			};
+			add_filter( 'wp_calculate_image_srcset', $filter );
+			$image_srcset = wp_get_attachment_image_srcset( $attachment_id, $size_array, $image_meta );
+			remove_filter( 'wp_calculate_image_srcset', $filter );
+			if ( is_string( $image_srcset ) ) {
+				$picture_sources .= sprintf(
+					'<source type="%s" srcset="%s"%s>',
+					esc_attr( $image_mime_type ),
+					esc_attr( $image_srcset ),
+					is_string( $sizes ) ? sprintf( ' sizes="%s"', esc_attr( $sizes ) ) : ''
+				);
 			}
-			return $filtered_sources;
-		};
-		add_filter( 'wp_calculate_image_srcset', $filter );
-		$image_srcset = wp_get_attachment_image_srcset( $attachment_id, $size_array, $image_meta );
-		remove_filter( 'wp_calculate_image_srcset', $filter );
-		if ( false === $image_srcset ) {
-			continue;
 		}
-		$picture_sources .= sprintf(
-			'<source type="%s"%s%s>',
-			esc_attr( $image_mime_type ),
-			is_string( $image_srcset ) ? sprintf( ' srcset="%s"', esc_attr( $image_srcset ) ) : '',
-			is_string( $sizes ) ? sprintf( ' sizes="%s"', esc_attr( $sizes ) ) : ''
-		);
+	} else {
+		foreach ( $mime_types as $image_mime_type ) {
+			$image_srcset = webp_uploads_get_mime_type_image( $attachment_id, $src, $image_mime_type );
+			if ( is_string( $image_srcset ) ) {
+				$picture_sources .= sprintf(
+					'<source type="%s" srcset="%s">',
+					esc_attr( $image_mime_type ),
+					esc_attr( $image_srcset )
+				);
+			}
+		}
 	}
 
 	return sprintf(
Index: readme.txt
===================================================================
--- readme.txt	(revision 3156461)
+++ readme.txt	(working copy)
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   2.1.0
+Stable tag:   2.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -13,7 +13,7 @@
 
 This plugin adds WebP and AVIF support for media uploads within the WordPress application. By default, AVIF images will be generated if supported on the hosting server, otherwise WebP will be used as the output format. When both formats are available, the output format can be selected under `Settings > Media`. Modern images will be generated only for new uploads, pre-existing images will only converted to a modern format if images are regenerated. Images can be regenerated with a plugin like [Regenerate Thumbnails](https://wordpress.org/plugins/regenerate-thumbnails/) or via WP-CLI with the `wp media regenerate` [command](https://developer.wordpress.org/cli/commands/media/regenerate/).
 
-By default, only modern image format sub-sizes will be generated for JPEG uploads - only the original uploaded file will still exist as a JPEG image, generated image sizes use be WebP or AVIF files. To change this behavior, there is a checkbox in `Settings > Media` "Also output JPEG" that - when checked - will result in the plugin generating both JPEG and WebP or AVIF images for every sub-size (noting again that this will only affect newly uploaded images, i.e. after making said change).
+By default, only modern image format sub-sizes will be generated for JPEG or PNG uploads - only the original uploaded file will still exist as a JPEG/PNG image, generated image sizes will be WebP or AVIF files. To change this behavior, there is a checkbox in `Settings > Media` "Output fallback images" that - when checked - will result in the plugin generating both the original format as well as WebP or AVIF images for every sub-size (noting again that this will only affect newly uploaded images, i.e. after making said change).
 
 _This plugin was formerly known as WebP Uploads._
 
@@ -60,6 +60,16 @@
 
 == Changelog ==
 
+= 2.2.0 =
+
+**Enhancements**
+
+* Convert uploaded PNG files to AVIF or WebP. ([1421](https://github.com/WordPress/performance/pull/1421))
+
+**Bug Fixes**
+
+* Account for responsive images being disabled when generating a PICTURE element. ([1449](https://github.com/WordPress/performance/pull/1449))
+
 = 2.1.0 =
 
 **Enhancements**
Index: settings.php
===================================================================
--- settings.php	(revision 3156461)
+++ settings.php	(working copy)
@@ -86,10 +86,10 @@
 		return;
 	}
 
-	// Add JPEG Output settings field.
+	// Add fallback image output settings field.
 	add_settings_field(
 		'perflab_generate_webp_and_jpeg',
-		__( 'Also output JPEG', 'webp-uploads' ),
+		__( 'Output fallback images', 'webp-uploads' ),
 		'webp_uploads_generate_webp_jpeg_setting_callback',
 		'media',
 		'perflab_modern_image_format_settings',
@@ -145,7 +145,7 @@
 	<label for="perflab_modern_image_format">
 		<?php esc_html_e( 'Generate images in this format', 'webp-uploads' ); ?>
 	</label>
-	<p class="description" id="perflab_modern_image_format_description"><?php esc_html_e( 'Select the format to use when generating new images from uploaded JPEGs.', 'webp-uploads' ); ?></p>
+	<p class="description" id="perflab_modern_image_format_description"><?php esc_html_e( 'Select the format to use when generating new images from uploaded images.', 'webp-uploads' ); ?></p>
 	<?php if ( ! $avif_supported ) : ?>
 		<br />
 		<div class="notice notice-warning inline">
@@ -172,9 +172,9 @@
 	?>
 		<label for="perflab_generate_webp_and_jpeg">
 			<input name="perflab_generate_webp_and_jpeg" type="checkbox" id="perflab_generate_webp_and_jpeg" aria-describedby="perflab_generate_webp_and_jpeg_description" value="1"<?php checked( '1', get_option( 'perflab_generate_webp_and_jpeg' ) ); ?> />
-			<?php esc_html_e( 'Output JPEG images in addition to the modern format', 'webp-uploads' ); ?>
+			<?php esc_html_e( 'Also generate fallback images in the original upload format', 'webp-uploads' ); ?>
 		</label>
-		<p class="description" id="perflab_generate_webp_and_jpeg_description"><?php esc_html_e( 'Enabling JPEG output can improve compatibility, but will increase the filesystem storage use of your images.', 'webp-uploads' ); ?></p>
+		<p class="description" id="perflab_generate_webp_and_jpeg_description"><?php esc_html_e( 'Enabling fallback image output can improve compatibility, but will increase the filesystem storage use of your images.', 'webp-uploads' ); ?></p>
 	<?php
 }
 
@@ -186,7 +186,7 @@
 function webp_uploads_use_picture_element_callback(): void {
 	// Picture element support requires the JPEG output to be enabled.
 	$picture_element_option    = 1 === (int) get_option( 'webp_uploads_use_picture_element', 0 );
-	$jpeg_fallback_enabled     = webp_uploads_is_jpeg_fallback_enabled();
+	$jpeg_fallback_enabled     = webp_uploads_is_fallback_enabled();
 	$picture_element_hidden_id = 'webp_uploads_use_picture_element_hidden';
 	?>
 	<style>
@@ -196,7 +196,7 @@
 		}
 	</style>
 	<div id="webp_uploads_picture_element_notice" class="notice notice-info inline" <?php echo $jpeg_fallback_enabled ? 'hidden' : ''; ?>>
-		<p><?php esc_html_e( 'This setting requires JPEG also be output as a fallback option.', 'webp-uploads' ); ?></p>
+		<p><?php esc_html_e( 'This setting requires fallback image output to be enabled.', 'webp-uploads' ); ?></p>
 	</div>
 	<div id="webp_uploads_picture_element_fieldset" class="<?php echo ! $jpeg_fallback_enabled ? 'disabled' : ''; ?>">
 		<label for="webp_uploads_use_picture_element" id="webp_uploads_use_picture_element_label">
@@ -228,9 +228,9 @@
 			?>
 			<em><?php esc_html_e( '(experimental)', 'webp-uploads' ); ?></em>
 		</label>
-		<p class="description" id="webp_uploads_use_picture_element_description"><?php esc_html_e( 'The picture element serves a modern image format with a fallback to JPEG. Warning: Make sure you test your theme and plugins for compatibility. In particular, CSS selectors will not match images when using the child combinator (e.g. figure > img).', 'webp-uploads' ); ?></p>
+		<p class="description" id="webp_uploads_use_picture_element_description"><?php esc_html_e( 'The picture element serves a modern image format with a fallback to the original upload format. Warning: Make sure you test your theme and plugins for compatibility. In particular, CSS selectors will not match images when using the child combinator (e.g. figure > img).', 'webp-uploads' ); ?></p>
 		<div id="webp_uploads_jpeg_fallback_notice" class="notice notice-info inline" <?php echo $picture_element_option ? '' : 'hidden'; ?>>
-			<p><?php esc_html_e( 'Picture elements will only be used when JPEG fallback images are available. So this will not apply to any images you may have uploaded while the "Also generate JPEG" setting was disabled.', 'webp-uploads' ); ?></p>
+			<p><?php esc_html_e( 'Picture elements will only be used when fallback images are available. So this will only apply to  images you have uploaded while the "Also generate fallback images" setting was enabled.', 'webp-uploads' ); ?></p>
 		</div>
 	</div>
 	<script>
@@ -239,7 +239,7 @@
 			document.getElementById( 'webp_uploads_jpeg_fallback_notice' ).hidden = ! this.checked;
 		} );
 
-		// Listen for clicks on the JPEG output checkbox, enabling/disabling the
+		// Listen for clicks on the fallback output checkbox, enabling/disabling the
 		// picture element checkbox accordingly.
 		document.getElementById( 'perflab_generate_webp_and_jpeg' ).addEventListener( 'change', function () {
 			document.querySelector( '.webp-uploads-use-picture-element' ).classList.toggle( 'webp-uploads-disabled', ! this.checked );
```
</details>

