### PR TITLE
Prepare 3.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ The feature plugins which are currently featured by this plugin are:
 
 Plugin                          | Slug                      | Experimental | Links
 --------------------------------|---------------------------|--------------|-------------
-[Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][8],  [Issues][15], [PRs][22]
-[Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][9],  [Issues][16], [PRs][23]
-[Performant Translations][3]    | `performant-translations` | No           | [Source][10], [Issues][17], [PRs][24]
-[Speculative Loading][4]        | `speculation-rules`       | No           | [Source][11], [Issues][18], [PRs][25]
-[Embed Optimizer][5]            | `embed-optimizer`         | Yes          | [Source][12], [Issues][19], [PRs][26]
-[Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][13], [Issues][20], [PRs][27]
-[Image Prioritizer][7]          | `image-prioritizer`       | Yes          | [Source][14], [Issues][21], [PRs][28]
+[Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][9],  [Issues][17], [PRs][25]
+[Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
+[Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
+[Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
+[Embed Optimizer][5]            | `embed-optimizer`         | Yes          | [Source][13], [Issues][21], [PRs][29]
+[Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][14], [Issues][22], [PRs][30]
+[Image Prioritizer][7]          | `image-prioritizer`       | Yes          | [Source][15], [Issues][23], [PRs][31]
+[Web Worker Offloading][8]      | `web-worker-offloading`   | Yes          | [Source][16], [Issues][24], [PRs][32]
 
 [1]: https://wordpress.org/plugins/dominant-color-images/
 [2]: https://wordpress.org/plugins/webp-uploads/
@@ -26,29 +27,33 @@ Plugin                          | Slug                      | Experimental | Lin
 [5]: https://wordpress.org/plugins/embed-optimizer/
 [6]: https://wordpress.org/plugins/auto-sizes/
 [7]: https://wordpress.org/plugins/image-prioritizer/
+[8]: https://wordpress.org/plugins/web-worker-offloading/
 
-[8]: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
-[9]: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
-[10]: https://github.com/swissspidy/performant-translations
-[11]: https://github.com/WordPress/performance/tree/trunk/plugins/speculation-rules
-[12]: https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer
-[13]: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
-[14]: https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer
+[9]: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
+[10]: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
+[11]: https://github.com/swissspidy/performant-translations
+[12]: https://github.com/WordPress/performance/tree/trunk/plugins/speculation-rules
+[13]: https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer
+[14]: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
+[15]: https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer
+[16]: https://github.com/WordPress/performance/tree/trunk/plugins/web-worker-offloading
 
-[15]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
-[16]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
-[17]: https://github.com/swissspidy/performant-translations/issues
-[18]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
-[19]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
-[20]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
-[21]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[17]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
+[18]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
+[19]: https://github.com/swissspidy/performant-translations/issues
+[20]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
+[21]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
+[22]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
+[23]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[24]: https://github.com/WordPress/performance/issues?q=is%3Aopen%20label%3A%22%5BPlugin%5D%20Web%20Worker%20Offloading%22
 
-[22]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
-[23]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
-[24]: https://github.com/swissspidy/performant-translations/pulls
-[25]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
-[26]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
-[27]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
-[28]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[25]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
+[26]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
+[27]: https://github.com/swissspidy/performant-translations/pulls
+[28]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
+[29]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
+[30]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
+[31]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[32]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Web%20Worker%20Offloading%22
 
 Note that the plugin names sometimes diverge from the plugin slugs due to scope changes. For example, a plugin's purpose may change as some of its features are merged into WordPress core.

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -1,7 +1,7 @@
 === Enhanced Responsive Images ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   1.3.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -1,7 +1,7 @@
 === Image Placeholders ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   1.1.2
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -31,7 +31,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	/**
 	 * Determines whether the processor is currently at a figure.wp-block-embed tag.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param OD_HTML_Tag_Processor $processor Processor.
 	 * @return bool Whether at the tag.
@@ -47,7 +47,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	/**
 	 * Determines whether the processor is currently at a div.wp-block-embed__wrapper tag (which is a child of figure.wp-block-embed).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param OD_HTML_Tag_Processor $processor Processor.
 	 * @return bool Whether the tag should be measured and stored in URL metrics.
@@ -196,7 +196,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	/**
 	 * Gets the XPath for the embed wrapper DIV which is the sole child of the embed block FIGURE.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param string $embed_block_xpath XPath for the embed block FIGURE tag. For example: `/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]`.
 	 * @return string XPath for the child DIV. For example: `/*[1][self::HTML]/*[2][self::BODY]/*[1][self::FIGURE]/*[1][self::DIV]`
@@ -208,7 +208,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	/**
 	 * Reduces layout shifts.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.3.0
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
 	 */

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -26,7 +26,7 @@ add_action( 'init', 'embed_optimizer_add_hooks' );
 /**
  * Adds hooks for when the Optimization Detective logic is not running.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  */
 function embed_optimizer_add_non_optimization_detective_hooks(): void {
 	if ( false === has_action( 'od_register_tag_visitors', 'embed_optimizer_register_tag_visitors' ) ) {
@@ -37,7 +37,7 @@ function embed_optimizer_add_non_optimization_detective_hooks(): void {
 /**
  * Initializes Embed Optimizer when Optimization Detective has loaded.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */
@@ -81,7 +81,7 @@ function embed_optimizer_register_tag_visitors( OD_Tag_Visitor_Registry $registr
 /**
  * Filters additional properties for the element item schema for Optimization Detective.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @param array<string, array{type: string}> $additional_properties Additional properties.
  * @return array<string, array{type: string}> Additional properties.
@@ -112,7 +112,7 @@ function embed_optimizer_add_element_item_schema_properties( array $additional_p
 /**
  * Filters the list of Optimization Detective extension module URLs to include the extension for Embed Optimizer.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @param string[]|mixed $extension_module_urls Extension module URLs.
  * @return string[] Extension module URLs.
@@ -130,7 +130,7 @@ function embed_optimizer_filter_extension_module_urls( $extension_module_urls ):
  *
  * This ensures that the module for handling embeds is only loaded when there is an embed on the page.
  *
- * @since n.e.x.t
+ * @since 0.3.0
  *
  * @param string|mixed $html The oEmbed HTML.
  * @return string Unchanged oEmbed HTML.

--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -5,7 +5,7 @@
  * Description: Optimizes the performance of embeds by lazy-loading iframes and scripts.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.3.0-alpha
+ * Version: 0.3.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -70,7 +70,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'embed_optimizer_pending_plugin',
-	'0.3.0-alpha',
+	'0.3.0',
 	static function ( string $version ): void {
 		if ( defined( 'EMBED_OPTIMIZER_VERSION' ) ) {
 			return;

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.2.0
+Stable tag:   0.3.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, embeds
@@ -50,6 +50,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.3.0 =
 
 = 0.2.0 =
 

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -53,6 +53,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.3.0 =
 
+**Enhancements**
+
+* Leverage URL metrics to reserve space for embeds to reduce CLS. ([1373](https://github.com/WordPress/performance/pull/1373))
+* Moves embed-optimizer-lazy-load script to js file. ([1601](https://github.com/WordPress/performance/pull/1601))
+
 = 0.2.0 =
 
 **Enhancements**

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -1,7 +1,7 @@
 === Embed Optimizer ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   0.3.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -56,7 +56,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 **Enhancements**
 
 * Leverage URL metrics to reserve space for embeds to reduce CLS. ([1373](https://github.com/WordPress/performance/pull/1373))
-* Moves embed-optimizer-lazy-load script to js file. ([1601](https://github.com/WordPress/performance/pull/1601))
+* Avoid lazy-loading images and embeds unless there are URL Metrics for both mobile and desktop. ([1604](https://github.com/WordPress/performance/pull/1604))
 
 = 0.2.0 =
 

--- a/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
@@ -42,7 +42,7 @@ abstract class Image_Prioritizer_Tag_Visitor {
 	/**
 	 * Gets attribute value for select attributes.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 * @todo Move this into the OD_HTML_Tag_Processor/OD_HTML_Processor class eventually.
 	 *
 	 * @phpstan-param NormalizedAttributeNames $attribute_name

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -5,7 +5,7 @@
  *
  * @package image-prioritizer
  *
- * @since n.e.x.t
+ * @since 0.2.0
  */
 
 // Exit if accessed directly.
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Image Prioritizer: Image_Prioritizer_Video_Tag_Visitor class
  *
- * @since n.e.x.t
+ * @since 0.2.0
  *
  * @access private
  */
@@ -25,7 +25,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	/**
 	 * Class name used to indicate a video which is lazy-loaded.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 * @var string
 	 */
 	const LAZY_VIDEO_CLASS_NAME = 'od-lazy-video';
@@ -33,7 +33,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	/**
 	 * Whether the lazy-loading script was added to the body.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 * @var bool
 	 */
 	protected $added_lazy_script = false;
@@ -41,7 +41,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	/**
 	 * Visits a tag.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
 	 * @return bool Whether the tag should be tracked in URL metrics.
@@ -69,7 +69,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	 *
 	 * Skips empty poster attributes and data: URLs.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context.
 	 * @return non-empty-string|null Poster or null if not defined or is a data: URL.
@@ -85,7 +85,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	/**
 	 * Reduces poster image size by choosing one that fits the maximum video size more closely.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 *
 	 * @param non-empty-string       $poster  Poster image URL.
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
@@ -128,7 +128,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	/**
 	 * Preloads poster image for the LCP <video> element.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 *
 	 * @param non-empty-string       $poster  Poster image URL.
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at a VIDEO tag.
@@ -164,7 +164,7 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 	/**
 	 * Optimizes the VIDEO tag based on whether it is the LCP element or else whether it is displayed in any initial viewport.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.2.0
 	 *
 	 * @param non-empty-string|null  $poster  Poster image URL.
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Initializes Image Prioritizer when Optimization Detective has loaded.
  *
- * @since n.e.x.t
+ * @since 0.2.0
  *
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */

--- a/plugins/image-prioritizer/hooks.php
+++ b/plugins/image-prioritizer/hooks.php
@@ -19,7 +19,7 @@ add_action( 'od_init', 'image_prioritizer_init' );
  *
  * Handles 'autoplay' and 'preload' attributes accordingly.
  *
- * @since n.e.x.t
+ * @since 0.2.0
  */
 function image_prioritizer_get_lazy_load_script(): string {
 	$script = file_get_contents( __DIR__ . '/lazy-load.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.5
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.1.5-alpha
+ * Version: 0.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.1.5-alpha',
+	'0.2.0',
 	static function ( string $version ): void {
 		if ( defined( 'IMAGE_PRIORITIZER_VERSION' ) ) {
 			return;

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -66,11 +66,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 **Enhancements**
 
-* Add fetchpriority=low to occluded initial-viewport images. ([1482](https://github.com/WordPress/performance/pull/1482))
-* Avoid lazy-loading images and embeds unless there are URL Metrics for both mobile and desktop. ([1604](https://github.com/WordPress/performance/pull/1604))
-* Choose smaller poster image size based on actual dimensions. ([1595](https://github.com/WordPress/performance/pull/1595))
 * Lazy load videos and video posters. ([1596](https://github.com/WordPress/performance/pull/1596))
 * Prioritize loading poster image of video LCP elements. ([1498](https://github.com/WordPress/performance/pull/1498))
+* Choose smaller video poster image size based on actual dimensions. ([1595](https://github.com/WordPress/performance/pull/1595))
+* Add fetchpriority=low to occluded initial-viewport images (e.g. images in hidden carousel slides). ([1482](https://github.com/WordPress/performance/pull/1482))
+* Avoid lazy-loading images and embeds unless there are URL Metrics for both mobile and desktop. ([1604](https://github.com/WordPress/performance/pull/1604))
 
 = 0.1.4 =
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -64,6 +64,14 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.2.0 =
 
+**Enhancements**
+
+* Add fetchpriority=low to occluded initial-viewport images. ([1482](https://github.com/WordPress/performance/pull/1482))
+* Avoid lazy-loading images and embeds unless there are URL Metrics for both mobile and desktop. ([1604](https://github.com/WordPress/performance/pull/1604))
+* Choose smaller poster image size based on actual dimensions. ([1595](https://github.com/WordPress/performance/pull/1595))
+* Lazy load videos and video posters. ([1596](https://github.com/WordPress/performance/pull/1596))
+* Prioritize loading poster image of video LCP elements. ([1498](https://github.com/WordPress/performance/pull/1498))
+
 = 0.1.4 =
 
 **Enhancements**

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.1.4
+Stable tag:   0.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -61,6 +61,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.2.0 =
 
 = 0.1.4 =
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -1,7 +1,7 @@
 === Image Prioritizer ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   0.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -3,7 +3,7 @@
  * Optimization Detective: OD_Element class
  *
  * @package optimization-detective
- * @since n.e.x.t
+ * @since 0.7.0
  */
 
 // Exit if accessed directly.
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @implements ArrayAccess<key-of<ElementData>, ElementData[key-of<ElementData>]>
  * @todo The above implements tag should account for additional undefined keys which can be supplied by extending the element schema. May depend on <https://github.com/phpstan/phpstan/issues/8438>.
  *
- * @since n.e.x.t
+ * @since 0.7.0
  * @access private
  */
 class OD_Element implements ArrayAccess, JsonSerializable {
@@ -27,7 +27,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Data.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 * @var ElementData
 	 */
 	protected $data;
@@ -35,7 +35,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * URL metric that this element belongs to.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 * @var OD_URL_Metric
 	 */
 	protected $url_metric;
@@ -43,7 +43,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Constructor.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @phpstan-param ElementData $data
 	 *
@@ -58,7 +58,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Gets the URL metric that this element belongs to.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return OD_URL_Metric URL Metric.
 	 */
@@ -69,7 +69,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Gets the group that this element's URL metric is a part of (which may not be any).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return OD_URL_Metric_Group|null Group.
 	 */
@@ -82,7 +82,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 *
 	 * This is particularly useful in conjunction with the `od_url_metric_schema_element_item_additional_properties` filter.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param string $key Property.
 	 * @return mixed|null The property value, or null if not set.
@@ -94,7 +94,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Determines whether element was detected as LCP.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return bool Whether LCP.
 	 */
@@ -105,7 +105,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Determines whether element was detected as an LCP candidate.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return bool Whether LCP candidate.
 	 */
@@ -116,7 +116,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Gets XPath for element.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return non-empty-string XPath.
 	 */
@@ -127,7 +127,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Gets intersectionRatio for element.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return float Intersection ratio.
 	 */
@@ -138,7 +138,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Gets intersectionRect for element.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @phpstan-return DOMRect
 	 *
@@ -151,7 +151,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Gets boundingClientRect for element.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @phpstan-return DOMRect
 	 *
@@ -164,7 +164,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Checks whether an offset exists.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param mixed $offset Key.
 	 * @return bool Whether the offset exists.
@@ -176,7 +176,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Retrieves an offset.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @template T of key-of<ElementData>
 	 * @phpstan-param T $offset
@@ -196,7 +196,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 *
 	 * This is disallowed. Attempting to set a property will throw an error.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param mixed $offset Key.
 	 * @param mixed $value  Value.
@@ -212,7 +212,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 *
 	 * This is disallowed. Attempting to unset a property will throw an error.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param mixed $offset Offset.
 	 *
@@ -225,7 +225,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Specifies data which should be serialized to JSON.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 * @return ElementData Exports to be serialized by json_encode().
 	 */
 	public function jsonSerialize(): array {

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -181,7 +181,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Whether the end of the document was reached.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 * @see self::next_token()
 	 * @var bool
 	 */

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -61,7 +61,7 @@ final class OD_Tag_Visitor_Context {
 	/**
 	 * Gets deprecated property.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 * @todo Remove this when no plugins are possibly referring to the url_metrics_group_collection property anymore.
 	 *
 	 * @param string $name Property name.
@@ -80,7 +80,7 @@ final class OD_Tag_Visitor_Context {
 						__CLASS__ . '::$url_metric_group_collection'
 					)
 				),
-				'optimization-detective n.e.x.t'
+				'optimization-detective 0.7.0'
 			);
 			return $this->url_metric_group_collection;
 		}

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -167,7 +167,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * and the maximum viewport width corresponds to the smallest defined breakpoint returned by
 	 * {@see od_get_breakpoint_max_widths()}.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return OD_URL_Metric_Group First URL Metric group.
 	 */
@@ -182,7 +182,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * defined as one greater than the largest breakpoint returned by {@see od_get_breakpoint_max_widths()}.
 	 * The maximum viewport is always `PHP_INT_MAX`, or in other words it is unbounded.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return OD_URL_Metric_Group Last URL Metric group.
 	 */
@@ -449,7 +449,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * (the default sample size). Therefore, given the number (n) of visited elements on the page this will only
 	 * end up running n*4*3 times.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return array<string, non-empty-array<int, OD_Element>> Keys are XPaths and values are the element instances.
 	 */
@@ -514,7 +514,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * Furthermore, the element may be positioned _above_ the initial viewport or to the left or right of the viewport,
 	 * in which case the element may be dynamically displayed at any time in response to a user interaction.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return array<string, bool> Keys are XPaths and values whether the element is positioned in any initial viewport.
 	 */
@@ -556,7 +556,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	/**
 	 * Determines whether an element is positioned in any initial viewport.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param string $xpath XPath for the element.
 	 * @return bool|null Whether element is positioned in any initial viewport of null if unknown.

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -66,7 +66,7 @@ class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Group.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 * @var OD_URL_Metric_Group|null
 	 */
 	protected $group = null;
@@ -127,7 +127,7 @@ class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Gets the group that this URL metric is a part of (which may not be any).
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @return OD_URL_Metric_Group|null Group.
 	 */
@@ -138,7 +138,7 @@ class OD_URL_Metric implements JsonSerializable {
 	/**
 	 * Sets the group that this URL metric is a part of.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param OD_URL_Metric_Group $group Group.
 	 *

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -41,7 +41,7 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 	/**
 	 * Filters the list of extension script module URLs to import when performing detection.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param string[] $extension_module_urls Extension module URLs.
 	 */

--- a/plugins/optimization-detective/helper.php
+++ b/plugins/optimization-detective/helper.php
@@ -13,13 +13,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Initializes extensions for Optimization Detective.
  *
- * @since n.e.x.t
+ * @since 0.7.0
  */
 function od_initialize_extensions(): void {
 	/**
 	 * Fires when extensions to Optimization Detective can be loaded and initialized.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param string $version Optimization Detective version.
 	 */
@@ -29,7 +29,7 @@ function od_initialize_extensions(): void {
 /**
  * Generates a media query for the provided minimum and maximum viewport widths.
  *
- * @since n.e.x.t
+ * @since 0.7.0
  *
  * @param int|null $minimum_viewport_width Minimum viewport width.
  * @param int|null $maximum_viewport_width Maximum viewport width.
@@ -37,7 +37,7 @@ function od_initialize_extensions(): void {
  */
 function od_generate_media_query( ?int $minimum_viewport_width, ?int $maximum_viewport_width ): ?string {
 	if ( is_int( $minimum_viewport_width ) && is_int( $maximum_viewport_width ) && $minimum_viewport_width > $maximum_viewport_width ) {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'The minimum width must be greater than the maximum width.', 'optimization-detective' ), 'Optimization Detective n.e.x.t' );
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'The minimum width must be greater than the maximum width.', 'optimization-detective' ), 'Optimization Detective 0.7.0' );
 		return null;
 	}
 	$media_attributes = array();

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.7.0-alpha
+ * Version: 0.7.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -70,7 +70,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.7.0-alpha',
+	'0.7.0',
 	static function ( string $version ): void {
 		if ( defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			return;

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -159,6 +159,16 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.7.0 =
 
+**Enhancements**
+
+* Add group collection helper methods to get the first/last groups. ([1602](https://github.com/WordPress/performance/pull/1602))
+* Introduce OD_Element class. ([1585](https://github.com/WordPress/performance/pull/1585))
+
+**Bug Fixes**
+
+* Fix Optimization Detective compatibility with WooCommerce when Coming Soon page is served. ([1565](https://github.com/WordPress/performance/pull/1565))
+* Fix storage of URL Metric when plain non-pretty permalinks are enabled. ([1574](https://github.com/WordPress/performance/pull/1574))
+
 = 0.6.0 =
 
 **Enhancements**

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   0.6.0
+Stable tag:   0.7.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -156,6 +156,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.7.0 =
 
 = 0.6.0 =
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -1,7 +1,7 @@
 === Optimization Detective ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   0.7.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -33,6 +33,10 @@ When the `WP_DEBUG` constant is enabled, additional logging for Optimization Det
 
 = Hooks =
 
+**Action:** `od_init` (argument: plugin version)
+
+Fires when the Optimization Detective is initializing. This action is useful for loading extension code that depends on Optimization Detective to be running. The version of the plugin is passed as the sole argument so that if the required version is not present, the callback can short circuit.
+
 **Filter:** `od_breakpoint_max_widths` (default: [480, 600, 782])
 
 Filters the breakpoint max widths to group URL metrics for various viewports. Each number represents the maximum width (inclusive) for a given breakpoint. So if there is one number, 480, then this means there will be two viewport groupings, one for 0<=480, and another >480. If instead there were three provided breakpoints (320, 480, 576) then this means there will be four groups:
@@ -161,8 +165,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 **Enhancements**
 
+* Send gathered URL metric data when the page is hidden/unloaded as opposed to once the page has loaded; this enables the ability to track layout shifts and INP scores over the life of the page. ([1373](https://github.com/WordPress/performance/pull/1373))
+* Introduce client-side extensions in the form of script modules which are loaded when the detection logic runs. ([1373](https://github.com/WordPress/performance/pull/1373))
+* Add an `od_init` action for extensions to load their code. ([1373](https://github.com/WordPress/performance/pull/1373))
+* Introduce `OD_Element` class and improve PHP API. ([1585](https://github.com/WordPress/performance/pull/1585))
 * Add group collection helper methods to get the first/last groups. ([1602](https://github.com/WordPress/performance/pull/1602))
-* Introduce OD_Element class. ([1585](https://github.com/WordPress/performance/pull/1585))
 
 **Bug Fixes**
 

--- a/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
+++ b/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
@@ -3,7 +3,7 @@
  * Optimization Detective: OD_URL_Metric_Store_Request_Context class
  *
  * @package optimization-detective
- * @since n.e.x.t
+ * @since 0.7.0
  */
 
 // Exit if accessed directly.
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Context for when a URL metric is successfully stored via the REST API.
  *
- * @since n.e.x.t
+ * @since 0.7.0
  * @access private
  */
 final class OD_URL_Metric_Store_Request_Context {

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -174,7 +174,7 @@ function od_handle_rest_request( WP_REST_Request $request ) {
 	/**
 	 * Fires whenever a URL Metric was successfully stored.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.7.0
 	 *
 	 * @param OD_URL_Metric_Store_Request_Context $context Context about the successful URL Metric collection.
 	 */

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 3.4.1
+ * Version: 3.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.4.1' );
+define( 'PERFLAB_VERSION', '3.5.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -1,7 +1,7 @@
 === Performance Lab ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   3.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.6
-Stable tag:   3.4.1
+Stable tag:   3.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -69,6 +69,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.5.0 =
 
 = 3.4.1 =
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -72,6 +72,12 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.5.0 =
 
+**Enhancements**
+
+* Add Web Worker Offloading to list of Performance features. ([1577](https://github.com/WordPress/performance/pull/1577))
+* Only store info for relevant standalone plugins in the transient cache. ([1573](https://github.com/WordPress/performance/pull/1573))
+* Use a single WordPress.org API request to get information for all plugins. ([1562](https://github.com/WordPress/performance/pull/1562))
+
 = 3.4.1 =
 
 **Bug Fixes**

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -22,6 +22,7 @@ The feature plugins which are currently featured by this plugin are:
 * [Embed Optimizer](https://wordpress.org/plugins/embed-optimizer/) _(experimental)_
 * [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/) _(experimental)_
 * [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/) _(experimental)_
+* [Web Worker Offloading](https://wordpress.org/plugins/web-worker-offloading/) _(experimental)_
 
 These plugins can also be installed separately from installing Performance Lab, but having the Performance Lab plugin also active will ensure you find out about new performance features as they are developed.
 

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -1,7 +1,7 @@
 === Speculative Loading ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   1.3.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -127,7 +127,7 @@ add_filter( 'wp_inline_script_attributes', 'plwwo_filter_inline_script_attribute
  *
  * See {@see 'wp_head'}.
  *
- * @since n.e.x.t
+ * @since 0.1.1
  */
 function plwwo_render_generator_meta_tag(): void {
 	// Use the plugin slug as it is immutable.

--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -5,7 +5,7 @@
  * Description: Offloads select JavaScript execution to a Web Worker to reduce work on the main thread and improve the Interaction to Next Paint (INP) metric.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.1.0
+ * Version: 0.1.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -43,7 +43,7 @@ if (
 	);
 }
 
-define( 'WEB_WORKER_OFFLOADING_VERSION', '0.1.0' );
+define( 'WEB_WORKER_OFFLOADING_VERSION', '0.1.1' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg
 Tested up to:      6.6
-Stable tag:        0.1.0
+Stable tag:        0.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, JavaScript, web worker, partytown, analytics
@@ -93,6 +93,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/web-worker-offloading) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.1.1 =
 
 = 0.1.0 =
 

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -96,6 +96,10 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.1.1 =
 
+**Enhancements**
+
+* Add Web Worker Offloading meta generator. ([1598](https://github.com/WordPress/performance/pull/1598))
+
 = 0.1.0 =
 
 * Initial release.

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -1,11 +1,11 @@
 === Web Worker Offloading ===
 
-Contributors:      wordpressdotorg
-Tested up to:      6.6
-Stable tag:        0.1.1
-License:           GPLv2 or later
-License URI:       https://www.gnu.org/licenses/gpl-2.0.html
-Tags:              performance, JavaScript, web worker, partytown, analytics
+Contributors: wordpressdotorg
+Tested up to: 6.7
+Stable tag:   0.1.1
+License:      GPLv2 or later
+License URI:  https://www.gnu.org/licenses/gpl-2.0.html
+Tags:         performance, JavaScript, web worker, partytown, analytics
 
 Offloads select JavaScript execution to a Web Worker to reduce work on the main thread and improve the Interaction to Next Paint (INP) metric.
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -1,7 +1,7 @@
 === Modern Image Formats ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.6
+Tested up to: 6.7
 Stable tag:   2.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
- **Bump versions**
- **Populate since version tags**
- **Generate changelogs**

The following plugins are slated for release:

1. embed-optimizer v0.3.0
2. image-prioritizer v0.2.0
3. optimization-detective v0.7.0
4. performance-lab v3.5.0
5. web-worker-offloading v0.1.1

Fixes #1608.