### PR TITLE
Add unminified source JS files to builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ nbproject/
 
 build
 .wp-env.override.json
+*.min.js
 *.asset.php
 
 ############

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -121,7 +121,7 @@ function embed_optimizer_filter_extension_module_urls( $extension_module_urls ):
 	if ( ! is_array( $extension_module_urls ) ) {
 		$extension_module_urls = array();
 	}
-	$extension_module_urls[] = add_query_arg( 'ver', EMBED_OPTIMIZER_VERSION, plugin_dir_url( __FILE__ ) . 'detect.js' );
+	$extension_module_urls[] = add_query_arg( 'ver', EMBED_OPTIMIZER_VERSION, plugin_dir_url( __FILE__ ) . sprintf( 'detect%s.js', wp_scripts_get_suffix() ) );
 	return $extension_module_urls;
 }
 
@@ -326,7 +326,7 @@ function embed_optimizer_lazy_load_scripts(): void {
  * @since 0.2.0
  */
 function embed_optimizer_get_lazy_load_script(): string {
-	$script = file_get_contents( __DIR__ . '/lazy-load.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
+	$script = file_get_contents( __DIR__ . sprintf( '/lazy-load%s.js', wp_scripts_get_suffix() ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
 
 	if ( false === $script ) {
 		return '';

--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -76,6 +76,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 			return;
 		}
 
+		if (
+			( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) &&
+			! file_exists( __DIR__ . '/detect.min.js' )
+		) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error(
+				esc_html(
+					sprintf(
+						/* translators: 1: File path. 2: CLI command. */
+						'[Embed Optimizer] ' . __( 'Unable to load %1$s. Please make sure you have run %2$s.', 'embed-optimizer' ),
+						'detect.min.js',
+						'`npm install && npm run build:plugin:embed-optimizer`'
+					)
+				),
+				E_USER_ERROR
+			);
+		}
+
 		define( 'EMBED_OPTIMIZER_VERSION', $version );
 
 		// Load in the Embed Optimizer plugin hooks.

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -67,6 +67,12 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
+= n.e.x.t =
+
+**Enhancements**
+
+* Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
+
 = 0.3.0 =
 
 **Enhancements**

--- a/plugins/image-prioritizer/hooks.php
+++ b/plugins/image-prioritizer/hooks.php
@@ -22,7 +22,7 @@ add_action( 'od_init', 'image_prioritizer_init' );
  * @since 0.2.0
  */
 function image_prioritizer_get_lazy_load_script(): string {
-	$script = file_get_contents( __DIR__ . '/lazy-load.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
+	$script = file_get_contents( __DIR__ . sprintf( '/lazy-load%s.js', wp_scripts_get_suffix() ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
 
 	if ( false === $script ) {
 		return '';

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -77,6 +77,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 			return;
 		}
 
+		if (
+			( is_admin() || ( defined( 'WP_CLI' ) && WP_CLI ) ) &&
+			! file_exists( __DIR__ . '/lazy-load.min.js' )
+		) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+			trigger_error(
+				esc_html(
+					sprintf(
+						/* translators: 1: File path. 2: CLI command. */
+						'[Image Prioritizer] ' . __( 'Unable to load %1$s. Please make sure you have run %2$s.', 'image-prioritizer' ),
+						'lazy-load.min.js',
+						'`npm install && npm run build:plugin:image-prioritizer`'
+					)
+				),
+				E_USER_ERROR
+			);
+		}
+
 		define( 'IMAGE_PRIORITIZER_VERSION', $version );
 
 		require_once __DIR__ . '/helper.php';

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -62,6 +62,12 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
+= n.e.x.t =
+
+**Enhancements**
+
+* Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
+
 = 0.2.0 =
 
 **Enhancements**

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -76,15 +76,10 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		$detect_args['urlMetricGroupCollection'] = $group_collection;
 	}
 
-	$detection_script_file = 'detect.min.js';
-	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-		$detection_script_file = 'detect.js';
-	}
-
 	return wp_get_inline_script_tag(
 		sprintf(
 			'import detect from %s; detect( %s );',
-			wp_json_encode( add_query_arg( 'ver', OPTIMIZATION_DETECTIVE_VERSION, plugin_dir_url( __FILE__ ) . $detection_script_file ) ),
+			wp_json_encode( add_query_arg( 'ver', OPTIMIZATION_DETECTIVE_VERSION, plugin_dir_url( __FILE__ ) . sprintf( 'detect%s.js', wp_scripts_get_suffix() ) ) ),
 			wp_json_encode( $detect_args )
 		),
 		array( 'type' => 'module' )

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -76,10 +76,15 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		$detect_args['urlMetricGroupCollection'] = $group_collection;
 	}
 
+	$detection_script_file = 'detect.min.js';
+	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		$detection_script_file = 'detect.js';
+	}
+
 	return wp_get_inline_script_tag(
 		sprintf(
 			'import detect from %s; detect( %s );',
-			wp_json_encode( add_query_arg( 'ver', OPTIMIZATION_DETECTIVE_VERSION, plugin_dir_url( __FILE__ ) . 'detect.js' ) ),
+			wp_json_encode( add_query_arg( 'ver', OPTIMIZATION_DETECTIVE_VERSION, plugin_dir_url( __FILE__ ) . $detection_script_file ) ),
 			wp_json_encode( $detect_args )
 		),
 		array( 'type' => 'module' )

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -253,6 +253,12 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
+= n.e.x.t =
+
+**Enhancements**
+
+* Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
+
 = 0.7.0 =
 
 **Enhancements**

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -21,7 +21,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 function plwwo_register_default_scripts( WP_Scripts $scripts ): void {
 	// The source code for partytown.js is built from <https://github.com/BuilderIO/partytown/blob/b292a14047a0c12ca05ba97df1833935d42fdb66/src/lib/main/snippet.ts>.
 	// See webpack config in the WordPress/performance repo: <https://github.com/WordPress/performance/blob/282a068f3eb2575d37aeb9034e894e7140fcddca/webpack.config.js#L84-L130>.
-	$partytown_js = file_get_contents( __DIR__ . '/build/partytown.js' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
+	$partytown_js_path = '/build/partytown.js';
+	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
+		$partytown_js_path = '/build/debug/partytown.js';
+	}
+
+	$partytown_js = file_get_contents( __DIR__ . $partytown_js_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
 	if ( false === $partytown_js ) {
 		return;
 	}

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -21,9 +21,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 function plwwo_register_default_scripts( WP_Scripts $scripts ): void {
 	// The source code for partytown.js is built from <https://github.com/BuilderIO/partytown/blob/b292a14047a0c12ca05ba97df1833935d42fdb66/src/lib/main/snippet.ts>.
 	// See webpack config in the WordPress/performance repo: <https://github.com/WordPress/performance/blob/282a068f3eb2575d37aeb9034e894e7140fcddca/webpack.config.js#L84-L130>.
-	$partytown_js_path = '/build/partytown.js';
 	if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
 		$partytown_js_path = '/build/debug/partytown.js';
+	} else {
+		$partytown_js_path = '/build/partytown.js';
 	}
 
 	$partytown_js = file_get_contents( __DIR__ . $partytown_js_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -94,6 +94,12 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
+= n.e.x.t =
+
+**Enhancements**
+
+* Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
+
 = 0.1.1 =
 
 **Enhancements**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ const optimizationDetective = ( env ) => {
 	const source = path.resolve( __dirname, 'node_modules/web-vitals' );
 	const destination = path.resolve(
 		__dirname,
-		'plugins/optimization-detective/build'
+		'plugins/optimization-detective'
 	);
 
 	return {
@@ -61,15 +61,19 @@ const optimizationDetective = ( env ) => {
 				patterns: [
 					{
 						from: `${ source }/dist/web-vitals.js`,
-						to: `${ destination }/web-vitals.js`,
+						to: `${ destination }/build/web-vitals.js`,
 					},
 					{
 						from: `${ source }/package.json`,
-						to: `${ destination }/web-vitals.asset.php`,
+						to: `${ destination }/build/web-vitals.asset.php`,
 						transform: {
 							transformer: assetDataTransformer,
 							cache: false,
 						},
+					},
+					{
+						from: `${ destination }/detect.js`,
+						to: `${ destination }/detect.min.js`,
 					},
 				],
 			} ),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -168,7 +168,7 @@ const buildPlugin = ( env ) => {
 					{
 						from,
 						to,
-						info: { minimized: true }, // Terser skip minimization
+						info: { minimized: true },
 						globOptions: {
 							dot: true,
 							ignore: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,6 +164,7 @@ const buildPlugin = ( env ) => {
 					{
 						from,
 						to,
+						info: { minimized: true }, // Terser skip minimization
 						globOptions: {
 							dot: true,
 							ignore: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,48 @@ const sharedConfig = {
 };
 
 // Store plugins that require build process.
-const pluginsWithBuild = [ 'optimization-detective', 'web-worker-offloading' ];
+const pluginsWithBuild = [
+	'embed-optimizer',
+	'optimization-detective',
+	'web-worker-offloading',
+];
+
+/**
+ * Webpack Config: Embed Optimizer
+ *
+ * @param {*} env Webpack environment
+ * @return {Object} Webpack configuration
+ */
+const embedOptimizer = ( env ) => {
+	if ( env.plugin && env.plugin !== 'embed-optimizer' ) {
+		return defaultBuildConfig;
+	}
+
+	const pluginDir = path.resolve( __dirname, 'plugins/embed-optimizer' );
+
+	return {
+		...sharedConfig,
+		name: 'embed-optimizer',
+		plugins: [
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						from: `${ pluginDir }/detect.js`,
+						to: `${ pluginDir }/detect.min.js`,
+					},
+					{
+						from: `${ pluginDir }/lazy-load.js`,
+						to: `${ pluginDir }/lazy-load.min.js`,
+					},
+				],
+			} ),
+			new WebpackBar( {
+				name: 'Building Embed Optimizer Assets',
+				color: '#2196f3',
+			} ),
+		],
+	};
+};
 
 /**
  * Webpack Config: Optimization Detective
@@ -210,4 +251,9 @@ const buildPlugin = ( env ) => {
 	};
 };
 
-module.exports = [ optimizationDetective, webWorkerOffloading, buildPlugin ];
+module.exports = [
+	embedOptimizer,
+	optimizationDetective,
+	webWorkerOffloading,
+	buildPlugin,
+];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,6 +62,7 @@ const optimizationDetective = ( env ) => {
 					{
 						from: `${ source }/dist/web-vitals.js`,
 						to: `${ destination }/build/web-vitals.js`,
+						info: { minimized: true },
 					},
 					{
 						from: `${ source }/package.json`,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,7 @@ const sharedConfig = {
 // Store plugins that require build process.
 const pluginsWithBuild = [
 	'embed-optimizer',
+	'image-prioritizer',
 	'optimization-detective',
 	'web-worker-offloading',
 ];
@@ -71,6 +72,39 @@ const embedOptimizer = ( env ) => {
 			} ),
 			new WebpackBar( {
 				name: 'Building Embed Optimizer Assets',
+				color: '#2196f3',
+			} ),
+		],
+	};
+};
+
+/**
+ * Webpack Config: Image Prioritizer
+ *
+ * @param {*} env Webpack environment
+ * @return {Object} Webpack configuration
+ */
+const imagePrioritizer = ( env ) => {
+	if ( env.plugin && env.plugin !== 'image-prioritizer' ) {
+		return defaultBuildConfig;
+	}
+
+	const pluginDir = path.resolve( __dirname, 'plugins/image-prioritizer' );
+
+	return {
+		...sharedConfig,
+		name: 'image-prioritizer',
+		plugins: [
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						from: `${ pluginDir }/lazy-load.js`,
+						to: `${ pluginDir }/lazy-load.min.js`,
+					},
+				],
+			} ),
+			new WebpackBar( {
+				name: 'Building Image Prioritizer Assets',
 				color: '#2196f3',
 			} ),
 		],
@@ -253,6 +287,7 @@ const buildPlugin = ( env ) => {
 
 module.exports = [
 	embedOptimizer,
+	imagePrioritizer,
 	optimizationDetective,
 	webWorkerOffloading,
 	buildPlugin,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,6 +115,7 @@ const webWorkerOffloading = ( env ) => {
 					{
 						from: `${ source }/lib/`,
 						to: `${ destination }`,
+						info: { minimized: true },
 					},
 					{
 						from: `${ source }/package.json`,


### PR DESCRIPTION
## Summary

Fixes #1493 

## Relevant technical choices

- The unminified version of `web-vitals.js` is not included because the file is copied directly from the pre-minified version in `node_modules`.
- Source maps are excluded, as the unminified development version of the script will be loaded when `SCRIPT_DEBUG` is enabled.