### PR TITLE
Fix Optimization Detective compatibility with WooCommerce when Coming Soon page is served

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -27,10 +27,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @access private
  * @link https://core.trac.wordpress.org/ticket/43258
  *
- * @param string $passthrough Value for the template_include filter which is passed through.
- * @return string Unmodified value of $passthrough.
+ * @param string|mixed $passthrough Value for the template_include filter which is passed through.
+ * @return string|mixed Unmodified value of $passthrough.
  */
-function od_buffer_output( string $passthrough ): string {
+function od_buffer_output( $passthrough ) {
 	/*
 	 * Instead of the default PHP_OUTPUT_HANDLER_STDFLAGS (cleanable, flushable, and removable) being used for flags,
 	 * we need to omit PHP_OUTPUT_HANDLER_FLUSHABLE. If the buffer were flushable, then each time that ob_flush() is


### PR DESCRIPTION
When testing WooCommerce, I discovered an unexpected result when attempting to access the Shop page:

> ![image](https://github.com/user-attachments/assets/20fd6b13-2ddd-4a7e-9581-bd8839efc2db)

In my local testing site, I imported some sample products but didn't "launch" the store yet, so WooCommerce is attempting to serve the Coming Soon page to a logged-out user. The relevant code is [`ComingSoonRequestHandler::handle_template_include()`](https://github.com/woocommerce/woocommerce/blob/2e9ec00dd2864c5c7efde3c115b0937a0d3b34e1/plugins/woocommerce/src/Internal/ComingSoon/ComingSoonRequestHandler.php#L36-L101) which filters `template_include` to conditionally return `null` on FSE themes:

```php
		if ( $is_fse_theme ) {
			// Since we've already rendered a template, return null to ensure no other template is rendered.
			return null;
		} else {
			// In non-FSE themes, other templates will still be rendered.
			// We need to exit to prevent further processing.
			exit();
		}
```

This causes a fatal error in Optimization Detective:

```
PHP Fatal error:  Uncaught TypeError: od_buffer_output(): Argument #1 ($passthrough) must be of type string, null given, called in /var/www/html/wp-includes/class-wp-hook.php on line 324 and defined in /var/www/html/wp-content/plugins/optimization-detective/optimization.php:33
Stack trace:
#0 /var/www/html/wp-includes/class-wp-hook.php(324): od_buffer_output(NULL)
#1 /var/www/html/wp-includes/plugin.php(205): WP_Hook->apply_filters(NULL, Array)
#2 /var/www/html/wp-includes/template-loader.php(104): apply_filters('template_includ...', '/var/www/html/w...')
#3 /var/www/html/wp-blog-header.php(19): require_once('/var/www/html/w...')
#4 /var/www/html/index.php(17): require('/var/www/html/w...')
#5 {main}
  thrown in /var/www/html/wp-content/plugins/optimization-detective/optimization.php on line 33
```

This is because `od_buffer_output()` is erroneously defined with a strict `string` type for the method parameter. Well, I suppose WooCommerce is also erroneously returning `null` when it should instead return an empty string (which has the same effect) since the `template_include` filter is defined as passing a `string` and not `string|null`. 

In any case, since we don't actually do anything with the variable we can just remove the typing. The result is the page as expected:

> ![image](https://github.com/user-attachments/assets/df8440a6-0e9e-4b65-91ae-28127ad49f65)

