### PR TITLE
Only store info for relevant standalone plugins in the transient cache

### DIFF
--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -21,7 +21,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 function perflab_query_plugin_info( string $plugin_slug ) {
 	$transient_key = 'perflab_plugins_info';
 	$plugins       = get_transient( $transient_key );
-	$fields        = array(
+
+	if ( is_array( $plugins ) ) {
+		// If the specific plugin_slug is not in the cache, return an error.
+		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
+			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
+		}
+		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
+	}
+
+	$fields = array(
 		'name',
 		'slug',
 		'short_description',
@@ -31,14 +40,6 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		'download_link',
 		'version', // Needed by install_plugin_install_status().
 	);
-
-	if ( is_array( $plugins ) ) {
-		// If the specific plugin_slug is not in the cache, return an error.
-		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
-			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
-		}
-		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
-	}
 
 	// Proceed with API request since no cache hit.
 	$response = plugins_api(
@@ -69,6 +70,9 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 
 	$plugins = array();
 	foreach ( $response->plugins as $plugin_data ) {
+		if ( ! in_array( $plugin_data['slug'], perflab_get_standalone_plugins(), true ) ) {
+			continue;
+		}
 		$plugins[ $plugin_data['slug'] ] = wp_array_slice_assoc( $plugin_data, $fields );
 	}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -68,9 +68,10 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		return new WP_Error( 'no_plugins', __( 'No plugins found in the API response.', 'performance-lab' ) );
 	}
 
-	$plugins = array();
+	$plugins            = array();
+	$standalone_plugins = array_flip( perflab_get_standalone_plugins() );
 	foreach ( $response->plugins as $plugin_data ) {
-		if ( ! in_array( $plugin_data['slug'], perflab_get_standalone_plugins(), true ) ) {
+		if ( ! isset( $standalone_plugins[ $plugin_data['slug'] ] ) ) {
 			continue;
 		}
 		$plugins[ $plugin_data['slug'] ] = wp_array_slice_assoc( $plugin_data, $fields );


### PR DESCRIPTION
Follow-up on #1562

The current API query `https://api.wordpress.org/plugins/info/1.2/?action=query_plugins&request[author]=wordpressdotorg&request[tag]=performance&request[per_page]=100` is returning some unrelated plugins like `Plugin Check (PCP)` and `SQLite Database Integration`. In the future, if anyone else uses `Performance` as a tag, it will also be added to our `transient`. However, we only need the standalone plugins defined in `perflab_get_standalone_plugin_data()`.

I’ve also moved the array definition for `$fields` after the cache check, as it's redundant in the cached version.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
