### PR TITLE
Choose smaller poster image size based on actual dimensions

### DIFF
--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -208,7 +208,7 @@ final class Embed_Optimizer_Tag_Visitor {
 		$embed_wrapper_xpath = self::get_embed_wrapper_xpath( $processor->get_xpath() );
 
 		/**
-		 * Collection of the minimum heights for the element with each group keyed by the minimum viewport with.
+		 * Collection of the minimum heights for the element with each group keyed by the minimum viewport width.
 		 *
 		 * @var array<int, array{group: OD_URL_Metric_Group, height: int}> $minimums
 		 */

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -45,6 +45,8 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	/**
 	 * Gets the poster from the current VIDEO element.
 	 *
+	 * Skips empty poster attributes and data: URLs.
+	 *
 	 * @since n.e.x.t
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
@@ -69,12 +71,6 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
 
-		// Skip empty poster attributes and data: URLs.
-		$poster = trim( (string) $processor->get_attribute( 'poster' ) );
-		if ( '' === $poster || $this->is_data_url( $poster ) ) {
-			return false;
-		}
-
 		$xpath = $processor->get_xpath();
 
 		$max_element_width = 0;
@@ -83,6 +79,12 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		foreach ( $denormalized_elements as list( , , $element ) ) {
 			$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] ?? 0 );
+		}
+
+		$poster = $this->get_poster( $context );
+
+		if ( null === $poster ) {
+			return false;
 		}
 
 		$poster_id = attachment_url_to_postid( $poster );
@@ -106,9 +108,9 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	private function preload_poster_image( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
 
-		// Skip empty poster attributes and data: URLs.
-		$poster = trim( (string) $processor->get_attribute( 'poster' ) );
-		if ( '' === $poster || $this->is_data_url( $poster ) ) {
+		$poster = $this->get_poster( $context );
+
+		if ( null === $poster ) {
 			return false;
 		}
 

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -42,13 +42,28 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		return $reduced_poster_size || $preload_poster;
 	}
-
 	/**
-	 * Reduce poster image size by choosing one that fits the maximum video size more closely.
+	 * Gets the poster from the current VIDEO element.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
+	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
+	 * @return non-empty-string|null Poster or null if not defined or is a data: URL.
+	 */
+	private function get_poster( OD_Tag_Visitor_Context $context ): ?string {
+		$poster = trim( (string) $context->processor->get_attribute( 'poster' ) );
+		if ( '' === $poster || $this->is_data_url( $poster ) ) {
+			return null;
+		}
+		return $poster;
+	}
+
+	/**
+	 * Reduces poster image size by choosing one that fits the maximum video size more closely.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
 	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): bool {
@@ -81,11 +96,11 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	}
 
 	/**
-	 * Preload poster image for the LCP <video> element.
+	 * Preloads poster image for the LCP <video> element.
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
+	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
 	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
 	private function preload_poster_image( OD_Tag_Visitor_Context $context ): bool {

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -51,7 +51,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
 	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ) {
+	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
 
 		// Skip empty poster attributes and data: URLs.
@@ -88,7 +88,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
 	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function preload_poster_image( OD_Tag_Visitor_Context $context ) {
+	private function preload_poster_image( OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
 
 		// Skip empty poster attributes and data: URLs.

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -37,10 +37,16 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		// TODO: If $context->url_metric_group_collection->get_element_max_intersection_ratio( $xpath ) is 0.0, then the video is not in any initial viewport and the VIDEO tag could get the preload=none attribute added.
 
-		$reduced_poster_size = $this->reduce_poster_image_size( $context );
-		$preload_poster      = $this->preload_poster_image( $context );
+		$poster = $this->get_poster( $context );
 
-		return $reduced_poster_size || $preload_poster;
+		if ( null !== $poster ) {
+			$reduced_poster_size = $this->reduce_poster_image_size( $poster, $context );
+			$preload_poster      = $this->preload_poster_image( $poster, $context );
+
+			return true;
+		}
+
+		return false;
 	}
 	/**
 	 * Gets the poster from the current VIDEO element.
@@ -65,10 +71,11 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 *
 	 * @since n.e.x.t
 	 *
+	 * @param non-empty-string       $poster  Poster image URL.
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
 	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): bool {
+	private function reduce_poster_image_size( string $poster, OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
 
 		$xpath = $processor->get_xpath();
@@ -79,12 +86,6 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		foreach ( $denormalized_elements as list( , , $element ) ) {
 			$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] ?? 0 );
-		}
-
-		$poster = $this->get_poster( $context );
-
-		if ( null === $poster ) {
-			return false;
 		}
 
 		$poster_id = attachment_url_to_postid( $poster );
@@ -102,17 +103,12 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 *
 	 * @since n.e.x.t
 	 *
+	 * @param non-empty-string       $poster  Poster image URL.
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
 	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function preload_poster_image( OD_Tag_Visitor_Context $context ): bool {
+	private function preload_poster_image( string $poster, OD_Tag_Visitor_Context $context ): bool {
 		$processor = $context->processor;
-
-		$poster = $this->get_poster( $context );
-
-		if ( null === $poster ) {
-			return false;
-		}
 
 		$xpath = $processor->get_xpath();
 

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -35,17 +35,67 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 			return false;
 		}
 
+		// TODO: If $context->url_metric_group_collection->get_element_max_intersection_ratio( $xpath ) is 0.0, then the video is not in any initial viewport and the VIDEO tag could get the preload=none attribute added.
+
+		$this->reduce_poster_image_size( $context );
+		$this->preload_poster_image( $context );
+
+		return true;
+	}
+
+	/**
+	 * Reduce poster image size by choosing one that fits the maximum video size more closely.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
+	 */
+	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): void {
+		$processor = $context->processor;
+
 		// Skip empty poster attributes and data: URLs.
 		$poster = trim( (string) $processor->get_attribute( 'poster' ) );
 		if ( '' === $poster || $this->is_data_url( $poster ) ) {
-			return false;
+			return;
 		}
-
-		$this->reduce_poster_image_size( $context );
 
 		$xpath = $processor->get_xpath();
 
-		// TODO: If $context->url_metric_group_collection->get_element_max_intersection_ratio( $xpath ) is 0.0, then the video is not in any initial viewport and the VIDEO tag could get the preload=none attribute added.
+		$max_element_width = 0;
+
+		$denormalized_elements = $context->url_metric_group_collection->get_all_denormalized_elements()[ $xpath ] ?? array();
+
+		foreach ( $denormalized_elements as list( , , $element ) ) {
+			$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] ?? 0 );
+		}
+
+		$poster_id = attachment_url_to_postid( $poster );
+
+		if ( $poster_id > 0 && $max_element_width > 0 ) {
+			$smaller_image_url = wp_get_attachment_image_url( $poster_id, array( (int) $max_element_width, 0 ) );
+			$processor->set_attribute( 'poster', $smaller_image_url );
+		}
+	}
+
+	/**
+	 * Preload poster image for the LCP <video> element.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
+	 */
+	private function preload_poster_image( OD_Tag_Visitor_Context $context ): void {
+		$processor = $context->processor;
+
+		// Skip empty poster attributes and data: URLs.
+		$poster = trim( (string) $processor->get_attribute( 'poster' ) );
+		if ( '' === $poster || $this->is_data_url( $poster ) ) {
+			return;
+		}
+
+		$xpath = $processor->get_xpath();
 
 		// If this element is the LCP (for a breakpoint group), add a preload link for it.
 		foreach ( $context->url_metric_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
@@ -67,36 +117,6 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 				$group->get_minimum_viewport_width(),
 				$group->get_maximum_viewport_width()
 			);
-		}
-
-		return true;
-	}
-
-	/**
-	 * Reduce poster image size by choosing one that fits the maximum video size more closely.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
-	 */
-	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): void {
-		$processor = $context->processor;
-		$xpath     = $processor->get_xpath();
-
-		$max_element_width = 0;
-
-		$denormalized_elements = $context->url_metric_group_collection->get_all_denormalized_elements()[ $xpath ] ?? array();
-
-		foreach ( $denormalized_elements as list( , , $element ) ) {
-			$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] ?? 0 );
-		}
-
-		$poster    = trim( (string) $processor->get_attribute( 'poster' ) );
-		$poster_id = attachment_url_to_postid( $poster );
-
-		if ( $poster_id > 0 && $max_element_width > 0 ) {
-			$smaller_image_url = wp_get_attachment_image_url( $poster_id, array( (int) $max_element_width, 0 ) );
-			$processor->set_attribute( 'poster', $smaller_image_url );
 		}
 	}
 }

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -82,8 +82,6 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @since n.e.x.t
-	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
 	 */
 	private function preload_poster_image( OD_Tag_Visitor_Context $context ): void {

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -40,8 +40,8 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 		$poster = $this->get_poster( $context );
 
 		if ( null !== $poster ) {
-			$reduced_poster_size = $this->reduce_poster_image_size( $poster, $context );
-			$preload_poster      = $this->preload_poster_image( $poster, $context );
+			$this->reduce_poster_image_size( $poster, $context );
+			$this->preload_poster_image( $poster, $context );
 
 			return true;
 		}
@@ -73,9 +73,8 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 *
 	 * @param non-empty-string       $poster  Poster image URL.
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
-	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function reduce_poster_image_size( string $poster, OD_Tag_Visitor_Context $context ): bool {
+	private function reduce_poster_image_size( string $poster, OD_Tag_Visitor_Context $context ): void {
 		$processor = $context->processor;
 
 		$xpath = $processor->get_xpath();
@@ -94,8 +93,6 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 			$smaller_image_url = wp_get_attachment_image_url( $poster_id, array( (int) $max_element_width, 0 ) );
 			$processor->set_attribute( 'poster', $smaller_image_url );
 		}
-
-		return true;
 	}
 
 	/**
@@ -105,9 +102,8 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 *
 	 * @param non-empty-string       $poster  Poster image URL.
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
-	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function preload_poster_image( string $poster, OD_Tag_Visitor_Context $context ): bool {
+	private function preload_poster_image( string $poster, OD_Tag_Visitor_Context $context ): void {
 		$processor = $context->processor;
 
 		$xpath = $processor->get_xpath();
@@ -133,7 +129,5 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 				$group->get_maximum_viewport_width()
 			);
 		}
-
-		return true;
 	}
 }

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -48,6 +48,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		return false;
 	}
+
 	/**
 	 * Gets the poster from the current VIDEO element.
 	 *
@@ -107,9 +108,11 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		$poster_id = attachment_url_to_postid( $poster );
 
-		if ( $poster_id > 0 && $max_element_width > 0 ) {
+		if ( $poster_id > 0 ) {
 			$smaller_image_url = wp_get_attachment_image_url( $poster_id, array( (int) $max_element_width, 0 ) );
-			$processor->set_attribute( 'poster', $smaller_image_url );
+			if ( is_string( $smaller_image_url ) ) {
+				$processor->set_attribute( 'poster', $smaller_image_url );
+			}
 		}
 	}
 

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -37,10 +37,10 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		// TODO: If $context->url_metric_group_collection->get_element_max_intersection_ratio( $xpath ) is 0.0, then the video is not in any initial viewport and the VIDEO tag could get the preload=none attribute added.
 
-		$this->reduce_poster_image_size( $context );
-		$this->preload_poster_image( $context );
+		$reduced_poster_size = $this->reduce_poster_image_size( $context );
+		$preload_poster      = $this->preload_poster_image( $context );
 
-		return true;
+		return $reduced_poster_size || $preload_poster;
 	}
 
 	/**
@@ -49,14 +49,15 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 * @since n.e.x.t
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): void {
+	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ) {
 		$processor = $context->processor;
 
 		// Skip empty poster attributes and data: URLs.
 		$poster = trim( (string) $processor->get_attribute( 'poster' ) );
 		if ( '' === $poster || $this->is_data_url( $poster ) ) {
-			return;
+			return false;
 		}
 
 		$xpath = $processor->get_xpath();
@@ -75,6 +76,8 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 			$smaller_image_url = wp_get_attachment_image_url( $poster_id, array( (int) $max_element_width, 0 ) );
 			$processor->set_attribute( 'poster', $smaller_image_url );
 		}
+
+		return true;
 	}
 
 	/**
@@ -83,14 +86,15 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 * @since n.e.x.t
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
+	 * @return bool Whether the tag should be tracked in URL metrics.
 	 */
-	private function preload_poster_image( OD_Tag_Visitor_Context $context ): void {
+	private function preload_poster_image( OD_Tag_Visitor_Context $context ) {
 		$processor = $context->processor;
 
 		// Skip empty poster attributes and data: URLs.
 		$poster = trim( (string) $processor->get_attribute( 'poster' ) );
 		if ( '' === $poster || $this->is_data_url( $poster ) ) {
-			return;
+			return false;
 		}
 
 		$xpath = $processor->get_xpath();
@@ -116,5 +120,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 				$group->get_maximum_viewport_width()
 			);
 		}
+
+		return true;
 	}
 }

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -41,6 +41,8 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 			return false;
 		}
 
