### PR TITLE
Fix bug that would prevent uploaded images from being converted to the intended output format when having fallback formats enabled

### DIFF
--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -52,18 +52,27 @@ if ( ! defined( 'ABSPATH' ) ) {
  * } An array with the updated structure for the metadata before is stored in the database.
  */
 function webp_uploads_create_sources_property( array $metadata, int $attachment_id ): array {
-	// This should take place only on the JPEG image.
-	$valid_mime_transforms = webp_uploads_get_upload_image_mime_transforms();
-
-	// Not a supported mime type to create the sources property.
-	$mime_type = get_post_mime_type( $attachment_id );
-	if ( ! is_string( $mime_type ) || ! isset( $valid_mime_transforms[ $mime_type ] ) ) {
-		return $metadata;
-	}
-
 	$file = get_attached_file( $attachment_id, true );
 	// File does not exist.
 	if ( false === $file || ! file_exists( $file ) ) {
+		return $metadata;
+	}
+
+	/*
+	 * We need to get the MIME type ideally from the file, as WordPress Core may have already altered it.
+	 * The post MIME type is typically not updated during that process.
+	 */
+	$filetype = wp_check_filetype( $file );
+	if ( isset( $filetype['type'] ) ) {
+		$mime_type = $filetype['type'];
+	} else {
+		$mime_type = get_post_mime_type( $attachment_id );
+	}
+
+	$valid_mime_transforms = webp_uploads_get_upload_image_mime_transforms();
+
+	// Not a supported mime type to create the sources property.
+	if ( ! is_string( $mime_type ) || ! isset( $valid_mime_transforms[ $mime_type ] ) ) {
 		return $metadata;
 	}
 

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -62,17 +62,16 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 	 * We need to get the MIME type ideally from the file, as WordPress Core may have already altered it.
 	 * The post MIME type is typically not updated during that process.
 	 */
-	$filetype = wp_check_filetype( $file );
-	if ( isset( $filetype['type'] ) ) {
-		$mime_type = $filetype['type'];
-	} else {
-		$mime_type = get_post_mime_type( $attachment_id );
+	$filetype  = wp_check_filetype( $file );
+	$mime_type = $filetype['type'] ?? get_post_mime_type( $attachment_id );
+	if ( ! is_string( $mime_type ) ) {
+		return $metadata;
 	}
 
 	$valid_mime_transforms = webp_uploads_get_upload_image_mime_transforms();
 
 	// Not a supported mime type to create the sources property.
-	if ( ! is_string( $mime_type ) || ! isset( $valid_mime_transforms[ $mime_type ] ) ) {
+	if ( ! isset( $valid_mime_transforms[ $mime_type ] ) ) {
 		return $metadata;
 	}
 

--- a/plugins/webp-uploads/tests/test-image-edit.php
+++ b/plugins/webp-uploads/tests/test-image-edit.php
@@ -77,7 +77,6 @@ class Test_WebP_Uploads_Image_Edit extends TestCase {
 
 		wp_restore_image( $attachment_id );
 
-		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 
 		$metadata               = wp_get_attachment_metadata( $attachment_id );

--- a/plugins/webp-uploads/tests/test-image-edit.php
+++ b/plugins/webp-uploads/tests/test-image-edit.php
@@ -77,6 +77,7 @@ class Test_WebP_Uploads_Image_Edit extends TestCase {
 
 		wp_restore_image( $attachment_id );
 
+		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 
 		$metadata               = wp_get_attachment_metadata( $attachment_id );

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -117,42 +117,6 @@ class Test_WebP_Uploads_Load extends TestCase {
 	}
 
 	/**
-	 * Create JPEG and output type for JPEG images, if opted in.
-	 *
-	 * @dataProvider data_provider_supported_image_types
-	 */
-	public function test_it_should_create_jpeg_and_webp_for_jpeg_images_if_opted_in( string $image_type ): void {
-		$mime_type = 'image/' . $image_type;
-		if ( ! webp_uploads_mime_type_supported( $mime_type ) ) {
-			$this->markTestSkipped( "Mime type $mime_type is not supported." );
-		}
-		$this->set_image_output_type( $image_type );
-
-		update_option( 'perflab_generate_webp_and_jpeg', true );
-		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
-
-		// There should be JPEG and mime_type sources for the full image.
-		$this->assertImageHasSource( $attachment_id, 'image/jpeg' );
-		$this->assertImageHasSource( $attachment_id, $mime_type );
-
-		$metadata = wp_get_attachment_metadata( $attachment_id );
-
-		// The full image should be a JPEG.
-		$this->assertArrayHasKey( 'file', $metadata );
-		$this->assertStringEndsWith( $metadata['sources']['image/jpeg']['file'], $metadata['file'] );
-		$this->assertStringEndsWith( $metadata['sources']['image/jpeg']['file'], get_attached_file( $attachment_id ) );
-
-		// The post MIME type should be JPEG.
-		$this->assertSame( 'image/jpeg', get_post_mime_type( $attachment_id ) );
-
-		// There should be JPEG and WebP sources for all sizes.
-		foreach ( array_keys( $metadata['sizes'] ) as $size_name ) {
-			$this->assertImageHasSizeSource( $attachment_id, $size_name, 'image/jpeg' );
-			$this->assertImageHasSizeSource( $attachment_id, $size_name, $mime_type );
-		}
-	}
-
-	/**
 	 * Create JPEG and output format for JPEG images, if perflab_generate_webp_and_jpeg option set.
 	 *
 	 * @dataProvider data_provider_supported_image_types

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -45,7 +45,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 	 *
 	 * @dataProvider data_provider_supported_image_types_with_threshold
 	 */
-	public function test_it_should_not_create_the_original_mime_type_for_jpeg_images( string $image_type, bool $apply_threshold = false ): void {
+	public function test_it_should_not_create_the_original_mime_type_for_jpeg_images( string $image_type, bool $above_big_image_size = false ): void {
 		$mime_type = 'image/' . $image_type;
 		$this->set_image_output_type( $image_type );
 		if ( ! webp_uploads_mime_type_supported( $mime_type ) ) {
@@ -53,7 +53,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 		}
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
 
-		if ( $apply_threshold ) {
+		if ( $above_big_image_size ) {
 			// Add threshold to create a `-scaled` output image for testing.
 			add_filter(
 				'big_image_size_threshold',

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -55,6 +55,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 
 		// There should be an image_type source, but no JPEG source for the full image.
 		$this->assertImageHasSource( $attachment_id, $mime_type );
+		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
@@ -262,6 +263,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$file    = get_attached_file( $attachment_id, true );
 		$dirname = pathinfo( $file, PATHINFO_DIRNAME );
 
+		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
+
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 		$this->assertFileExists( path_join( $dirname, $metadata['sources']['image/webp']['file'] ) );
 		$this->assertSame( $metadata['sources']['image/webp']['filesize'], wp_filesize( path_join( $dirname, $metadata['sources']['image/webp']['file'] ) ) );
@@ -282,6 +285,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertEmpty( $metadata['sizes'] );
 
+		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 	}
 
@@ -702,6 +706,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$this->assertArrayHasKey( 'sources', $metadata );
 		$this->assertIsArray( $metadata['sources'] );
 
+		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 		$this->assertImageHasSource( $attachment_id, 'image/' . $image_type );
 
 		$this->assertImageNotHasSizeSource( $attachment_id, 'thumbnail', 'image/jpeg' );

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -55,7 +55,6 @@ class Test_WebP_Uploads_Load extends TestCase {
 
 		// There should be an image_type source, but no JPEG source for the full image.
 		$this->assertImageHasSource( $attachment_id, $mime_type );
-		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 
@@ -263,8 +262,6 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$file    = get_attached_file( $attachment_id, true );
 		$dirname = pathinfo( $file, PATHINFO_DIRNAME );
 
-		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
-
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 		$this->assertFileExists( path_join( $dirname, $metadata['sources']['image/webp']['file'] ) );
 		$this->assertSame( $metadata['sources']['image/webp']['filesize'], wp_filesize( path_join( $dirname, $metadata['sources']['image/webp']['file'] ) ) );
@@ -285,7 +282,6 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		$this->assertEmpty( $metadata['sizes'] );
 
-		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 		$this->assertImageHasSource( $attachment_id, 'image/webp' );
 	}
 
@@ -706,7 +702,6 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$this->assertArrayHasKey( 'sources', $metadata );
 		$this->assertIsArray( $metadata['sources'] );
 
-		$this->assertImageNotHasSource( $attachment_id, 'image/jpeg' );
 		$this->assertImageHasSource( $attachment_id, 'image/' . $image_type );
 
 		$this->assertImageNotHasSizeSource( $attachment_id, 'thumbnail', 'image/jpeg' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1634


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
