### PR TITLE
Add Web Worker Offloading to list of Performance features

### DIFF
--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -47,7 +47,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		array(
 			'author'   => 'wordpressdotorg',
 			'tag'      => 'performance',
-			'per_page' => 99, // Decremented from 100 to bust WordPress.org response cache.
+			'per_page' => 100,
 			'fields'   => array_fill_keys( $fields, true ),
 		)
 	);

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -47,7 +47,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		array(
 			'author'   => 'wordpressdotorg',
 			'tag'      => 'performance',
-			'per_page' => 100,
+			'per_page' => 99, // Decremented from 100 to bust WordPress.org response cache.
 			'fields'   => array_fill_keys( $fields, true ),
 		)
 	);

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -114,6 +114,10 @@ function perflab_get_standalone_plugin_data(): array {
 		'speculation-rules'       => array(
 			'constant' => 'SPECULATION_RULES_VERSION',
 		),
+		'web-worker-offloading'   => array(
+			'constant'     => 'WEB_WORKER_OFFLOADING_VERSION',
+			'experimental' => true,
+		),
 		'webp-uploads'            => array(
 			'constant' => 'WEBP_UPLOADS_VERSION',
 		),

--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Web Worker Offloading
  * Plugin URI: https://github.com/WordPress/performance/issues/176
- * Description: Offload JavaScript execution to a Web Worker.
+ * Description: Offloads select JavaScript execution to a Web Worker to reduce work on the main thread and improve the Interaction to Next Paint (INP) metric.
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Version: 0.1.0

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -7,7 +7,7 @@ License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, JavaScript, web worker, partytown, analytics
 
-Offload JavaScript execution to a Web Worker.
+Offloads select JavaScript execution to a Web Worker to reduce work on the main thread and improve the Interaction to Next Paint (INP) metric.
 
 == Description ==
 


### PR DESCRIPTION
The Web Worker Offloading plugin is now live! https://wordpress.org/plugins/web-worker-offloading/

This adds the plugin to the list of experimental performance features to activate:

![image](https://github.com/user-attachments/assets/a3fd9c6c-aac6-4667-95da-917075ef1e5a)

Note the modification of the `per_page` field is simply to bust the WordPress.org API response cache, as otherwise the plugin is not currently included in the results and the screen is:

![Screenshot 2024-10-03 12 02 06](https://github.com/user-attachments/assets/61d54a58-1a0e-40af-bb9e-cfbaa76e156b)

I'm not sure how long the responses are cached. Perhaps in another hour it will be flushed.