### PR TITLE
Introduce `webp_uploads_get_file_mime_type` helper function

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -483,7 +483,7 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
  * @param int    $attachment_id The attachment ID.
  * @return string The MIME type of the file, or false if not found.
  */
-function get_file_mime_type( string $file, int $attachment_id ): string {
+function webp_uploads_get_file_mime_type( string $file, int $attachment_id ): string {
 	/*
 	 * We need to get the MIME type ideally from the file, as WordPress Core may have already altered it.
 	 * The post MIME type is typically not updated during that process.

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -468,3 +468,27 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
 
 	return null;
 }
+
+/**
+ * Retrieves the MIME type of a file, checking the file directly if possible,
+ * and falling back to the attachment's MIME type if needed.
+ *
+ * The function attempts to determine the MIME type directly from the file.
+ * If that information is unavailable, it uses the MIME type from the attachment metadata.
+ * If neither is available, it defaults to an empty string.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $file          The path to the file.
+ * @param int    $attachment_id The attachment ID.
+ * @return string The MIME type of the file, or false if not found.
+ */
+function get_file_mime_type( string $file, int $attachment_id ): string {
+	/*
+	 * We need to get the MIME type ideally from the file, as WordPress Core may have already altered it.
+	 * The post MIME type is typically not updated during that process.
+	 */
+	$filetype  = wp_check_filetype( $file );
+	$mime_type = $filetype['type'] ?? get_post_mime_type( $attachment_id );
+	return is_string( $mime_type ) ? $mime_type : '';
+}

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -481,7 +481,7 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
  *
  * @param string $file          The path to the file.
  * @param int    $attachment_id The attachment ID.
- * @return string The MIME type of the file, or false if not found.
+ * @return string The MIME type of the file, or an empty string if not found.
  */
 function webp_uploads_get_file_mime_type( string $file, int $attachment_id ): string {
 	/*

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -58,7 +58,7 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 		return $metadata;
 	}
 
-	$mime_type = get_file_mime_type( $file, $attachment_id );
+	$mime_type = webp_uploads_get_file_mime_type( $file, $attachment_id );
 	if ( '' === $mime_type ) {
 		return $metadata;
 	}

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -58,13 +58,8 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 		return $metadata;
 	}
 
-	/*
-	 * We need to get the MIME type ideally from the file, as WordPress Core may have already altered it.
-	 * The post MIME type is typically not updated during that process.
-	 */
-	$filetype  = wp_check_filetype( $file );
-	$mime_type = $filetype['type'] ?? get_post_mime_type( $attachment_id );
-	if ( ! is_string( $mime_type ) ) {
+	$mime_type = get_file_mime_type( $file, $attachment_id );
+	if ( '' === $mime_type ) {
 		return $metadata;
 	}
 

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -22,9 +22,21 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 	if ( 'the_content' !== $context ) {
 		return $image;
 	}
-	$image_meta              = wp_get_attachment_metadata( $attachment_id );
-	$original_file_mime_type = get_post_mime_type( $attachment_id );
-	if ( false === $original_file_mime_type || ! isset( $image_meta['sizes'] ) ) {
+
+	$file = get_attached_file( $attachment_id, true );
+	// File does not exist.
+	if ( false === $file || ! file_exists( $file ) ) {
+		return $image;
+	}
+
+	$original_file_mime_type = get_file_mime_type( $file, $attachment_id );
+	if ( '' === $original_file_mime_type ) {
+		return $image;
+	}
+
+	$image_meta = wp_get_attachment_metadata( $attachment_id );
+
+	if ( ! isset( $image_meta['sizes'] ) ) {
 		return $image;
 	}
 

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -29,7 +29,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		return $image;
 	}
 
-	$original_file_mime_type = get_file_mime_type( $file, $attachment_id );
+	$original_file_mime_type = webp_uploads_get_file_mime_type( $file, $attachment_id );
 	if ( '' === $original_file_mime_type ) {
 		return $image;
 	}


### PR DESCRIPTION
## Summary

Follow-up work per https://github.com/WordPress/performance/pull/1635#pullrequestreview-2421429667


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
