### PR TITLE
Integrate with WooCommerce to offload Google Analytics to Web Worker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "performance",
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@builder.io/partytown": "^0.10.2",
+        "@builder.io/partytown": "github:westonruter/partytown#add/wp-i18n-workaround",
         "web-vitals": "4.2.3"
       },
       "devDependencies": {
@@ -2040,8 +2040,7 @@
     },
     "node_modules/@builder.io/partytown": {
       "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@builder.io/partytown/-/partytown-0.10.2.tgz",
-      "integrity": "sha512-A9U+4PREWcS+CCYzKGIPovtGB/PBgnH/8oQyCE6Nr9drDJk6cMPpLQIEajpGPmG9tYF7N3FkRvhXm/AS9+0iKg==",
+      "resolved": "git+ssh://git@github.com/westonruter/partytown.git#255d06ed3467c5ed9357a9b2a9890e2400cb68c9",
       "bin": {
         "partytown": "bin/partytown.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "npm": ">=10.2.3"
   },
   "dependencies": {
-    "@builder.io/partytown": "^0.10.2",
+    "@builder.io/partytown": "github:westonruter/partytown#add/wp-i18n-workaround",
     "web-vitals": "4.2.3"
   },
   "devDependencies": {

--- a/plugins.json
+++ b/plugins.json
@@ -7,6 +7,7 @@
     "optimization-detective",
     "performance-lab",
     "speculation-rules",
+    "web-worker-offloading",
     "webp-uploads"
   ]
 }

--- a/plugins/web-worker-offloading/helper.php
+++ b/plugins/web-worker-offloading/helper.php
@@ -15,13 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 0.1.0
  * @link https://partytown.builder.io/configuration
+ * @link https://github.com/BuilderIO/partytown/blob/b292a14047a0c12ca05ba97df1833935d42fdb66/src/lib/types.ts#L393-L548
  *