+		$this->reduce_poster_image_size( $context );
+
 		$xpath = $processor->get_xpath();
 
 		// TODO: If $context->url_metric_group_collection->get_element_max_intersection_ratio( $xpath ) is 0.0, then the video is not in any initial viewport and the VIDEO tag could get the preload=none attribute added.
@@ -68,5 +70,33 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 		}
 
 		return true;
+	}
+
+	/**
+	 * Reduce poster image size by choosing one that fits the maximum video size more closely.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
+	 */
+	private function reduce_poster_image_size( OD_Tag_Visitor_Context $context ): void {
+		$processor = $context->processor;
+		$xpath     = $processor->get_xpath();
+
+		$max_element_width = 0;
+
+		$denormalized_elements = $context->url_metric_group_collection->get_all_denormalized_elements()[ $xpath ] ?? array();
+
+		foreach ( $denormalized_elements as list( , , $element ) ) {
+			$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] ?? 0 );
+		}
+
+		$poster    = trim( (string) $processor->get_attribute( 'poster' ) );
+		$poster_id = attachment_url_to_postid( $poster );
+
+		if ( $poster_id > 0 && $max_element_width > 0 ) {
+			$smaller_image_url = wp_get_attachment_image_url( $poster_id, array( (int) $max_element_width, 0 ) );
+			$processor->set_attribute( 'poster', $smaller_image_url );
+		}
 	}
 }

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -79,12 +79,30 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		$xpath = $processor->get_xpath();
 
