### PR TITLE
Try: Add fetchpriority=high for LCP video elements that autoplay

### DIFF
--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -35,36 +35,101 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 			return false;
 		}
 
-		// Skip empty poster attributes and data: URLs.
-		$poster = trim( (string) $processor->get_attribute( 'poster' ) );
-		if ( '' === $poster || $this->is_data_url( $poster ) ) {
-			return false;
-		}
+		$poster                 = trim( (string) $processor->get_attribute( 'poster' ) );
+		$has_preloadable_poster = ( '' !== $poster && ! $this->is_data_url( $poster ) );
+		$crossorigin            = $this->get_attribute_value( $processor, 'crossorigin' );
+		$is_autoplay            = null !== $processor->get_attribute( 'autoplay' );
+		$is_muted               = null !== $processor->get_attribute( 'muted' );
 
 		$xpath = $processor->get_xpath();
 
-		// TODO: If $context->url_metric_group_collection->get_element_max_intersection_ratio( $xpath ) is 0.0, then the video is not in any initial viewport and the VIDEO tag could get the preload=none attribute added.
+		$added_preload_link = false;
+		if ( $is_autoplay && $is_muted ) {
+			$sources = array();
 
-		// If this element is the LCP (for a breakpoint group), add a preload link for it.
-		foreach ( $context->url_metric_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
-			$link_attributes = array(
-				'rel'           => 'preload',
-				'fetchpriority' => 'high',
-				'as'            => 'image',
-				'href'          => $poster,
-				'media'         => 'screen',
-			);
-
-			$crossorigin = $this->get_attribute_value( $processor, 'crossorigin' );
-			if ( null !== $crossorigin ) {
-				$link_attributes['crossorigin'] = 'use-credentials' === $crossorigin ? 'use-credentials' : 'anonymous';
+			$video_src = trim( (string) $processor->get_attribute( 'src' ) );
+			if ( '' !== $video_src && ! $this->is_data_url( $video_src ) ) {
+				$sources[] = array(
+					'href' => $video_src,
+				);
 			}
 
-			$context->link_collection->add_link(
-				$link_attributes,
-				$group->get_minimum_viewport_width(),
-				$group->get_maximum_viewport_width()
-			);
+			$count = 0;
+
+			while ( $processor->next_tag() ) {
+				if ( 'SOURCE' === $processor->get_tag() ) { // @phpstan-ignore identical.alwaysFalse
+					$src = trim( (string) $processor->get_attribute( 'src' ) );
+					if ( '' === $src || $this->is_data_url( $src ) ) {
+						continue;
+					}
+					$source = array(
+						'href' => $src,
+					);
+
+					$media = trim( (string) $processor->get_attribute( 'media' ) );
+					if ( '' !== $media ) {
+						$source['media'] = $media;
+					}
+					$type = trim( (string) $processor->get_attribute( 'type' ) );
+					if ( '' !== $type ) {
+						$source['type'] = $type;
+					}
+					$sources[] = $source;
+				}
+				// @phpstan-ignore identical.alwaysTrue
+				if ( 'VIDEO' === $processor->get_tag() ) { // That is, the closing </VIDEO> tag.
+					break;
+				}
+			}
+
+			/*
+			 * If there is more than one SOURCE defined, we cannot preload the video because there would be multiple
+			 * video types to chose between. If we added a preload link for MP4 and WebM, then the result could be that
+			 * the browser preloads both even though only one would be used in the VIDEO.
+			 */
+			if ( count( $sources ) === 1 ) {
+				foreach ( $context->url_metric_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
+					$link_attributes = array_merge(
+						array(
+							'rel'           => 'preload',
+							'fetchpriority' => 'high',
+							'as'            => 'video',
+						),
+						$sources[0]
+					);
+					if ( null !== $crossorigin ) {
+						$link_attributes['crossorigin'] = 'use-credentials' === $crossorigin ? 'use-credentials' : 'anonymous';
+					}
+					$context->link_collection->add_link(
+						$link_attributes,
+						$group->get_minimum_viewport_width(),
+						$group->get_maximum_viewport_width()
+					);
+					$added_preload_link = true;
+				}
+			}
+		}
+
+		// If this element is the LCP (for a breakpoint group), add a preload link for it.
+		if ( $has_preloadable_poster && ! $added_preload_link ) {
+			foreach ( $context->url_metric_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
+				$link_attributes = array(
+					'rel'           => 'preload',
+					'fetchpriority' => 'high',
+					'as'            => 'image',
+					'href'          => $poster,
+					'media'         => 'screen',
+				);
+				if ( null !== $crossorigin ) {
+					$link_attributes['crossorigin'] = 'use-credentials' === $crossorigin ? 'use-credentials' : 'anonymous';
+				}
+
+				$context->link_collection->add_link(
+					$link_attributes,
+					$group->get_minimum_viewport_width(),
+					$group->get_maximum_viewport_width()
+				);
+			}
 		}
 
 		return true;


### PR DESCRIPTION
This PR attempts to implement this aspect of #1592: 

> When a video is in all initial viewports, it should probably get `preload=auto` especially when it is the LCP element. It may even make sense to add `fetchpriority=high` preload links when it is the LCP element, particularly when the video has `autoplay`.

However, when I implemented this I discovered that it is not supported in Chrome!

> `<link rel=preload>` uses an unsupported `as` value

Apparently this used to be part of the Preload spec but was removed. See [StackOverflow answer](https://stackoverflow.com/a/68368601/93579):

> As of July 13, 2021, https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload has a note about 1/3rd of the way down that says "Note: video preloading is included in the Preload spec, but is not currently implemented by browsers." Perhaps that is why you see this warning (I see it too)? If so, then no, it is not possible to use preload this.

There is currently no mention of `video` on that MDN page.