### PR TITLE
Add ReturnTypeWillChange attribute for offsetGet to suppress notice

### DIFF
--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -186,6 +186,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * @param mixed $offset Key.
 	 * @return mixed May return any value from ElementData including possible extensions.
 	 */
+	#[ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		return $this->data[ $offset ] ?? null;
 	}


### PR DESCRIPTION
I noticed a deprecation warning after #1585:

> Return type of OD_Element::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice	

This adds `#[ReturnTypeWillChange]` attribute as suggested.

This is also used in core, for example: https://github.com/WordPress/wordpress-develop/blob/de51a4412dc3fa4d2591c59492fa76227cdddd29/src/wp-includes/class-wp-block-list.php#L81-L92