- * @return array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } Configuration for Partytown.
+ * @return array<string, mixed> Configuration for Partytown.
  */
 function wwo_get_configuration(): array {
 	$config = array(
-		'lib'     => wp_parse_url( plugin_dir_url( __FILE__ ), PHP_URL_PATH ) . 'build/',
-		'forward' => array(),
+		'lib' => wp_parse_url( plugin_dir_url( __FILE__ ), PHP_URL_PATH ) . 'build/',
 	);
 
 	if ( WP_DEBUG && SCRIPT_DEBUG ) {
@@ -31,10 +31,40 @@ function wwo_get_configuration(): array {
 	/**
 	 * Add configuration for Web Worker Offloading.
 	 *
+	 * Many of the configuration options are not documented publicly, so refer to the TypeScript definitions.
+	 * Additionally, not all of the configuration options (e.g. functions) can be serialized as JSON and must instead be
+	 * defined in JavaScript instead. To do so, use the following PHP code instead of filtering `wwo_configuration`:
+	 *
+	 *     add_action(
+	 *         'wp_enqueue_scripts',
+	 *         function () {
+	 *             wp_add_inline_script(
+	 *                 'web-worker-offloading',
+	 *                 <<<JS
+	 *                 window.partytown = {
+	 *                     ...(window.partytown || {}),
+	 *                     resolveUrl: (url, location, type) => {
+	 *                         if (type === 'script') {
+	 *                             const proxyUrl = new URL('https://my-reverse-proxy.com/');
+	 *                             proxyUrl.searchParams.append('url', url.href);
+	 *                             return proxyUrl;
+	 *                         }
+	 *                         return url;
+	 *                     },
+	 *                 };
+	 *                 JS,
+	 *                 'before'
+	 *             );
+	 *         }
+	 *     );
+	 *
+	 * There are also many configuration options which are not documented, so refer to the TypeScript definitions.
+	 *
 	 * @since 0.1.0
 	 * @link https://partytown.builder.io/configuration
+	 * @link https://github.com/BuilderIO/partytown/blob/b292a14047a0c12ca05ba97df1833935d42fdb66/src/lib/types.ts#L393-L548
 	 *
-	 * @param array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } $config Configuration for Partytown.
+	 * @param array<string, mixed> $config Configuration for Partytown.
 	 */
 	return (array) apply_filters( 'wwo_configuration', $config );
 }

--- a/plugins/web-worker-offloading/helper.php
+++ b/plugins/web-worker-offloading/helper.php
@@ -45,7 +45,7 @@ function wwo_get_configuration(): array {
 	 *                     ...(window.partytown || {}),
 	 *                     resolveUrl: (url, location, type) => {
 	 *                         if (type === 'script') {
-	 *                             const proxyUrl = new URL('https://my-reverse-proxy.com/');
+	 *                             const proxyUrl = new URL('https://my-reverse-proxy.example.com/');
 	 *                             proxyUrl.searchParams.append('url', url.href);
 	 *                             return proxyUrl;
 	 *                         }

--- a/plugins/web-worker-offloading/helper.php
+++ b/plugins/web-worker-offloading/helper.php
@@ -36,5 +36,5 @@ function wwo_get_configuration(): array {
 	 *
 	 * @param array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } $config Configuration for Partytown.
 	 */
-	return apply_filters( 'wwo_configuration', $config );
+	return (array) apply_filters( 'wwo_configuration', $config );
 }

--- a/plugins/web-worker-offloading/helper.php
+++ b/plugins/web-worker-offloading/helper.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Helpers for Web Worker Offloading.
+ *
+ * @since 0.1.0
+ * @package web-worker-offloading
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Gets configuration for Web Worker Offloading.
+ *
+ * @since 0.1.0
+ * @link https://partytown.builder.io/configuration
+ *
+ * @return array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } Configuration for Partytown.
+ */
+function wwo_get_configuration(): array {
+	$config = array(
+		'lib'     => wp_parse_url( plugin_dir_url( __FILE__ ), PHP_URL_PATH ) . 'build/',
+		'forward' => array(),
+	);
+
+	/**
+	 * Add configuration for Web Worker Offloading.
+	 *
+	 * @since 0.1.0
+	 * @link https://partytown.builder.io/configuration
+	 *
+	 * @param array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } $config Configuration for Partytown.
+	 */
+	return apply_filters( 'wwo_configuration', $config );
+}

--- a/plugins/web-worker-offloading/helper.php
+++ b/plugins/web-worker-offloading/helper.php
@@ -24,6 +24,10 @@ function wwo_get_configuration(): array {
 		'forward' => array(),
 	);
 
+	if ( WP_DEBUG && SCRIPT_DEBUG ) {
+		$config['debug'] = true;
+	}
+
 	/**
 	 * Add configuration for Web Worker Offloading.
 	 *

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -11,31 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Gets configuration for Web Worker Offloading.
- *
- * @since 0.1.0
- * @link https://partytown.builder.io/configuration
- *
- * @return array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } Configuration for Partytown.
- */
-function wwo_get_configuration(): array {
-	$config = array(
-		'lib'     => wp_parse_url( plugin_dir_url( __FILE__ ), PHP_URL_PATH ) . 'build/',
-		'forward' => array(),
-	);
-
-	/**
-	 * Add configuration for Web Worker Offloading.
-	 *
-	 * @since 0.1.0
-	 * @link https://partytown.builder.io/configuration
-	 *
-	 * @param array{ debug?: bool, forward?: non-empty-string[], lib: non-empty-string, loadScriptsOnMainThread?: non-empty-string[], nonce?: non-empty-string } $config Configuration for Partytown.
-	 */
-	return apply_filters( 'wwo_configuration', $config );
-}
-
-/**
  * Registers defaults scripts for Web Worker Offloading.
  *
  * @since 0.1.0

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Registers defaults scripts for Web Worker Offloading.
  *
  * @since 0.1.0
+ * @access private
  *
  * @param WP_Scripts $scripts WP_Scripts instance.
  */
@@ -48,6 +49,7 @@ add_action( 'wp_default_scripts', 'wwo_register_default_scripts' );
  * Prepends web-worker-offloading to the list of scripts to print if one of the queued scripts is offloaded to a worker.
  *
  * @since 0.1.0
+ * @access private
  *
  * @param string[]|mixed $script_handles An array of enqueued script dependency handles.
  * @return string[] Script handles.
@@ -69,6 +71,7 @@ add_filter( 'print_scripts_array', 'wwo_filter_print_scripts_array', PHP_INT_MAX
  * Updates script type for handles having `web-worker-offloading` as dependency.
  *
  * @since 0.1.0
+ * @access private
  *
  * @param string|mixed $tag    Script tag.
  * @param string       $handle Script handle.
@@ -97,6 +100,7 @@ add_filter( 'script_loader_tag', 'wwo_update_script_type', 10, 2 );
  * Filters inline script attributes to offload to a worker if the script has been opted-in.
  *
  * @since 0.1.0
+ * @access private
  *
  * @param array<string, mixed>|mixed $attributes Attributes.
  * @return array<string, mixed> Attributes.

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -96,6 +96,8 @@ add_filter( 'script_loader_tag', 'wwo_update_script_type', 10, 2 );
 /**
  * Filters inline script attributes to offload to a worker if the script has been opted-in.
  *
+ * @since 0.1.0
+ *
  * @param array<string, mixed>|mixed $attributes Attributes.
  * @return array<string, mixed> Attributes.
  */

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -35,7 +35,7 @@ function wwo_register_default_scripts( WP_Scripts $scripts ): void {
 	$scripts->add_inline_script(
 		'web-worker-offloading',
 		sprintf(
-			'window.partytown = %s;',
+			'window.partytown = {...(window.partytown || {}), ...%s};',
 			wp_json_encode( wwo_get_configuration() )
 		),
 		'before'

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -58,11 +58,12 @@ function wwo_filter_print_scripts_array( $script_handles ): array {
 		if ( true === (bool) $scripts->get_data( $handle, 'worker' ) ) {
 			$scripts->set_group( 'web-worker-offloading', false, 0 ); // Try to print in the head.
 			array_unshift( $script_handles, 'web-worker-offloading' );
+			break;
 		}
 	}
 	return $script_handles;
 }
-add_filter( 'print_scripts_array', 'wwo_filter_print_scripts_array' );
+add_filter( 'print_scripts_array', 'wwo_filter_print_scripts_array', PHP_INT_MAX );
 
 /**
  * Updates script type for handles having `web-worker-offloading` as dependency.

--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -45,5 +45,5 @@ if (
 
 define( 'WEB_WORKER_OFFLOADING_VERSION', '0.1.0' );
 
-// Load the hooks.
+require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';

--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -47,3 +47,4 @@ define( 'WEB_WORKER_OFFLOADING_VERSION', '0.1.0' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';
+require_once __DIR__ . '/third-party.php';

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -11,14 +11,22 @@ Offload JavaScript execution to a Web Worker.
 
 == Description ==
 
-This plugin offloads JavaScript execution to a Web Worker, improving performance by freeing up the main thread.
+This plugin offloads JavaScript execution to a Web Worker, improving performance by freeing up the main thread. This should translate into improved [Interaction to Next Paint](https://web.dev/articles/inp) (INP) scores. _This functionality is considered experimental._
 
-In order to opt-in a script to be loaded in a worker, simply add `worker` script data to a registered script. For example,
+In order to opt in a script to be loaded in a worker, simply add `worker` script data to a registered script. For example,
 if you have a script registered with the handle of `foo`, opt-in to offload it to a web worker by doing:
 
 `
 wp_script_add_data( 'foo', 'worker', true );
 `
+
+Otherwise, the plugin currently ships with built-in integrations to offload Google Analytics to a web worker for the following plugins:
+
+* [Rank Math SEO](https://wordpress.org/plugins/seo-by-rank-math/)
+* [Site Kit by Google](https://wordpress.org/plugins/google-site-kit/)
+* [WooCommerce](https://wordpress.org/plugins/woocommerce/)
+
+Please monitor your analytics once activating to ensure all the expected events are being logged. At the same time, monitor your INP scores to check for improvement.
 
 == Frequently Asked Questions ==
 

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -20,6 +20,8 @@ if you have a script registered with the handle of `foo`, opt-in to offload it t
 wp_script_add_data( 'foo', 'worker', true );
 `
 
+Unlike with the script loading strategies (async/defer), any inline before/after scripts associated with the worker-offloaded registered script will also be offloaded to the worker, whereas with the script strategies an inline after script would block the script from being delayed.
+
 Otherwise, the plugin currently ships with built-in integrations to offload Google Analytics to a web worker for the following plugin:
 
 * [WooCommerce](https://wordpress.org/plugins/woocommerce/)

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -58,7 +58,7 @@ add_action(
 				...(window.partytown || {}),
 				resolveUrl: (url, location, type) => {
 					if (type === 'script') {
-						const proxyUrl = new URL('https://my-reverse-proxy.com/');
+						const proxyUrl = new URL('https://my-reverse-proxy.example.com/');
 						proxyUrl.searchParams.append('url', url.href);
 						return proxyUrl;
 					}

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -5,7 +5,7 @@ Tested up to:      6.6
 Stable tag:        0.1.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, JavaScript, web worker, partytown
+Tags:              performance, JavaScript, web worker, partytown, analytics
 
 Offload JavaScript execution to a Web Worker.
 

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -28,8 +28,36 @@ Otherwise, the plugin currently ships with built-in integrations to offload Goog
 
 Please monitor your analytics once activating to ensure all the expected events are being logged. At the same time, monitor your INP scores to check for improvement.
 
+This plugin relies on the [Partytown 🎉](https://partytown.builder.io/) library by Builder.io, released under the MIT license. This library is in beta and there are quite a few [open bugs](https://github.com/BuilderIO/partytown/issues?q=is%3Aopen+is%3Aissue+label%3Abug). The [Partytown configuration](https://partytown.builder.io/configuration) can be modified via the `wwo_configuration` filter. For example:
+
+`
+<?php
+add_filter( 'wwo_configuration', function ( $config ) {
+	$config['mainWindowAccessors'][] = 'wp'; // Make the wp global available in the worker (e.g. wp.i18n and wp.hooks).
+	return $config;
+} );
+`
+
 == Frequently Asked Questions ==
 
 = Why are my offloaded scripts not working and I see a 404 error in the console for `partytown-sandbox-sw.html`? =
 
 If you find that your offloaded scripts aren't working while also seeing a 404 error in the console for a file at `/wp-content/plugins/web-worker-offloading/build/partytown-sandbox-sw.html?1727389399791` then it's likely you have Chrome DevTools open with the "Bypass for Network" toggle enabled in the Application panel.
+
+= Where can I report security bugs? =
+
+The Performance team and WordPress community take security bugs seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please visit the [WordPress HackerOne](https://hackerone.com/wordpress) program.
+
+= How can I contribute to the plugin? =
+
+Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
+
+The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/web-worker-offloading) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
+
+== Changelog ==
+
+= 0.1.0 =
+
+* Initial release.

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -20,11 +20,11 @@ if you have a script registered with the handle of `foo`, opt-in to offload it t
 wp_script_add_data( 'foo', 'worker', true );
 `
 
-Otherwise, the plugin currently ships with built-in integrations to offload Google Analytics to a web worker for the following plugins:
+Otherwise, the plugin currently ships with built-in integrations to offload Google Analytics to a web worker for the following plugin:
 
-* [Rank Math SEO](https://wordpress.org/plugins/seo-by-rank-math/)
-* [Site Kit by Google](https://wordpress.org/plugins/google-site-kit/)
 * [WooCommerce](https://wordpress.org/plugins/woocommerce/)
+
+Support for [Site Kit by Google](https://wordpress.org/plugins/google-site-kit/) and [Rank Math SEO](https://wordpress.org/plugins/seo-by-rank-math/) are [planned](https://github.com/WordPress/performance/issues/1455).
 
 Please monitor your analytics once activating to ensure all the expected events are being logged. At the same time, monitor your INP scores to check for improvement.
 

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -102,11 +102,11 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 			'add-inline-scripts'                         => array(
 				'set_up'   => static function (): void {
 					wp_register_script( 'foo', false, array(), '1.0.0' );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, Before World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_enqueue_script( 'foo' );
 				},
-				'expected' => '<script id="foo-js-before">console.log("Hello, World!");</script><script id="foo-js-after">console.log("Hello, World!");</script>',
+				'expected' => '<script id="foo-js-before">console.log("Hello, Before World!");</script><script id="foo-js-after">console.log("Hello, After World!");</script>',
 			),
 			'add-script-for-web-worker-offloading'       => array(
 				'set_up'   => static function (): void {
@@ -132,55 +132,55 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 			'add-script-for-web-worker-offloading-with-before-data' => array(
 				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, Before World!");', 'before' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>',
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>',
 			),
 			'add-script-for-web-worker-offloading-with-after-data' => array(
 				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
 			),
 			'add-script-for-web-worker-offloading-with-before-and-after-data' => array(
 				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, Before World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
 			),
 			'add-async-script-for-web-worker-offloading-with-before-and-after-data' => array(
 				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', array( 'strategy' => 'async' ) );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, Before World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="async"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="async"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
 			),
 			'add-defer-script-for-web-worker-offloading-with-before-and-after-data' => array(
 				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', array( 'strategy' => 'defer' ) );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, Before World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="defer"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="defer"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
 			),
 			'add-inline-script-offloaded-to-web-worker'  => array(
 				'set_up'   => static function (): void {
 					wp_register_script( 'foo', false, array(), '1.0.0' );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
-					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, Before World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 					wp_enqueue_script( 'foo' );
 				},
-				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
 			),
 		);
 	}

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -33,9 +33,6 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		$config                = wwo_get_configuration();
 
 		$this->assertArrayHasKey( 'lib', $config );
-		$this->assertArrayHasKey( 'forward', $config );
-		$this->assertEmpty( $config['forward'] );
-		$this->assertIsArray( $config['forward'] );
 		$this->assertStringStartsWith( '/' . basename( $wp_content_dir ), $config['lib'] );
 		$this->assertStringEndsWith( $partytown_assets_path, $config['lib'] );
 

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -93,83 +93,93 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 	public static function data_update_script_types(): array {
 		return array(
 			'add-script'                                 => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
 				},
-				'expected'       => '<script src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>',
-				'doing_it_wrong' => false,
+				'expected' => '<script src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>',
+			),
+			'add-inline-scripts'                         => array(
+				'set_up'   => static function (): void {
+					wp_register_script( 'foo', false, array(), '1.0.0' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_enqueue_script( 'foo' );
+				},
+				'expected' => '<script id="foo-js-before">console.log("Hello, World!");</script><script id="foo-js-after">console.log("Hello, World!");</script>',
 			),
 			'add-script-for-web-worker-offloading'       => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"  ></script>',
-				'doing_it_wrong' => false,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>',
 			),
 			'add-defer-script-for-web-worker-offloading' => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', array( 'strategy' => 'defer' ) );
 					wp_script_add_data( 'foo', 'worker', 1 );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" defer data-wp-strategy="defer"></script>',
-				'doing_it_wrong' => false,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" defer data-wp-strategy="defer"></script>',
 			),
 			'add-async-script-for-web-worker-offloading' => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', array( 'strategy' => 'async' ) );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" async data-wp-strategy="async"></script>',
-				'doing_it_wrong' => false,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" async data-wp-strategy="async"></script>',
 			),
 			'add-script-for-web-worker-offloading-with-before-data' => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"  ></script>',
-				'doing_it_wrong' => false,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>',
 			),
 			'add-script-for-web-worker-offloading-with-after-data' => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script src="https://example.com/foo.js?ver=1.0.0" id="foo-js" ></script><script id="foo-js-after">console.log("Hello, World!");</script>',
-				'doing_it_wrong' => true,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
 			),
 			'add-script-for-web-worker-offloading-with-before-and-after-data' => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', true );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before">console.log("Hello, World!");</script><script src="https://example.com/foo.js?ver=1.0.0" id="foo-js" ></script><script id="foo-js-after">console.log("Hello, World!");</script>',
-				'doing_it_wrong' => true,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
 			),
 			'add-async-script-for-web-worker-offloading-with-before-and-after-data' => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', array( 'strategy' => 'async' ) );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before">console.log("Hello, World!");</script><script src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="async"></script><script id="foo-js-after">console.log("Hello, World!");</script>',
-				'doing_it_wrong' => true,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="async"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
 			),
 			'add-defer-script-for-web-worker-offloading-with-before-and-after-data' => array(
-				'set_up'         => static function (): void {
+				'set_up'   => static function (): void {
 					wp_enqueue_script( 'foo', 'https://example.com/foo.js', array(), '1.0.0', array( 'strategy' => 'defer' ) );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
 					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected'       => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before">console.log("Hello, World!");</script><script src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="defer"></script><script id="foo-js-after">console.log("Hello, World!");</script>',
-				'doing_it_wrong' => true,
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js" data-wp-strategy="defer"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
+			),
+			'add-inline-script-offloaded-to-web-worker'  => array(
+				'set_up'   => static function (): void {
+					wp_register_script( 'foo', false, array(), '1.0.0' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'before' );
+					wp_add_inline_script( 'foo', 'console.log("Hello, World!");', 'after' );
+					wp_script_add_data( 'foo', 'worker', true );
+					wp_enqueue_script( 'foo' );
+				},
+				'expected' => '{{ wwo_config }}{{ wwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, World!");</script><script id="foo-js-after" type="text/partytown">console.log("Hello, World!");</script>',
 			),
 		);
 	}
@@ -179,19 +189,15 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 	 *
 	 * @covers ::wwo_update_script_type
 	 * @covers ::wwo_filter_print_scripts_array
+	 * @cogers ::wwo_filter_inline_script_attributes
 	 *
 	 * @dataProvider data_update_script_types
 	 *
-	 * @param Closure $set_up         Closure to set up the test.
-	 * @param string  $expected       Expected output.
-	 * @param bool    $doing_it_wrong Whether to expect a `_doing_it_wrong` notice.
+	 * @param Closure $set_up   Closure to set up the test.
+	 * @param string  $expected Expected output.
 	 */
-	public function test_update_script_types( Closure $set_up, string $expected, bool $doing_it_wrong ): void {
+	public function test_update_script_types( Closure $set_up, string $expected ): void {
 		$expected = $this->replace_placeholders( $expected );
-
-		if ( $doing_it_wrong ) {
-			$this->setExpectedIncorrectUsage( 'wwo_update_script_type' );
-		}
 
 		$set_up();
 
@@ -218,7 +224,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		wp_script_add_data( 'foo', 'worker', true );
 
 		$this->assertEquals(
-			$this->replace_placeholders( '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"  ></script>' ),
+			$this->replace_placeholders( '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>' ),
 			trim( get_echo( 'wp_print_head_scripts' ) )
 		);
 
@@ -226,7 +232,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		wp_script_add_data( 'bar', 'worker', true );
 
 		$this->assertEquals(
-			$this->replace_placeholders( '<script type="text/partytown" src="https://example.com/bar.js?ver=1.0.0" id="bar-js"  ></script>' ),
+			$this->replace_placeholders( '<script type="text/partytown" src="https://example.com/bar.js?ver=1.0.0" id="bar-js"></script>' ),
 			trim( get_echo( 'wp_print_footer_scripts' ) )
 		);
 	}
@@ -242,7 +248,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		wp_script_add_data( 'foo', 'worker', true );
 
 		$this->assertEquals(
-			$this->replace_placeholders( '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"  ></script>' ),
+			$this->replace_placeholders( '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/foo.js?ver=1.0.0" id="foo-js"></script>' ),
 			trim( get_echo( 'wp_print_head_scripts' ) )
 		);
 
@@ -272,7 +278,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		wp_script_add_data( 'bar', 'worker', true );
 
 		$this->assertEquals(
-			$this->replace_placeholders( '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/bar.js?ver=1.0.0" id="bar-js"  ></script>' ),
+			$this->replace_placeholders( '{{ wwo_config }}{{ wwo_inline_script }}<script type="text/partytown" src="https://example.com/bar.js?ver=1.0.0" id="bar-js"></script>' ),
 			trim( get_echo( 'wp_print_footer_scripts' ) )
 		);
 	}

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -195,9 +195,14 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 
 		$set_up();
 
+		$normalize = static function ( $html ) {
+			$html = preg_replace( '/\r|\n/', '', $html );
+			return trim( preg_replace( '#(?=<[^/])#', "\n", $html ) );
+		};
+
 		// Normalize the output.
-		$actual   = preg_replace( '/\r|\n/', '', get_echo( 'wp_print_scripts' ) );
-		$expected = preg_replace( '/\r|\n/', '', $expected );
+		$actual   = $normalize( get_echo( 'wp_print_scripts' ) );
+		$expected = $normalize( $expected );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -77,8 +77,12 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		$this->assertTrue( wp_script_is( 'web-worker-offloading', 'registered' ) );
 		$this->assertNotEmpty( $before_data );
 		$this->assertNotEmpty( $after_data );
-		$this->assertEquals(
-			sprintf( 'window.partytown = %s;', wp_json_encode( $partytown_config ) ),
+		$this->assertStringContainsString(
+			'window.partytown',
+			$before_data
+		);
+		$this->assertStringContainsString(
+			wp_json_encode( $partytown_config ),
 			$before_data
 		);
 		$this->assertEquals( file_get_contents( $partytown_lib . 'partytown.js' ), $after_data );

--- a/plugins/web-worker-offloading/third-party.php
+++ b/plugins/web-worker-offloading/third-party.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds scripts to be offloaded to a worker.
  *
+ * @since 0.1.0
+ * @access private
+ *
  * @param string[] $script_handles Script handles.
  */
 function wwo_mark_scripts_for_offloading( array $script_handles ): void {
@@ -32,6 +35,7 @@ function wwo_mark_scripts_for_offloading( array $script_handles ): void {
  * Loads third party plugin integrations for active plugins.
  *
  * @since 0.1.0
+ * @access private
  */
 function wwo_load_third_party_integrations(): void {
 	$plugins_with_integrations = array(

--- a/plugins/web-worker-offloading/third-party.php
+++ b/plugins/web-worker-offloading/third-party.php
@@ -11,22 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Adds forwarded events for Google Analytics.
- *
- * @since 0.1.0
- * @link https://partytown.builder.io/google-tag-manager#forward-events
- *
- * @param array<string, mixed>|mixed $configuration Configuration.
- * @return array<string, mixed> Configuration.
- */
-function wwo_add_google_analytics_forwarded_events( $configuration ): array {
-	$configuration = (array) $configuration;
-
-	$configuration['forward'][] = 'dataLayer.push';
-	return $configuration;
-}
-
-/**
  * Adds scripts to be offloaded to a worker.
  *
  * @param string[] $script_handles Script handles.

--- a/plugins/web-worker-offloading/third-party.php
+++ b/plugins/web-worker-offloading/third-party.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Third-party integration loader for Web Worker Offloading.
+ *
+ * @since 0.1.0
+ * @package web-worker-offloading
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Adds forwarded events for Google Analytics.
+ *
+ * @since 0.1.0
+ * @link https://partytown.builder.io/google-tag-manager#forward-events
+ *
+ * @param array<string, mixed>|mixed $configuration Configuration.
+ * @return array<string, mixed> Configuration.
+ */
+function wwo_add_google_analytics_forwarded_events( $configuration ): array {
+	$configuration = (array) $configuration;
+
+	$configuration['forward'][] = 'dataLayer.push';
+	return $configuration;
+}
+
+/**
+ * Adds a script to be offloaded to a worker.
+ *
+ * @param string $script_handle Script handle.
+ */
+function wwo_mark_script_for_offloading( string $script_handle ): void {
+	add_filter(
+		'print_scripts_array',
+		static function ( $script_handles ) use ( $script_handle ) {
+			if ( in_array( $script_handle, (array) $script_handles, true ) ) {
+				wp_script_add_data( $script_handle, 'worker', true );
+			}
+			return $script_handles;
+		}
+	);
+}
+
+/**
+ * Loads third party plugin integrations for active plugins.
+ *
+ * @since 0.1.0
+ */
+function wwo_load_third_party_integrations(): void {
+	$plugins_with_integrations = array(
+		// TODO: google-site-kit.
+		// TODO: seo-by-rank-math.
+		'woocommerce',
+	);
+
+	// Load corresponding file for each string in $plugins if the WordPress plugin is installed and active.
+	$active_plugin_slugs = array_filter(
+		array_map(
+			static function ( $plugin_file ) {
+				if ( is_string( $plugin_file ) && str_contains( $plugin_file, '/' ) ) {
+					return strtok( $plugin_file, '/' );
+				} else {
+					return false;
+				}
+			},
+			(array) get_option( 'active_plugins' )
+		)
+	);
+
+	foreach ( array_intersect( $active_plugin_slugs, $plugins_with_integrations ) as $plugin_slug ) {
+		require_once __DIR__ . '/third-party/' . $plugin_slug . '.php';
+	}
+}
+add_action( 'plugins_loaded', 'wwo_load_third_party_integrations' );

--- a/plugins/web-worker-offloading/third-party.php
+++ b/plugins/web-worker-offloading/third-party.php
@@ -41,25 +41,16 @@ function wwo_load_third_party_integrations(): void {
 	$plugins_with_integrations = array(
 		// TODO: google-site-kit.
 		// TODO: seo-by-rank-math.
-		'woocommerce',
+		'woocommerce' => static function (): bool {
+			// See <https://woocommerce.com/document/query-whether-woocommerce-is-activated/>.
+			return class_exists( 'WooCommerce' );
+		},
 	);
 
-	// Load corresponding file for each string in $plugins if the WordPress plugin is installed and active.
-	$active_plugin_slugs = array_filter(
-		array_map(
-			static function ( $plugin_file ) {
-				if ( is_string( $plugin_file ) && str_contains( $plugin_file, '/' ) ) {
-					return strtok( $plugin_file, '/' );
-				} else {
-					return false;
-				}
-			},
-			(array) get_option( 'active_plugins' )
-		)
-	);
-
-	foreach ( array_intersect( $active_plugin_slugs, $plugins_with_integrations ) as $plugin_slug ) {
-		require_once __DIR__ . '/third-party/' . $plugin_slug . '.php';
+	foreach ( $plugins_with_integrations as $plugin_slug => $active_callback ) {
+		if ( $active_callback() ) {
+			require_once __DIR__ . '/third-party/' . $plugin_slug . '.php';
+		}
 	}
 }
 add_action( 'plugins_loaded', 'wwo_load_third_party_integrations' );

--- a/plugins/web-worker-offloading/third-party.php
+++ b/plugins/web-worker-offloading/third-party.php
@@ -27,18 +27,19 @@ function wwo_add_google_analytics_forwarded_events( $configuration ): array {
 }
 
 /**
- * Adds a script to be offloaded to a worker.
+ * Adds scripts to be offloaded to a worker.
  *
- * @param string $script_handle Script handle.
+ * @param string[] $script_handles Script handles.
  */
-function wwo_mark_script_for_offloading( string $script_handle ): void {
+function wwo_mark_scripts_for_offloading( array $script_handles ): void {
 	add_filter(
 		'print_scripts_array',
-		static function ( $script_handles ) use ( $script_handle ) {
-			if ( in_array( $script_handle, (array) $script_handles, true ) ) {
-				wp_script_add_data( $script_handle, 'worker', true );
+		static function ( $to_do ) use ( $script_handles ) {
+			$worker_script_handles = array_intersect( (array) $to_do, $script_handles );
+			foreach ( $worker_script_handles as $worker_script_handle ) {
+				wp_script_add_data( $worker_script_handle, 'worker', true );
 			}
-			return $script_handles;
+			return $to_do;
 		}
 	);
 }

--- a/plugins/web-worker-offloading/third-party.php
+++ b/plugins/web-worker-offloading/third-party.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.1.0
  * @access private
  *
- * @param string[] $script_handles Script handles.
+ * @param non-empty-string[] $script_handles Script handles.
  */
 function wwo_mark_scripts_for_offloading( array $script_handles ): void {
 	add_filter(

--- a/plugins/web-worker-offloading/third-party/woocommerce.php
+++ b/plugins/web-worker-offloading/third-party/woocommerce.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Web Worker Offloading integration with WooCommerce.
+ *
+ * @since 0.1.0
+ * @package web-worker-offloading
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+add_filter( 'wwo_configuration', 'wwo_add_google_analytics_forwarded_events' );
+wwo_mark_script_for_offloading( 'google-tag-manager' );
+wwo_mark_script_for_offloading( 'woocommerce-google-analytics-integration-gtag' );

--- a/plugins/web-worker-offloading/third-party/woocommerce.php
+++ b/plugins/web-worker-offloading/third-party/woocommerce.php
@@ -10,10 +10,30 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-add_filter( 'wwo_configuration', 'wwo_add_google_analytics_forwarded_events' );
+/**
+ * Configures WWO for WooCommerce and Google Analytics.
+ *
+ * @since 0.1.0
+ * @link https://partytown.builder.io/google-tag-manager#forward-events
+ *
+ * @param array<string, mixed>|mixed $configuration Configuration.
+ * @return array<string, mixed> Configuration.
+ */
+function wwo_woocommerce_configure( $configuration ): array {
+	$configuration = (array) $configuration;
+
+	$configuration['mainWindowAccessors'][] = 'wp'; // Because woocommerce-google-analytics-integration needs to access wp.i18n.
+	$configuration['globalFns'][]           = 'gtag'; // Because gtag() is defined in one script and called in another.
+	$configuration['forward'][]             = 'dataLayer.push'; // Because the Partytown integration has this in its example config.
+	return $configuration;
+}
+add_filter( 'wwo_configuration', 'wwo_woocommerce_configure' );
+
 wwo_mark_scripts_for_offloading(
 	array(
 		'google-tag-manager',
+		'woocommerce-google-analytics-integration',
+		'woocommerce-google-analytics-integration-data',
 		'woocommerce-google-analytics-integration-gtag',
 	)
 );

--- a/plugins/web-worker-offloading/third-party/woocommerce.php
+++ b/plugins/web-worker-offloading/third-party/woocommerce.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Configures WWO for WooCommerce and Google Analytics.
  *
  * @since 0.1.0
+ * @access private
  * @link https://partytown.builder.io/google-tag-manager#forward-events
  *
  * @param array<string, mixed>|mixed $configuration Configuration.

--- a/plugins/web-worker-offloading/third-party/woocommerce.php
+++ b/plugins/web-worker-offloading/third-party/woocommerce.php
@@ -11,5 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_filter( 'wwo_configuration', 'wwo_add_google_analytics_forwarded_events' );
-wwo_mark_script_for_offloading( 'google-tag-manager' );
-wwo_mark_script_for_offloading( 'woocommerce-google-analytics-integration-gtag' );
+wwo_mark_scripts_for_offloading(
+	array(
+		'google-tag-manager',
+		'woocommerce-google-analytics-integration-gtag',
+	)
+);

--- a/plugins/web-worker-offloading/third-party/woocommerce.php
+++ b/plugins/web-worker-offloading/third-party/woocommerce.php
@@ -22,7 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 function wwo_woocommerce_configure( $configuration ): array {
 	$configuration = (array) $configuration;
 
-	$configuration['mainWindowAccessors'][] = 'wp'; // Because woocommerce-google-analytics-integration needs to access wp.i18n.
+	$configuration['mainWindowAccessors'][] = 'wp';   // Because woocommerce-google-analytics-integration needs to access wp.i18n.
+	$configuration['mainWindowAccessors'][] = 'ga4w'; // Because woocommerce-google-analytics-integration needs to access window.ga4w.
 	$configuration['globalFns'][]           = 'gtag'; // Because gtag() is defined in one script and called in another.
 	$configuration['forward'][]             = 'dataLayer.push'; // Because the Partytown integration has this in its example config.
 	return $configuration;
@@ -33,7 +34,6 @@ wwo_mark_scripts_for_offloading(
 	array(
 		'google-tag-manager',
 		'woocommerce-google-analytics-integration',
-		'woocommerce-google-analytics-integration-data',
 		'woocommerce-google-analytics-integration-gtag',
 	)
 );


### PR DESCRIPTION
## Summary

This integrates WooCommerce's Google Analytics integration with Partytown to offload `gtag()` to a worker. Inline scripts now no longer block a registered script from being offloaded to a worker; any associated inline scripts are also offloaded to a worker. It also improves the way that the configuration is managed and fleshes out the README for the initial release.

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
See #1455 (integration with Site Kit and Rank Math can be done in separate PRs)

<details><summary>Diff of Prettier-formatted page with plugin active</summary>

```diff
--- /tmp/before.html	2024-09-28 23:41:35.338249993 -0700
+++ /tmp/after.html	2024-09-28 23:44:32.403255392 -0700
@@ -1729,7 +1729,153 @@
         visibility: visible;
       }
     </style>
-    <script id="woocommerce-google-analytics-integration-gtag-js-after">
+    <script id="web-worker-offloading-js-before">
+      window.partytown = {
+        lib: "\/wp-content\/plugins\/web-worker-offloading\/build\/",
+        forward: ["dataLayer.push"],
+        debug: true,
+        mainWindowAccessors: ["wp", "ga4w"],
+        globalFns: ["gtag"],
+      };
+    </script>
+    <script id="web-worker-offloading-js-after">
+      const t = { preserveBehavior: !1 },
+        e = (e) => {
+          if ("string" == typeof e) return [e, t];
+          const [n, r = t] = e;
+          return [n, { ...t, ...r }];
+        },
+        n = Object.freeze(
+          (() => {
+            const t = new Set();
+            let e = [];
+            do {
+              Object.getOwnPropertyNames(e).forEach((n) => {
+                "function" == typeof e[n] && t.add(n);
+              });
+            } while ((e = Object.getPrototypeOf(e)) !== Object.prototype);
+            return Array.from(t);
+          })(),
+        );
+      !(function (t, r, o, i, a, s, c, d, l, p, u = t, f) {
+        function h() {
+          f ||
+            ((f = 1),
+            "/" ==
+              (c = (s.lib || "/~partytown/") + (s.debug ? "debug/" : ""))[0] &&
+              ((l = r.querySelectorAll('script[type="text/partytown"]')),
+              i != t
+                ? i.dispatchEvent(new CustomEvent("pt1", { detail: t }))
+                : ((d = setTimeout(v, 999999999)),
+                  r.addEventListener("pt0", w),
+                  a
+                    ? y(1)
+                    : o.serviceWorker
+                    ? o.serviceWorker
+                        .register(c + (s.swPath || "partytown-sw.js"), {
+                          scope: c,
+                        })
+                        .then(function (t) {
+                          t.active
+                            ? y()
+                            : t.installing &&
+                              t.installing.addEventListener(
+                                "statechange",
+                                function (t) {
+                                  "activated" == t.target.state && y();
+                                },
+                              );
+                        }, console.error)
+                    : v())));
+        }
+        function y(e) {
+          (p = r.createElement(e ? "script" : "iframe")),
+            (t._pttab = Date.now()),
+            e ||
+              ((p.style.display = "block"),
+              (p.style.width = "0"),
+              (p.style.height = "0"),
+              (p.style.border = "0"),
+              (p.style.visibility = "hidden"),
+              p.setAttribute("aria-hidden", !0)),
+            (p.src =
+              c +
+              "partytown-" +
+              (e
+                ? "atomics.js?v=0.10.2-dev1727590485751"
+                : "sandbox-sw.html?" + t._pttab)),
+            r.querySelector(s.sandboxParent || "body").appendChild(p);
+        }
+        function v(n, o) {
+          for (
+            w(),
+              i == t &&
+                (s.forward || []).map(function (n) {
+                  const [r] = e(n);
+                  delete t[r.split(".")[0]];
+                }),
+              n = 0;
+            n < l.length;
+            n++
+          )
+            ((o = r.createElement("script")).innerHTML = l[n].innerHTML),
+              (o.nonce = s.nonce),
+              r.head.appendChild(o);
+          p && p.parentNode.removeChild(p);
+        }
+        function w() {
+          clearTimeout(d);
+        }
+        (s = t.partytown || {}),
+          i == t &&
+            (s.forward || []).map(function (r) {
+              const [o, { preserveBehavior: i }] = e(r);
+              (u = t),
+                o.split(".").map(function (e, r, o) {
+                  var a;
+                  u = u[o[r]] =
+                    r + 1 < o.length
+                      ? u[o[r]] || ((a = o[r + 1]), n.includes(a) ? [] : {})
+                      : (() => {
+                          let e = null;
+                          if (i) {
+                            const { methodOrProperty: n, thisObject: r } = ((
+                              t,
+                              e,
+                            ) => {
+                              let n = t;
+                              for (let t = 0; t < e.length - 1; t += 1)
+                                n = n[e[t]];
+                              return {
+                                thisObject: n,
+                                methodOrProperty:
+                                  e.length > 0 ? n[e[e.length - 1]] : void 0,
+                              };
+                            })(t, o);
+                            "function" == typeof n &&
+                              (e = (...t) => n.apply(r, ...t));
+                          }
+                          return function () {
+                            let n;
+                            return (
+                              e && (n = e(arguments)),
+                              (t._ptf = t._ptf || []).push(o, arguments),
+                              n
+                            );
+                          };
+                        })();
+                });
+            }),
+          "complete" == r.readyState
+            ? h()
+            : (t.addEventListener("DOMContentLoaded", h),
+              t.addEventListener("load", h));
+      })(window, document, navigator, top, window.crossOriginIsolated);
+    </script>
+    <script
+      id="woocommerce-google-analytics-integration-gtag-js-after"
+      type="text/partytown"
+    >
       /* Google Analytics for WooCommerce (gtag.js) */
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -3637,12 +3783,13 @@
       id="wc-product-collection-block-frontend-js"
     ></script>
     <script
-      async
+      type="text/partytown"
       src="https://www.googletagmanager.com/gtag/js?id=G-12345"
       id="google-tag-manager-js"
       data-wp-strategy="async"
     ></script>
     <script
+      type="text/partytown"
       src="http://localhost:8888/wp-content/plugins/woocommerce-google-analytics-integration/assets/js/build/main.js?ver=0fcb8d9b3b96ceffc047"
       id="woocommerce-google-analytics-integration-js"
     ></script>
```

</details> 

Looking at network logs after click an Add to Cart button...

Before:

![image](https://github.com/user-attachments/assets/c0b4486c-a9dc-4229-845a-6363e514e2b1)


After:

![image](https://github.com/user-attachments/assets/09518568-4ae6-49a3-afd7-a907d75fda21)

As can be seen here, with the WWO plugin active, the HTTP request to Google Analytics is happening in a worker.

## How to test

1. Install [WooCommerce](https://wordpress.org/plugins/woocommerce/) 
2. Install [Google Analytics for WooCommerce](https://wordpress.org/plugins/woocommerce-google-analytics-integration/)
3. Configure a Shop with imported sample products.
4. Make the Shop live rather than serve a Coming Soon page.
5. Navigate to `/wp-admin/admin.php?page=wc-settings&tab=integration&section=google_analytics` and supply some GA ID, for example: ![image](https://github.com/user-attachments/assets/cbdfde08-a554-49b5-97af-2fd13f5bb199)
6. Try clicking an Add to Cart button on the Shop page.
7. Look at the Network log and confirm that the request to google-analytics.com is being made in the Web Worker as opposed to the main thread.

Ideally you would also look at Google Analytics itself to see that the events are being tracked as expected, but this is beyond my off-hand knowledge.

## Relevant technical choices

<!-- Please describe your changes. -->


WooCommerce needs to access `wp.i18n` from a worker-offloaded script, but unfortunately Partytown skips serializing any object properties that begin with `_`, meaning calling `wp.i18n.__()` will throw an error. I've raised this issue as https://github.com/BuilderIO/partytown/issues/629 and implemented a workaround in my fork https://github.com/westonruter/partytown/pull/1. I've updated the `@builder.io/partytown` npm dependency to use my fork.

See PR comments for additional annotations.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
