### PR TITLE
Enhance Server-Timing implementation to support new Chrome DevTools Performance Panel integration

### DIFF
--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing-metric.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing-metric.php
@@ -30,12 +30,13 @@ class Perflab_Server_Timing_Metric {
 	private $value;
 
 	/**
-	 * The value measured before relevant execution logic in seconds, if used.
+	 * The value measured before relevant execution logic in milliseconds, if used.
 	 *
 	 * @since 1.8.0
-	 * @var float|null
+	 * @since n.e.x.t Renamed from $before_value to $start_value.
+	 * @var int|float|null
 	 */
-	private $before_value;
+	private $start_value;
 
 	/**
 	 * Constructor.
@@ -70,23 +71,7 @@ class Perflab_Server_Timing_Metric {
 	 * @param int|float|mixed $value The metric value to set, in milliseconds.
 	 */
 	public function set_value( $value ): void {
-		if ( ! is_numeric( $value ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				/* translators: %s: PHP parameter name */
-				sprintf( esc_html__( 'The %s parameter must be an integer, float, or numeric string.', 'performance-lab' ), '$value' ),
-				''
-			);
-			return;
-		}
-
-		if ( 0 !== did_action( 'perflab_server_timing_send_header' ) && ! doing_action( 'perflab_server_timing_send_header' ) ) {
-			_doing_it_wrong(
-				__METHOD__,
-				/* translators: %s: WordPress action name */
-				sprintf( esc_html__( 'The method must be called before or during the %s action.', 'performance-lab' ), 'perflab_server_timing_send_header' ),
-				''
-			);
+		if ( ! $this->check_value( $value, __METHOD__ ) ) {
 			return;
 		}
 
@@ -99,7 +84,32 @@ class Perflab_Server_Timing_Metric {
 	}
 
 	/**
-	 * Gets the metric value.
+	 * Sets the start value for the metric.
+	 *
+	 * For metrics where the start value is set, this timestamp will be sent via an optional `start` parameter.
+	 *
+	 * Alternatively to setting the start value directly, the {@see Perflab_Server_Timing_Metric::measure_start()} and
+	 * {@see Perflab_Server_Timing_Metric::measure_end()} methods can be used to further simplify measuring.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param int|float|mixed $value The start value to set for the metric, in milliseconds.
+	 */
+	public function set_start_value( $value ): void {
+		if ( ! $this->check_value( $value, __METHOD__ ) ) {
+			return;
+		}
+
+		// In case e.g. a numeric string is passed, cast it.
+		if ( ! is_int( $value ) && ! is_float( $value ) ) {
+			$value = (float) $value;
+		}
+
+		$this->start_value = $value;
+	}
+
+	/**
+	 * Gets the metric value, if set.
 	 *
 	 * @since 1.8.0
 	 *
@@ -110,36 +120,112 @@ class Perflab_Server_Timing_Metric {
 	}
 
 	/**
-	 * Captures the current time, as a reference point to calculate the duration of a task afterward.
+	 * Gets the metric start value, if set.
 	 *
-	 * This should be used in combination with {@see Perflab_Server_Timing_Metric::measure_after()}. Alternatively,
-	 * {@see Perflab_Server_Timing_Metric::set_value()} can be used to set a calculated value manually.
+	 * @since n.e.x.t
 	 *
-	 * @since 1.8.0
+	 * @return int|float|null The metric start value, or null if none set.
 	 */
-	public function measure_before(): void {
-		$this->before_value = microtime( true );
+	public function get_start_value() {
+		return $this->start_value;
 	}
 
 	/**
-	 * Captures the current time and compares it to the reference point to calculate a task's duration.
+	 * Captures the current time as metric start time, to calculate the duration of a task afterward.
 	 *
-	 * This should be used in combination with {@see Perflab_Server_Timing_Metric::measure_before()}. Alternatively,
-	 * {@see Perflab_Server_Timing_Metric::set_value()} can be used to set a calculated value manually.
+	 * This should be used in combination with {@see Perflab_Server_Timing_Metric::measure_end()}. Alternatively,
+	 * {@see Perflab_Server_Timing_Metric::set_value()} and {@see Perflab_Server_Timing_Metric::set_start_value()} can
+	 * be used to set a calculated value manually.
 	 *
-	 * @since 1.8.0
+	 * @since n.e.x.t
 	 */
-	public function measure_after(): void {
-		if ( null === $this->before_value ) {
+	public function measure_start(): void {
+		$this->set_start_value( microtime( true ) * 1000.0 );
+	}
+
+	/**
+	 * Captures the current time and compares it to the metric start time to calculate a task's duration.
+	 *
+	 * This should be used in combination with {@see Perflab_Server_Timing_Metric::measure_start()}. Alternatively,
+	 * {@see Perflab_Server_Timing_Metric::set_value()} and {@see Perflab_Server_Timing_Metric::set_start_value()} can
+	 * be used to set a calculated value manually.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function measure_end(): void {
+		if ( null === $this->start_value ) {
 			_doing_it_wrong(
 				__METHOD__,
-				/* translators: %s: PHP method name */
-				sprintf( esc_html__( 'The %s method must be called before.', 'performance-lab' ), __CLASS__ . '::measure_before()' ),
+				sprintf(
+					/* translators: 1: PHP method name, 2: alternative PHP method name */
+					esc_html__( 'The %1$s method or %2$s method must be called before.', 'performance-lab' ),
+					__CLASS__ . '::measure_start()',
+					__CLASS__ . '::set_start_value()'
+				),
 				''
 			);
 			return;
 		}
 
-		$this->set_value( ( microtime( true ) - $this->before_value ) * 1000.0 );
+		$this->set_value( microtime( true ) * 1000.0 - $this->start_value );
+	}
+
+	/**
+	 * Captures the current time, as a reference point to calculate the duration of a task afterward.
+	 *
+	 * @since 1.8.0
+	 * @deprecated n.e.x.t
+	 * @see Perflab_Server_Timing_Metric::measure_start()
+	 */
+	public function measure_before(): void {
+		_deprecated_function( __METHOD__, 'n.e.x.t (Performance Lab)', __CLASS__ . '::measure_start()' );
+		$this->measure_start();
+	}
+
+	/**
+	 * Captures the current time and compares it to the reference point to calculate a task's duration.
+	 *
+	 * @since 1.8.0
+	 * @deprecated n.e.x.t
+	 * @see Perflab_Server_Timing_Metric::measure_end()
+	 */
+	public function measure_after(): void {
+		_deprecated_function( __METHOD__, 'n.e.x.t (Performance Lab)', __CLASS__ . '::measure_end()' );
+		$this->measure_end();
+	}
+
+	/**
+	 * Checks whether the passed metric value is valid and whether the timing of the method call is correct.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param int|float|mixed $value The value to check, in milliseconds.
+	 * @param string          $method The method name originally called (typically passed via `__METHOD__`).
+	 * @return bool True if the method call with the value is valid, false otherwise.
+	 */
+	private function check_value( $value, string $method ): bool {
+		if ( ! is_numeric( $value ) ) {
+			_doing_it_wrong(
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				$method,
+				/* translators: %s: PHP parameter name */
+				sprintf( esc_html__( 'The %s parameter must be an integer, float, or numeric string.', 'performance-lab' ), '$value' ),
+				''
+			);
+			return false;
+		}
+
+		if ( 0 !== did_action( 'perflab_server_timing_send_header' ) && ! doing_action( 'perflab_server_timing_send_header' ) ) {
+			_doing_it_wrong(
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				$method,
+				/* translators: %s: WordPress action name */
+				sprintf( esc_html__( 'The method must be called before or during the %s action.', 'performance-lab' ), 'perflab_server_timing_send_header' ),
+				''
+			);
+			return false;
+		}
+
+		return true;
 	}
 }

--- a/plugins/performance-lab/includes/server-timing/load.php
+++ b/plugins/performance-lab/includes/server-timing/load.php
@@ -132,13 +132,13 @@ function perflab_wrap_server_timing( callable $callback, string $metric_slug, st
 		}
 
 		// Measure time before the callback.
-		$server_timing_metric->measure_before();
+		$server_timing_metric->measure_start();
 
 		// Execute the callback.
 		$result = call_user_func_array( $callback, $callback_args );
 
 		// Measure time after the callback and calculate total.
-		$server_timing_metric->measure_after();
+		$server_timing_metric->measure_end();
 
 		// Return result (e.g. in case this is a filter callback).
 		return $result;

--- a/plugins/performance-lab/tests/includes/server-timing/test-perflab-server-timing-metric.php
+++ b/plugins/performance-lab/tests/includes/server-timing/test-perflab-server-timing-metric.php
@@ -48,6 +48,7 @@ class Test_Perflab_Server_Timing_Metric extends WP_UnitTestCase {
 		$this->setExpectedIncorrectUsage( Perflab_Server_Timing_Metric::class . '::set_value' );
 
 		$this->metric->set_value( 2 );
+		remove_all_actions( 'perflab_server_timing_send_header' );
 		do_action( 'perflab_server_timing_send_header' );
 		$this->metric->set_value( 3 );
 
@@ -80,6 +81,7 @@ class Test_Perflab_Server_Timing_Metric extends WP_UnitTestCase {
 		$this->setExpectedIncorrectUsage( Perflab_Server_Timing_Metric::class . '::set_start_value' );
 
 		$this->metric->set_start_value( 2 );
+		remove_all_actions( 'perflab_server_timing_send_header' );
 		do_action( 'perflab_server_timing_send_header' );
 		$this->metric->set_start_value( 3 );
 

--- a/plugins/performance-lab/tests/includes/server-timing/test-perflab-server-timing-metric.php
+++ b/plugins/performance-lab/tests/includes/server-timing/test-perflab-server-timing-metric.php
@@ -54,25 +54,72 @@ class Test_Perflab_Server_Timing_Metric extends WP_UnitTestCase {
 		$this->assertSame( 2, $this->metric->get_value() );
 	}
 
+	public function test_set_start_value_with_integer(): void {
+		$this->metric->set_start_value( 123 );
+		$this->assertSame( 123, $this->metric->get_start_value() );
+	}
+
+	public function test_set_start_value_with_float(): void {
+		$this->metric->set_start_value( 123.4567 );
+		$this->assertSame( 123.4567, $this->metric->get_start_value() );
+	}
+
+	public function test_set_start_value_with_numeric_string(): void {
+		$this->metric->set_start_value( '123.4567' );
+		$this->assertSame( 123.4567, $this->metric->get_start_value() );
+	}
+
+	public function test_set_start_value_requires_integer_or_float_or_numeric_string(): void {
+		$this->setExpectedIncorrectUsage( Perflab_Server_Timing_Metric::class . '::set_start_value' );
+
+		$this->metric->set_start_value( 'not-a-number' );
+		$this->assertNull( $this->metric->get_start_value() );
+	}
+
+	public function test_set_start_value_prevents_late_measurement(): void {
+		$this->setExpectedIncorrectUsage( Perflab_Server_Timing_Metric::class . '::set_start_value' );
+
+		$this->metric->set_start_value( 2 );
+		do_action( 'perflab_server_timing_send_header' );
+		$this->metric->set_start_value( 3 );
+
+		$this->assertSame( 2, $this->metric->get_start_value() );
+	}
+
 	public function test_get_value(): void {
 		$this->metric->set_value( 86.42 );
 		$this->assertSame( 86.42, $this->metric->get_value() );
 	}
 
-	public function test_measure_before_and_after_correctly(): void {
-		$this->metric->measure_before();
+	public function test_get_start_value(): void {
+		$t = microtime( true ) * 1000.0;
+		$this->metric->set_start_value( $t );
+		$this->assertSame( $t, $this->metric->get_start_value() );
+	}
+
+	public function test_measure_start_and_end_correctly(): void {
+		$this->metric->measure_start();
 		sleep( 1 );
-		$this->metric->measure_after();
+		$this->metric->measure_end();
 
 		// Loose float comparison with 100ms delta, since measurement won't be exactly 1000ms.
 		$this->assertEqualsWithDelta( 1000.0, $this->metric->get_value(), 100.0 );
 	}
 
-	public function test_measure_after_without_before(): void {
-		$this->setExpectedIncorrectUsage( Perflab_Server_Timing_Metric::class . '::measure_after' );
+	public function test_measure_end_without_start(): void {
+		$this->setExpectedIncorrectUsage( Perflab_Server_Timing_Metric::class . '::measure_end' );
 
-		$this->metric->measure_after();
+		$this->metric->measure_end();
 
 		$this->assertNull( $this->metric->get_value() );
+	}
+
+	public function test_measure_custom_start_and_end_correctly(): void {
+		$this->metric->set_start_value( microtime( true ) * 1000.0 );
+		sleep( 1 );
+		$this->metric->measure_end();
+
+		// Loose float comparison with 100ms delta, since measurement won't be exactly 1000ms.
+		$this->assertEqualsWithDelta( 1000.0, $this->metric->get_value(), 100.0 );
 	}
 }

--- a/plugins/performance-lab/tests/includes/server-timing/test-perflab-server-timing.php
+++ b/plugins/performance-lab/tests/includes/server-timing/test-perflab-server-timing.php
@@ -176,6 +176,10 @@ class Test_Perflab_Server_Timing extends WP_UnitTestCase {
 		$measure_12point345 = static function ( Perflab_Server_Timing_Metric $metric ): void {
 			$metric->set_value( 12.345 );
 		};
+		$measure_with_start = static function ( Perflab_Server_Timing_Metric $metric ): void {
+			$metric->set_start_value( 100000000.36 );
+			$metric->set_value( 100.72 );
+		};
 
 		return array(
 			'single metric'                      => array(
@@ -217,6 +221,15 @@ class Test_Perflab_Server_Timing extends WP_UnitTestCase {
 					),
 					'with-cap'    => array(
 						'measure_callback' => $measure_42,
+						'access_cap'       => 'exist',
+					),
+				),
+			),
+			'metric with start'                  => array(
+				'wp-with-start;dur=100.72;start=100000000.36',
+				array(
+					'with-start' => array(
+						'measure_callback' => $measure_with_start,
 						'access_cap'       => 'exist',
 					),
 				),


### PR DESCRIPTION
## Summary

Fixes #

## Relevant technical choices

* Allows accessing the `$start_value` property (formerly called `$before_value`) of Server-Timing metrics via new methods.
* Modifies that `$start_value` property to now store values in milliseconds instead of seconds. This is fine because the value could never be set from outside the class, so we have full control over it.
* Introduces new metric methods `measure_start()` and `measure_end()`, replacing the now deprecated `measure_before()` and `measure_after()` (mostly in accordance with the better naming encouraged by the new Chrome integration.
* Updates relevant default metrics to use the new methods.
* Automatically outputs non-standard metrics `response-start` and `response-end`, which are used to provide timing context to the browser so that the browser can display Server-Timing metrics correctly in relation to the other client-side metrics. This is relevant as the server-side clock may be off in comparison to the browser clock.

## Testing
* Use Chrome 129+ Beta.
* Go to _DevTools > Settings > Experiments > Performance panel_ and enable server timings in the timeline.
* Open the DevTools Performance panel and record a session including the request where the Server-Timing header with the metrics is added.