### PR TITLE
Introduce OD_Element class and improve PHP API

### DIFF
--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Tag visitor that optimizes embeds.
  *
+ * @phpstan-import-type DOMRect from OD_URL_Metric
+ *
  * @since 0.2.0
  * @access private
  */
@@ -216,6 +218,11 @@ final class Embed_Optimizer_Tag_Visitor {
 
 		$elements = $context->url_metric_group_collection->get_all_elements()[ $embed_wrapper_xpath ] ?? array();
 		foreach ( $elements as $element ) {
+			/**
+			 * Resized bounding client rect.
+			 *
+			 * @var DOMRect|null $resized_bounding_client_rect
+			 */
 			$resized_bounding_client_rect = $element->get( 'resizedBoundingClientRect' );
 			if ( ! is_array( $resized_bounding_client_rect ) ) {
 				continue;

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -216,7 +216,8 @@ final class Embed_Optimizer_Tag_Visitor {
 
 		$elements = $context->url_metric_group_collection->get_all_elements()[ $embed_wrapper_xpath ] ?? array();
 		foreach ( $elements as $element ) {
-			if ( ! isset( $element['resizedBoundingClientRect'] ) ) {
+			$resized_bounding_client_rect = $element->get( 'resizedBoundingClientRect' );
+			if ( ! is_array( $resized_bounding_client_rect ) ) {
 				continue;
 			}
 			$group           = $element->url_metric->group;
@@ -224,12 +225,12 @@ final class Embed_Optimizer_Tag_Visitor {
 			if ( ! isset( $minimums[ $group_min_width ] ) ) {
 				$minimums[ $group_min_width ] = array(
 					'group'  => $group,
-					'height' => $element['resizedBoundingClientRect']['height'],
+					'height' => $resized_bounding_client_rect['height'],
 				);
 			} else {
 				$minimums[ $group_min_width ]['height'] = min(
 					$minimums[ $group_min_width ]['height'],
-					$element['resizedBoundingClientRect']['height']
+					$resized_bounding_client_rect['height']
 				);
 			}
 		}

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -214,11 +214,12 @@ final class Embed_Optimizer_Tag_Visitor {
 		 */
 		$minimums = array();
 
-		$denormalized_elements = $context->url_metric_group_collection->get_all_denormalized_elements()[ $embed_wrapper_xpath ] ?? array();
-		foreach ( $denormalized_elements as list( $group, $url_metric, $element ) ) {
+		$elements = $context->url_metric_group_collection->get_all_elements()[ $embed_wrapper_xpath ] ?? array();
+		foreach ( $elements as $element ) {
 			if ( ! isset( $element['resizedBoundingClientRect'] ) ) {
 				continue;
 			}
+			$group           = $element->url_metric->group;
 			$group_min_width = $group->get_minimum_viewport_width();
 			if ( ! isset( $minimums[ $group_min_width ] ) ) {
 				$minimums[ $group_min_width ] = array(

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -216,7 +216,7 @@ final class Embed_Optimizer_Tag_Visitor {
 		 */
 		$minimums = array();
 
-		$elements = $context->url_metric_group_collection->get_all_elements()[ $embed_wrapper_xpath ] ?? array();
+		$elements = $context->url_metric_group_collection->get_xpath_elements_map()[ $embed_wrapper_xpath ] ?? array();
 		foreach ( $elements as $element ) {
 			/**
 			 * Resized bounding client rect.

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -227,7 +227,10 @@ final class Embed_Optimizer_Tag_Visitor {
 			if ( ! is_array( $resized_bounding_client_rect ) ) {
 				continue;
 			}
-			$group           = $element->url_metric->group;
+			$group = $element->get_url_metric_group();
+			if ( null === $group ) {
+				continue; // Technically could be null but in practice it never will be.
+			}
 			$group_min_width = $group->get_minimum_viewport_width();
 			if ( ! isset( $minimums[ $group_min_width ] ) ) {
 				$minimums[ $group_min_width ] = array(

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -46,7 +46,7 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 		 * will also be added. Additionally, ensure that this common LCP element is never lazy-loaded.
 		 */
 		$common_lcp_element = $context->url_metric_group_collection->get_common_lcp_element();
-		if ( ! is_null( $common_lcp_element ) && $xpath === $common_lcp_element->get_xpath() ) {
+		if ( $common_lcp_element instanceof OD_Element && $xpath === $common_lcp_element->get_xpath() ) {
 			if ( 'high' === $this->get_attribute_value( $processor, 'fetchpriority' ) ) {
 				$processor->set_meta_attribute( 'fetchpriority-already-added', true );
 			} else {

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -46,7 +46,7 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 		 * will also be added. Additionally, ensure that this common LCP element is never lazy-loaded.
 		 */
 		$common_lcp_element = $context->url_metric_group_collection->get_common_lcp_element();
-		if ( ! is_null( $common_lcp_element ) && $xpath === $common_lcp_element['xpath'] ) {
+		if ( ! is_null( $common_lcp_element ) && $xpath === $common_lcp_element->get_xpath() ) {
 			if ( 'high' === $this->get_attribute_value( $processor, 'fetchpriority' ) ) {
 				$processor->set_meta_attribute( 'fetchpriority-already-added', true );
 			} else {

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -88,8 +88,8 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 		$max_element_width = 0;
 		foreach ( $context->url_metric_group_collection->get_last_group() as $url_metric ) {
 			foreach ( $url_metric->get_elements() as $element ) {
-				if ( $element['xpath'] === $xpath ) {
-					$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] );
+				if ( $element->get_xpath() === $xpath ) {
+					$max_element_width = max( $max_element_width, $element->get_bounding_client_rect()['width'] );
 					break; // Move on to the next URL Metric.
 				}
 			}

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -210,7 +210,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 		 * TODO: The above paragraph.
 		 */
 		$common_lcp_element = $context->url_metric_group_collection->get_common_lcp_element();
-		if ( null !== $common_lcp_element && $xpath === $common_lcp_element['xpath'] ) {
+		if ( $common_lcp_element instanceof OD_Element && $xpath === $common_lcp_element->get_xpath() ) {
 			if ( 'auto' !== $initial_preload ) {
 				$processor->set_attribute( 'preload', 'auto' );
 			}

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Optimization Detective: OD_Element class
+ *
+ * @package optimization-detective
+ * @since n.e.x.t
+ */
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Data for a single element in a URL metric.
+ *
+ * @phpstan-import-type ElementData from OD_URL_Metric
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+class OD_Element implements ArrayAccess, JsonSerializable {
+
+	/**
+	 * Data.
+	 *
+	 * @since n.e.x.t
+	 * @var ElementData
+	 */
+	protected $data;
+
+	/**
+	 * URL metric that this element belongs to.
+	 *
+	 * @since n.e.x.t
+	 * @var OD_URL_Metric
+	 * @readonly
+	 */
+	public $url_metric;
+
+	/**
+	 * Constructor.
+	 *
+	 * @phpstan-param ElementData $data
+	 *
+	 * @param array<string, mixed> $data       Element data.
+	 * @param OD_URL_Metric        $url_metric URL metric.
+	 */
+	public function __construct( array $data, OD_URL_Metric $url_metric ) {
+		$this->data       = $data;
+		$this->url_metric = $url_metric;
+	}
+
+	/**
+	 * Checks whether an offset exists.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param mixed $offset Key.
+	 * @return bool Whether the offset exists.
+	 */
+	public function offsetExists( $offset ): bool {
+		return isset( $this->data[ $offset ] );
+	}
+
+	/**
+	 * Retrieves an offset.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param mixed $offset Key.
+	 * @return mixed Can return all value types.
+	 */
+	public function offsetGet( $offset ) { // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+		if ( ! is_scalar( $offset ) ) {
+			return null;
+		}
+		return $this->data[ $offset ] ?? null;
+	}
+
+	/**
+	 * Sets an offset.
+	 *
+	 * @param TKey   $offset Key.
+	 * @param TValue $value  Value.
+	 */
+	public function offsetSet( $offset, $value ): void {
+		// @todo Throw an error.
+		$this->data[ $offset ] = $value;
+	}
+
+	/**
+	 * Offset to unset
+	 * @link https://php.net/manual/en/arrayaccess.offsetunset.php
+	 *
+	 * @param TKey $offset <p>
+	 *                     The offset to unset.
+	 *                     </p>
+	 *
+	 * @return void
+	 */
+	public function offsetUnset( $offset ){
+		// @todo Throw an error since read only.
+		unset( $this->data[ $offset ] );
+	}
+
+	/**
+	 * Specifies data which should be serialized to JSON.
+	 *
+	 * @return ElementData Exports to be serialized by json_encode().
+	 */
+	public function jsonSerialize(): array {
+		return $this->data;
+	}
+}

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @phpstan-import-type ElementData from OD_URL_Metric
  * @phpstan-import-type DOMRect from OD_URL_Metric
  * @implements ArrayAccess<key-of<ElementData>, ElementData[key-of<ElementData>]>
+ * @todo The above implements tag should account for additional undefined keys which can be supplied by extending the element schema.
  *
  * @since n.e.x.t
  * @access private
@@ -157,6 +158,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * @template T of key-of<ElementData>
 	 * @phpstan-param T $offset
 	 * @phpstan-return ElementData[T]|null
+	 * @todo This should account for additional undefined keys which can be supplied by extending the element schema.
 	 *
 	 * @param mixed $offset Key.
 	 * @return mixed May return any value from ElementData including possible extensions.

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @phpstan-import-type ElementData from OD_URL_Metric
  * @phpstan-import-type DOMRect from OD_URL_Metric
  * @implements ArrayAccess<key-of<ElementData>, ElementData[key-of<ElementData>]>
- * @todo The above implements tag should account for additional undefined keys which can be supplied by extending the element schema.
+ * @todo The above implements tag should account for additional undefined keys which can be supplied by extending the element schema. May depend on <https://github.com/phpstan/phpstan/issues/8438>.
  *
  * @since n.e.x.t
  * @access private
@@ -158,7 +158,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * @template T of key-of<ElementData>
 	 * @phpstan-param T $offset
 	 * @phpstan-return ElementData[T]|null
-	 * @todo This should account for additional undefined keys which can be supplied by extending the element schema.
+	 * @todo This should account for additional undefined keys which can be supplied by extending the element schema. May depend on <https://github.com/phpstan/phpstan/issues/8438>.
 	 *
 	 * @param mixed $offset Key.
 	 * @return mixed May return any value from ElementData including possible extensions.

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -44,6 +44,8 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Constructor.
 	 *
+	 * @since n.e.x.t
+	 *
 	 * @phpstan-param ElementData $data
 	 *
 	 * @param array<string, mixed> $data       Element data.
@@ -201,6 +203,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Specifies data which should be serialized to JSON.
 	 *
+	 * @since n.e.x.t
 	 * @return ElementData Exports to be serialized by json_encode().
 	 */
 	public function jsonSerialize(): array {

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -180,7 +180,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * @throws Exception When attempting to set a property.
 	 */
 	public function offsetSet( $offset, $value ): void {
-		throw new Exception( 'Offsets may not be set.' );
+		throw new Exception( 'Element data may not be set.' );
 	}
 
 	/**
@@ -195,7 +195,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * @throws Exception When attempting to unset a property.
 	 */
 	public function offsetUnset( $offset ): void {
-		throw new Exception( 'Offsets may not be unset.' );
+		throw new Exception( 'Element data may not be unset.' );
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -37,7 +37,6 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 *
 	 * @since n.e.x.t
 	 * @var OD_URL_Metric
-	 * @readonly
 	 */
 	protected $url_metric;
 

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -15,6 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Data for a single element in a URL metric.
  *
  * @phpstan-import-type ElementData from OD_URL_Metric
+ * @phpstan-import-type DOMRect from OD_URL_Metric
+ * @implements ArrayAccess<key-of<ElementData>, ElementData[key-of<ElementData>]>
  *
  * @since n.e.x.t
  * @access private
@@ -52,6 +54,90 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	}
 
 	/**
+	 * Gets property value for an arbitrary key.
+	 *
+	 * This is particularly useful in conjunction with the `od_url_metric_schema_element_item_additional_properties` filter.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $key Property.
+	 * @return mixed|null The property value, or null if not set.
+	 */
+	public function get( string $key ) {
+		return $this->data[ $key ] ?? null;
+	}
+
+	/**
+	 * Determines whether element was detected as LCP.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool Whether LCP.
+	 */
+	public function is_lcp(): bool {
+		return $this->data['isLCP'];
+	}
+
+	/**
+	 * Determines whether element was detected as an LCP candidate.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return bool Whether LCP candidate.
+	 */
+	public function is_lcp_candidate(): bool {
+		return $this->data['isLCPCandidate'];
+	}
+
+	/**
+	 * Gets XPath for element.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return non-empty-string XPath.
+	 */
+	public function get_xpath(): string {
+		return $this->data['xpath'];
+	}
+
+	/**
+	 * Gets intersectionRatio for element.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return float Intersection ratio.
+	 */
+	public function get_intersection_ratio(): float {
+		return $this->data['intersectionRatio'];
+	}
+
+	/**
+	 * Gets intersectionRect for element.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @phpstan-return DOMRect
+	 *
+	 * @return array Intersection rect.
+	 */
+	public function get_intersection_rect(): array {
+		return $this->data['intersectionRect'];
+	}
+
+	/**
+	 * Gets boundingClientRect for element.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @phpstan-return DOMRect
+	 *
+	 * @return array Bounding client rect.
+	 */
+	public function get_bounding_client_rect(): array {
+		return $this->data['boundingClientRect'];
+	}
+
+	/**
 	 * Checks whether an offset exists.
 	 *
 	 * @since n.e.x.t
@@ -68,40 +154,46 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 *
 	 * @since n.e.x.t
 	 *
+	 * @template T of key-of<ElementData>
+	 * @phpstan-param T $offset
+	 * @phpstan-return ElementData[T]|null
+	 *
 	 * @param mixed $offset Key.
-	 * @return mixed Can return all value types.
+	 * @return mixed May return any value from ElementData including possible extensions.
 	 */
-	public function offsetGet( $offset ) { // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
-		if ( ! is_scalar( $offset ) ) {
-			return null;
-		}
+	public function offsetGet( $offset ) {
 		return $this->data[ $offset ] ?? null;
 	}
 
 	/**
 	 * Sets an offset.
 	 *
-	 * @param TKey   $offset Key.
-	 * @param TValue $value  Value.
+	 * This is disallowed. Attempting to set a property will throw an error.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param mixed $offset Key.
+	 * @param mixed $value  Value.
+	 *
+	 * @throws Exception When attempting to set a property.
 	 */
 	public function offsetSet( $offset, $value ): void {
-		// @todo Throw an error.
-		$this->data[ $offset ] = $value;
+		throw new Exception( 'Offsets may not be set.' );
 	}
 
 	/**
-	 * Offset to unset
-	 * @link https://php.net/manual/en/arrayaccess.offsetunset.php
+	 * Offset to unset.
 	 *
-	 * @param TKey $offset <p>
-	 *                     The offset to unset.
-	 *                     </p>
+	 * This is disallowed. Attempting to unset a property will throw an error.
 	 *
-	 * @return void
+	 * @since n.e.x.t
+	 *
+	 * @param mixed $offset Offset.
+	 *
+	 * @throws Exception When attempting to unset a property.
 	 */
-	public function offsetUnset( $offset ){
-		// @todo Throw an error since read only.
-		unset( $this->data[ $offset ] );
+	public function offsetUnset( $offset ): void {
+		throw new Exception( 'Offsets may not be unset.' );
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -39,7 +39,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * @var OD_URL_Metric
 	 * @readonly
 	 */
-	public $url_metric;
+	protected $url_metric;
 
 	/**
 	 * Constructor.
@@ -54,6 +54,28 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	public function __construct( array $data, OD_URL_Metric $url_metric ) {
 		$this->data       = $data;
 		$this->url_metric = $url_metric;
+	}
+
+	/**
+	 * Gets the URL metric that this element belongs to.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return OD_URL_Metric URL Metric.
+	 */
+	public function get_url_metric(): OD_URL_Metric {
+		return $this->url_metric;
+	}
+
+	/**
+	 * Gets the group that this element's URL metric is a part of (which may not be any).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return OD_URL_Metric_Group|null Group.
+	 */
+	public function get_url_metric_group(): ?OD_URL_Metric_Group {
+		return $this->url_metric->get_group();
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -14,8 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Collection of URL groups according to the breakpoints.
  *
- * @phpstan-import-type ElementData from OD_URL_Metric
- *
  * @implements IteratorAggregate<int, OD_URL_Metric_Group>
  *
  * @since 0.1.0
@@ -533,11 +531,11 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *             freshness_ttl: 0|positive-int,
 	 *             sample_size: positive-int,
 	 *             all_element_max_intersection_ratios: array<string, float>,
-	 *             common_lcp_element: ?ElementData,
+	 *             common_lcp_element: ?OD_Element,
 	 *             every_group_complete: bool,
 	 *             every_group_populated: bool,
 	 *             groups: array<int, array{
-	 *                 lcp_element: ?ElementData,
+	 *                 lcp_element: ?OD_Element,
 	 *                 minimum_viewport_width: 0|positive-int,
 	 *                 maximum_viewport_width: positive-int,
 	 *                 complete: bool,

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -79,9 +79,9 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *          is_any_group_populated?: bool,
 	 *          is_every_group_complete?: bool,
 	 *          get_groups_by_lcp_element?: array<string, OD_URL_Metric_Group[]>,
-	 *          get_common_lcp_element?: ElementData|null,
+	 *          get_common_lcp_element?: OD_Element|null,
 	 *          get_all_element_max_intersection_ratios?: array<string, float>,
-	 *          get_all_denormalized_elements?: array<string, non-empty-array<int, array{OD_URL_Metric_Group, OD_URL_Metric, ElementData}>>,
+	 *          get_all_denormalized_elements?: array<string, non-empty-array<int, array{OD_URL_Metric_Group, OD_URL_Metric, OD_Element}>>,
 	 *      }
 	 */
 	private $result_cache = array();
@@ -362,9 +362,9 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *
 	 * @since 0.3.0
 	 *
-	 * @return ElementData|null
+	 * @return OD_Element|null Common LCP element if it exists.
 	 */
-	public function get_common_lcp_element(): ?array {
+	public function get_common_lcp_element(): ?OD_Element {
 		if ( array_key_exists( __FUNCTION__, $this->result_cache ) ) {
 			return $this->result_cache[ __FUNCTION__ ];
 		}

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -79,7 +79,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *          get_groups_by_lcp_element?: array<string, OD_URL_Metric_Group[]>,
 	 *          get_common_lcp_element?: OD_Element|null,
 	 *          get_all_element_max_intersection_ratios?: array<string, float>,
-	 *          get_all_elements?: array<string, non-empty-array<int, OD_Element>>,
+	 *          get_xpath_elements_map?: array<string, non-empty-array<int, OD_Element>>,
 	 *      }
 	 */
 	private $result_cache = array();
@@ -419,7 +419,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *
 	 * @return array<string, non-empty-array<int, OD_Element>> Keys are XPaths and values are the element instances.
 	 */
-	public function get_all_elements(): array {
+	public function get_xpath_elements_map(): array {
 		if ( array_key_exists( __FUNCTION__, $this->result_cache ) ) {
 			return $this->result_cache[ __FUNCTION__ ];
 		}
@@ -454,7 +454,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 
 		$result = ( function () {
 			$elements_max_intersection_ratios = array();
-			foreach ( $this->get_all_elements() as $xpath => $elements ) {
+			foreach ( $this->get_xpath_elements_map() as $xpath => $elements ) {
 				$element_intersection_ratios = array();
 				foreach ( $elements as $element ) {
 					$element_intersection_ratios[] = $element->get_intersection_ratio();

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -343,7 +343,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 			$groups = array();
 			foreach ( $this->groups as $group ) {
 				$lcp_element = $group->get_lcp_element();
-				if ( ! is_null( $lcp_element ) && $xpath === $lcp_element['xpath'] ) {
+				if ( $lcp_element instanceof OD_Element && $xpath === $lcp_element->get_xpath() ) {
 					$groups[] = $group;
 				}
 			}
@@ -380,9 +380,9 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 			$group_has_unknown_lcp_element = false;
 			foreach ( $this->groups as $group ) {
 				$lcp_element = $group->get_lcp_element();
-				if ( ! is_null( $lcp_element ) ) {
-					$groups_by_lcp_element_xpath[ $lcp_element['xpath'] ][] = $group;
-					$lcp_elements_by_xpath[ $lcp_element['xpath'] ][]       = $lcp_element;
+				if ( $lcp_element instanceof OD_Element ) {
+					$groups_by_lcp_element_xpath[ $lcp_element->get_xpath() ][] = $group;
+					$lcp_elements_by_xpath[ $lcp_element->get_xpath() ][]       = $lcp_element;
 				} else {
 					$group_has_unknown_lcp_element = true;
 				}
@@ -429,7 +429,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 			foreach ( $this->groups as $group ) {
 				foreach ( $group as $url_metric ) {
 					foreach ( $url_metric->get_elements() as $element ) {
-						$all_elements[ (string) $element['xpath'] ][] = $element;
+						$all_elements[ $element->get_xpath() ][] = $element;
 					}
 				}
 			}
@@ -457,7 +457,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 			foreach ( $this->get_all_elements() as $xpath => $elements ) {
 				$element_intersection_ratios = array();
 				foreach ( $elements as $element ) {
-					$element_intersection_ratios[] = $element['intersectionRatio'];
+					$element_intersection_ratios[] = $element->get_intersection_ratio();
 				}
 				$elements_max_intersection_ratios[ $xpath ] = (float) max( $element_intersection_ratios );
 			}

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -72,7 +72,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * Result cache.
 	 *
 	 * @var array{
-	 *          get_lcp_element?: ElementData|null,
+	 *          get_lcp_element?: OD_Element|null,
 	 *          is_complete?: bool
 	 *      }
 	 */
@@ -246,10 +246,10 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	/**
 	 * Gets the LCP element in the viewport group.
 	 *
-	 * @return ElementData|null LCP element data or null if not available, either because there are no URL metrics or
+	 * @return OD_Element|null LCP element data or null if not available, either because there are no URL metrics or
 	 *                          the LCP element type is not supported.
 	 */
-	public function get_lcp_element(): ?array {
+	public function get_lcp_element(): ?OD_Element {
 		if ( array_key_exists( __FUNCTION__, $this->result_cache ) ) {
 			return $this->result_cache[ __FUNCTION__ ];
 		}

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -193,7 +193,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 			$this->collection->clear_cache();
 		}
 
-		$url_metric->group   = $this;
+		$url_metric->set_group( $this );
 		$this->url_metrics[] = $url_metric;
 
 		// If we have too many URL metrics now, remove the oldest ones up to the sample size.

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -15,7 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * URL metrics grouped by viewport according to breakpoints.
  *
  * @implements IteratorAggregate<int, OD_URL_Metric>
- * @phpstan-import-type ElementData from OD_URL_Metric
  *
  * @since 0.1.0
  * @access private
@@ -281,20 +280,20 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 			/**
 			 * Breadcrumb element.
 			 *
-			 * @var array<int, ElementData> $breadcrumb_element
+			 * @var array<int, OD_Element> $breadcrumb_element
 			 */
 			$breadcrumb_element = array();
 
 			foreach ( $this->url_metrics as $url_metric ) {
 				foreach ( $url_metric->get_elements() as $element ) {
-					if ( ! $element['isLCP'] ) {
+					if ( ! $element->is_lcp() ) {
 						continue;
 					}
 
-					$i = array_search( $element['xpath'], $seen_breadcrumbs, true );
+					$i = array_search( $element->get_xpath(), $seen_breadcrumbs, true );
 					if ( false === $i ) {
 						$i                       = count( $seen_breadcrumbs );
-						$seen_breadcrumbs[ $i ]  = $element['xpath'];
+						$seen_breadcrumbs[ $i ]  = $element->get_xpath();
 						$breadcrumb_counts[ $i ] = 0;
 					}
 
@@ -349,7 +348,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 *             sample_size: positive-int,
 	 *             minimum_viewport_width: 0|positive-int,
 	 *             maximum_viewport_width: positive-int,
-	 *             lcp_element: ?ElementData,
+	 *             lcp_element: ?OD_Element,
 	 *             complete: bool,
 	 *             url_metrics: OD_URL_Metric[]
 	 *         } Data which can be serialized by json_encode().

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -194,6 +194,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 			$this->collection->clear_cache();
 		}
 
+		$url_metric->group   = $this;
 		$this->url_metrics[] = $url_metric;
 
 		// If we have too many URL metrics now, remove the oldest ones up to the sample size.

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -57,6 +57,13 @@ class OD_URL_Metric implements JsonSerializable {
 	protected $data;
 
 	/**
+	 * Elements.
+	 *
+	 * @var OD_Element[]
+	 */
+	protected $elements;
+
+	/**
 	 * Group.
 	 *
 	 * @since n.e.x.t
@@ -363,6 +370,9 @@ class OD_URL_Metric implements JsonSerializable {
 	 * @return mixed|null The property value, or null if not set.
 	 */
 	public function get( string $key ) {
+		if ( 'elements' === $key ) {
+			return $this->get_elements();
+		}
 		return $this->data[ $key ] ?? null;
 	}
 
@@ -417,12 +427,15 @@ class OD_URL_Metric implements JsonSerializable {
 	 * @return OD_Element[] Elements.
 	 */
 	public function get_elements(): array {
-		return array_map(
-			function ( array $element ): OD_Element {
-				return new OD_Element( $element, $this );
-			},
-			$this->data['elements']
-		);
+		if ( ! is_array( $this->elements ) ) {
+			$this->elements = array_map(
+				function ( array $element ): OD_Element {
+					return new OD_Element( $element, $this );
+				},
+				$this->data['elements']
+			);
+		}
+		return $this->elements;
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -406,10 +406,15 @@ class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Gets elements.
 	 *
-	 * @return ElementData[] Elements.
+	 * @return OD_Element[] Elements.
 	 */
 	public function get_elements(): array {
-		return $this->data['elements'];
+		return array_map(
+			function ( array $element ): OD_Element {
+				return new OD_Element( $element, $this );
+			},
+			$this->data['elements']
+		);
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -31,14 +31,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @phpstan-type ElementData  array{
  *                                isLCP: bool,
  *                                isLCPCandidate: bool,
- *                                xpath: string,
+ *                                xpath: non-empty-string,
  *                                intersectionRatio: float,
  *                                intersectionRect: DOMRect,
  *                                boundingClientRect: DOMRect,
  *                            }
  * @phpstan-type Data         array{
- *                                uuid: string,
- *                                url: string,
+ *                                uuid: non-empty-string,
+ *                                url: non-empty-string,
  *                                timestamp: float,
  *                                viewport: ViewportRect,
  *                                elements: ElementData[]

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -144,7 +144,7 @@ class OD_URL_Metric implements JsonSerializable {
 	 * @throws InvalidArgumentException When the supplied group has minimum/maximum viewport widths which are out of bounds with the viewport width for this URL Metric.
 	 */
 	public function set_group( OD_URL_Metric_Group $group ): void {
-		if ( $this->get_viewport_width() < $group->get_minimum_viewport_width() || $this->get_viewport_width() > $group->get_maximum_viewport_width() ) {
+		if ( ! $group->is_viewport_width_in_range( $this->get_viewport_width() ) ) {
 			throw new InvalidArgumentException( 'Group does not have the correct minimum or maximum viewport widths for this URL Metric.' );
 		}
 		$this->group = $group;

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -57,6 +57,14 @@ class OD_URL_Metric implements JsonSerializable {
 	protected $data;
 
 	/**
+	 * Group.
+	 *
+	 * @since n.e.x.t
+	 * @var OD_URL_Metric_Group
+	 */
+	public $group;
+
+	/**
 	 * Constructor.
 	 *
 	 * @phpstan-param Data|array<string, mixed> $data Valid data or invalid data (in which case an exception is thrown).

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -67,9 +67,9 @@ class OD_URL_Metric implements JsonSerializable {
 	 * Group.
 	 *
 	 * @since n.e.x.t
-	 * @var OD_URL_Metric_Group
+	 * @var OD_URL_Metric_Group|null
 	 */
-	public $group;
+	protected $group = null;
 
 	/**
 	 * Constructor.
@@ -121,6 +121,33 @@ class OD_URL_Metric implements JsonSerializable {
 			);
 		}
 		return rest_sanitize_value_from_schema( $data, $schema, self::class );
+	}
+
+	/**
+	 * Gets the group that this URL metric is a part of (which may not be any).
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return OD_URL_Metric_Group|null Group.
+	 */
+	public function get_group(): ?OD_URL_Metric_Group {
+		return $this->group;
+	}
+
+	/**
+	 * Sets the group that this URL metric is a part of.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param OD_URL_Metric_Group $group Group.
+	 *
+	 * @throws InvalidArgumentException When the supplied group has minimum/maximum viewport widths which are out of bounds with the viewport width for this URL Metric.
+	 */
+	public function set_group( OD_URL_Metric_Group $group ): void {
+		if ( $this->get_viewport_width() < $group->get_minimum_viewport_width() || $this->get_viewport_width() > $group->get_maximum_viewport_width() ) {
+			throw new InvalidArgumentException( 'Group does not have the correct minimum or maximum viewport widths for this URL Metric.' );
+		}
+		$this->group = $group;
 	}
 
 	/**

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -102,6 +102,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		require_once __DIR__ . '/class-od-data-validation-exception.php';
 		require_once __DIR__ . '/class-od-html-tag-processor.php';
 		require_once __DIR__ . '/class-od-url-metric.php';
+		require_once __DIR__ . '/class-od-element.php';
 		require_once __DIR__ . '/class-od-strict-url-metric.php';
 		require_once __DIR__ . '/class-od-url-metric-group.php';
 		require_once __DIR__ . '/class-od-url-metric-group-collection.php';

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -523,7 +523,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 			array(
 				'viewport_width' => 480,
 				'element'        => array(
-					'xpath' => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::DIV]/*[1][self::MAIN]/*[0][self::DIV]/*[0][self::FIGURE]/*[0][self::IMG]',
+					'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::DIV]/*[2][self::MAIN]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::IMG]',
 				),
 			)
 		)->jsonSerialize();

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -89,7 +89,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 
 		$url_metrics = OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post );
 		$this->assertCount( 1, $url_metrics, 'Expected number of URL metrics stored.' );
-		$this->assertSame( $valid_params['elements'], $url_metrics[0]->get( 'elements' ) );
+		$this->assertSame( $valid_params['elements'], $this->get_array_json_data( $url_metrics[0]->get( 'elements' ) ) );
 		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport_width() );
 
 		$expected_data = $valid_params;

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -89,7 +89,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 
 		$url_metrics = OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post );
 		$this->assertCount( 1, $url_metrics, 'Expected number of URL metrics stored.' );
-		$this->assertSame( $valid_params['elements'], $url_metrics[0]->get_elements() );
+		$this->assertSame( $valid_params['elements'], $url_metrics[0]->get( 'elements' ) );
 		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport_width() );
 
 		$expected_data = $valid_params;

--- a/plugins/optimization-detective/tests/test-class-od-element.php
+++ b/plugins/optimization-detective/tests/test-class-od-element.php
@@ -13,6 +13,8 @@ class Test_OD_Element extends WP_UnitTestCase {
 	 * Tests construction.
 	 *
 	 * @covers ::get
+	 * @covers ::get_url_metric
+	 * @covers ::get_url_metric_group
 	 * @covers ::is_lcp
 	 * @covers ::is_lcp_candidate
 	 * @covers ::get_xpath
@@ -67,6 +69,11 @@ class Test_OD_Element extends WP_UnitTestCase {
 
 		$element = $url_metric->get_elements()[0];
 		$this->assertInstanceOf( OD_Element::class, $element );
+		$this->assertSame( $url_metric, $element->get_url_metric() );
+		$this->assertNull( $element->get_url_metric_group() );
+		$collection = new OD_URL_Metric_Group_Collection( array( $url_metric ), array(), 1, DAY_IN_SECONDS );
+		$collection->add_url_metric( $url_metric );
+		$this->assertSame( iterator_to_array( $collection )[0], $element->get_url_metric_group() );
 
 		$this->assertSame( $element_data['xpath'], $element->get_xpath() );
 		$this->assertSame( $element_data['xpath'], $element['xpath'] );

--- a/plugins/optimization-detective/tests/test-class-od-element.php
+++ b/plugins/optimization-detective/tests/test-class-od-element.php
@@ -112,13 +112,13 @@ class Test_OD_Element extends WP_UnitTestCase {
 
 		$this->assertNull( $element['notFound'] );
 		$this->assertNull( $element->get( 'notFound' ) );
-		$this->assertNull( $element->offsetGet( 'notFound' ) ); // @phpstan-ignore argument.templateType
+		$this->assertNull( $element->offsetGet( 'notFound' ) ); // @phpstan-ignore argument.templateType (Likely resolved by <https://github.com/phpstan/phpstan/issues/8438>)
 		$this->assertFalse( isset( $element['notFound'] ) );
 		$this->assertFalse( $element->offsetExists( 'notFound' ) );
 
-		$this->assertSame( $element_data['customProp'], $element['customProp'] );
+		$this->assertSame( $element_data['customProp'], $element['customProp'] ); // TODO: Why is PHPStan not complaining about the argument.templateType here?
 		$this->assertSame( $element_data['customProp'], $element->get( 'customProp' ) );
-		$this->assertSame( $element_data['customProp'], $element->offsetGet( 'customProp' ) ); // @phpstan-ignore argument.templateType
+		$this->assertSame( $element_data['customProp'], $element->offsetGet( 'customProp' ) ); // @phpstan-ignore argument.templateType (Likely resolved by <https://github.com/phpstan/phpstan/issues/8438>)
 		$this->assertTrue( isset( $element['customProp'] ) );
 		$this->assertTrue( $element->offsetExists( 'customProp' ) );
 

--- a/plugins/optimization-detective/tests/test-class-od-element.php
+++ b/plugins/optimization-detective/tests/test-class-od-element.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Tests for optimization-detective class OD_Element.
+ *
+ * @package optimization-detective
+ *
+ * @coversDefaultClass OD_Element
+ */
+class Test_OD_Element extends WP_UnitTestCase {
+	use Optimization_Detective_Test_Helpers;
+
+	/**
+	 * Tests construction.
+	 *
+	 * @covers ::get
+	 * @covers ::is_lcp
+	 * @covers ::is_lcp_candidate
+	 * @covers ::get_xpath
+	 * @covers ::get_intersection_ratio
+	 * @covers ::get_intersection_rect
+	 * @covers ::get_bounding_client_rect
+	 * @covers ::offsetExists
+	 * @covers ::offsetGet
+	 * @covers ::offsetSet
+	 * @covers ::offsetUnset
+	 * @covers ::jsonSerialize
+	 */
+	public function test_constructor(): void {
+		add_filter(
+			'od_url_metric_schema_element_item_additional_properties',
+			static function ( array $schema ): array {
+				$schema['customProp'] = array(
+					'type' => 'string',
+				);
+				return $schema;
+			}
+		);
+
+		$element_data = array(
+			'xpath'              => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+			'isLCP'              => false,
+			'isLCPCandidate'     => true,
+			'intersectionRatio'  => 0.123,
+			'intersectionRect'   => array(
+				'width'  => 100.0,
+				'height' => 200.0,
+				'x'      => 0.0,
+				'y'      => 101.0,
+				'top'    => 1.0,
+				'right'  => 2000.0,
+				'bottom' => 90.0,
+				'left'   => 111.0,
+			),
+			'boundingClientRect' => array(
+				'width'  => 200.0,
+				'height' => 400.0,
+				'x'      => 1.0,
+				'y'      => 201.0,
+				'top'    => 2.0,
+				'right'  => 4000.0,
+				'bottom' => 180.0,
+				'left'   => 211.0,
+			),
+			'customProp'         => 'customValue',
+		);
+		$url_metric   = $this->get_sample_url_metric( array( 'element' => $element_data ) );
+
+		$element = $url_metric->get_elements()[0];
+		$this->assertInstanceOf( OD_Element::class, $element );
+
+		$this->assertSame( $element_data['xpath'], $element->get_xpath() );
+		$this->assertSame( $element_data['xpath'], $element['xpath'] );
+		$this->assertSame( $element_data['xpath'], $element->offsetGet( 'xpath' ) );
+		$this->assertSame( $element_data['xpath'], $element->get( 'xpath' ) );
+		$this->assertTrue( isset( $element['xpath'] ) );
+		$this->assertTrue( $element->offsetExists( 'xpath' ) );
+
+		$this->assertSame( $element_data['isLCP'], $element->is_lcp() );
+		$this->assertSame( $element_data['isLCP'], $element['isLCP'] );
+		$this->assertSame( $element_data['isLCP'], $element->offsetGet( 'isLCP' ) );
+		$this->assertSame( $element_data['isLCP'], $element->get( 'isLCP' ) );
+		$this->assertTrue( isset( $element['isLCP'] ) );
+		$this->assertTrue( $element->offsetExists( 'isLCP' ) );
+
+		$this->assertSame( $element_data['isLCPCandidate'], $element->is_lcp_candidate() );
+		$this->assertSame( $element_data['isLCPCandidate'], $element['isLCPCandidate'] );
+		$this->assertSame( $element_data['isLCPCandidate'], $element->offsetGet( 'isLCPCandidate' ) );
+		$this->assertSame( $element_data['isLCPCandidate'], $element->get( 'isLCPCandidate' ) );
+		$this->assertTrue( isset( $element['isLCPCandidate'] ) );
+		$this->assertTrue( $element->offsetExists( 'isLCPCandidate' ) );
+
+		$this->assertSame( $element_data['intersectionRatio'], $element->get_intersection_ratio() );
+		$this->assertSame( $element_data['intersectionRatio'], $element['intersectionRatio'] );
+		$this->assertSame( $element_data['intersectionRatio'], $element->offsetGet( 'intersectionRatio' ) );
+		$this->assertSame( $element_data['intersectionRatio'], $element->get( 'intersectionRatio' ) );
+		$this->assertTrue( isset( $element['intersectionRatio'] ) );
+		$this->assertTrue( $element->offsetExists( 'intersectionRatio' ) );
+
+		$this->assertSame( $element_data['intersectionRect'], $element->get_intersection_rect() );
+		$this->assertSame( $element_data['intersectionRect'], $element['intersectionRect'] );
+		$this->assertSame( $element_data['intersectionRect'], $element->offsetGet( 'intersectionRect' ) );
+		$this->assertSame( $element_data['intersectionRect'], $element->get( 'intersectionRect' ) );
+		$this->assertTrue( isset( $element['intersectionRect'] ) );
+		$this->assertTrue( $element->offsetExists( 'intersectionRect' ) );
+
+		$this->assertSame( $element_data['boundingClientRect'], $element->get_bounding_client_rect() );
+		$this->assertSame( $element_data['boundingClientRect'], $element['boundingClientRect'] );
+		$this->assertSame( $element_data['boundingClientRect'], $element->offsetGet( 'boundingClientRect' ) );
+		$this->assertSame( $element_data['boundingClientRect'], $element->get( 'boundingClientRect' ) );
+		$this->assertTrue( isset( $element['boundingClientRect'] ) );
+		$this->assertTrue( $element->offsetExists( 'boundingClientRect' ) );
+
+		$this->assertNull( $element['notFound'] );
+		$this->assertNull( $element->get( 'notFound' ) );
+		$this->assertNull( $element->offsetGet( 'notFound' ) ); // @phpstan-ignore argument.templateType
+		$this->assertFalse( isset( $element['notFound'] ) );
+		$this->assertFalse( $element->offsetExists( 'notFound' ) );
+
+		$this->assertSame( $element_data['customProp'], $element['customProp'] );
+		$this->assertSame( $element_data['customProp'], $element->get( 'customProp' ) );
+		$this->assertSame( $element_data['customProp'], $element->offsetGet( 'customProp' ) ); // @phpstan-ignore argument.templateType
+		$this->assertTrue( isset( $element['customProp'] ) );
+		$this->assertTrue( $element->offsetExists( 'customProp' ) );
+
+		$this->assertEquals( $element_data, $element->jsonSerialize() );
+
+		$exception = null;
+		try {
+			$element['isLCP'] = true;
+		} catch ( Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertInstanceOf( Exception::class, $exception );
+
+		$exception = null;
+		try {
+			unset( $element['isLCP'] );
+		} catch ( Exception $e ) { // @phpstan-ignore catch.neverThrown (It is thrown by offsetUnset actually.)
+			$exception = $e;
+		}
+		$this->assertInstanceOf( Exception::class, $exception ); // @phpstan-ignore method.impossibleType (It is thrown by offsetUnset actually.)
+	}
+}

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -233,7 +233,15 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			$this->assertSame( array_map( 'floatval', $data['elements'][ $i ]['boundingClientRect'] ), $url_metric->get_elements()[ $i ]['boundingClientRect'] );
 			$this->assertSame( array_map( 'floatval', $data['elements'][ $i ]['intersectionRect'] ), $url_metric->get_elements()[ $i ]['intersectionRect'] );
 		}
-		$this->assertSame( $url_metric->get_elements(), $url_metric->get( 'elements' ) );
+		$this->assertSame(
+			array_map(
+				static function ( OD_Element $element ) {
+					return $element->jsonSerialize();
+				},
+				$url_metric->get_elements()
+			),
+			$url_metric->get( 'elements' )
+		);
 
 		$this->assertSame( $data['url'], $url_metric->get_url() );
 		$this->assertSame( $data['url'], $url_metric->get( 'url' ) );

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -205,6 +205,8 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 	 * @covers ::jsonSerialize
 	 * @covers ::get
 	 * @covers ::get_json_schema
+	 * @covers ::set_group
+	 * @covers ::get_group
 	 *
 	 * @dataProvider data_provider_to_test_constructor
 	 *
@@ -217,6 +219,10 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 			$this->expectExceptionMessage( $error );
 		}
 		$url_metric = new OD_URL_Metric( $data );
+		$this->assertNull( $url_metric->get_group() );
+		$group = new OD_URL_Metric_Group( array( $url_metric ), 0, PHP_INT_MAX, 1, DAY_IN_SECONDS );
+		$url_metric->set_group( $group );
+		$this->assertSame( $group, $url_metric->get_group() );
 
 		$this->assertSame( array_map( 'intval', $data['viewport'] ), $url_metric->get_viewport() );
 		$this->assertSame( array_map( 'intval', $data['viewport'] ), $url_metric->get( 'viewport' ) );

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -240,7 +240,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 				},
 				$url_metric->get_elements()
 			),
-			$url_metric->get( 'elements' )
+			$this->get_array_json_data( $url_metric->get( 'elements' ) )
 		);
 
 		$this->assertSame( $data['url'], $url_metric->get_url() );

--- a/plugins/optimization-detective/tests/test-class-od-url-metric.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metric.php
@@ -22,7 +22,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 		$valid_element = array(
 			'isLCP'              => true,
 			'isLCPCandidate'     => true,
-			'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+			'xpath'              => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
 			'intersectionRatio'  => 1.0,
 			'intersectionRect'   => $this->get_sample_dom_rect(),
 			'boundingClientRect' => $this->get_sample_dom_rect(),
@@ -272,7 +272,7 @@ class Test_OD_URL_Metric extends WP_UnitTestCase {
 		$valid_element = array(
 			'isLCP'              => true,
 			'isLCPCandidate'     => true,
-			'xpath'              => '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]',
+			'xpath'              => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
 			'intersectionRatio'  => 1.0,
 			'intersectionRect'   => $this->get_sample_dom_rect(),
 			'boundingClientRect' => $this->get_sample_dom_rect(),

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -710,7 +710,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_all_element_max_intersection_ratios
 	 * @covers ::get_element_max_intersection_ratio
-	 * @covers ::get_all_elements
+	 * @covers ::get_xpath_elements_map
 	 *
 	 * @dataProvider data_provider_element_max_intersection_ratios
 	 *
@@ -729,7 +729,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		}
 
 		// Check get_all_denormalized_elements.
-		$all_elements = $group_collection->get_all_elements();
+		$all_elements = $group_collection->get_xpath_elements_map();
 		$xpath_counts = array();
 		foreach ( $url_metrics as $url_metric ) {
 			foreach ( $url_metric->get_elements() as $element ) {

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -710,7 +710,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 	 *
 	 * @covers ::get_all_element_max_intersection_ratios
 	 * @covers ::get_element_max_intersection_ratio
-	 * @covers ::get_all_denormalized_elements
+	 * @covers ::get_all_elements
 	 *
 	 * @dataProvider data_provider_element_max_intersection_ratios
 	 *
@@ -729,8 +729,8 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		}
 
 		// Check get_all_denormalized_elements.
-		$all_denormalized_elements = $group_collection->get_all_denormalized_elements();
-		$xpath_counts              = array();
+		$all_elements = $group_collection->get_all_elements();
+		$xpath_counts = array();
 		foreach ( $url_metrics as $url_metric ) {
 			foreach ( $url_metric->get_elements() as $element ) {
 				if ( ! isset( $xpath_counts[ $element['xpath'] ] ) ) {
@@ -739,13 +739,11 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 				$xpath_counts[ $element['xpath'] ] += 1;
 			}
 		}
-		$this->assertCount( count( $xpath_counts ), $all_denormalized_elements );
-		foreach ( $all_denormalized_elements as $xpath => $denormalized_elements ) {
-			foreach ( $denormalized_elements as list( $group, $url_metric, $element ) ) {
-				$this->assertContains( $url_metric, iterator_to_array( $group ) );
-				$this->assertContains( $element->jsonSerialize(), $url_metric->get( 'elements' ) );
-				$this->assertInstanceOf( OD_URL_Metric_Group::class, $group );
-				$this->assertInstanceOf( OD_URL_Metric::class, $url_metric );
+		$this->assertCount( count( $xpath_counts ), $all_elements );
+		foreach ( $all_elements as $xpath => $elements ) {
+			foreach ( $elements as $element ) {
+				$this->assertInstanceOf( OD_URL_Metric::class, $element->url_metric );
+				$this->assertInstanceOf( OD_URL_Metric_Group::class, $element->url_metric->group );
 				$this->assertInstanceOf( OD_Element::class, $element );
 				$this->assertSame( $xpath, $element['xpath'] );
 			}

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -547,9 +547,9 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 	 */
 	public function test_get_groups_by_lcp_element(): void {
 
-		$first_child_image_xpath  = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]';
-		$second_child_image_xpath = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[2]';
-		$first_child_h1_xpath     = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::H1]/*[1]';
+		$first_child_image_xpath  = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]';
+		$second_child_image_xpath = '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]';
+		$first_child_h1_xpath     = '/*[1][self::HTML]/*21][self::BODY]/*[1][self::H1]';
 
 		$get_url_metric_with_one_lcp_element = function ( int $viewport_width, string $lcp_element_xpath ): OD_URL_Metric {
 			return $this->get_sample_url_metric(
@@ -613,7 +613,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 			HOUR_IN_SECONDS
 		);
 
-		$lcp_element_xpath = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]';
+		$lcp_element_xpath = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[1]';
 
 		foreach ( array_merge( $breakpoints, array( 1000 ) ) as $viewport_width ) {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
@@ -643,9 +643,9 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 	 * @return array<string, mixed>
 	 */
 	public function data_provider_element_max_intersection_ratios(): array {
-		$xpath1 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]';
-		$xpath2 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[2]';
-		$xpath3 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[3]';
+		$xpath1 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[1]';
+		$xpath2 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[2]';
+		$xpath3 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[3]';
 
 		$get_sample_url_metric = function ( int $viewport_width, string $lcp_element_xpath, float $intersection_ratio ): OD_URL_Metric {
 			return $this->get_sample_url_metric(
@@ -756,9 +756,9 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 	 * @return array<string, mixed>
 	 */
 	public function data_provider_element_minimum_heights(): array {
-		$xpath1 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[1]';
-		$xpath2 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[2]';
-		$xpath3 = '/*[0][self::HTML]/*[1][self::BODY]/*[0][self::IMG]/*[3]';
+		$xpath1 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[1]';
+		$xpath2 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[2]';
+		$xpath3 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[3]';
 
 		$get_sample_url_metric = function ( int $viewport_width, string $lcp_element_xpath, float $element_height ): OD_URL_Metric {
 			return $this->get_sample_url_metric(

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -633,7 +633,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 
 		$this->assertCount( 3, $group_collection );
 		$common_lcp_element = $group_collection->get_common_lcp_element();
-		$this->assertIsArray( $common_lcp_element );
+		$this->assertInstanceOf( OD_Element::class, $common_lcp_element );
 		$this->assertSame( $lcp_element_xpath, $common_lcp_element['xpath'] );
 	}
 
@@ -743,10 +743,10 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		foreach ( $all_denormalized_elements as $xpath => $denormalized_elements ) {
 			foreach ( $denormalized_elements as list( $group, $url_metric, $element ) ) {
 				$this->assertContains( $url_metric, iterator_to_array( $group ) );
-				$this->assertContains( $element, $url_metric->get_elements() );
+				$this->assertContains( $element->jsonSerialize(), $url_metric->get( 'elements' ) );
 				$this->assertInstanceOf( OD_URL_Metric_Group::class, $group );
 				$this->assertInstanceOf( OD_URL_Metric::class, $url_metric );
-				$this->assertIsArray( $element );
+				$this->assertInstanceOf( OD_Element::class, $element );
 				$this->assertSame( $xpath, $element['xpath'] );
 			}
 		}

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -742,8 +742,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		$this->assertCount( count( $xpath_counts ), $all_elements );
 		foreach ( $all_elements as $xpath => $elements ) {
 			foreach ( $elements as $element ) {
-				$this->assertInstanceOf( OD_URL_Metric::class, $element->url_metric );
-				$this->assertInstanceOf( OD_URL_Metric_Group::class, $element->url_metric->group );
+				$this->assertSame( $element->get_url_metric()->get_group(), $element->get_url_metric_group() );
 				$this->assertInstanceOf( OD_Element::class, $element );
 				$this->assertSame( $xpath, $element['xpath'] );
 			}

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -123,4 +123,19 @@ trait Optimization_Detective_Test_Helpers {
 	public function remove_initial_tabs( string $input ): string {
 		return (string) preg_replace( '/^\t+/m', '', $input );
 	}
+
+	/**
+	 * Gets JSON-serializable data from an array of JsonSerializable objects.
+	 *
+	 * @param JsonSerializable[] $items Items.
+	 * @return array<string|int, mixed> Data from items.
+	 */
+	public function get_array_json_data( array $items ): array {
+		return array_map(
+			static function ( JsonSerializable $item ) {
+				return $item->jsonSerialize();
+			},
+			$items
+		);
+	}
 }


### PR DESCRIPTION
See https://github.com/WordPress/performance/pull/1373/files#r1792652840:

> See note below on the `get_all_denormalized_elements()` method that I'd like to instead have `$element` be an `OD_Element` class instance which has a `$url_metric` property to access the `OD_URL_Metric` instance if is a part of. In the same way, the `OD_URL_Metric` class can have a `$group` property to indicate the `OD_URL_Metric_Group` it is a part of. This would eliminate the need to pass back an array of tuples and instead. So instead, to get the `$group` this code could do `$element->url_metric->group`.

The `OD_Element` class implements `ArrayAccess` so it is fully backwards-compatible with using values as arrays. So where existing plugins may do `$element['isLCP']` this will still continue to work, although `$element->is_lcp()` would now be preferable. There is also a `$element->get()` method which allows accessing extended element data. This is closely related to #1492 which did the same for `OD_URL_Metric`.