### PR TITLE
Replace remaining instances of "URL metric" with "URL Metric"

### DIFF
--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -67,7 +67,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	}
 
 	/**
-	 * Gets the group that this element's URL metric is a part of (which may not be any).
+	 * Gets the group that this element's URL Metric is a part of (which may not be any).
 	 *
 	 * @since 0.7.0
 	 *

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -26,9 +26,9 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *
 	 * The number of groups corresponds to one greater than the number of
 	 * breakpoints. This is because breakpoints are the dividing line between
-	 * the groups of URL metrics with specific viewport widths. This extends
+	 * the groups of URL Metrics with specific viewport widths. This extends
 	 * even to when there are zero breakpoints: there will still be one group
-	 * in this case, in which every single URL metric is added.
+	 * in this case, in which every single URL Metric is added.
 	 *
 	 * @var OD_URL_Metric_Group[]
 	 * @phpstan-var non-empty-array<OD_URL_Metric_Group>
@@ -54,7 +54,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	private $breakpoints;
 
 	/**
-	 * Sample size for URL metrics for a given breakpoint.
+	 * Sample size for URL Metrics for a given breakpoint.
 	 *
 	 * @var int
 	 * @phpstan-var positive-int
@@ -62,9 +62,9 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	private $sample_size;
 
 	/**
-	 * Freshness age (TTL) for a given URL metric.
+	 * Freshness age (TTL) for a given URL Metric.
 	 *
-	 * A freshness age of zero means a URL metric will always be considered stale.
+	 * A freshness age of zero means a URL Metric will always be considered stale.
 	 *
 	 * @var int
 	 * @phpstan-var 0|positive-int
@@ -93,10 +93,10 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *
 	 * @throws InvalidArgumentException When an invalid argument is supplied.
 	 *
-	 * @param OD_URL_Metric[] $url_metrics   URL metrics.
+	 * @param OD_URL_Metric[] $url_metrics   URL Metrics.
 	 * @param int[]           $breakpoints   Breakpoints in max widths.
 	 * @param int             $sample_size   Sample size for the maximum number of viewports in a group between breakpoints.
-	 * @param int             $freshness_ttl Freshness age (TTL) for a given URL metric.
+	 * @param int             $freshness_ttl Freshness age (TTL) for a given URL Metric.
 	 */
 	public function __construct( array $url_metrics, array $breakpoints, int $sample_size, int $freshness_ttl ) {
 		// Set breakpoints.
@@ -153,7 +153,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 		}
 		$this->freshness_ttl = $freshness_ttl;
 
-		// Create groups and the URL metrics to them.
+		// Create groups and the URL Metrics to them.
 		$this->groups = $this->create_groups();
 		foreach ( $url_metrics as $url_metric ) {
 			$this->add_url_metric( $url_metric );
@@ -220,14 +220,14 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Adds a new URL metric to a group.
+	 * Adds a new URL Metric to a group.
 	 *
-	 * Once a group reaches the sample size, the oldest URL metric is pushed out.
+	 * Once a group reaches the sample size, the oldest URL Metric is pushed out.
 	 *
 	 * @since 0.1.0
-	 * @throws InvalidArgumentException If there is no group available to add a URL metric to.
+	 * @throws InvalidArgumentException If there is no group available to add a URL Metric to.
 	 *
-	 * @param OD_URL_Metric $new_url_metric New URL metric.
+	 * @param OD_URL_Metric $new_url_metric New URL Metric.
 	 */
 	public function add_url_metric( OD_URL_Metric $new_url_metric ): void {
 		foreach ( $this->groups as $group ) {
@@ -237,7 +237,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 			}
 		}
 		throw new InvalidArgumentException(
-			esc_html__( 'No group available to add URL metric to.', 'optimization-detective' )
+			esc_html__( 'No group available to add URL Metric to.', 'optimization-detective' )
 		);
 	}
 
@@ -248,7 +248,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * @throws InvalidArgumentException When there is no group for the provided viewport width. This would only happen if a negative width is provided.
 	 *
 	 * @param int $viewport_width Viewport width.
