### PR TITLE
Add option to delete the original file on upload

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -411,6 +411,17 @@ function webp_uploads_is_fallback_enabled(): bool {
 }
 
 /**
+ * Checks if the `webp_uploads_delete_original` option is enabled.
+ *
+ * @since 2.2.0
+ *
+ * @return bool True if the option is enabled, false otherwise.
+ */
+function webp_uploads_is_delete_original_enabled(): bool {
+	return (bool) get_option( 'webp_uploads_delete_original' );
+}
+
+/**
  * Retrieves the image URL for a specified MIME type from the attachment metadata.
  *
  * This function attempts to locate an alternate image source URL in the

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -168,9 +168,8 @@ function webp_uploads_generate_additional_image_source( int $attachment_id, stri
 	$editor->resize( $width, $height, $crop );
 
 	if ( null === $destination_file_name ) {
-		$ext                   = pathinfo( $image_path, PATHINFO_EXTENSION );
 		$suffix                = $editor->get_suffix();
-		$suffix               .= "-{$ext}";
+		$suffix                = false !== $suffix ? $suffix : '';
 		$extension             = explode( '|', $allowed_mimes[ $mime ] );
 		$destination_file_name = $editor->generate_filename( $suffix, null, $extension[0] );
 	}

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -88,7 +88,6 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 
 	$original_directory = pathinfo( $file, PATHINFO_DIRNAME );
 	$filename           = pathinfo( $file, PATHINFO_FILENAME );
-	$ext                = pathinfo( $file, PATHINFO_EXTENSION );
 	$allowed_mimes      = array_flip( wp_get_mime_types() );
 
 	// Create the sources for the full sized image.
@@ -104,7 +103,7 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 		}
 
 		$extension   = explode( '|', $allowed_mimes[ $targeted_mime ] );
-		$destination = trailingslashit( $original_directory ) . "{$filename}-{$ext}.{$extension[0]}";
+		$destination = trailingslashit( $original_directory ) . "{$filename}.{$extension[0]}";
 		$image       = webp_uploads_generate_additional_image_source( $attachment_id, 'full', $original_size_data, $targeted_mime, $destination );
 
 		if ( is_wp_error( $image ) ) {

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -236,24 +236,24 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 
 	// Delete the original file if the option is enabled and new formats exist.
 	if ( webp_uploads_is_delete_original_enabled() && ! empty( $metadata['sources'] ) ) {
-		$new_formats_exist = false;
+		$supported_modern_image_formats = array();
 
-		// Check if the 'sources' property has a file with the expected extensions.
-		foreach ( $metadata['sources'] as $current_mime_type => $source ) {
-			if ( isset( $source['file'] ) ) {
-				$file_extension = pathinfo( $source['file'], PATHINFO_EXTENSION );
-				if ( in_array( $file_extension, array( 'avif', 'webp' ), true ) ) {
-					$new_formats_exist = true;
-					break;
-				}
-			}
+		if ( webp_uploads_mime_type_supported( 'image/avif' ) ) {
+			$supported_modern_image_formats[] = 'avif';
+		}
+		if ( webp_uploads_mime_type_supported( 'image/webp' ) ) {
+			$supported_modern_image_formats[] = 'webp';
 		}
 
-		if ( $new_formats_exist ) {
-			// Update the original_image metadata to point to the new primary image
+		$original_file_extension  = pathinfo( $file, PATHINFO_EXTENSION );
+		$generated_file_extension = ! empty( $metadata['file'] ) ? pathinfo( $metadata['file'], PATHINFO_EXTENSION ) : '';
+		$delete_original_file     = ! in_array( $original_file_extension, $supported_modern_image_formats, true ) && in_array( $generated_file_extension, $supported_modern_image_formats, true );
+
+		if ( $delete_original_file ) {
+			// Update the original_image metadata value to point to the new primary image
 			// file since original image will be deleted.
 			$first_source = reset( $metadata['sources'] );
-			if ( ! empty( $first_source['file'] ) ) {
+			if ( isset( $metadata['original_image'] ) && ! empty( $first_source['file'] ) ) {
 				$metadata['original_image'] = $first_source['file'];
 				wp_update_attachment_metadata( $attachment_id, $metadata );
 			}

--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -51,6 +51,17 @@ function webp_uploads_register_media_settings_field(): void {
 			'show_in_rest' => false,
 		)
 	);
+
+	// Add a setting to delete the original image file after conversion.
+	register_setting(
+		'media',
+		'webp_uploads_delete_original',
+		array(
+			'type'         => 'boolean',
+			'default'      => false,
+			'show_in_rest' => false,
+		)
+	);
 }
 add_action( 'init', 'webp_uploads_register_media_settings_field' );
 
@@ -104,6 +115,16 @@ function webp_uploads_add_media_settings_fields(): void {
 		'media',
 		'perflab_modern_image_format_settings',
 		array( 'class' => 'webp-uploads-use-picture-element' )
+	);
+
+	// Add delete original image setting field.
+	add_settings_field(
+		'webp_uploads_delete_original',
+		__( 'Delete Original Image', 'webp-uploads' ),
+		'webp_uploads_delete_original_setting_callback',
+		'media',
+		'perflab_modern_image_format_settings',
+		array( 'class' => 'webp-uploads-delete-original' )
 	);
 }
 add_action( 'admin_init', 'webp_uploads_add_media_settings_fields' );
@@ -267,6 +288,23 @@ function webp_uploads_use_picture_element_callback(): void {
 		} );
 	} )( <?php echo wp_json_encode( $picture_element_hidden_id ); ?> );
 	</script>
+	<?php
+}
+
+/**
+ * Renders the settings field for the 'webp_uploads_delete_original' setting.
+ *
+ * @since 2.2.0
+ */
+function webp_uploads_delete_original_setting_callback(): void {
+	?>
+	<label for="webp_uploads_delete_original">
+		<input name="webp_uploads_delete_original" type="checkbox" id="webp_uploads_delete_original" value="1" <?php checked( '1', get_option( 'webp_uploads_delete_original' ) ); ?> />
+		<?php esc_html_e( 'Delete the original JPEG/PNG file after conversion', 'webp-uploads' ); ?>
+	</label>
+	<p class="description" id="webp_uploads_delete_original_description">
+		<?php esc_html_e( 'If enabled, the original image file will be deleted after conversion to modern formats. This will reduce filesystem storage but may cause incompatibility in certain cases.', 'webp-uploads' ); ?>
+	</p>
 	<?php
 }
 

