### PR TITLE
Add group collection helper methods to get the first/last groups

### DIFF
--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -86,13 +86,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 		 * mobile viewports that an excessively-small poster would end up getting served to the first desktop visitor.
 		 */
 		$max_element_width = 0;
-		$widest_group      = array_reduce(
-			iterator_to_array( $context->url_metric_group_collection ),
-			static function ( $carry, OD_URL_Metric_Group $group ) {
-				return ( null === $carry || $group->get_minimum_viewport_width() > $carry->get_minimum_viewport_width() ) ? $group : $carry;
-			}
-		);
-		foreach ( $widest_group as $url_metric ) {
+		foreach ( $context->url_metric_group_collection->get_last_group() as $url_metric ) {
 			foreach ( $url_metric->get_elements() as $element ) {
 				if ( $element['xpath'] === $xpath ) {
 					$max_element_width = max( $max_element_width, $element['boundingClientRect']['width'] );

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -47,6 +47,9 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *    until PHP_INT_MAX. So a breakpoint cannot be PHP_INT_MAX because then the minimum viewport width for the final group
 	 *    would end up being larger than PHP_INT_MAX.
 	 *
+	 * This array may be empty in which case there are no responsive breakpoints and all URL Metrics are collected in a
+	 * single group.
+	 *
 	 * @var int[]
 	 * @phpstan-var positive-int[]
 	 */

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -159,6 +159,36 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
+	 * Gets the first URL Metric group.
+	 *
+	 * This group normally represents viewports for mobile devices. This group always has a minimum viewport width of 0
+	 * and the maximum viewport width corresponds to the smallest defined breakpoint returned by
+	 * {@see od_get_breakpoint_max_widths()}.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return OD_URL_Metric_Group First URL Metric group.
+	 */
+	public function get_first_group(): OD_URL_Metric_Group {
+		return $this->groups[0];
+	}
+
+	/**
+	 * Gets the last URL Metric group.
+	 *
+	 * This group normally represents viewports for desktop devices.  This group always has a minimum viewport width
+	 * defined as one greater than the largest breakpoint returned by {@see od_get_breakpoint_max_widths()}.
+	 * The maximum viewport is always `PHP_INT_MAX`, or in other words it is unbounded.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return OD_URL_Metric_Group Last URL Metric group.
+	 */
+	public function get_last_group(): OD_URL_Metric_Group {
+		return $this->groups[ count( $this->groups ) - 1 ];
+	}
+
+	/**
 	 * Clear result cache.
 	 *
 	 * @since 0.3.0

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -243,6 +243,9 @@ function od_get_maximum_viewport_aspect_ratio(): float {
  *
  * These breakpoints appear to be used the most in media queries that affect frontend styles.
  *
+ * This array may be empty in which case there are no responsive breakpoints and all URL Metrics are collected in a
+ * single group.
+ *
  * @since 0.1.0
  * @access private
  * @link https://github.com/WordPress/gutenberg/blob/093d52cbfd3e2c140843d3fb91ad3d03330320a5/packages/base-styles/_breakpoints.scss#L11-L13
@@ -287,7 +290,8 @@ function od_get_breakpoint_max_widths(): array {
 		/**
 		 * Filters the breakpoint max widths to group URL metrics for various viewports.
 		 *
-		 * A breakpoint must be greater than zero and less than PHP_INT_MAX.
+		 * A breakpoint must be greater than zero and less than PHP_INT_MAX. This array may be empty in which case there
+		 * are no responsive breakpoints and all URL Metrics are collected in a single group.
 		 *
 		 * @since 0.1.0
 		 *

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -298,6 +298,17 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					),
 				),
 			),
+			'0-breakpoints-and-4-viewport-widths' => array(
+				'breakpoints'     => array(),
+				'viewport_widths' => array( 250, 500, 1000 ),
+				'expected_groups' => array(
+					array(
+						'minimum_viewport_width'     => 0,
+						'maximum_viewport_width'     => PHP_INT_MAX,
+						'url_metric_viewport_widths' => array( 250, 500, 1000 ),
+					),
+				),
+			),
 		);
 	}
 

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -302,9 +302,11 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test getIterator().
+	 * Test getIterator(), get_first_group(), and get_last_group().
 	 *
 	 * @covers ::getIterator
+	 * @covers ::get_first_group
+	 * @covers ::get_last_group
 	 *
 	 * @dataProvider data_provider_test_get_iterator
 	 *
@@ -343,6 +345,10 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		}
 
 		$this->assertEquals( $expected_groups, $actual_groups );
+
+		$groups_array = iterator_to_array( $group_collection );
+		$this->assertSame( $groups_array[0], $group_collection->get_first_group() );
+		$this->assertSame( $groups_array[ count( $groups_array ) - 1 ], $group_collection->get_last_group() );
 	}
 
 	/**


### PR DESCRIPTION
In #1596 we need to exclusively look at the desktop group of URL metrics to determine the widest possible width for a given element, excluding widths from narrower viewport groups (e.g. mobile) since they could result in an image size being chosen which would look bad on desktop. This adds a `OD_URL_Metric_Group_Collection::get_last_group()` helper method to facilitate this. It also adds a `OD_URL_Metric_Group_Collection::get_first_group()` for parity.