+		/*
+		 * Obtain maximum width of the element exclusively from the URL metrics group with the widest viewport width,
+		 * which would be desktop. This prevents the situation where if URL metrics have only so far been gathered for
+		 * mobile viewports that an excessively-small poster would end up getting served to the first desktop visitor.
+		 */
 		$max_element_width = 0;
+		$widest_group      = array_reduce(
+			iterator_to_array( $context->url_metric_group_collection ),
+			static function ( $carry, OD_URL_Metric_Group $group ) {
+				return ( null === $carry || $group->get_minimum_viewport_width() > $carry->get_minimum_viewport_width() ) ? $group : $carry;
+			}
+		);
+		foreach ( $widest_group as $url_metric ) {
+			foreach ( $url_metric->get_elements() as $element ) {
+				if ( $element['xpath'] === $xpath ) {
+					$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] );
+					break; // Move on to the next URL Metric.
+				}
+			}
+		}
 
-		$denormalized_elements = $context->url_metric_group_collection->get_all_denormalized_elements()[ $xpath ] ?? array();
-
-		foreach ( $denormalized_elements as list( , , $element ) ) {
-			$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] ?? 0 );
+		// If the element wasn't present in any URL Metrics gathered for desktop, then abort downsizing the poster.
+		if ( 0 === $max_element_width ) {
+			return;
 		}
 
 		$poster_id = attachment_url_to_postid( $poster );

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected.php
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected.php
@@ -1,0 +1,81 @@
+<?php
+
+$full_url     = '';
+$expected_url = '';
+
+return array(
+	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case, WP_UnitTest_Factory $factory ) use ( &$full_url, &$expected_url ): void {
+		$breakpoint_max_widths = array( 480, 600, 782 );
+		add_filter(
+			'od_breakpoint_max_widths',
+			static function () use ( $breakpoint_max_widths ) {
+				return $breakpoint_max_widths;
+			}
+		);
+
+		$element = array(
+			'isLCP'              => false,
+			'xpath'              => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::VIDEO]',
+			'boundingClientRect' => $test_case->get_sample_dom_rect(),
+		);
+
+		foreach ( array_merge( $breakpoint_max_widths, array( 1000 ) ) as $viewport_width ) {
+			OD_URL_Metrics_Post_Type::store_url_metric(
+				od_get_url_metrics_slug( od_get_normalized_query_vars() ),
+				$test_case->get_sample_url_metric(
+					array(
+						'viewport_width' => $viewport_width,
+						'elements'       => array( $element ),
+					)
+				)
+			);
+		}
+
+		$attachment_id = $factory->attachment->create_object(
+			DIR_TESTDATA . '/images/33772.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_excerpt'   => 'A sample caption',
+			)
+		);
+
+		wp_generate_attachment_metadata( $attachment_id, DIR_TESTDATA . '/images/33772.jpg' );
+
+		$full_url     = wp_get_attachment_url( $attachment_id );
+		$expected_url = wp_get_attachment_image_url( $attachment_id, array( (int) $element['boundingClientRect']['width'], 0 ) );
+	},
+	'buffer'   => static function () use ( &$full_url ) {
+		return "
+		<html lang=\"en\">
+			<head>
+				<meta charset=\"utf-8\">
+				<title>...</title>
+			</head>
+			<body>
+				<video class=\"desktop\" poster=\"$full_url\" width=\"1200\" height=\"500\" crossorigin>
+					<source src=\"https://example.com/header.webm\" type=\"video/webm\">
+					<source src=\"https://example.com/header.mp4\" type=\"video/mp4\">
+				</video>
+			</body>
+		</html>
+	";
+	},
+	'expected' => static function () use ( &$full_url, &$expected_url ) {
+		return "
+		<html lang=\"en\">
+			<head>
+				<meta charset=\"utf-8\">
+				<title>...</title>
+			</head>
+			<body>
+				<video data-od-replaced-poster=\"$full_url\" data-od-xpath=\"/*[1][self::HTML]/*[2][self::BODY]/*[1][self::VIDEO]\" class=\"desktop\" poster=\"$expected_url\" width=\"1200\" height=\"500\" crossorigin>
+					<source src=\"https://example.com/header.webm\" type=\"video/webm\">
+					<source src=\"https://example.com/header.mp4\" type=\"video/mp4\">
+				</video>
+				<script type=\"module\">/* import detect ... */</script>
+			</body>
+		</html>
+	";
+	},
+);

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster.php
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster.php
@@ -1,10 +1,10 @@
 <?php
 
