### PR TITLE
Avoid lazy-loading images and embeds unless there are URL Metrics for both mobile and desktop

### DIFF
--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -101,78 +101,85 @@ final class Embed_Optimizer_Tag_Visitor {
 
 		$this->reduce_layout_shifts( $context );
 
-		$max_intersection_ratio = $context->url_metric_group_collection->get_element_max_intersection_ratio( self::get_embed_wrapper_xpath( $processor->get_xpath() ) );
-		if ( $max_intersection_ratio > 0 ) {
-			/*
-			 * The following embeds have been chosen for optimization due to their relative popularity among all embed types.
-			 * See <https://colab.sandbox.google.com/drive/1nSpg3qoCLY-cBTV2zOUkgUCU7R7X2f_R?resourcekey=0-MgT7Ur0pT__vw-5_AHjgWQ#scrollTo=utZv59sXzXvS>.
-			 * The list of hosts being preconnected to was obtained by inserting an embed into a post and then looking
-			 * at the network log on the frontend as the embed renders. Each should include the host of the iframe src
-			 * as well as URLs for assets used by the embed, _if_ the URL looks like it is not geotargeted (e.g. '-us')
-			 * or load-balanced (e.g. 's0.example.com'). For the load balancing case, attempt to load the asset by
-			 * incrementing the number appearing in the subdomain (e.g. s1.example.com). If the asset still loads, then
-			 * it is a likely case of a load balancing domain name which cannot be safely preconnected since it could
-			 * not end up being the load balanced domain used for the embed. Lastly, these domains are only for the URLs
-			 * for GET requests, as POST requests are not likely to be part of the critical rendering path.
-			 */
-			$preconnect_hrefs = array();
-			$has_class        = static function ( string $wanted_class ) use ( $processor ): bool {
-				return true === $processor->has_class( $wanted_class );
-			};
-			if ( $has_class( 'wp-block-embed-youtube' ) ) {
-				$preconnect_hrefs[] = 'https://www.youtube.com';
-				$preconnect_hrefs[] = 'https://i.ytimg.com';
-			} elseif ( $has_class( 'wp-block-embed-twitter' ) ) {
-				$preconnect_hrefs[] = 'https://syndication.twitter.com';
-				$preconnect_hrefs[] = 'https://pbs.twimg.com';
-			} elseif ( $has_class( 'wp-block-embed-vimeo' ) ) {
-				$preconnect_hrefs[] = 'https://player.vimeo.com';
-				$preconnect_hrefs[] = 'https://f.vimeocdn.com';
-				$preconnect_hrefs[] = 'https://i.vimeocdn.com';
-			} elseif ( $has_class( 'wp-block-embed-spotify' ) ) {
-				$preconnect_hrefs[] = 'https://apresolve.spotify.com';
-				$preconnect_hrefs[] = 'https://embed-cdn.spotifycdn.com';
-				$preconnect_hrefs[] = 'https://encore.scdn.co';
-				$preconnect_hrefs[] = 'https://i.scdn.co';
-			} elseif ( $has_class( 'wp-block-embed-videopress' ) || $has_class( 'wp-block-embed-wordpress-tv' ) ) {
-				$preconnect_hrefs[] = 'https://video.wordpress.com';
-				$preconnect_hrefs[] = 'https://public-api.wordpress.com';
-				$preconnect_hrefs[] = 'https://videos.files.wordpress.com';
-				$preconnect_hrefs[] = 'https://v0.wordpress.com'; // This does not appear to be a load-balanced domain since v1.wordpress.com is not valid.
-			} elseif ( $has_class( 'wp-block-embed-instagram' ) ) {
-				$preconnect_hrefs[] = 'https://www.instagram.com';
-				$preconnect_hrefs[] = 'https://static.cdninstagram.com';
-				$preconnect_hrefs[] = 'https://scontent.cdninstagram.com';
-			} elseif ( $has_class( 'wp-block-embed-tiktok' ) ) {
-				$preconnect_hrefs[] = 'https://www.tiktok.com';
-				// Note: The other domains used for TikTok embeds include https://lf16-tiktok-web.tiktokcdn-us.com,
-				// https://lf16-cdn-tos.tiktokcdn-us.com, and https://lf16-tiktok-common.tiktokcdn-us.com among others
-				// which either appear to be geo-targeted ('-us') _or_ load-balanced ('lf16'). So these are not added
-				// to the preconnected hosts.
-			} elseif ( $has_class( 'wp-block-embed-amazon' ) ) {
-				$preconnect_hrefs[] = 'https://read.amazon.com';
-				$preconnect_hrefs[] = 'https://m.media-amazon.com';
-			} elseif ( $has_class( 'wp-block-embed-soundcloud' ) ) {
-				$preconnect_hrefs[] = 'https://w.soundcloud.com';
-				$preconnect_hrefs[] = 'https://widget.sndcdn.com';
-				// Note: There is also https://i1.sndcdn.com which is for the album art, but the '1' indicates it may be geotargeted/load-balanced.
-			} elseif ( $has_class( 'wp-block-embed-pinterest' ) ) {
-				$preconnect_hrefs[] = 'https://assets.pinterest.com';
-				$preconnect_hrefs[] = 'https://widgets.pinterest.com';
-				$preconnect_hrefs[] = 'https://i.pinimg.com';
-			}
+		// Preconnect links and lazy-loading can only be done once there are URL metrics collected for both mobile and desktop.
+		if (
+			$context->url_metric_group_collection->get_first_group()->count() > 0
+			&&
+			$context->url_metric_group_collection->get_last_group()->count() > 0
+		) {
+			$max_intersection_ratio = $context->url_metric_group_collection->get_element_max_intersection_ratio( self::get_embed_wrapper_xpath( $processor->get_xpath() ) );
+			if ( $max_intersection_ratio > 0 ) {
+				/*
+				 * The following embeds have been chosen for optimization due to their relative popularity among all embed types.
+				 * See <https://colab.sandbox.google.com/drive/1nSpg3qoCLY-cBTV2zOUkgUCU7R7X2f_R?resourcekey=0-MgT7Ur0pT__vw-5_AHjgWQ#scrollTo=utZv59sXzXvS>.
+				 * The list of hosts being preconnected to was obtained by inserting an embed into a post and then looking
+				 * at the network log on the frontend as the embed renders. Each should include the host of the iframe src
+				 * as well as URLs for assets used by the embed, _if_ the URL looks like it is not geotargeted (e.g. '-us')
+				 * or load-balanced (e.g. 's0.example.com'). For the load balancing case, attempt to load the asset by
+				 * incrementing the number appearing in the subdomain (e.g. s1.example.com). If the asset still loads, then
+				 * it is a likely case of a load balancing domain name which cannot be safely preconnected since it could
+				 * not end up being the load balanced domain used for the embed. Lastly, these domains are only for the URLs
+				 * for GET requests, as POST requests are not likely to be part of the critical rendering path.
+				 */
+				$preconnect_hrefs = array();
+				$has_class        = static function ( string $wanted_class ) use ( $processor ): bool {
+					return true === $processor->has_class( $wanted_class );
+				};
+				if ( $has_class( 'wp-block-embed-youtube' ) ) {
+					$preconnect_hrefs[] = 'https://www.youtube.com';
+					$preconnect_hrefs[] = 'https://i.ytimg.com';
+				} elseif ( $has_class( 'wp-block-embed-twitter' ) ) {
+					$preconnect_hrefs[] = 'https://syndication.twitter.com';
+					$preconnect_hrefs[] = 'https://pbs.twimg.com';
+				} elseif ( $has_class( 'wp-block-embed-vimeo' ) ) {
+					$preconnect_hrefs[] = 'https://player.vimeo.com';
+					$preconnect_hrefs[] = 'https://f.vimeocdn.com';
+					$preconnect_hrefs[] = 'https://i.vimeocdn.com';
+				} elseif ( $has_class( 'wp-block-embed-spotify' ) ) {
+					$preconnect_hrefs[] = 'https://apresolve.spotify.com';
+					$preconnect_hrefs[] = 'https://embed-cdn.spotifycdn.com';
+					$preconnect_hrefs[] = 'https://encore.scdn.co';
+					$preconnect_hrefs[] = 'https://i.scdn.co';
+				} elseif ( $has_class( 'wp-block-embed-videopress' ) || $has_class( 'wp-block-embed-wordpress-tv' ) ) {
+					$preconnect_hrefs[] = 'https://video.wordpress.com';
+					$preconnect_hrefs[] = 'https://public-api.wordpress.com';
+					$preconnect_hrefs[] = 'https://videos.files.wordpress.com';
+					$preconnect_hrefs[] = 'https://v0.wordpress.com'; // This does not appear to be a load-balanced domain since v1.wordpress.com is not valid.
+				} elseif ( $has_class( 'wp-block-embed-instagram' ) ) {
+					$preconnect_hrefs[] = 'https://www.instagram.com';
+					$preconnect_hrefs[] = 'https://static.cdninstagram.com';
+					$preconnect_hrefs[] = 'https://scontent.cdninstagram.com';
+				} elseif ( $has_class( 'wp-block-embed-tiktok' ) ) {
+					$preconnect_hrefs[] = 'https://www.tiktok.com';
+					// Note: The other domains used for TikTok embeds include https://lf16-tiktok-web.tiktokcdn-us.com,
+					// https://lf16-cdn-tos.tiktokcdn-us.com, and https://lf16-tiktok-common.tiktokcdn-us.com among others
+					// which either appear to be geo-targeted ('-us') _or_ load-balanced ('lf16'). So these are not added
+					// to the preconnected hosts.
+				} elseif ( $has_class( 'wp-block-embed-amazon' ) ) {
+					$preconnect_hrefs[] = 'https://read.amazon.com';
+					$preconnect_hrefs[] = 'https://m.media-amazon.com';
+				} elseif ( $has_class( 'wp-block-embed-soundcloud' ) ) {
+					$preconnect_hrefs[] = 'https://w.soundcloud.com';
+					$preconnect_hrefs[] = 'https://widget.sndcdn.com';
+					// Note: There is also https://i1.sndcdn.com which is for the album art, but the '1' indicates it may be geotargeted/load-balanced.
+				} elseif ( $has_class( 'wp-block-embed-pinterest' ) ) {
+					$preconnect_hrefs[] = 'https://assets.pinterest.com';
+					$preconnect_hrefs[] = 'https://widgets.pinterest.com';
+					$preconnect_hrefs[] = 'https://i.pinimg.com';
+				}
 
-			foreach ( $preconnect_hrefs as $preconnect_href ) {
-				$context->link_collection->add_link(
-					array(
-						'rel'  => 'preconnect',
-						'href' => $preconnect_href,
-					)
-				);
+				foreach ( $preconnect_hrefs as $preconnect_href ) {
+					$context->link_collection->add_link(
+						array(
+							'rel'  => 'preconnect',
+							'href' => $preconnect_href,
+						)
+					);
+				}
+			} elseif ( embed_optimizer_update_markup( $processor, false ) && ! $this->added_lazy_script ) {
+				$processor->append_body_html( wp_get_inline_script_tag( embed_optimizer_get_lazy_load_script(), array( 'type' => 'module' ) ) );
+				$this->added_lazy_script = true;
 			}
-		} elseif ( embed_optimizer_update_markup( $processor, false ) && ! $this->added_lazy_script ) {
-			$processor->append_body_html( wp_get_inline_script_tag( embed_optimizer_get_lazy_load_script(), array( 'type' => 'module' ) ) );
-			$this->added_lazy_script = true;
 		}
 
 		/*

--- a/plugins/embed-optimizer/tests/test-cases/nested-figure-embed.php
+++ b/plugins/embed-optimizer/tests/test-cases/nested-figure-embed.php
@@ -1,24 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
-
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => false,
 					'intersectionRatio'         => 1,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 				array(
 					'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]/*[1][self::VIDEO]',
@@ -29,7 +18,7 @@ return array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => false,
 					'intersectionRatio'         => 0,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 654 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 654 ) ),
 				),
 				array(
 					'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[2][self::FIGURE]/*[1][self::DIV]/*[1][self::FIGURE]/*[2][self::VIDEO]',

--- a/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script.php
@@ -1,25 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
-
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => false,
 					'intersectionRatio'         => 0,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 			),
 			false

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data.php
@@ -1,16 +1,6 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
 		$test_case->populate_url_metrics(
 			array(
 				array(

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport.php
@@ -1,23 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => true,
 					'intersectionRatio'         => 1,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 			)
 		);

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport.php
@@ -1,23 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => false,
 					'intersectionRatio'         => 0,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 			)
 		);

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport.php
@@ -1,23 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => true,
 					'intersectionRatio'         => 1,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 			),
 			false

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport.php
@@ -1,23 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => false,
 					'intersectionRatio'         => 0,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 			),
 			false

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport.php
@@ -1,23 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => true,
 					'intersectionRatio'         => 1,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 			)
 		);

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics.php
@@ -1,0 +1,55 @@
+<?php
+return array(
+	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
+		OD_URL_Metrics_Post_Type::store_url_metric(
+			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
+			$test_case->get_sample_url_metric(
+				array(
+					'viewport_width' => 100,
+					'elements'       => array(
+						array(
+							'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
+							'isLCP'                     => false,
+							'intersectionRatio'         => 0.0,
+							'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
+						),
+					),
+				)
+			)
+		);
+	},
+	'buffer'   => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+			</head>
+			<body>
+				<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+					<div class="wp-block-embed__wrapper">
+						<iframe title="Matt Mullenweg: State of the Word 2023" width="750" height="422" src="https://www.youtube.com/embed/c7M4mBVgP3Y?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+					</div>
+				</figure>
+			</body>
+		</html>
+	',
+	'expected' => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+				<style>
+				@media (max-width: 480px) { #embed-optimizer-a7659db28ecaa36ddee6ae66857dabd8 { min-height: 500px; } }
+				</style>
+			</head>
+			<body>
+				<figure data-od-added-id id="embed-optimizer-a7659db28ecaa36ddee6ae66857dabd8" class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+					<div data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]" class="wp-block-embed__wrapper">
+						<iframe title="Matt Mullenweg: State of the Word 2023" width="750" height="422" src="https://www.youtube.com/embed/c7M4mBVgP3Y?feature=oembed" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+					</div>
+				</figure>
+				<script type="module">/* import detect ... */</script>
+			</body>
+		</html>
+	',
+);

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport.php
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport.php
@@ -1,23 +1,13 @@
 <?php
 return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
-		$rect = array(
-			'width'  => 500.1,
-			'height' => 500.2,
-			'x'      => 100.3,
-			'y'      => 100.4,
-			'top'    => 0.1,
-			'right'  => 0.2,
-			'bottom' => 0.3,
-			'left'   => 0.4,
-		);
 		$test_case->populate_url_metrics(
 			array(
 				array(
 					'xpath'                     => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]',
 					'isLCP'                     => false,
 					'intersectionRatio'         => 0,
-					'resizedBoundingClientRect' => array_merge( $rect, array( 'height' => 500 ) ),
+					'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
 				),
 			)
 		);

--- a/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks.php
+++ b/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks.php
@@ -3,6 +3,17 @@ return array(
 	'set_up'   => static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
 		$test_case->setExpectedIncorrectUsage( 'WP_HTML_Tag_Processor::set_bookmark' );
 
+		$test_case->populate_url_metrics(
+			array(
+				array(
+					'xpath'             => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::BOGUS]',
+					'isLCP'             => false,
+					'intersectionRatio' => 0.0,
+				),
+			),
+			false
+		);
+
 		// Check what happens when there are too many bookmarks.
 		add_action(
 			'od_register_tag_visitors',

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -178,7 +178,6 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 		 * metrics collected for mobile then the VIDEO will get lazy-loaded which is good for mobile but for desktop
 		 * it will hurt performance. So this is why it is important to have URL metrics collected for both desktop and
 		 * mobile to verify whether maximum intersectionRatio is accounting for both screen sizes.
-		 * TODO: Add this same condition to IMG lazy-loading and Embed lazy-loading.
 		 */
 		if (
 			$context->url_metric_group_collection->get_first_group()->count() === 0

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
@@ -4,7 +4,7 @@ return array(
 		$slug = od_get_url_metrics_slug( od_get_normalized_query_vars() );
 		$sample_size = od_get_url_metrics_breakpoint_sample_size();
 
-		// Only populate the largest viewport group.
+		// Only populate the largest (desktop) viewport group.
 		for ( $i = 0; $i < $sample_size; $i++ ) {
 			OD_URL_Metrics_Post_Type::store_url_metric(
 				$slug,
@@ -26,6 +26,7 @@ return array(
 			);
 		}
 	},
+	// Note: loading=lazy is not removed from these images URL Metrics are only gathered for desktop so far. Both mobile and desktop URL Metrics are required to proceed with lazy-loading.
 	'buffer'   => '
 		<html lang="en">
 			<head>
@@ -46,8 +47,8 @@ return array(
 				<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (min-width: 783px)">
 			</head>
 			<body>
-				<img data-od-removed-loading="lazy" data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" >
-				<img data-od-removed-fetchpriority="high" data-od-removed-loading="lazy" data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]" src="https://example.com/bar.jpg" alt="Bar" width="10" height="10"  >
+				<img data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" loading="lazy">
+				<img data-od-removed-fetchpriority="high" data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[2][self::IMG]" src="https://example.com/bar.jpg" alt="Bar" width="10" height="10" loading="lazy" >
 				<script type="module">/* import detect ... */</script>
 			</body>
 		</html>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data.php
@@ -26,7 +26,7 @@ return array(
 			);
 		}
 	},
-	// Note: loading=lazy is not removed from these images URL Metrics are only gathered for desktop so far. Both mobile and desktop URL Metrics are required to proceed with lazy-loading.
+	// Note: loading=lazy is not removed from these images because URL Metrics are only gathered for desktop so far. Both mobile and desktop URL Metrics are required to proceed with lazy-loading.
 	'buffer'   => '
 		<html lang="en">
 			<head>


### PR DESCRIPTION
See discussion in https://github.com/WordPress/performance/pull/1596#discussion_r1804594668

We can only safely lazy-load anything once we have collected URL metrics for both mobile and desktop. If we've only collected URL metrics for mobile and there is a lazy-loadable element which is not visible, it would be an error to lazy-load it if that element does get displayed on a larger viewport (e.g. desktop).