-	 * @return OD_URL_Metric_Group URL metric group for the viewport width.
+	 * @return OD_URL_Metric_Group URL Metric group for the viewport width.
 	 */
 	public function get_group_for_viewport_width( int $viewport_width ): OD_URL_Metric_Group {
 		if ( array_key_exists( __FUNCTION__, $this->result_cache ) && array_key_exists( $viewport_width, $this->result_cache[ __FUNCTION__ ] ) ) {
@@ -265,7 +265,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 				esc_html(
 					sprintf(
 						/* translators: %d is viewport width */
-						__( 'No URL metric group found for viewport width: %d', 'optimization-detective' ),
+						__( 'No URL Metric group found for viewport width: %d', 'optimization-detective' ),
 						$viewport_width
 					)
 				)
@@ -277,11 +277,11 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Checks whether any group is populated with at least one URL metric.
+	 * Checks whether any group is populated with at least one URL Metric.
 	 *
 	 * @since 0.5.0
 	 *
-	 * @return bool Whether at least one group has some URL metrics.
+	 * @return bool Whether at least one group has some URL Metrics.
 	 */
 	public function is_any_group_populated(): bool {
 		if ( array_key_exists( __FUNCTION__, $this->result_cache ) ) {
@@ -302,17 +302,17 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Checks whether every group is populated with at least one URL metric each.
+	 * Checks whether every group is populated with at least one URL Metric each.
 	 *
 	 * They aren't necessarily filled to the sample size, however.
-	 * The URL metrics may also be stale (non-fresh). This method
+	 * The URL Metrics may also be stale (non-fresh). This method
 	 * should be contrasted with the `is_every_group_complete()`
 	 * method below.
 	 *
 	 * @since 0.1.0
 	 * @see OD_URL_Metric_Group_Collection::is_every_group_complete()
 	 *
-	 * @return bool Whether all groups have some URL metrics.
+	 * @return bool Whether all groups have some URL Metrics.
 	 */
 	public function is_every_group_populated(): bool {
 		if ( array_key_exists( __FUNCTION__, $this->result_cache ) ) {
@@ -442,10 +442,10 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Gets all elements from all URL metrics from all groups keyed by the elements' XPaths.
+	 * Gets all elements from all URL Metrics from all groups keyed by the elements' XPaths.
 	 *
 	 * This is an O(n^3) function so its results must be cached. This being said, the number of groups should be 4 (one
-	 * more than the default number of breakpoints) and the number of URL metrics for each group should be 3
+	 * more than the default number of breakpoints) and the number of URL Metrics for each group should be 3
 	 * (the default sample size). Therefore, given the number (n) of visited elements on the page this will only
 	 * end up running n*4*3 times.
 	 *
@@ -475,7 +475,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Gets the max intersection ratios of all elements across all groups and their captured URL metrics.
+	 * Gets the max intersection ratios of all elements across all groups and their captured URL Metrics.
 	 *
 	 * @since 0.3.0
 	 *
@@ -506,7 +506,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * Gets all elements' status for whether they are positioned in any initial viewport.
 	 *
 	 * An element is positioned in the initial viewport if its `boundingClientRect.top` is less than the
-	 * `viewport.height` for any of its recorded URL metrics. Note that even though the element may be positioned in the
+	 * `viewport.height` for any of its recorded URL Metrics. Note that even though the element may be positioned in the
 	 * initial viewport, it may not actually be visible. It could be occluded as a latter slide in a carousel in which
 	 * case it will have intersectionRatio of 0. Or the element may not be visible due to it or an ancestor having the
 	 * `visibility:hidden` style, such as in the case of a dropdown navigation menu. When, for example, an IMG element
@@ -542,7 +542,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Gets the max intersection ratio of an element across all groups and their captured URL metrics.
+	 * Gets the max intersection ratio of an element across all groups and their captured URL Metrics.
 	 *
 	 * @since 0.3.0
 	 *
@@ -566,11 +566,11 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Gets URL metrics from all groups flattened into one list.
+	 * Gets URL Metrics from all groups flattened into one list.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return OD_URL_Metric[] All URL metrics.
+	 * @return OD_URL_Metric[] All URL Metrics.
 	 */
 	public function get_flattened_url_metrics(): array {
 		// The duplication of iterator_to_array is not a mistake. This collection is an
@@ -585,7 +585,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Returns an iterator for the groups of URL metrics.
+	 * Returns an iterator for the groups of URL Metrics.
 	 *
 	 * @since 0.1.0
 	 *
@@ -596,7 +596,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	}
 
 	/**
-	 * Counts the URL metric groups in the collection.
+	 * Counts the URL Metric groups in the collection.
 	 *
 	 * @since 0.1.0
 	 *

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSerializable {
 
 	/**
-	 * URL metrics.
+	 * URL Metrics.
 	 *
 	 * @var OD_URL_Metric[]
 	 */
@@ -45,7 +45,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	private $maximum_viewport_width;
 
 	/**
-	 * Sample size for URL metrics for a given breakpoint.
+	 * Sample size for URL Metrics for a given breakpoint.
 	 *
 	 * @var int
 	 * @phpstan-var positive-int
@@ -53,7 +53,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	private $sample_size;
 
 	/**
-	 * Freshness age (TTL) for a given URL metric.
+	 * Freshness age (TTL) for a given URL Metric.
 	 *
 	 * @var int
 	 * @phpstan-var 0|positive-int
@@ -82,11 +82,11 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 *
 	 * @throws InvalidArgumentException If arguments are invalid.
 	 *
-	 * @param OD_URL_Metric[]                     $url_metrics            URL metrics to add to the group.
+	 * @param OD_URL_Metric[]                     $url_metrics            URL Metrics to add to the group.
 	 * @param int                                 $minimum_viewport_width Minimum possible viewport width for the group. Must be zero or greater.
 	 * @param int                                 $maximum_viewport_width Maximum possible viewport width for the group. Must be greater than zero and the minimum viewport width.
 	 * @param int                                 $sample_size            Sample size for the maximum number of viewports in a group between breakpoints.
-	 * @param int                                 $freshness_ttl          Freshness age (TTL) for a given URL metric.
+	 * @param int                                 $freshness_ttl          Freshness age (TTL) for a given URL Metric.
 	 * @param OD_URL_Metric_Group_Collection|null $collection             Collection that this instance belongs to. Optional.
 	 */
 	public function __construct( array $url_metrics, int $minimum_viewport_width, int $maximum_viewport_width, int $sample_size, int $freshness_ttl, ?OD_URL_Metric_Group_Collection $collection = null ) {
@@ -175,16 +175,16 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	}
 
 	/**
-	 * Adds a URL metric to the group.
+	 * Adds a URL Metric to the group.
 	 *
-	 * @throws InvalidArgumentException If the viewport width of the URL metric is not within the min/max bounds of the group.
+	 * @throws InvalidArgumentException If the viewport width of the URL Metric is not within the min/max bounds of the group.
 	 *
-	 * @param OD_URL_Metric $url_metric URL metric.
+	 * @param OD_URL_Metric $url_metric URL Metric.
 	 */
 	public function add_url_metric( OD_URL_Metric $url_metric ): void {
 		if ( ! $this->is_viewport_width_in_range( $url_metric->get_viewport_width() ) ) {
 			throw new InvalidArgumentException(
-				esc_html__( 'URL metric is not in the viewport range for group.', 'optimization-detective' )
+				esc_html__( 'URL Metric is not in the viewport range for group.', 'optimization-detective' )
 			);
 		}
 
@@ -196,10 +196,10 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 		$url_metric->set_group( $this );
 		$this->url_metrics[] = $url_metric;
 
-		// If we have too many URL metrics now, remove the oldest ones up to the sample size.
+		// If we have too many URL Metrics now, remove the oldest ones up to the sample size.
 		if ( count( $this->url_metrics ) > $this->sample_size ) {
 
-			// Sort URL metrics in descending order by timestamp.
+			// Sort URL Metrics in descending order by timestamp.
 			usort(
 				$this->url_metrics,
 				static function ( OD_URL_Metric $a, OD_URL_Metric $b ): int {
@@ -207,16 +207,16 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 				}
 			);
 
-			// Only keep the sample size of the newest URL metrics.
+			// Only keep the sample size of the newest URL Metrics.
 			$this->url_metrics = array_slice( $this->url_metrics, 0, $this->sample_size );
 		}
 	}
 
 	/**
-	 * Determines whether the URL metric group is complete.
+	 * Determines whether the URL Metric group is complete.
 	 *
-	 * A group is complete if it has the full sample size of URL metrics
-	 * and all of these URL metrics are fresh.
+	 * A group is complete if it has the full sample size of URL Metrics
+	 * and all of these URL Metrics are fresh.
 	 *
 	 * @return bool Whether complete.
 	 */
@@ -246,7 +246,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	/**
 	 * Gets the LCP element in the viewport group.
 	 *
-	 * @return OD_Element|null LCP element data or null if not available, either because there are no URL metrics or
+	 * @return OD_Element|null LCP element data or null if not available, either because there are no URL Metrics or
 	 *                          the LCP element type is not supported.
 	 */
 	public function get_lcp_element(): ?OD_Element {
@@ -299,7 +299,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 
 					$breadcrumb_counts[ $i ] += 1;
 					$breadcrumb_element[ $i ] = $element;
-					break; // We found the LCP element for the URL metric, go to the next URL metric.
+					break; // We found the LCP element for the URL Metric, go to the next URL Metric.
 				}
 			}
 
@@ -321,7 +321,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	}
 
 	/**
-	 * Returns an iterator for the URL metrics in the group.
+	 * Returns an iterator for the URL Metrics in the group.
 	 *
 	 * @return ArrayIterator<int, OD_URL_Metric> ArrayIterator for OD_URL_Metric instances.
 	 */
@@ -330,9 +330,9 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	}
 
 	/**
-	 * Counts the URL metrics in the group.
+	 * Counts the URL Metrics in the group.
 	 *
-	 * @return int<0, max> URL metric count.
+	 * @return int<0, max> URL Metric count.
 	 */
 	public function count(): int {
 		return count( $this->url_metrics );

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -232,7 +232,7 @@ class OD_URL_Metric implements JsonSerializable {
 					'additionalProperties' => false,
 				),
 				'timestamp' => array(
-					'description' => __( 'Timestamp at which the URL metric was captured.', 'optimization-detective' ),
+					'description' => __( 'Timestamp at which the URL Metric was captured.', 'optimization-detective' ),
 					'type'        => 'number',
 					'required'    => true,
 					'readonly'    => true, // Omit from REST API.
@@ -284,7 +284,7 @@ class OD_URL_Metric implements JsonSerializable {
 		);
 
 		/**
-		 * Filters additional schema properties which should be allowed at the root of a URL metric.
+		 * Filters additional schema properties which should be allowed at the root of a URL Metric.
 		 *
 		 * @since 0.6.0
 		 *
@@ -296,7 +296,7 @@ class OD_URL_Metric implements JsonSerializable {
 		}
 
 		/**
-		 * Filters additional schema properties which should be allowed for an element's item in a URL metric.
+		 * Filters additional schema properties which should be allowed for an element's item in a URL Metric.
 		 *
 		 * @since 0.6.0
 		 *

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -497,7 +497,7 @@ export default async function detect( {
 	}
 
 	if ( isDebug ) {
-		log( 'Current URL metric:', urlMetric );
+		log( 'Current URL Metric:', urlMetric );
 	}
 
 	// Wait for the page to be hidden.
@@ -545,7 +545,7 @@ export default async function detect( {
 	setStorageLock( getCurrentTime() );
 
 	if ( isDebug ) {
-		log( 'Sending URL metric:', urlMetric );
+		log( 'Sending URL Metric:', urlMetric );
 	}
 
 	const url = new URL( restApiEndpoint );

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -80,7 +80,7 @@ Refer to [Image Prioritizer](https://github.com/WordPress/performance/tree/trunk
 
 **Filter:** `od_breakpoint_max_widths` (default: `array(480, 600, 782)`)
 
-Filters the breakpoint max widths to group URL Metrics for various viewports. Each number represents the maximum width (inclusive) for a given breakpoint. So if there is one number, 480, then this means there will be two viewport groupings, one for 0\<=480, and another \>480. If instead there are the two breakpoints defined, 480 and 782, then this means there will be three viewport groups of URL metrics, one for 0\<=480 (i.e. mobile), another 481\<=782 (i.e. phablet/tablet), and another \>782 (i.e. desktop).
+Filters the breakpoint max widths to group URL Metrics for various viewports. Each number represents the maximum width (inclusive) for a given breakpoint. So if there is one number, 480, then this means there will be two viewport groupings, one for 0\<=480, and another \>480. If instead there are the two breakpoints defined, 480 and 782, then this means there will be three viewport groups of URL Metrics, one for 0\<=480 (i.e. mobile), another 481\<=782 (i.e. phablet/tablet), and another \>782 (i.e. desktop).
 
 These default breakpoints are reused from Gutenberg which appear to be used the most in media queries that affect frontend styles.
 
@@ -261,7 +261,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 **Enhancements**
 
-* Send gathered URL metric data when the page is hidden/unloaded as opposed to once the page has loaded; this enables the ability to track layout shifts and INP scores over the life of the page. ([1373](https://github.com/WordPress/performance/pull/1373))
+* Send gathered URL Metric data when the page is hidden/unloaded as opposed to once the page has loaded; this enables the ability to track layout shifts and INP scores over the life of the page. ([1373](https://github.com/WordPress/performance/pull/1373))
 * Introduce client-side extensions in the form of script modules which are loaded when the detection logic runs. ([1373](https://github.com/WordPress/performance/pull/1373))
 * Add an `od_init` action for extensions to load their code. ([1373](https://github.com/WordPress/performance/pull/1373))
 * Introduce `OD_Element` class and improve PHP API. ([1585](https://github.com/WordPress/performance/pull/1585))
@@ -276,9 +276,9 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 **Enhancements**
 
-* Allow URL metric schema to be extended. ([1492](https://github.com/WordPress/performance/pull/1492))
+* Allow URL Metric schema to be extended. ([1492](https://github.com/WordPress/performance/pull/1492))
 * Clarify docs around a tag visitor's boolean return value. ([1479](https://github.com/WordPress/performance/pull/1479))
-* Include UUID with each URL metric. ([1489](https://github.com/WordPress/performance/pull/1489))
+* Include UUID with each URL Metric. ([1489](https://github.com/WordPress/performance/pull/1489))
 * Introduce get_cursor_move_count() to use instead of get_seek_count() and get_next_token_count(). ([1478](https://github.com/WordPress/performance/pull/1478))
 
 **Bug Fixes**
@@ -320,11 +320,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 **Enhancements**
 
-* Log URL metrics group collection to console when debugging is enabled (`WP_DEBUG` is true). ([1295](https://github.com/WordPress/performance/pull/1295))
+* Log URL Metrics group collection to console when debugging is enabled (`WP_DEBUG` is true). ([1295](https://github.com/WordPress/performance/pull/1295))
 
 **Bug Fixes**
 
-* Include non-intersecting elements in URL metrics to fix lazy-load optimization. ([1293](https://github.com/WordPress/performance/pull/1293))
+* Include non-intersecting elements in URL Metrics to fix lazy-load optimization. ([1293](https://github.com/WordPress/performance/pull/1293))
 
 = 0.3.0 =
 

--- a/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
+++ b/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Context for when a URL metric is successfully stored via the REST API.
+ * Context for when a URL Metric is successfully stored via the REST API.
  *
  * @since 0.7.0
  * @access private
@@ -28,7 +28,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	public $request;
 
 	/**
-	 * ID for the URL metric post.
+	 * ID for the URL Metric post.
 	 *
 	 * @var int
 	 * @readonly
@@ -36,7 +36,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	public $post_id;
 
 	/**
-	 * URL metric group collection.
+	 * URL Metric group collection.
 	 *
 	 * @var OD_URL_Metric_Group_Collection
 	 * @readonly
@@ -44,7 +44,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	public $url_metric_group_collection;
 
 	/**
-	 * URL metric group.
+	 * URL Metric group.
 	 *
 	 * @var OD_URL_Metric_Group
 	 * @readonly
@@ -52,7 +52,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	public $url_metric_group;
 
 	/**
-	 * URL metric.
+	 * URL Metric.
 	 *
 	 * @var OD_URL_Metric
 	 * @readonly
@@ -65,10 +65,10 @@ final class OD_URL_Metric_Store_Request_Context {
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @param WP_REST_Request                $request                     REST API request.
-	 * @param int                            $post_id                     ID for the URL metric post.
-	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL metric group collection.
-	 * @param OD_URL_Metric_Group            $url_metric_group            URL metric group.
-	 * @param OD_URL_Metric                  $url_metric                  URL metric.
+	 * @param int                            $post_id                     ID for the URL Metric post.
+	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL Metric group collection.
+	 * @param OD_URL_Metric_Group            $url_metric_group            URL Metric group.
+	 * @param OD_URL_Metric                  $url_metric                  URL Metric.
 	 */
 	public function __construct( WP_REST_Request $request, int $post_id, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_URL_Metric_Group $url_metric_group, OD_URL_Metric $url_metric ) {
 		$this->request                     = $request;

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -143,7 +143,7 @@ function od_get_url_metrics_slug( array $query_vars ): string {
 /**
  * Computes nonce for storing URL Metrics for a specific slug.
  *
- * This is used in the REST API to authenticate the storage of new URL metrics from a given URL.
+ * This is used in the REST API to authenticate the storage of new URL Metrics from a given URL.
  *
  * @since 0.1.0
  * @access private
@@ -161,7 +161,7 @@ function od_get_url_metrics_storage_nonce( string $slug, string $url ): string {
 }
 
 /**
- * Verifies nonce for storing URL metrics for a specific slug.
+ * Verifies nonce for storing URL Metrics for a specific slug.
  *
  * @since 0.1.0
  * @access private
@@ -180,16 +180,16 @@ function od_verify_url_metrics_storage_nonce( string $nonce, string $slug, strin
 }
 
 /**
- * Gets the minimum allowed viewport aspect ratio for URL metrics.
+ * Gets the minimum allowed viewport aspect ratio for URL Metrics.
  *
  * @since 0.6.0
  * @access private
  *
- * @return float Minimum viewport aspect ratio for URL metrics.
+ * @return float Minimum viewport aspect ratio for URL Metrics.
  */
 function od_get_minimum_viewport_aspect_ratio(): float {
 	/**
-	 * Filters the minimum allowed viewport aspect ratio for URL metrics.
+	 * Filters the minimum allowed viewport aspect ratio for URL Metrics.
 	 *
 	 * The 0.4 default value is intended to accommodate the phone with the greatest known aspect
 	 * ratio at 21:9 when rotated 90 degrees to 9:21 (0.429).
@@ -202,16 +202,16 @@ function od_get_minimum_viewport_aspect_ratio(): float {
 }
 
 /**
- * Gets the maximum allowed viewport aspect ratio for URL metrics.
+ * Gets the maximum allowed viewport aspect ratio for URL Metrics.
  *
  * @since 0.6.0
  * @access private
  *
- * @return float Maximum viewport aspect ratio for URL metrics.
+ * @return float Maximum viewport aspect ratio for URL Metrics.
  */
 function od_get_maximum_viewport_aspect_ratio(): float {
 	/**
-	 * Filters the maximum allowed viewport aspect ratio for URL metrics.
+	 * Filters the maximum allowed viewport aspect ratio for URL Metrics.
 	 *
 	 * The 2.5 default value is intended to accommodate the phone with the greatest known aspect
 	 * ratio at 21:9 (2.333).
@@ -224,7 +224,7 @@ function od_get_maximum_viewport_aspect_ratio(): float {
 }
 
 /**
- * Gets the breakpoint max widths to group URL metrics for various viewports.
+ * Gets the breakpoint max widths to group URL Metrics for various viewports.
  *
  * Each number represents the maximum width (inclusive) for a given breakpoint. So if there is one number, 480, then
  * this means there will be two viewport groupings, one for 0<=480, and another >480. If instead there were three
@@ -288,7 +288,7 @@ function od_get_breakpoint_max_widths(): array {
 			return $breakpoint;
 		},
 		/**
-		 * Filters the breakpoint max widths to group URL metrics for various viewports.
+		 * Filters the breakpoint max widths to group URL Metrics for various viewports.
 		 *
 		 * A breakpoint must be greater than zero and less than PHP_INT_MAX. This array may be empty in which case there
 		 * are no responsive breakpoints and all URL Metrics are collected in a single group.
@@ -306,11 +306,11 @@ function od_get_breakpoint_max_widths(): array {
 }
 
 /**
- * Gets the sample size for a breakpoint's URL metrics on a given URL.
+ * Gets the sample size for a breakpoint's URL Metrics on a given URL.
  *
- * A breakpoint divides URL metrics for viewports which are smaller and those which are larger. Given the default
+ * A breakpoint divides URL Metrics for viewports which are smaller and those which are larger. Given the default
  * sample size of 3 and there being just a single breakpoint (480) by default, for a given URL, there would be a maximum
- * total of 6 URL metrics stored for a given URL: 3 for mobile and 3 for desktop.
+ * total of 6 URL Metrics stored for a given URL: 3 for mobile and 3 for desktop.
  *
  * @since 0.1.0
  * @access private
@@ -319,7 +319,7 @@ function od_get_breakpoint_max_widths(): array {
  */
 function od_get_url_metrics_breakpoint_sample_size(): int {
 	/**
-	 * Filters the sample size for a breakpoint's URL metrics on a given URL.
+	 * Filters the sample size for a breakpoint's URL Metrics on a given URL.
 	 *
 	 * The sample size must be greater than zero.
 	 *


### PR DESCRIPTION
Somehow the `s/URL metric/URL Metric/` replacement I did in #1636 did not catch all instances. This PR finishes the job:

> Additionally, the term "URL Metric" has been normalized in copy to have a capital M since it is a thing. So "URL Metric" instead of "URL metric".