### PR TITLE
Use a single WordPress.org API request to get information for all plugins

### DIFF
--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -52,7 +52,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	}
 
 	/* Check if the response contains plugins. */
-	if ( ! is_object( $response ) ) {
+	if ( ! ( is_object( $response ) && property_exists( $response, 'plugins' ) ) ) {
 		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'performance-lab' ) );
 	}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -30,7 +30,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
 	}
 
-	/* Proceed with API request since no cache hit. */
+	// Proceed with API request since no cache hit.
 	$response = plugins_api(
 		'query_plugins',
 		array(

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -33,7 +33,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	);
 
 	if ( is_array( $plugins ) ) {
-		/* If the specific plugin_slug is not in the cache, return an error. */
+		// If the specific plugin_slug is not in the cache, return an error.
 		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
 			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
 		}

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -41,7 +41,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 
 	$plugins = array();
 	foreach ( $data['plugins'] as $plugin_data ) {
-		$plugins[ $plugin_data['slug'] ] = wp_array_slice_assoc(
+		$plugin_info = wp_array_slice_assoc(
 			$plugin_data,
 			array(
 				'name',
@@ -54,6 +54,17 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 				'version',
 			)
 		);
+
+		// Ensure the 'requires_plugins' is always an array.
+		if ( ! isset( $plugin_info['requires_plugins'] ) || ! is_array( $plugin_info['requires_plugins'] ) ) {
+			$plugin_info['requires_plugins'] = array();
+		}
+
+		// Ensure 'requires' and 'requires_php' are either strings or false.
+		$plugin_info['requires']     = isset( $plugin_info['requires'] ) ? $plugin_info['requires'] : false;
+		$plugin_info['requires_php'] = isset( $plugin_info['requires_php'] ) ? $plugin_info['requires_php'] : false;
+
+		$plugins[ $plugin_data['slug'] ] = $plugin_info;
 	}
 
 	set_transient( $transient_key, $plugins, HOUR_IN_SECONDS );
@@ -62,6 +73,11 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
 	}
 
+	/**
+	 * Validated (mostly) plugin data.
+	 *
+	 * @var array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: array<string>, download_link: string, version: string} $plugin
+	 */
 	return $plugins[ $plugin_slug ];
 }
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -22,8 +22,12 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	$transient_key = 'perflab_plugins_info';
 	$plugins       = get_transient( $transient_key );
 
-	if ( is_array( $plugins ) && isset( $plugins[ $plugin_slug ] ) ) {
-		return $plugins[ $plugin_slug ];
+	if ( is_array( $plugins ) ) {
+		/* If the specific plugin_slug is not in the cache, return an error. */
+		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
+			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
+		}
+		return $plugins[ $plugin_slug ]; // Return cached plugin info if found
 	}
 
 	$response = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=wordpressdotorg&request[tag]=performance&request[per_page]=100' );

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -77,8 +77,8 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		}
 
 		// Ensure 'requires' and 'requires_php' are either strings or false.
-		$plugin_info['requires']     = isset( $plugin_info['requires'] ) ? $plugin_info['requires'] : false;
-		$plugin_info['requires_php'] = isset( $plugin_info['requires_php'] ) ? $plugin_info['requires_php'] : false;
+		$plugin_info['requires']     = $plugin_info['requires'] ?? false;
+		$plugin_info['requires_php'] = $plugin_info['requires_php'] ?? false;
 
 		$plugins[ $plugin_data['slug'] ] = $plugin_info;
 	}

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -69,18 +69,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 
 	$plugins = array();
 	foreach ( $response->plugins as $plugin_data ) {
-		$plugin_info = wp_array_slice_assoc( $plugin_data, $fields );
-
-		// Ensure the 'requires_plugins' is always an array.
-		if ( ! isset( $plugin_info['requires_plugins'] ) || ! is_array( $plugin_info['requires_plugins'] ) ) {
-			$plugin_info['requires_plugins'] = array();
-		}
-
-		// Ensure 'requires' and 'requires_php' are either strings or false.
-		$plugin_info['requires']     = $plugin_info['requires'] ?? false;
-		$plugin_info['requires_php'] = $plugin_info['requires_php'] ?? false;
-
-		$plugins[ $plugin_data['slug'] ] = $plugin_info;
+		$plugins[ $plugin_data['slug'] ] = wp_array_slice_assoc( $plugin_data, $fields );
 	}
 
 	set_transient( $transient_key, $plugins, HOUR_IN_SECONDS );

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -52,7 +52,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	}
 
 	/* Check if the response contains plugins. */
-	if ( ! is_object( $response ) || ! isset( $response->plugins ) || ! is_array( $response->plugins ) ) {
+	if ( ! is_object( $response ) ) {
 		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'performance-lab' ) );
 	}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -52,7 +52,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	}
 
 	/* Check if the response contains plugins. */
-	if ( ! isset( $response->plugins ) || ! is_array( $response->plugins ) ) {
+	if ( ! is_object( $response ) || ! isset( $response->plugins ) || ! is_array( $response->plugins ) ) {
 		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'performance-lab' ) );
 	}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -41,8 +41,8 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 
 	$plugins = array();
 	foreach ( $data['plugins'] as $plugin_data ) {
-		$plugins[ $plugin_data['slug'] ] = wp_array_slice_assoc( 
-			$plugin_data, 
+		$plugins[ $plugin_data['slug'] ] = wp_array_slice_assoc(
+			$plugin_data,
 			array(
 				'name',
 				'slug',

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -62,7 +62,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		);
 	}
 
-	/* Check if the response contains plugins. */
+	// Check if the response contains plugins.
 	if ( ! ( is_object( $response ) && property_exists( $response, 'plugins' ) ) ) {
 		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'performance-lab' ) );
 	}

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -27,7 +27,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
 			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
 		}
