### PR TITLE
Fix plugin bootstrapping when embedded after the after_setup_theme action

### DIFF
--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -30,24 +30,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param Closure $load            Callback that loads the plugin.
 	 */
 	static function ( string $global_var_name, string $version, Closure $load ): void {
-		if ( ! isset( $GLOBALS[ $global_var_name ] ) ) {
-			$bootstrap = static function () use ( $global_var_name ): void {
-				if (
-					isset( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] )
-					&&
-					$GLOBALS[ $global_var_name ]['load'] instanceof Closure
-					&&
-					is_string( $GLOBALS[ $global_var_name ]['version'] )
-				) {
-					call_user_func( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] );
-					unset( $GLOBALS[ $global_var_name ] );
-				}
-			};
-
-			// Wait until after the plugins have loaded and the theme has loaded. The after_setup_theme action is used
-			// because it is the first action that fires once the theme is loaded.
-			add_action( 'after_setup_theme', $bootstrap, PHP_INT_MIN );
-		}
+		$bootstrap = static function () use ( $global_var_name ): void {
+			if (
+				isset( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] )
+				&&
+				$GLOBALS[ $global_var_name ]['load'] instanceof Closure
+				&&
+				is_string( $GLOBALS[ $global_var_name ]['version'] )
+			) {
+				call_user_func( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] );
+				unset( $GLOBALS[ $global_var_name ] );
+			}
+		};
 
 		// Register this copy of the plugin.
 		if (
@@ -62,6 +56,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 		) {
 			$GLOBALS[ $global_var_name ]['version'] = $version;
 			$GLOBALS[ $global_var_name ]['load']    = $load;
+		}
+
+		// Wait until after the plugins have loaded and the theme has loaded. The after_setup_theme action is used
+		// because it is the first action that fires once the theme is loaded. Otherwise, if the after_setup_theme
+		// action has already fired, then bootstrap right away.
+		if ( 0 === did_action( 'after_setup_theme' ) ) {
+			add_action( 'after_setup_theme', $bootstrap, PHP_INT_MIN );
+		} else {
+			$bootstrap();
 		}
 	}
 )(


### PR DESCRIPTION
Several of the plugins are designed to be embedded in other plugins or themes. They are intended to bootstrap at the `after_setup_theme` at the latest since this is first action that fires when a theme is loaded. However, I discovered in https://github.com/elementor/elementor/pull/28844 that modules in Elementor are loaded even after this action, meaning that the bootstrap logic doesn't work. This then necessitates a [workaround](https://github.com/elementor/elementor/blob/fd62792795c22d930baecc48e1d880663128801a/modules/optimization-detective/module.php#L26-L52). (Specifically, it loads at the [`init` action with priority 0](https://github.com/elementor/elementor/blob/a627ce730837b8b8d4381d8fdfab106dda35f96b/includes/plugin.php#L877).) Ideally the plugins would bootstrap themselves correctly even when the bootstrap files are included after the `after_setup_theme` action.

The same change is done for each of the plugins.