### PR TITLE
Install and activate Optimization Detective when the Embed Optimizer feature is activated from the Performance screen

### DIFF
--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -325,12 +325,8 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
 	}
 
 	// Add recommended plugins (soft dependencies) to the list of plugins installed and activated.
-	$standalone_plugin_data = perflab_get_standalone_plugin_data();
-	if ( isset( $standalone_plugin_data[ $plugin_slug ]['suggest'] ) ) {
-		$plugin_data['requires_plugins'] = array_merge(
-			$plugin_data['requires_plugins'],
-			$standalone_plugin_data[ $plugin_slug ]['suggest']
-		);
+	if ( 'embed-optimizer' === $plugin_slug ) {
+		$plugin_data['requires_plugins'][] = 'optimization-detective';
 	}
 
 	// Install and activate plugin dependencies first.

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -325,8 +325,12 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
 	}
 
 	// Add recommended plugins (soft dependencies) to the list of plugins installed and activated.
-	if ( 'embed-optimizer' === $plugin_slug ) {
-		$plugin_data['requires_plugins'][] = 'optimization-detective';
+	$standalone_plugin_data = perflab_get_standalone_plugin_data();
+	if ( isset( $standalone_plugin_data[ $plugin_slug ]['suggest'] ) ) {
+		$plugin_data['requires_plugins'] = array_merge(
+			$plugin_data['requires_plugins'],
+			$standalone_plugin_data[ $plugin_slug ]['suggest']
+		);
 	}
 
 	// Install and activate plugin dependencies first.

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -71,7 +71,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	$plugins            = array();
 	$standalone_plugins = array_merge(
 		array_flip( perflab_get_standalone_plugins() ),
-		array( 'optimization-detective' => array() ) // TODO: Programmatically discover the plugin dependencies and add them here.
+		array( 'optimization-detective' => array() ) // TODO: Programmatically discover the plugin dependencies and add them here. See <https://github.com/WordPress/performance/issues/1616>.
 	);
 	foreach ( $response->plugins as $plugin_data ) {
 		if ( ! isset( $standalone_plugins[ $plugin_data['slug'] ] ) ) {
@@ -322,6 +322,11 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
 	$plugin_data = perflab_query_plugin_info( $plugin_slug );
 	if ( $plugin_data instanceof WP_Error ) {
 		return $plugin_data;
+	}
+
+	// Add recommended plugins (soft dependencies) to the list of plugins installed and activated.
+	if ( 'embed-optimizer' === $plugin_slug ) {
+		$plugin_data['requires_plugins'][] = 'optimization-detective';
 	}
 
 	// Install and activate plugin dependencies first.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -83,7 +83,7 @@ add_action( 'wp_head', 'perflab_render_generator' );
  *
  * @since 3.0.0
  *
- * @return array<string, array{'constant': string, 'experimental'?: bool, 'suggest'?: string[]}> Associative array of $plugin_slug => $plugin_data pairs.
+ * @return array<string, array{'constant': string, 'experimental'?: bool}> Associative array of $plugin_slug => $plugin_data pairs.
  */
 function perflab_get_standalone_plugin_data(): array {
 	/*
@@ -91,7 +91,6 @@ function perflab_get_standalone_plugin_data(): array {
 	 * Supported keys per plugin are:
 	 * - 'constant' (string, required)
 	 * - 'experimental' (boolean, optional)
-	 * - 'suggest' (string[], optional)
 	 */
 	return array(
 		'auto-sizes'              => array(
@@ -104,7 +103,6 @@ function perflab_get_standalone_plugin_data(): array {
 		'embed-optimizer'         => array(
 			'constant'     => 'EMBED_OPTIMIZER_VERSION',
 			'experimental' => true,
-			'suggest'      => array( 'optimization-detective' ),
 		),
 		'image-prioritizer'       => array(
 			'constant'     => 'IMAGE_PRIORITIZER_VERSION',

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -83,7 +83,7 @@ add_action( 'wp_head', 'perflab_render_generator' );
  *
  * @since 3.0.0
  *
- * @return array<string, array{'constant': string, 'experimental'?: bool}> Associative array of $plugin_slug => $plugin_data pairs.
+ * @return array<string, array{'constant': string, 'experimental'?: bool, 'suggest'?: string[]}> Associative array of $plugin_slug => $plugin_data pairs.
  */
 function perflab_get_standalone_plugin_data(): array {
 	/*
@@ -91,6 +91,7 @@ function perflab_get_standalone_plugin_data(): array {
 	 * Supported keys per plugin are:
 	 * - 'constant' (string, required)
 	 * - 'experimental' (boolean, optional)
+	 * - 'suggest' (string[], optional)
 	 */
 	return array(
 		'auto-sizes'              => array(
@@ -103,6 +104,7 @@ function perflab_get_standalone_plugin_data(): array {
 		'embed-optimizer'         => array(
 			'constant'     => 'EMBED_OPTIMIZER_VERSION',
 			'experimental' => true,
+			'suggest'      => array( 'optimization-detective' ),
 		),
 		'image-prioritizer'       => array(
 			'constant'     => 'IMAGE_PRIORITIZER_VERSION',


### PR DESCRIPTION
Fixes #1615

Most of the optimizations provided by Embed Optimizer require the Optimization Detective plugin. So this PR will automatically install and activate Optimization Detective when the Embed Optimizer feature is activated from the Performance screen.

Screen recording:

[Screen recording 2024-11-11 09.03.26.webm](https://github.com/user-attachments/assets/4a3b40f5-6fb9-457c-8e1b-533539a9d947)

Build for testing: [performance-lab.zip](https://github.com/user-attachments/files/17706319/performance-lab.zip)