-		return $plugins[ $plugin_slug ]; // Return cached plugin info if found
+		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
 	}
 
 	$response = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=wordpressdotorg&request[tag]=performance&request[per_page]=100' );

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -29,7 +29,14 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	$response = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=wordpressdotorg&request[tag]=performance&request[per_page]=100' );
 
 	if ( is_wp_error( $response ) ) {
-		return new WP_Error( 'api_error', __( 'Failed to retrieve plugins data from WordPress.org API: ' . $request->get_error_message(), 'performance-lab' ) );
+		return new WP_Error(
+			'api_error',
+			sprintf(
+				/* translators: %s: API error message */
+				__( 'Failed to retrieve plugins data from WordPress.org API: %s', 'performance-lab' ),
+				$request->get_error_message()
+			)
+		);
 	}
 
 	$body = wp_remote_retrieve_body( $response );

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -30,7 +30,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
 	}
 
-	// Proceed with API request since no cache hit.
+	/* Proceed with API request since no cache hit. */
 	$response = plugins_api(
 		'query_plugins',
 		array(
@@ -51,10 +51,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		);
 	}
 
-	$body = wp_remote_retrieve_body( $response );
-	$data = json_decode( $body, true );
-
-	// Check if the response contains plugins.
+	/* Check if the response contains plugins. */
 	if ( ! isset( $response->plugins ) || ! is_array( $response->plugins ) ) {
 		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'performance-lab' ) );
 	}

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -62,11 +62,6 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
 	}
 
-	/**
-	 * Validated (mostly) plugin data.
-	 *
-	 * @var array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: string[], download_link: string, version: string} $plugin
-	 */
 	return $plugins[ $plugin_slug ];
 }
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -34,7 +34,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 			sprintf(
 				/* translators: %s: API error message */
 				__( 'Failed to retrieve plugins data from WordPress.org API: %s', 'performance-lab' ),
-				$request->get_error_message()
+				$response->get_error_message()
 			)
 		);
 	}

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -26,17 +26,17 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		return $plugins[ $plugin_slug ];
 	}
 
-	$request = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=wordpressdotorg&request[tag]=performance&request[per_page]=100' );
+	$response = wp_remote_get( 'https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=wordpressdotorg&request[tag]=performance&request[per_page]=100' );
 
-	if ( is_wp_error( $request ) ) {
-		return new WP_Error( 'api_error', __( 'Failed to retrieve plugins data from WordPress.org API.', 'default' ) );
+	if ( is_wp_error( $response ) ) {
+		return new WP_Error( 'api_error', __( 'Failed to retrieve plugins data from WordPress.org API: ' . $request->get_error_message(), 'performance-lab' ) );
 	}
 
-	$body = wp_remote_retrieve_body( $request );
+	$body = wp_remote_retrieve_body( $response );
 	$data = json_decode( $body, true );
 
 	if ( ! isset( $data['plugins'] ) || ! is_array( $data['plugins'] ) ) {
-		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'default' ) );
+		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'performance-lab' ) );
 	}
 
 	$plugins = array();
@@ -70,7 +70,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	set_transient( $transient_key, $plugins, HOUR_IN_SECONDS );
 
 	if ( ! isset( $plugins[ $plugin_slug ] ) ) {
-		return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
+		return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
 	}
 
 	/**

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -21,6 +21,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 function perflab_query_plugin_info( string $plugin_slug ) {
 	$transient_key = 'perflab_plugins_info';
 	$plugins       = get_transient( $transient_key );
+	$fields        = array(
+		'name',
+		'slug',
+		'short_description',
+		'requires',
+		'requires_php',
+		'requires_plugins',
+		'download_link',
+		'version', // Needed by install_plugin_install_status().
+	);
 
 	if ( is_array( $plugins ) ) {
 		/* If the specific plugin_slug is not in the cache, return an error. */
@@ -37,6 +47,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 			'author'   => 'wordpressdotorg',
 			'tag'      => 'performance',
 			'per_page' => 100,
+			'fields'   => array_fill_keys( $fields, true ),
 		)
 	);
 
@@ -58,19 +69,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 
 	$plugins = array();
 	foreach ( $response->plugins as $plugin_data ) {
-		$plugin_info = wp_array_slice_assoc(
-			$plugin_data,
-			array(
-				'name',
-				'slug',
-				'short_description',
-				'requires',
-				'requires_php',
-				'requires_plugins',
-				'download_link',
-				'version',
-			)
-		);
+		$plugin_info = wp_array_slice_assoc( $plugin_data, $fields );
 
 		// Ensure the 'requires_plugins' is always an array.
 		if ( ! isset( $plugin_info['requires_plugins'] ) || ! is_array( $plugin_info['requires_plugins'] ) ) {

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -76,7 +76,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	/**
 	 * Validated (mostly) plugin data.
 	 *
-	 * @var array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: array<string>, download_link: string, version: string} $plugin
+	 * @var array<string, array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: string[], download_link: string, version: string}> $plugins
 	 */
 	return $plugins[ $plugin_slug ];
 }


### PR DESCRIPTION
## Summary

In this PR we have implemented a single `WordPress.org API` request to get plugin information because currently, the Performance features screen makes individual plugin_information queries to the WordPress.org API, which is rather inefficient, especially the more plugins we have.

`https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=wordpressdotorg&request[tag]=performance&request[per_page]=100`

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1542

## Relevant technical choices

<!-- Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
