### PR TITLE
Eliminate the detection time window

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -232,8 +232,6 @@ function extendElementData( xpath, properties ) {
  * Detects the LCP element, loaded images, client viewport and store for future optimizations.
  *
  * @param {Object}                 args                            Args.
- * @param {number}                 args.serveTime                  The serve time of the page in milliseconds from PHP via `microtime( true ) * 1000`.
- * @param {number}                 args.detectionTimeWindow        The number of milliseconds between now and when the page was first generated in which detection should proceed.
  * @param {string[]}               args.extensionModuleUrls        URLs for extension script modules to import.
  * @param {number}                 args.minViewportAspectRatio     Minimum aspect ratio allowed for the viewport.
  * @param {number}                 args.maxViewportAspectRatio     Maximum aspect ratio allowed for the viewport.
@@ -248,8 +246,6 @@ function extendElementData( xpath, properties ) {
  * @param {Object}                 [args.urlMetricGroupCollection] URL Metric group collection, when in debug mode.
  */
 export default async function detect( {
-	serveTime,
-	detectionTimeWindow,
 	minViewportAspectRatio,
 	maxViewportAspectRatio,
 	isDebug,
@@ -263,20 +259,8 @@ export default async function detect( {
 	webVitalsLibrarySrc,
 	urlMetricGroupCollection,
 } ) {
-	const currentTime = getCurrentTime();
-
 	if ( isDebug ) {
 		log( 'Stored URL Metric group collection:', urlMetricGroupCollection );
-	}
-
-	// Abort running detection logic if it was served in a cached page.
-	if ( currentTime - serveTime > detectionTimeWindow ) {
-		if ( isDebug ) {
-			warn(
-				'Aborted detection due to being outside detection time window.'
-			);
-		}
-		return;
 	}
 
 	// Abort if the current viewport is not among those which need URL Metrics.
@@ -330,7 +314,7 @@ export default async function detect( {
 	// As an alternative to this, the od_print_detection_script() function can short-circuit if the
 	// od_is_url_metric_storage_locked() function returns true. However, the downside with that is page caching could
 	// result in metrics missed from being gathered when a user navigates around a site and primes the page cache.
-	if ( isStorageLocked( currentTime, storageLockTTL ) ) {
+	if ( isStorageLocked( getCurrentTime(), storageLockTTL ) ) {
 		if ( isDebug ) {
 			warn( 'Aborted detection due to storage being locked.' );
 		}

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -20,21 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param OD_URL_Metric_Group_Collection $group_collection URL Metric group collection.
  */
 function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $group_collection ): string {
-	/**
-	 * Filters the time window between serve time and run time in which loading detection is allowed to run.
-	 *
-	 * This is the allowance of milliseconds between when the page was first generated (and perhaps cached) and when the
-	 * detect function on the page is allowed to perform its detection logic and submit the request to store the results.
-	 * This avoids situations in which there is missing URL Metrics in which case a site with page caching which
-	 * also has a lot of traffic could result in a cache stampede.
-	 *
-	 * @since 0.1.0
-	 * @todo The value should probably be something like the 99th percentile of Time To Last Byte (TTLB) for WordPress sites in CrUX.
-	 *
-	 * @param int $detection_time_window Detection time window in milliseconds.
-	 */
-	$detection_time_window = apply_filters( 'od_detection_time_window', 5000 );
-
 	$web_vitals_lib_data = require __DIR__ . '/build/web-vitals.asset.php';
 	$web_vitals_lib_src  = add_query_arg( 'ver', $web_vitals_lib_data['version'], plugin_dir_url( __FILE__ ) . 'build/web-vitals.js' );
 
@@ -49,8 +34,6 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 
 	$current_url = od_get_current_url();
 	$detect_args = array(
-		'serveTime'              => microtime( true ) * 1000, // In milliseconds for comparison with `Date.now()` in JavaScript.
-		'detectionTimeWindow'    => $detection_time_window,
 		'minViewportAspectRatio' => od_get_minimum_viewport_aspect_ratio(),
 		'maxViewportAspectRatio' => od_get_maximum_viewport_aspect_ratio(),
 		'isDebug'                => WP_DEBUG,

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -132,10 +132,6 @@ Filters the freshness age (TTL) for a given URL Metric. The freshness TTL must b
 add_filter( 'od_url_metric_freshness_ttl', '__return_zero' );
 `
 
-**Filter:** `od_detection_time_window` (default: 5 seconds)
-
-Filters the time window between serve time and run time in which loading detection is allowed to run. This amount is the allowance between when the page was first generated (and perhaps cached) and when the detect function on the page is allowed to perform its detection logic and submit the request to store the results. This avoids situations in which there are missing URL Metrics in which case a site with page caching which also has a lot of traffic could result in a cache stampede.
-
 **Filter:** `od_minimum_viewport_aspect_ratio` (default: 0.4)
 
 Filters the minimum allowed viewport aspect ratio for URL Metrics.

--- a/plugins/optimization-detective/tests/test-detection.php
+++ b/plugins/optimization-detective/tests/test-detection.php
@@ -17,19 +17,12 @@ class Test_OD_Detection extends WP_UnitTestCase {
 			'unfiltered' => array(
 				'set_up'           => static function (): void {},
 				'expected_exports' => array(
-					'detectionTimeWindow' => 5000,
 					'storageLockTTL'      => MINUTE_IN_SECONDS,
 					'extensionModuleUrls' => array(),
 				),
 			),
 			'filtered'   => array(
 				'set_up'           => static function (): void {
-					add_filter(
-						'od_detection_time_window',
-						static function (): int {
-							return 2500;
-						}
-					);
 					add_filter(
 						'od_url_metric_storage_lock_ttl',
 						static function (): int {
@@ -45,7 +38,6 @@ class Test_OD_Detection extends WP_UnitTestCase {
 					);
 				},
 				'expected_exports' => array(
-					'detectionTimeWindow' => 2500,
 					'storageLockTTL'      => HOUR_IN_SECONDS,
 					'extensionModuleUrls' => array( home_url( '/my-extension.js', 'https' ) ),
 				),


### PR DESCRIPTION
This is the second PR to address #1496.

The detection time window fails to adequately account for page caching so it's gotta go. 

When the detection time window is enforced, new URL metrics are only collected if the user happened to visit when there was a page cache MISS or if the user happened to visit a couple seconds from within the time that someone else visited the page and the cache HIT returns a page that is only a couple seconds old. This is problematic, for example, on a site which primarily gets mobile traffic. If mobile visitors always trigger their responses to be cached, then when a desktop visitor comes around the detection time window will have already passed and that URL will be starved of URL Metrics for desktop.

Additionally, on a site that uses a stale-while-revalidate strategy for page caching, it's possible that the cached page is _always_ older than the detection time window, resulting in URL Metrics never being gathered. 

Also, a plugin like W3 Total Cache has a "Cache Preload" feature in which it will proactively crawl the site to prime the page cache. Since these requests are not coming from an actual user, they will circumvent a user causing a cache MISS and thus getting a page served within the detection time window.