-$full_url = '';
+$full_url     = '';
 $expected_url = '';
 
 return array(
-	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case, WP_UnitTest_Factory $factory ) use( &$full_url, &$expected_url ): void {
+	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case, WP_UnitTest_Factory $factory ) use ( &$full_url, &$expected_url ): void {
 		$breakpoint_max_widths = array( 480, 600, 782 );
 
 		add_filter(
@@ -65,7 +65,7 @@ return array(
 		$full_url = wp_get_attachment_url( $attachment_id );
 		$expected_url = wp_get_attachment_image_url( $attachment_id, array( (int) $dom_rect['width'], 0 ) );
 	},
-	'buffer' => static function () use ( &$full_url ) {
+	'buffer'   => static function () use ( &$full_url ) {
 		return "
 		<html lang=\"en\">
 			<head>

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster.php
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster.php
@@ -1,0 +1,101 @@
+<?php
+
+$full_url = '';
+$expected_url = '';
+
+return array(
+	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case, WP_UnitTest_Factory $factory ) use( &$full_url, &$expected_url ): void {
+		$breakpoint_max_widths = array( 480, 600, 782 );
+
+		add_filter(
+			'od_breakpoint_max_widths',
+			static function () use ( $breakpoint_max_widths ) {
+				return $breakpoint_max_widths;
+			}
+		);
+
+		foreach ( $breakpoint_max_widths as $non_desktop_viewport_width ) {
+			$elements = array(
+				array(
+					'isLCP'              => false,
+					'xpath'              => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::VIDEO]',
+					'boundingClientRect' => $test_case->get_sample_dom_rect(),
+				),
+			);
+			OD_URL_Metrics_Post_Type::store_url_metric(
+				od_get_url_metrics_slug( od_get_normalized_query_vars() ),
+				$test_case->get_sample_url_metric(
+					array(
+						'viewport_width' => $non_desktop_viewport_width,
+						'elements'       => $elements,
+					)
+				)
+			);
+		}
+
+		OD_URL_Metrics_Post_Type::store_url_metric(
+			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
+			$test_case->get_sample_url_metric(
+				array(
+					'viewport_width' => 1000,
+					'elements'       => array(
+						array(
+							'isLCP'              => false,
+							'xpath'              => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::VIDEO]',
+							'boundingClientRect' => $test_case->get_sample_dom_rect(),
+						),
+					),
+				)
+			)
+		);
+
+		$attachment_id = $factory->attachment->create_object(
+			DIR_TESTDATA . '/images/33772.jpg',
+			0,
+			array(
+				'post_mime_type' => 'image/jpeg',
+				'post_excerpt'   => 'A sample caption',
+			)
+		);
+
+		wp_generate_attachment_metadata( $attachment_id, DIR_TESTDATA . '/images/33772.jpg' );
+
+		$dom_rect = $test_case->get_sample_dom_rect();
+
+		$full_url = wp_get_attachment_url( $attachment_id );
+		$expected_url = wp_get_attachment_image_url( $attachment_id, array( (int) $dom_rect['width'], 0 ) );
+	},
+	'buffer' => static function () use ( &$full_url ) {
+		return "
+		<html lang=\"en\">
+			<head>
+				<meta charset=\"utf-8\">
+				<title>...</title>
+			</head>
+			<body>
+				<video class=\"desktop\" poster=\"$full_url\" width=\"1200\" height=\"500\" crossorigin>
+					<source src=\"https://example.com/header.webm\" type=\"video/webm\">
+					<source src=\"https://example.com/header.mp4\" type=\"video/mp4\">
+				</video>
+			</body>
+		</html>
+	";
+	},
+	'expected' => static function () use ( &$full_url, &$expected_url ) {
+		return "
+		<html lang=\"en\">
+			<head>
+				<meta charset=\"utf-8\">
+				<title>...</title>
+			</head>
+			<body>
+				<video data-od-replaced-poster=\"$full_url\" data-od-xpath=\"/*[1][self::HTML]/*[2][self::BODY]/*[1][self::VIDEO]\" class=\"desktop\" poster=\"$expected_url\" width=\"1200\" height=\"500\" crossorigin>
+					<source src=\"https://example.com/header.webm\" type=\"video/webm\">
+					<source src=\"https://example.com/header.mp4\" type=\"video/mp4\">
+				</video>
+				<script type=\"module\">/* import detect ... */</script>
+			</body>
+		</html>
+	";
+	},
+);

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -79,15 +79,22 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 * @covers Image_Prioritizer_Background_Image_Styled_Tag_Visitor
 	 *
 	 * @dataProvider data_provider_test_filter_tag_visitors
+	 *
+	 * @param callable        $set_up   Setup function.
+	 * @param callable|string $buffer   Content before.
+	 * @param callable|string $expected Expected content after.
 	 */
-	public function test_image_prioritizer_register_tag_visitors( Closure $set_up, string $buffer, string $expected ): void {
-		$set_up( $this );
+	public function test_image_prioritizer_register_tag_visitors( Closure $set_up, $buffer, $expected ): void {
+		$set_up( $this, $this::factory() );
 
+		$buffer = is_string( $buffer ) ? $buffer : $buffer();
 		$buffer = preg_replace(
 			':<script type="module">.+?</script>:s',
 			'<script type="module">/* import detect ... */</script>',
 			od_optimize_template_output_buffer( $buffer )
 		);
+
+		$expected = is_string( $expected ) ? $expected : $expected();
 
 		$this->assertEquals(
 			$this->remove_initial_tabs( $expected ),

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -84,7 +84,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 * @param callable|string $buffer   Content before.
 	 * @param callable|string $expected Expected content after.
 	 */
-	public function test_image_prioritizer_register_tag_visitors( Closure $set_up, $buffer, $expected ): void {
+	public function test_image_prioritizer_register_tag_visitors( callable $set_up, $buffer, $expected ): void {
 		$set_up( $this, $this::factory() );
 
 		$buffer = is_string( $buffer ) ? $buffer : $buffer();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1575

On my test post with 7 large videos, the videos were displayed ~610px wide on desktop. With this PR, the full image URLs (which were 1920px wide) are replaced with 767px wide versions. 

Image file sizes before this PR: 738 KB

After: 175 KB (!)

## Relevant technical choices

<!-- Please describe your changes. -->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
