### PR TITLE
Doc: Add `Web Worker Offloading` in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,14 @@ The feature plugins which are currently featured by this plugin are:
 
 Plugin                          | Slug                      | Experimental | Links
 --------------------------------|---------------------------|--------------|-------------
-[Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][8],  [Issues][15], [PRs][22]
-[Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][9],  [Issues][16], [PRs][23]
-[Performant Translations][3]    | `performant-translations` | No           | [Source][10], [Issues][17], [PRs][24]
-[Speculative Loading][4]        | `speculation-rules`       | No           | [Source][11], [Issues][18], [PRs][25]
-[Embed Optimizer][5]            | `embed-optimizer`         | Yes          | [Source][12], [Issues][19], [PRs][26]
-[Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][13], [Issues][20], [PRs][27]
-[Image Prioritizer][7]          | `image-prioritizer`       | Yes          | [Source][14], [Issues][21], [PRs][28]
+[Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][9],  [Issues][17], [PRs][25]
+[Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
+[Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
+[Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
+[Embed Optimizer][5]            | `embed-optimizer`         | Yes          | [Source][13], [Issues][21], [PRs][29]
+[Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][14], [Issues][22], [PRs][30]
+[Image Prioritizer][7]          | `image-prioritizer`       | Yes          | [Source][15], [Issues][23], [PRs][31]
+[Web Worker Offloading][8]      | `web-worker-offloading`   | Yes          | [Source][16], [Issues][24], [PRs][32]
 
 [1]: https://wordpress.org/plugins/dominant-color-images/
 [2]: https://wordpress.org/plugins/webp-uploads/
@@ -26,29 +27,33 @@ Plugin                          | Slug                      | Experimental | Lin
 [5]: https://wordpress.org/plugins/embed-optimizer/
 [6]: https://wordpress.org/plugins/auto-sizes/
 [7]: https://wordpress.org/plugins/image-prioritizer/
+[8]: https://wordpress.org/plugins/web-worker-offloading/
 
-[8]: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
-[9]: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
-[10]: https://github.com/swissspidy/performant-translations
-[11]: https://github.com/WordPress/performance/tree/trunk/plugins/speculation-rules
-[12]: https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer
-[13]: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
-[14]: https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer
+[9]: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
+[10]: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
+[11]: https://github.com/swissspidy/performant-translations
+[12]: https://github.com/WordPress/performance/tree/trunk/plugins/speculation-rules
+[13]: https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer
+[14]: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
+[15]: https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer
+[16]: https://github.com/WordPress/performance/tree/trunk/plugins/web-worker-offloading
 
-[15]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
-[16]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
-[17]: https://github.com/swissspidy/performant-translations/issues
-[18]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
-[19]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
-[20]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
-[21]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[17]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
+[18]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
+[19]: https://github.com/swissspidy/performant-translations/issues
+[20]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
+[21]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
+[22]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
+[23]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[24]: https://github.com/WordPress/performance/issues?q=is%3Aopen%20label%3A%22%5BPlugin%5D%20Web%20Worker%20Offloading%22
 
-[22]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
-[23]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
-[24]: https://github.com/swissspidy/performant-translations/pulls
-[25]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
-[26]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
-[27]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
-[28]: https://github.com/WordPress/performance/pulls?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[25]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
+[26]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
+[27]: https://github.com/swissspidy/performant-translations/pulls
+[28]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Speculative+Loading%22
+[29]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Embed+Optimizer%22
+[30]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
+[31]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
+[32]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Web%20Worker%20Offloading%22
 
 Note that the plugin names sometimes diverge from the plugin slugs due to scope changes. For example, a plugin's purpose may change as some of its features are merged into WordPress core.

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -22,6 +22,7 @@ The feature plugins which are currently featured by this plugin are:
 * [Embed Optimizer](https://wordpress.org/plugins/embed-optimizer/) _(experimental)_
 * [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/) _(experimental)_
 * [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/) _(experimental)_
+* [Web Worker Offloading](https://wordpress.org/plugins/web-worker-offloading/) _(experimental)_
 
 These plugins can also be installed separately from installing Performance Lab, but having the Performance Lab plugin also active will ensure you find out about new performance features as they are developed.
 


### PR DESCRIPTION
This PR adds the `Web Worker Offloading` plugin in readme files.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
