### PR TITLE
Revise the use of nonces in requests to store a URL Metric and block cross-origin requests

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -239,7 +239,6 @@ function extendElementData( xpath, properties ) {
  * @param {number}                 args.maxViewportAspectRatio     Maximum aspect ratio allowed for the viewport.
  * @param {boolean}                args.isDebug                    Whether to show debug messages.
  * @param {string}                 args.restApiEndpoint            URL for where to send the detection data.
- * @param {string}                 args.restApiNonce               Nonce for writing to the REST API.
  * @param {string}                 args.currentUrl                 Current URL.
  * @param {string}                 args.urlMetricSlug              Slug for URL Metric.
  * @param {string}                 args.urlMetricNonce             Nonce for URL Metric storage.
@@ -256,7 +255,6 @@ export default async function detect( {
 	isDebug,
 	extensionModuleUrls,
 	restApiEndpoint,
-	restApiNonce,
 	currentUrl,
 	urlMetricSlug,
 	urlMetricNonce,
@@ -549,7 +547,6 @@ export default async function detect( {
 	}
 
 	const url = new URL( restApiEndpoint );
-	url.searchParams.set( '_wpnonce', restApiNonce );
 	url.searchParams.set( 'slug', urlMetricSlug );
 	url.searchParams.set( 'nonce', urlMetricNonce );
 	navigator.sendBeacon(

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -241,7 +241,7 @@ function extendElementData( xpath, properties ) {
  * @param {string}                 args.restApiEndpoint            URL for where to send the detection data.
  * @param {string}                 args.currentUrl                 Current URL.
  * @param {string}                 args.urlMetricSlug              Slug for URL Metric.
- * @param {string}                 args.urlMetricNonce             Nonce for URL Metric storage.
+ * @param {string}                 args.urlMetricHMAC              HMAC for URL Metric storage.
  * @param {URLMetricGroupStatus[]} args.urlMetricGroupStatuses     URL Metric group statuses.
  * @param {number}                 args.storageLockTTL             The TTL (in seconds) for the URL Metric storage lock.
  * @param {string}                 args.webVitalsLibrarySrc        The URL for the web-vitals library.
@@ -257,7 +257,7 @@ export default async function detect( {
 	restApiEndpoint,
 	currentUrl,
 	urlMetricSlug,
-	urlMetricNonce,
+	urlMetricHMAC,
 	urlMetricGroupStatuses,
 	storageLockTTL,
 	webVitalsLibrarySrc,
@@ -548,7 +548,7 @@ export default async function detect( {
 
 	const url = new URL( restApiEndpoint );
 	url.searchParams.set( 'slug', urlMetricSlug );
-	url.searchParams.set( 'nonce', urlMetricNonce );
+	url.searchParams.set( 'hmac', urlMetricHMAC );
 	navigator.sendBeacon(
 		url,
 		new Blob( [ JSON.stringify( urlMetric ) ], {

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -58,7 +58,7 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		'restApiEndpoint'        => rest_url( OD_REST_API_NAMESPACE . OD_URL_METRICS_ROUTE ),
 		'currentUrl'             => $current_url,
 		'urlMetricSlug'          => $slug,
-		'urlMetricNonce'         => od_get_url_metrics_storage_nonce( $slug, $current_url ),
+		'urlMetricHMAC'          => od_get_url_metrics_storage_hmac( $slug, $current_url ),
 		'urlMetricGroupStatuses' => array_map(
 			static function ( OD_URL_Metric_Group $group ): array {
 				return array(

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -56,7 +56,6 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		'isDebug'                => WP_DEBUG,
 		'extensionModuleUrls'    => $extension_module_urls,
 		'restApiEndpoint'        => rest_url( OD_REST_API_NAMESPACE . OD_URL_METRICS_ROUTE ),
-		'restApiNonce'           => wp_create_nonce( 'wp_rest' ),
 		'currentUrl'             => $current_url,
 		'urlMetricSlug'          => $slug,
 		'urlMetricNonce'         => od_get_url_metrics_storage_nonce( $slug, $current_url ),

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -141,42 +141,45 @@ function od_get_url_metrics_slug( array $query_vars ): string {
 }
 
 /**
- * Computes nonce for storing URL Metrics for a specific slug.
+ * Computes HMAC for storing URL Metrics for a specific slug.
  *
  * This is used in the REST API to authenticate the storage of new URL metrics from a given URL.
  *
  * @since 0.1.0
+ * @since n.e.x.t Renamed from od_get_url_metrics_storage_nonce().
  * @access private
  *
- * @see wp_create_nonce()
- * @see od_verify_url_metrics_storage_nonce()
+ * @see od_verify_url_metrics_storage_hmac()
  * @see od_get_url_metrics_slug()
  *
  * @param string $slug Slug (hash of normalized query vars).
  * @param string $url  URL.
- * @return string Nonce.
+ *
+ * @return string HMAC.
  */
-function od_get_url_metrics_storage_nonce( string $slug, string $url ): string {
-	return wp_create_nonce( "store_url_metrics:$slug:$url" );
+function od_get_url_metrics_storage_hmac( string $slug, string $url ): string {
+	$action = "store_url_metric:$slug:$url";
+	return wp_hash( $action, 'nonce' );
 }
 
 /**
- * Verifies nonce for storing URL metrics for a specific slug.
+ * Verifies HMAC for storing URL metrics for a specific slug.
  *
  * @since 0.1.0
+ * @since n.e.x.t Renamed from od_verify_url_metrics_storage_nonce().
  * @access private
  *
- * @see wp_verify_nonce()
- * @see od_get_url_metrics_storage_nonce()
+ * @see od_get_url_metrics_storage_hmac()
  * @see od_get_url_metrics_slug()
  *
- * @param string $nonce Nonce.
- * @param string $slug  Slug (hash of normalized query vars).
- * @param String $url   URL.
- * @return bool Whether the nonce is valid.
+ * @param string $hmac HMAC.
+ * @param string $slug Slug (hash of normalized query vars).
+ * @param String $url  URL.
+ *
+ * @return bool Whether the HMAC is valid.
  */
-function od_verify_url_metrics_storage_nonce( string $nonce, string $slug, string $url ): bool {
-	return (bool) wp_verify_nonce( $nonce, "store_url_metrics:$slug:$url" );
+function od_verify_url_metrics_storage_hmac( string $hmac, string $slug, string $url ): bool {
+	return hash_equals( od_get_url_metrics_storage_hmac( $slug, $url ), $hmac );
 }
 
 /**

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -145,8 +145,7 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  *
  * This is used in the REST API to authenticate the storage of new URL Metrics from a given URL.
  *
- * @since 0.1.0
- * @since n.e.x.t Renamed from od_get_url_metrics_storage_nonce().
+ * @since n.e.x.t
  * @access private
  *
  * @see od_verify_url_metrics_storage_hmac()
@@ -165,8 +164,7 @@ function od_get_url_metrics_storage_hmac( string $slug, string $url ): string {
 /**
  * Verifies HMAC for storing URL Metrics for a specific slug.
  *
- * @since 0.1.0
- * @since n.e.x.t Renamed from od_verify_url_metrics_storage_nonce().
+ * @since n.e.x.t
  * @access private
  *
  * @see od_get_url_metrics_storage_hmac()

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -107,14 +107,20 @@ add_action( 'rest_api_init', 'od_register_endpoint' );
 function od_is_allowed_http_origin( string $origin ): bool {
 	$allowed_origins = get_allowed_http_origins();
 	$home_url_port   = wp_parse_url( home_url(), PHP_URL_PORT );
+
+	// Append the home URL's port to the allowed origins if they lack a port number.
 	if ( is_int( $home_url_port ) ) {
 		$allowed_origins = array_map(
 			static function ( string $allowed_origin ) use ( $home_url_port ): string {
-				return $allowed_origin . ':' . (string) $home_url_port;
+				if ( null === wp_parse_url( $allowed_origin, PHP_URL_PORT ) ) {
+					$allowed_origin .= ':' . (string) $home_url_port;
+				}
+				return $allowed_origin;
 			},
 			$allowed_origins
 		);
 	}
+
 	return in_array( $origin, $allowed_origins, true );
 }
 

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -38,22 +38,22 @@ const OD_URL_METRICS_ROUTE = '/url-metrics:store';
 function od_register_endpoint(): void {
 
 	$args = array(
-		'slug'  => array(
+		'slug' => array(
 			'type'        => 'string',
 			'description' => __( 'An MD5 hash of the query args.', 'optimization-detective' ),
 			'required'    => true,
 			'pattern'     => '^[0-9a-f]{32}$',
-			// This is further validated via the validate_callback for the nonce argument, as it is provided as input
-			// with the 'url' argument to create the nonce by the server. which then is verified to match in the REST API request.
+			// This is further validated via the validate_callback for the 'hmac' parameter, as it is provided as input
+			// with the 'url' argument to create the HMAC by the server. which then is verified to match in the REST API request.
 		),
-		'nonce' => array(
+		'hmac' => array(
 			'type'              => 'string',
-			'description'       => __( 'Nonce originally computed by server required to authorize the request.', 'optimization-detective' ),
+			'description'       => __( 'HMAC originally computed by server required to authorize the request.', 'optimization-detective' ),
 			'required'          => true,
 			'pattern'           => '^[0-9a-f]+$',
-			'validate_callback' => static function ( string $nonce, WP_REST_Request $request ) {
-				if ( ! od_verify_url_metrics_storage_nonce( $nonce, $request->get_param( 'slug' ), $request->get_param( 'url' ) ) ) {
-					return new WP_Error( 'invalid_nonce', __( 'URL Metrics nonce verification failure.', 'optimization-detective' ) );
+			'validate_callback' => static function ( string $hmac, WP_REST_Request $request ) {
+				if ( ! od_verify_url_metrics_storage_hmac( $hmac, $request->get_param( 'slug' ), $request->get_param( 'url' ) ) ) {
+					return new WP_Error( 'invalid_hmac', __( 'URL Metrics HMAC verification failure.', 'optimization-detective' ) );
 				}
 				return true;
 			},

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -98,30 +98,15 @@ add_action( 'rest_api_init', 'od_register_endpoint' );
  * @since n.e.x.t
  * @access private
  *
- * @see get_allowed_http_origins()
  * @see is_allowed_http_origin()
  *
  * @param string $origin Origin to check.
  * @return bool Whether the origin is allowed.
  */
 function od_is_allowed_http_origin( string $origin ): bool {
-	$allowed_origins = get_allowed_http_origins();
-	$home_url_port   = wp_parse_url( home_url(), PHP_URL_PORT );
-
-	// Append the home URL's port to the allowed origins if they lack a port number.
-	if ( is_int( $home_url_port ) ) {
-		$allowed_origins = array_map(
-			static function ( string $allowed_origin ) use ( $home_url_port ): string {
-				if ( null === wp_parse_url( $allowed_origin, PHP_URL_PORT ) ) {
-					$allowed_origin .= ':' . (string) $home_url_port;
-				}
-				return $allowed_origin;
-			},
-			$allowed_origins
-		);
-	}
-
-	return in_array( $origin, $allowed_origins, true );
+	// Strip out the port number since core does not account for it yet as noted in get_allowed_http_origins().
+	$origin = preg_replace( '/:\d+$/', '', $origin );
+	return '' !== is_allowed_http_origin( $origin );
 }
 
 /**

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -100,6 +100,16 @@ add_action( 'rest_api_init', 'od_register_endpoint' );
  * @return WP_REST_Response|WP_Error Response.
  */
 function od_handle_rest_request( WP_REST_Request $request ) {
+	// Block cross-origin storage requests since by definition URL Metrics data can only be sourced from the frontend of the site.
+	$origin = $request->get_header( 'origin' );
+	if ( null === $origin || home_url() !== $origin ) {
+		return new WP_Error(
+			'rest_cross_origin_forbidden',
+			__( 'Cross-origin requests are not allowed for this endpoint.', 'optimization-detective' ),
+			array( 'status' => 403 )
+		);
+	}
+
 	$post = OD_URL_Metrics_Post_Type::get_post( $request->get_param( 'slug' ) );
 
 	$url_metric_group_collection = new OD_URL_Metric_Group_Collection(

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -287,49 +287,17 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test od_get_url_metrics_storage_nonce().
+	 * Test od_get_url_metrics_storage_hmac() and od_verify_url_metrics_storage_hmac().
 	 *
-	 * @covers ::od_get_url_metrics_storage_nonce
-	 * @covers ::od_verify_url_metrics_storage_nonce
+	 * @covers ::od_get_url_metrics_storage_hmac
+	 * @covers ::od_verify_url_metrics_storage_hmac
 	 */
-	public function test_od_get_url_metrics_storage_nonce_and_od_verify_url_metrics_storage_nonce(): void {
-		$user_id = self::factory()->user->create();
-
-		$nonce_life_actions = array();
-		add_filter(
-			'nonce_life',
-			static function ( int $life, string $action ) use ( &$nonce_life_actions ): int {
-				$nonce_life_actions[] = $action;
-				return $life;
-			},
-			10,
-			2
-		);
-
-		// Create first nonce for unauthenticated user.
-		$url    = home_url( '/' );
-		$slug   = od_get_url_metrics_slug( array() );
-		$nonce1 = od_get_url_metrics_storage_nonce( $slug, $url );
-		$this->assertMatchesRegularExpression( '/^[0-9a-f]{10}$/', $nonce1 );
-		$this->assertTrue( od_verify_url_metrics_storage_nonce( $nonce1, $slug, $url ) );
-		$this->assertCount( 2, $nonce_life_actions );
-
-		// Create second nonce for unauthenticated user.
-		$nonce2 = od_get_url_metrics_storage_nonce( $slug, $url );
-		$this->assertSame( $nonce1, $nonce2 );
-		$this->assertCount( 3, $nonce_life_actions );
-
-		// Create third nonce, this time for authenticated user.
-		wp_set_current_user( $user_id );
-		$nonce3 = od_get_url_metrics_storage_nonce( $slug, $url );
-		$this->assertNotEquals( $nonce3, $nonce2 );
-		$this->assertFalse( od_verify_url_metrics_storage_nonce( $nonce1, $slug, $url ) );
-		$this->assertTrue( od_verify_url_metrics_storage_nonce( $nonce3, $slug, $url ) );
-		$this->assertCount( 6, $nonce_life_actions );
-
-		foreach ( $nonce_life_actions as $nonce_life_action ) {
-			$this->assertSame( "store_url_metrics:{$slug}:{$url}", $nonce_life_action );
-		}
+	public function test_od_get_url_metrics_storage_hmac_and_od_verify_url_metrics_storage_hmac(): void {
+		$url  = home_url( '/' );
+		$slug = od_get_url_metrics_slug( array() );
+		$hmac = od_get_url_metrics_storage_hmac( $slug, $url );
+		$this->assertMatchesRegularExpression( '/^[0-9a-f]+$/', $hmac );
+		$this->assertTrue( od_verify_url_metrics_storage_hmac( $hmac, $slug, $url ) );
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -93,7 +93,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		$this->assertSame( $valid_params['viewport']['width'], $url_metrics[0]->get_viewport_width() );
 
 		$expected_data = $valid_params;
-		unset( $expected_data['nonce'], $expected_data['slug'] );
+		unset( $expected_data['hmac'], $expected_data['slug'] );
 		$this->assertSame(
 			$expected_data,
 			wp_array_slice_assoc( $url_metrics[0]->jsonSerialize(), array_keys( $expected_data ) )
@@ -122,11 +122,11 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 				'bad_slug'                                 => array(
 					'slug' => '<script>document.write("evil")</script>',
 				),
-				'bad_nonce'                                => array(
-					'nonce' => 'not even a hash',
+				'bad_hmac'                                 => array(
+					'hmac' => 'not even a hash',
 				),
-				'invalid_nonce'                            => array(
-					'nonce' => od_get_url_metrics_storage_nonce( od_get_url_metrics_slug( array( 'different' => 'query vars' ) ), home_url( '/' ) ),
+				'invalid_hmac'                             => array(
+					'hmac' => od_get_url_metrics_storage_hmac( od_get_url_metrics_slug( array( 'different' => 'query vars' ) ), home_url( '/' ) ),
 				),
 				'invalid_viewport_type'                    => array(
 					'viewport' => '640x480',
@@ -562,8 +562,8 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		unset( $data['timestamp'], $data['uuid'] ); // Since these are readonly.
 		$data = array_merge(
 			array(
-				'slug'  => $slug,
-				'nonce' => od_get_url_metrics_storage_nonce( $slug, $data['url'] ),
+				'slug' => $slug,
+				'hmac' => od_get_url_metrics_storage_hmac( $slug, $data['url'] ),
 			),
 			$data
 		);
@@ -611,9 +611,9 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		 */
 		$request = new WP_REST_Request( 'POST', self::ROUTE );
 		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_query_params( wp_array_slice_assoc( $params, array( 'nonce', 'slug' ) ) );
+		$request->set_query_params( wp_array_slice_assoc( $params, array( 'hmac', 'slug' ) ) );
 		$request->set_header( 'Origin', home_url() );
-		unset( $params['nonce'], $params['slug'] );
+		unset( $params['hmac'], $params['slug'] );
 		$request->set_body( wp_json_encode( $params ) );
 		return $request;
 	}


### PR DESCRIPTION
This is the first PR to address #1496.

1. Eliminate the use of the `wp_rest` nonce when making POST requests to store a URL Metric. Since the endpoint does not require authentication, the nonce adds no value.
2. Add enforcement of the `Origin` request header so that it must match `home_url()` in order for the URL Metric storage POST request to be accepted. The WordPress REST API by default allows for cross-origin requests, but this makes no sense specifically for storing a URL Metric since the client must by definition be on the frontend of the site.
3. Eliminate the use of `wp_create_nonce()` to compute the HMAC to validate that the provided query-vars `slug` actually corresponds to the provided `url` in the request (that is, the URL of the current page). There is no need to use `wp_create_nonce()` here, since there does not need to be an expiration and it does not need to be tied to the current logged-in user.

By eliminating the use of nonces, clients will not have issues when submitting a URL Metric for storage when a page cache is holding onto the rendered page for longer than a day.