--- a/plugins/webp-uploads/tests/test-helper.php
+++ b/plugins/webp-uploads/tests/test-helper.php
@@ -106,8 +106,8 @@ class Test_WebP_Uploads_Helper extends TestCase {
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'filesize', $result );
 		$this->assertArrayHasKey( 'file', $result );
-		$this->assertStringEndsWith( '300x300-jpeg.webp', $result['file'] );
-		$this->assertFileExists( "{$directory}{$name}-300x300-jpeg.webp" );
+		$this->assertStringEndsWith( '300x300.webp', $result['file'] );
+		$this->assertFileExists( "{$directory}{$name}-300x300.webp" );
 	}
 
 	/**
@@ -575,8 +575,8 @@ class Test_WebP_Uploads_Helper extends TestCase {
 
 		$this->assertIsArray( $jpeg_image_result );
 		$this->assertIsArray( $jpg_image_result );
-		$this->assertStringEndsWith( '300x300-jpeg.webp', $jpeg_image_result['file'] );
-		$this->assertStringEndsWith( '300x300-jpg.webp', $jpg_image_result['file'] );
+		$this->assertStringEndsWith( '300x300.webp', $jpeg_image_result['file'] );
+		$this->assertStringEndsWith( '300x300.webp', $jpg_image_result['file'] );
 		$this->assertNotSame( $jpeg_image_result['file'], $jpg_image_result['file'] );
 	}
 

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -311,7 +311,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$this->assertStringEndsWith( '-scaled.jpg', get_attached_file( $attachment_id ) );
 		$this->assertImageHasSizeSource( $attachment_id, 'medium', 'image/webp' );
 		$this->assertStringEndsNotWith( '-scaled.webp', $metadata['sizes']['medium']['sources']['image/webp']['file'] );
-		$this->assertStringEndsWith( '-300x200-jpg.webp', $metadata['sizes']['medium']['sources']['image/webp']['file'] );
+		$this->assertStringEndsWith( '-300x200.webp', $metadata['sizes']['medium']['sources']['image/webp']['file'] );
 	}
 
 	/**

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -103,7 +103,7 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		if ( is_array( $image_src ) ) {
 			$img_src = $image_src[0];
 		}
-		$webp_srcset = str_replace( '.jpg', '-jpg.webp', $image_srcset );
+		$webp_srcset = str_replace( '.jpg', '.webp', $image_srcset );
 
 		// Prepare the expected HTML by replacing placeholders with expected values.
 		$replacements = array(

--- a/plugins/webp-uploads/uninstall.php
+++ b/plugins/webp-uploads/uninstall.php
@@ -38,4 +38,5 @@ webp_uploads_delete_plugin_option();
  */
 function webp_uploads_delete_plugin_option(): void {
 	delete_option( 'perflab_generate_webp_and_jpeg' );
+	delete_option( 'webp_uploads_delete_original' );
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1564 

This pull request introduces a new option in the Modern Image Format plugin settings to delete the original JPEG/PNG files after conversion to modern image formats like AVIF or WebP. This will help save disk space by removing the original files. Also, removed the old extension suffix (eg: `-jpg`, `-png`) from the filename.

## Relevant technical choices

<!-- Please describe your changes. -->

- Added a new checkbox option in the settings page to enable or disable the deletion of original JPEG/PNG files after conversion. 

- Updated the `original_image` metadata when the delete option is enabled so that the original image link in _Attachment details_ popup doesn't give 404.

- Added checks to ensure that the original file is only deleted if new image files have been generated. Also taken care of the case where the original image itself is in `avif` or `webp` format.

- Update the existing test cases by removing `-jpg`/`-jpeg`/`-png` from filenames checks.

## Screenshot:
<img width="1283" alt="Screenshot 2024-10-18 at 6 32 53 PM" src="https://github.com/user-attachments/assets/fd9c794e-1aa7-4e98-8eb0-7fed2522a2c1">


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
