### PR TITLE
Use AJAX for activating features / plugins in Performance Lab

### DIFF
--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -228,7 +228,7 @@ function perflab_enqueue_features_page_scripts(): void {
 	// Enqueue plugin activate AJAX script and localize script data.
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',
-		plugins_url( 'includes/admin/plugin-activate-ajax.js', PERFLAB_MAIN_FILE ),
+		plugin_dir_url( PERFLAB_MAIN_FILE ) . 'includes/admin/plugin-activate-ajax.js',
 		array( 'wp-i18n', 'wp-a11y', 'wp-api-fetch' ),
 		PERFLAB_VERSION,
 		true

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -225,9 +225,6 @@ function perflab_enqueue_features_page_scripts(): void {
 	wp_enqueue_style( 'thickbox' );
 	wp_enqueue_script( 'plugin-install' );
 
-	// Enqueue the a11y script.
-	wp_enqueue_script( 'wp-a11y' );
-
 	// Enqueue plugin activate AJAX script and localize script data.
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -232,7 +232,7 @@ function perflab_enqueue_features_page_scripts(): void {
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',
 		plugins_url( 'includes/admin/plugin-activate-ajax.js', PERFLAB_MAIN_FILE ),
-		array( 'jquery', 'wp-i18n', 'wp-a11y' ),
+		array( 'wp-i18n', 'wp-a11y' ),
 		PERFLAB_VERSION,
 		true
 	);

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -444,17 +444,18 @@ function perflab_print_plugin_progress_indicator_script(): void {
 	$nonce = wp_create_nonce( 'perflab_install_activate_plugin_ajax' );
 
 	$script_data = array(
-		'ajaxUrl'        => admin_url( 'admin-ajax.php' ),
-		'nonce'          => $nonce,
-		'activatingText' => __( 'Activating...', 'performance-lab' ),
-		'activateText'   => __( 'Activate', 'performance-lab' ),
-		'activatedText'  => __( 'Active', 'performance-lab' ),
-		'dismissText'    => __( 'Dismiss this notice.', 'performance-lab' ),
-		'successText'    => __( 'Feature activated.', 'performance-lab' ),
-		'reviewText'     => __( ' Review ', 'performance-lab' ),
-		'settingsText'   => __( 'settings', 'performance-lab' ),
-		'endText'        => _x( '.', 'Punctuation mark', 'performance-lab' ),
-		'errorText'      => __( 'There was an error activating the plugin. Please try again.', 'performance-lab' ),
+		'ajaxUrl'               => admin_url( 'admin-ajax.php' ),
+		'nonce'                 => $nonce,
+		'activatingText'        => __( 'Activating...', 'performance-lab' ),
+		'activateText'          => __( 'Activate', 'performance-lab' ),
+		'activatedText'         => __( 'Active', 'performance-lab' ),
+		'dismissText'           => __( 'Dismiss this notice.', 'performance-lab' ),
+		'successText'           => __( 'Feature activated.', 'performance-lab' ),
+		'reviewText'            => __( ' Review ', 'performance-lab' ),
+		'settingsPrimaryText'   => __( 'settings', 'performance-lab' ),
+		'settingsSecondaryText' => __( 'Settings', 'performance-lab' ),
+		'endText'               => _x( '.', 'Punctuation mark', 'performance-lab' ),
+		'errorText'             => __( 'There was an error activating the plugin. Please try again.', 'performance-lab' ),
 	);
 
 	$js_function = <<<JS
@@ -475,7 +476,7 @@ function perflab_print_plugin_progress_indicator_script(): void {
 
 						wp.a11y.speak( data.activatingText );
 
-						const pluginSlug = target.getAttribute( 'data-plugin-slug' );
+						const pluginSlug = target.getAttribute( 'data-plugin-slug' ).trim();
 
 						try {
 							const response = await fetch( data.ajaxUrl, {
@@ -510,8 +511,23 @@ function perflab_print_plugin_progress_indicator_script(): void {
 							newButton.textContent = data.activatedText;
 
 							target.parentNode.replaceChild( newButton, target );
-							console.log(responseData)
-							showAdminNotice( data.successText, 'success', responseData?.data?.pluginSettingsURL );
+
+							const pluginSettingsURL = responseData?.data?.pluginSettingsURL;
+
+							const actionButtonList = document.querySelector( '.plugin-card-' + pluginSlug + ' .plugin-action-buttons' )
+
+							if ( pluginSettingsURL && actionButtonList ) {
+								const listItem = document.createElement( 'li' );
+								const anchor = document.createElement( 'a' );
+
+								anchor.setAttribute( 'href', pluginSettingsURL );
+								anchor.textContent = data.settingsSecondaryText;
+
+								listItem.appendChild( anchor );
+								actionButtonList.appendChild( listItem );
+							}
+							
+							showAdminNotice( data.successText, 'success', pluginSettingsURL );
 						} catch (error) {
 							showAdminNotice( data.errorText );
 
@@ -535,7 +551,7 @@ function perflab_print_plugin_progress_indicator_script(): void {
 					
 					const anchor = document.createElement( 'a' );
 					anchor.setAttribute( 'href', pluginSettingsURL );
-					anchor.textContent = data.settingsText;
+					anchor.textContent = data.settingsPrimaryText;
 					
 					para.appendChild( anchor );
 					para.appendChild( document.createTextNode( data.endText ) );

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -310,6 +310,8 @@ add_action( 'admin_action_perflab_install_activate_plugin', 'perflab_install_act
 
 /**
  * Callback for handling installation/activation of plugin using ajax.
+ *
+ * @since n.e.x.t
  */
 function perflab_install_activate_plugin_ajax_callback(): void {
 	check_ajax_referer( 'perflab_install_activate_plugin_ajax', '_ajax_nonce' );

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -231,9 +231,9 @@ function perflab_enqueue_features_page_scripts(): void {
 	// Enqueue plugin activate AJAX script and localize script data.
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',
-		PERFLAB_PLUGIN_DIR_URL . 'includes/admin/plugin-activate-ajax.js',
+		plugins_url( 'includes/admin/plugin-activate-ajax.js', PERFLAB_MAIN_FILE ),
 		array( 'jquery', 'wp-i18n', 'wp-a11y' ),
-		(string) filemtime( PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/plugin-activate-ajax.js' ),
+		PERFLAB_VERSION,
 		true
 	);
 
@@ -337,7 +337,7 @@ function perflab_install_activate_plugin_ajax_callback(): void {
 	if ( null !== $plugin_settings_url ) {
 		wp_send_json_success(
 			array(
-				'pluginSettingsURL' => esc_url( $plugin_settings_url ),
+				'pluginSettingsURL' => esc_url_raw( $plugin_settings_url ),
 			)
 		);
 	}

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -39,8 +39,6 @@ add_action( 'admin_menu', 'perflab_add_features_page' );
  * @since 1.0.0
  * @since 3.0.0 Renamed to perflab_load_features_page(), and the
  *              $module and $hook_suffix parameters were removed.
- * @since n.e.x.t Removed added action for perflab_print_plugin_progress_indicator_script
- *                as this function is removed.
  */
 function perflab_load_features_page(): void {
 	// Handle script enqueuing for settings page.
@@ -220,7 +218,6 @@ add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 
  *
  * @since 2.8.0
  * @since 3.0.0 Renamed to perflab_enqueue_features_page_scripts().
- * @since n.e.x.t Added enqueue plugin activate AJAX script.
  */
 function perflab_enqueue_features_page_scripts(): void {
 	// These assets are needed for the "Learn more" popover.

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -38,11 +38,32 @@
 		const pluginSlug = target.dataset.pluginSlug;
 
 		try {
-			// Activate the plugin via the REST API.
+			// Activate the plugin/feature via the REST API.
 			await apiFetch( {
-				path: `/performance-lab/v1/plugins/${ pluginSlug }:activate`,
+				path: `/performance-lab/v1/features/${ pluginSlug }:activate`,
 				method: 'POST',
 			} );
+
+			// Fetch the plugin/feature information via the REST API.
+			const featureInfo = await apiFetch( {
+				path: `/performance-lab/v1/features/${ pluginSlug }`,
+				method: 'GET',
+			} );
+
+			if ( featureInfo?.settingsUrl ) {
+				const actionButtonList = document.querySelector(
+					`.plugin-card-${ pluginSlug } .plugin-action-buttons`
+				);
+
+				const listItem = document.createElement( 'li' );
+				const anchor = document.createElement( 'a' );
+
+				anchor.href = featureInfo.settingsUrl;
+				anchor.textContent = __( 'Settings', 'performance-lab' );
+
+				listItem.appendChild( anchor );
+				actionButtonList.appendChild( listItem );
+			}
 
 			a11y.speak( __( 'Plugin activated.', 'performance-lab' ) );
 
@@ -55,27 +76,6 @@
 			target.classList.remove( 'updating-message' );
 			target.textContent = __( 'Activate', 'performance-lab' );
 		}
-
-		try {
-			// Fetch the plugin settings URL via the REST API.
-			const settingsResponse = await apiFetch( {
-				path: `/performance-lab/v1/plugin-settings-url/${ pluginSlug }`,
-				method: 'GET',
-			} );
-
-			const actionButtonList = document.querySelector(
-				`.plugin-card-${ pluginSlug } .plugin-action-buttons`
-			);
-
-			const listItem = document.createElement( 'li' );
-			const anchor = document.createElement( 'a' );
-
-			anchor.href = settingsResponse.pluginSettingsURL;
-			anchor.textContent = __( 'Settings', 'performance-lab' );
-
-			listItem.appendChild( anchor );
-			actionButtonList.appendChild( listItem );
-		} catch ( error ) {}
 	}
 
 	// Attach the event listeners.

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -1,0 +1,193 @@
+/**
+ * Handles activation of Performance Features (Plugins) using AJAX.
+ */
+
+/* global perflabPluginActivateAjaxData */
+document.addEventListener( 'DOMContentLoaded', function () {
+	// @ts-ignore
+	const { i18n, a11y } = wp;
+	const { __, _x } = i18n;
+
+	/**
+	 * Adds a click event listener to the document.
+	 *
+	 * This asynchronous function listens for click events on the document and executes
+	 * the provided callback function if triggered.
+	 *
+	 * @param {MouseEvent} event - The click event object that is triggered when the user clicks on the document.
+	 *
+	 * @return {Promise<void>} - The asynchronous function returns a promise that resolves to void.
+	 */
+	document.addEventListener( 'click', async function ( event ) {
+		const target = /** @type {HTMLElement} */ ( event.target );
+
+		if ( target.classList.contains( 'perflab-install-active-plugin' ) ) {
+			// Prevent the default link behavior.
+			event.preventDefault();
+
+			target.classList.add( 'updating-message' );
+			target.textContent = __( 'Activating…', 'performance-lab' );
+
+			a11y.speak( __( 'Activating…', 'performance-lab' ) );
+
+			const pluginSlug = target.getAttribute( 'data-plugin-slug' ).trim();
+
+			try {
+				const response = await fetch(
+					// @ts-ignore
+					perflabPluginActivateAjaxData.ajaxUrl,
+					{
+						method: 'POST',
+						credentials: 'same-origin',
+						headers: {
+							'Content-Type': 'application/x-www-form-urlencoded',
+						},
+						body: new URLSearchParams( {
+							action: 'perflab_install_activate_plugin',
+							slug: pluginSlug,
+							// @ts-ignore
+							_ajax_nonce: perflabPluginActivateAjaxData.nonce,
+						} ),
+					}
+				);
+
+				const responseData = await response.json();
+
+				if ( ! responseData.success ) {
+					showAdminNotice(
+						__(
+							'There was an error activating the plugin. Please try again.',
+							'performance-lab'
+						)
+					);
+
+					target.classList.remove( 'updating-message' );
+					target.textContent = __( 'Activate', 'performance-lab' );
+
+					return;
+				}
+
+				const newButton = document.createElement( 'button' );
+
+				newButton.type = 'button';
+				newButton.className = 'button button-disabled';
+				newButton.disabled = true;
+				newButton.textContent = __( 'Active', 'performance-lab' );
+
+				target.parentNode.replaceChild( newButton, target );
+
+				const pluginSettingsURL = responseData?.data?.pluginSettingsURL;
+
+				const actionButtonList = document.querySelector(
+					'.plugin-card-' + pluginSlug + ' .plugin-action-buttons'
+				);
+
+				if ( pluginSettingsURL && actionButtonList ) {
+					const listItem = document.createElement( 'li' );
+					const anchor = document.createElement( 'a' );
+
+					anchor.setAttribute( 'href', pluginSettingsURL );
+					anchor.textContent = __( 'Settings', 'performance-lab' );
+
+					listItem.appendChild( anchor );
+					actionButtonList.appendChild( listItem );
+				}
+
+				showAdminNotice(
+					__( 'Feature activated.', 'performance-lab' ),
+					'success',
+					pluginSettingsURL
+				);
+			} catch ( error ) {
+				showAdminNotice(
+					__(
+						'There was an error activating the plugin. Please try again.',
+						'performance-lab'
+					)
+				);
+
+				target.classList.remove( 'updating-message' );
+				target.textContent = __( 'Activate', 'performance-lab' );
+			}
+		}
+	} );
+
+	function showAdminNotice(
+		message,
+		type = 'error',
+		pluginSettingsURL = undefined
+	) {
+		// Create the notice container elements.
+		const notice = document.createElement( 'div' );
+		const para = document.createElement( 'p' );
+
+		notice.className = 'notice is-dismissible notice-' + type;
+		para.textContent = message;
+
+		if ( pluginSettingsURL ) {
+			para.textContent = `${ para.textContent } ${ __(
+				'Review',
+				'performance-lab'
+			) } `;
+
+			const anchor = document.createElement( 'a' );
+			anchor.setAttribute( 'href', pluginSettingsURL );
+			anchor.textContent = __( 'settings', 'performance-lab' );
+
+			para.appendChild( anchor );
+			para.appendChild(
+				document.createTextNode(
+					_x( '.', 'Punctuation mark', 'performance-lab' )
+				)
+			);
+		}
+
+		notice.appendChild( para );
+
+		const dismissButton = document.createElement( 'button' );
+		const dismissButtonTextWrap = document.createElement( 'span' );
+
+		dismissButton.type = 'button';
+		dismissButton.className = 'notice-dismiss';
+
+		dismissButtonTextWrap.className = 'screen-reader-text';
+		dismissButtonTextWrap.textContent = __(
+			'Dismiss this notice.',
+			'performance-lab'
+		);
+
+		dismissButton.appendChild( dismissButtonTextWrap );
+
+		// Add event listener to remove the notice when dismissed.
+		dismissButton.addEventListener( 'click', () => {
+			notice.remove();
+		} );
+
+		notice.appendChild( dismissButton );
+
+		// Insert the notice at the top of the admin notices area.
+		const noticeContainer =
+			document.querySelector( '.wrap.plugin-install-php' ) ||
+			document.body;
+
+		if ( ! noticeContainer ) {
+			// Fallback append to body if no suitable container is found.
+			document.body.prepend( notice );
+
+			return;
+		}
+
+		if ( noticeContainer.children.length >= 1 ) {
+			// Insert as the second child.
+			noticeContainer.insertBefore(
+				notice,
+				noticeContainer.children[ 1 ]
+			);
+
+			return;
+		}
+
+		// If there's only one child or none, append as the last child.
+		noticeContainer.appendChild( notice );
+	}
+} );

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -28,14 +28,19 @@
 		// Prevent the default link behavior.
 		event.preventDefault();
 
+		if (
+			target.classList.contains( 'updating-message' ) ||
+			target.classList.contains( 'disabled' )
+		) {
+			return;
+		}
+
 		target.classList.add( 'updating-message' );
 		target.textContent = __( 'Activating…', 'performance-lab' );
-		target.style.pointerEvents = 'none';
-		target.parentElement.style.cursor = 'not-allowed';
 
 		a11y.speak( __( 'Activating…', 'performance-lab' ) );
 
-		const pluginSlug = target.getAttribute( 'data-plugin-slug' ).trim();
+		const pluginSlug = target.dataset.pluginSlug;
 
 		// Send an AJAX POST request to activate the plugin.
 		try {
@@ -60,23 +65,14 @@
 			const responseData = await response.json();
 
 			if ( ! responseData.success ) {
-				target.classList.remove( 'updating-message' );
-				target.textContent = __( 'Activate', 'performance-lab' );
-				target.style.pointerEvents = '';
-				target.parentElement.style.cursor = '';
-
-				return;
+				throw Error();
 			}
 
-			const newButton = document.createElement( 'button' );
+			a11y.speak( __( 'Plugin activated.', 'performance-lab' ) );
 
-			newButton.type = 'button';
-			newButton.className = 'button button-disabled';
-			newButton.disabled = true;
-			newButton.textContent = __( 'Active', 'performance-lab' );
-			target.parentElement.style.cursor = '';
-
-			target.parentNode.replaceChild( newButton, target );
+			target.textContent = __( 'Active', 'performance-lab' );
+			target.classList.remove( 'updating-message' );
+			target.classList.add( 'disabled' );
 
 			const pluginSettingsURL = responseData?.data?.pluginSettingsURL;
 
@@ -88,17 +84,17 @@
 				const listItem = document.createElement( 'li' );
 				const anchor = document.createElement( 'a' );
 
-				anchor.setAttribute( 'href', pluginSettingsURL );
+				anchor.href = pluginSettingsURL;
 				anchor.textContent = __( 'Settings', 'performance-lab' );
 
 				listItem.appendChild( anchor );
 				actionButtonList.appendChild( listItem );
 			}
 		} catch ( error ) {
+			a11y.speak( __( 'Plugin failed to activate.', 'performance-lab' ) );
+
 			target.classList.remove( 'updating-message' );
 			target.textContent = __( 'Activate', 'performance-lab' );
-			target.style.pointerEvents = '';
-			target.parentElement.style.cursor = '';
 		}
 	}
 

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -30,6 +30,8 @@
 
 		target.classList.add( 'updating-message' );
 		target.textContent = __( 'Activating…', 'performance-lab' );
+		target.style.pointerEvents = 'none';
+		target.parentElement.style.cursor = 'not-allowed';
 
 		a11y.speak( __( 'Activating…', 'performance-lab' ) );
 
@@ -60,6 +62,8 @@
 			if ( ! responseData.success ) {
 				target.classList.remove( 'updating-message' );
 				target.textContent = __( 'Activate', 'performance-lab' );
+				target.style.pointerEvents = '';
+				target.parentElement.style.cursor = '';
 
 				return;
 			}
@@ -70,6 +74,7 @@
 			newButton.className = 'button button-disabled';
 			newButton.disabled = true;
 			newButton.textContent = __( 'Active', 'performance-lab' );
+			target.parentElement.style.cursor = '';
 
 			target.parentNode.replaceChild( newButton, target );
 
@@ -92,6 +97,8 @@
 		} catch ( error ) {
 			target.classList.remove( 'updating-message' );
 			target.textContent = __( 'Activate', 'performance-lab' );
+			target.style.pointerEvents = '';
+			target.parentElement.style.cursor = '';
 		}
 	}
 

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -45,6 +45,7 @@
 			} );
 
 			// Fetch the plugin/feature information via the REST API.
+			/** @type {{settingsUrl: string|null}} */
 			const featureInfo = await apiFetch( {
 				path: `/performance-lab/v1/features/${ pluginSlug }`,
 				method: 'GET',

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -50,7 +50,7 @@
 				method: 'GET',
 			} );
 
-			if ( featureInfo?.settingsUrl ) {
+			if ( featureInfo.settingsUrl ) {
 				const actionButtonList = document.querySelector(
 					`.plugin-card-${ pluginSlug } .plugin-action-buttons`
 				);

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -6,18 +6,18 @@
 ( function ( $ ) {
 	// @ts-ignore
 	const { i18n, a11y } = wp;
-	const { __, _x } = i18n;
+	const { __ } = i18n;
 
-	/**
-	 * Adds a click event listener to the plugin activate buttons.
-	 *
-	 * @param {MouseEvent} event - The click event object that is triggered when the user clicks on the document.
-	 *
-	 * @return {Promise<void>} - The asynchronous function returns a promise.
-	 */
 	$( document ).on(
 		'click',
 		'.perflab-install-active-plugin',
+		/**
+		 * Adds a click event listener to the plugin activate buttons.
+		 *
+		 * @param {MouseEvent} event - The click event object that is triggered when the user clicks on the document.
+		 *
+		 * @return {Promise<void>} - The asynchronous function returns a promise.
+		 */
 		async function ( event ) {
 			// Prevent the default link behavior.
 			event.preventDefault();
@@ -48,13 +48,6 @@
 				},
 				success( responseData ) {
 					if ( ! responseData.success ) {
-						showAdminNotice(
-							__(
-								'There was an error activating the plugin. Please try again.',
-								'performance-lab'
-							)
-						);
-
 						target
 							.removeClass( 'updating-message' )
 							.text( __( 'Activate', 'performance-lab' ) );
@@ -91,21 +84,8 @@
 							)
 						);
 					}
-
-					showAdminNotice(
-						__( 'Feature activated.', 'performance-lab' ),
-						'success',
-						pluginSettingsURL
-					);
 				},
 				error() {
-					showAdminNotice(
-						__(
-							'There was an error activating the plugin. Please try again.',
-							'performance-lab'
-						)
-					);
-
 					target
 						.removeClass( 'updating-message' )
 						.text( __( 'Activate', 'performance-lab' ) );
@@ -113,63 +93,6 @@
 			} );
 		}
 	);
-
-	/**
-	 * Displays an admin notice with the given message and type.
-	 *
-	 * @param {string} message             - The message to display in the notice.
-	 * @param {string} [type='error']      - The type of notice ('error', 'success', etc.).
-	 * @param {string} [pluginSettingsURL] - Optional URL for the plugin settings.
-	 */
-	function showAdminNotice(
-		message,
-		type = 'error',
-		pluginSettingsURL = undefined
-	) {
-		a11y.speak( message );
-
-		// Create the notice container elements.
-		const notice = $( '<div>', {
-			class: `notice is-dismissible notice-${ type }`,
-		} );
-
-		const messageWrap = $( '<p>' ).text( message );
-
-		// If a plugin settings URL is provided, append a 'Review settings.' link.
-		if ( pluginSettingsURL ) {
-			messageWrap
-				.append( ` ${ __( 'Review', 'performance-lab' ) } ` )
-				.append(
-					$( '<a>', {
-						href: pluginSettingsURL,
-						text: __( 'settings', 'performance-lab' ),
-					} )
-				)
-				.append( _x( '.', 'Punctuation mark', 'performance-lab' ) );
-		}
-
-		const dismissButton = $( '<button>', {
-			type: 'button',
-			class: 'notice-dismiss',
-			click: () => notice.remove(),
-		} ).append(
-			$( '<span>', {
-				class: 'screen-reader-text',
-				text: __( 'Dismiss this notice.', 'performance-lab' ),
-			} )
-		);
-
-		notice.append( messageWrap, dismissButton );
-
-		const noticeContainer = $( '.wrap.plugin-install-php' );
-
-		if ( noticeContainer.length ) {
-			// If the container exists, insert the notice after the first child.
-			noticeContainer.children().eq( 0 ).after( notice );
-		} else {
-			$( 'body' ).prepend( notice );
-		}
-	}
 
 	// @ts-ignore
 } )( window.jQuery );

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -383,7 +383,6 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
  * This is adapted from `WP_Plugin_Install_List_Table::display_rows()` in core.
  *
  * @since 2.8.0
- * @since n.e.x.t Added data attribute `data-plugin-slug` in plugin activate link.
  *
  * @see WP_Plugin_Install_List_Table::display_rows()
  * @link https://github.com/WordPress/wordpress-develop/blob/0b8ca16ea3bd9722bd1a38f8ab68901506b1a0e7/src/wp-admin/includes/class-wp-plugin-install-list-table.php#L467-L830

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -426,8 +426,9 @@ function perflab_render_plugin_card( array $plugin_data ): void {
 		);
 
 		$action_links[] = sprintf(
-			'<a class="button perflab-install-active-plugin" href="%s">%s</a>',
+			'<a class="button perflab-install-active-plugin" href="%s" data-plugin-slug="%s">%s</a>',
 			esc_url( $url ),
+			esc_attr( $plugin_data['slug'] ),
 			esc_html__( 'Activate', 'default' )
 		);
 	} else {

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -383,6 +383,7 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
  * This is adapted from `WP_Plugin_Install_List_Table::display_rows()` in core.
  *
  * @since 2.8.0
+ * @since n.e.x.t Added data attribute `data-plugin-slug` in plugin activate link.
  *
  * @see WP_Plugin_Install_List_Table::display_rows()
  * @link https://github.com/WordPress/wordpress-develop/blob/0b8ca16ea3bd9722bd1a38f8ab68901506b1a0e7/src/wp-admin/includes/class-wp-plugin-install-list-table.php#L467-L830

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -53,7 +53,7 @@ function perflab_register_endpoint(): void {
 			'args'                => array(
 				'slug' => array(
 					'type'              => 'string',
-					'description'       => __( 'Plugin slug of plugin/feature that needs to be activated.', 'performance-lab' ),
+					'description'       => __( 'Plugin slug of the Performance Lab feature to be activated.', 'performance-lab' ),
 					'required'          => true,
 					'validate_callback' => 'perflab_validate_slug_endpoint_arg',
 				),

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -74,7 +74,7 @@ function perflab_register_endpoint(): void {
 			'args'                => array(
 				'slug' => array(
 					'type'              => 'string',
-					'description'       => __( 'Plugin slug of plugin/feature whose settings URL is needed.', 'performance-lab' ),
+					'description'       => __( 'Plugin slug of plugin/feature whose information is needed.', 'performance-lab' ),
 					'required'          => true,
 					'validate_callback' => 'perflab_validate_slug_endpoint_arg',
 				),
@@ -85,7 +85,7 @@ function perflab_register_endpoint(): void {
 					return true;
 				}
 
-				return new WP_Error( 'cannot_access_plugin_settings_url', __( 'Sorry, you are not allowed to access plugin settings URL on this site.', 'performance-lab' ) );
+				return new WP_Error( 'cannot_access_plugin_settings_url', __( 'Sorry, you are not allowed to access plugin/feature information on this site.', 'performance-lab' ) );
 			},
 		)
 	);
@@ -127,7 +127,7 @@ function perflab_handle_feature_activation( WP_REST_Request $request ) {
 	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-ajax-upgrader-skin.php';
 
-	// Install and activate the plugin and its dependencies.
+	// Install and activate the plugin/feature and its dependencies.
 	$result = perflab_install_and_activate_plugin( $request['slug'] );
 	if ( is_wp_error( $result ) ) {
 		return new WP_Error(

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -127,6 +127,7 @@ function perflab_validate_slug_endpoint_arg( string $slug ): bool {
  * @return WP_REST_Response|WP_Error Response.
  */
 function perflab_handle_feature_activation( WP_REST_Request $request ) {
+	require_once ABSPATH . 'wp-admin/includes/file.php';
 	require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-ajax-upgrader-skin.php';

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * REST API integration for the plugin.
+ *
+ * @package performance-lab
+ * @since n.e.x.t
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Namespace for performance-lab REST API.
+ *
+ * @var string
+ */
+const PERFLAB_REST_API_NAMESPACE = 'performance-lab/v1';
+
+/**
+ * Route for activating plugin.
+ *
+ * @var string
+ */
+const PERFLAB_ACTIVATE_PLUGIN_ROUTE = '/activate-plugin';
+
+/**
+ * Route for fetching plugin settings URL.
+ *
+ * @var string
+ */
+const PERFLAB_PLUGIN_SETTINGS_URL_ROUTE = '/plugin-settings-url';
+
+/**
+ * Registers endpoint for performance-lab REST API.
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+function perflab_register_endpoint(): void {
+	register_rest_route(
+		PERFLAB_REST_API_NAMESPACE,
+		PERFLAB_ACTIVATE_PLUGIN_ROUTE,
+		array(
+			'methods'             => 'POST',
+			'args'                => array(
+				'slug' => array(
+					'type'        => 'string',
+					'description' => __( 'Plugin slug of plugin that needs to be activated.', 'performance-lab' ),
+					'required'    => true,
+				),
+			),
+			'callback'            => 'perflab_handle_activate_plugin',
+			'permission_callback' => static function () {
+				if ( current_user_can( 'install_plugins' ) ) {
+					return true;
+				}
+
+				return new WP_Error( 'cannot_install_plugin', __( 'Sorry, you are not allowed to install plugins on this site.', 'performance-lab' ) );
+			},
+		)
+	);
+
+	register_rest_route(
+		PERFLAB_REST_API_NAMESPACE,
+		PERFLAB_PLUGIN_SETTINGS_URL_ROUTE,
+		array(
+			'methods'             => 'POST',
+			'args'                => array(
+				'slug' => array(
+					'type'        => 'string',
+					'description' => __( 'Plugin slug of plugin whose settings URL is needed.', 'performance-lab' ),
+					'required'    => true,
+				),
+			),
+			'callback'            => 'perflab_handle_get_plugin_settings_url',
+			'permission_callback' => static function () {
+				if ( current_user_can( 'manage_options' ) ) {
+					return true;
+				}
+
+				return new WP_Error( 'cannot_access_plugin_settings_url', __( 'Sorry, you are not allowed to access plugin settings URL on this site.', 'performance-lab' ) );
+			},
+		)
+	);
+}
+add_action( 'rest_api_init', 'perflab_register_endpoint' );
+
+/**
+ * Handles REST API request to activate plugin.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+ *
+ * @param WP_REST_Request $request Request.
+ * @return WP_REST_Response|WP_Error Response.
+ */
+function perflab_handle_activate_plugin( WP_REST_Request $request ) {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+	require_once ABSPATH . 'wp-admin/includes/class-wp-ajax-upgrader-skin.php';
+
+	// Require to make helper functions available.
+	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/load.php';
+	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/plugins.php';
+
+	$params = $request->get_json_params();
+
+	// Ensure the 'slug' parameter is present.
+	if ( ! isset( $params['slug'] ) ) {
+		return new WP_Error(
+			'missing_parameter',
+			__( 'Missing required parameter "slug".', 'performance-lab' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$plugin_slug = perflab_sanitize_plugin_slug( wp_unslash( $params['slug'] ) );
+	if ( null === $plugin_slug ) {
+		return new WP_Error(
+			'invalid_plugin',
+			__( 'Invalid plugin slug provided.', 'performance-lab' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	// Install and activate the plugin and its dependencies.
+	$result = perflab_install_and_activate_plugin( $plugin_slug );
+	if ( is_wp_error( $result ) ) {
+		return new WP_Error(
+			'plugin_activation_failed',
+			$result->get_error_message(),
+			array( 'status' => 500 )
+		);
+	}
+
+	return new WP_REST_Response(
+		array(
+			'success' => true,
+		)
+	);
+}
+
+/**
+ * Handles REST API request to get plugin settings URL.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @phpstan-param WP_REST_Request<array<string, mixed>> $request
+ *
+ * @param WP_REST_Request $request Request.
+ * @return WP_REST_Response|WP_Error Response.
+ */
+function perflab_handle_get_plugin_settings_url( WP_REST_Request $request ) {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+	// Require to make helper functions available.
+	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/load.php';
+	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/plugins.php';
+
+	$params = $request->get_json_params();
+
+	// Ensure the 'slug' parameter is present.
+	if ( ! isset( $params['slug'] ) ) {
+		return new WP_Error(
+			'missing_parameter',
+			__( 'Missing required parameter "slug".', 'performance-lab' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$plugin_slug = perflab_sanitize_plugin_slug( wp_unslash( $params['slug'] ) );
+	if ( null === $plugin_slug ) {
+		return new WP_Error(
+			'invalid_plugin',
+			__( 'Invalid plugin slug provided.', 'performance-lab' ),
+			array( 'status' => 400 )
+		);
+	}
+
+	$plugin_settings_url = perflab_get_plugin_settings_url( $plugin_slug );
+	if ( null === $plugin_settings_url ) {
+		return new WP_REST_Response(
+			array(
+				'success'           => true,
+				'pluginSettingsURL' => false,
+			)
+		);
+	}
+
+	return new WP_REST_Response(
+		array(
+			'success'           => true,
+			'pluginSettingsURL' => esc_url_raw( $plugin_settings_url ),
+		)
+	);
+}

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -20,16 +20,20 @@ const PERFLAB_REST_API_NAMESPACE = 'performance-lab/v1';
 /**
  * Route for activating plugin.
  *
+ * Note the `:activate` art of the endpoint follows Google's guidance in AIP-136 for the use of the POST method in a way
+ * that does not strictly follow the standard usage.
+ *
+ * @link https://google.aip.dev/136
  * @var string
  */
-const PERFLAB_ACTIVATE_PLUGIN_ROUTE = '/activate-plugin';
+const PERFLAB_ACTIVATE_PLUGIN_ROUTE = '/plugins/(?P<slug>[a-z0-9_-]+):activate';
 
 /**
  * Route for fetching plugin settings URL.
  *
  * @var string
  */
-const PERFLAB_PLUGIN_SETTINGS_URL_ROUTE = '/plugin-settings-url';
+const PERFLAB_PLUGIN_SETTINGS_URL_ROUTE = '/plugin-settings-url/(?P<slug>[a-z0-9_-]+)';
 
 /**
  * Registers endpoint for performance-lab REST API.
@@ -45,9 +49,10 @@ function perflab_register_endpoint(): void {
 			'methods'             => 'POST',
 			'args'                => array(
 				'slug' => array(
-					'type'        => 'string',
-					'description' => __( 'Plugin slug of plugin that needs to be activated.', 'performance-lab' ),
-					'required'    => true,
+					'type'              => 'string',
+					'description'       => __( 'Plugin slug of plugin that needs to be activated.', 'performance-lab' ),
+					'required'          => true,
+					'validate_callback' => 'perflab_validate_slug_endpoint_arg',
 				),
 			),
 			'callback'            => 'perflab_handle_activate_plugin',
@@ -65,12 +70,13 @@ function perflab_register_endpoint(): void {
 		PERFLAB_REST_API_NAMESPACE,
 		PERFLAB_PLUGIN_SETTINGS_URL_ROUTE,
 		array(
-			'methods'             => 'POST',
+			'methods'             => 'GET',
 			'args'                => array(
 				'slug' => array(
-					'type'        => 'string',
-					'description' => __( 'Plugin slug of plugin whose settings URL is needed.', 'performance-lab' ),
-					'required'    => true,
+					'type'              => 'string',
+					'description'       => __( 'Plugin slug of plugin whose settings URL is needed.', 'performance-lab' ),
+					'required'          => true,
+					'validate_callback' => 'perflab_validate_slug_endpoint_arg',
 				),
 			),
 			'callback'            => 'perflab_handle_get_plugin_settings_url',
@@ -87,6 +93,25 @@ function perflab_register_endpoint(): void {
 add_action( 'rest_api_init', 'perflab_register_endpoint' );
 
 /**
+ * Validates whether the provided plugin slug is a valid Performance Lab plugin.
+ *
+ * Note that an enum is not being used because additional PHP files have to be required to access the necessary functions,
+ * and this would not be ideal to do at rest_api_init.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @param string $slug Plugin slug.
+ * @return bool Whether valid.
+ */
+function perflab_validate_slug_endpoint_arg( string $slug ): bool {
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/load.php';
+	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/plugins.php';
+	return in_array( $slug, perflab_get_standalone_plugins(), true );
+}
+
+/**
  * Handles REST API request to activate plugin.
  *
  * @since n.e.x.t
@@ -98,37 +123,12 @@ add_action( 'rest_api_init', 'perflab_register_endpoint' );
  * @return WP_REST_Response|WP_Error Response.
  */
 function perflab_handle_activate_plugin( WP_REST_Request $request ) {
-	require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 	require_once ABSPATH . 'wp-admin/includes/class-wp-ajax-upgrader-skin.php';
 
-	// Require to make helper functions available.
-	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/load.php';
-	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/plugins.php';
-
-	$params = $request->get_json_params();
-
-	// Ensure the 'slug' parameter is present.
-	if ( ! isset( $params['slug'] ) ) {
-		return new WP_Error(
-			'missing_parameter',
-			__( 'Missing required parameter "slug".', 'performance-lab' ),
-			array( 'status' => 400 )
-		);
-	}
-
-	$plugin_slug = perflab_sanitize_plugin_slug( wp_unslash( $params['slug'] ) );
-	if ( null === $plugin_slug ) {
-		return new WP_Error(
-			'invalid_plugin',
-			__( 'Invalid plugin slug provided.', 'performance-lab' ),
-			array( 'status' => 400 )
-		);
-	}
-
 	// Install and activate the plugin and its dependencies.
-	$result = perflab_install_and_activate_plugin( $plugin_slug );
+	$result = perflab_install_and_activate_plugin( $request['slug'] );
 	if ( is_wp_error( $result ) ) {
 		return new WP_Error(
 			'plugin_activation_failed',
@@ -156,46 +156,14 @@ function perflab_handle_activate_plugin( WP_REST_Request $request ) {
  * @return WP_REST_Response|WP_Error Response.
  */
 function perflab_handle_get_plugin_settings_url( WP_REST_Request $request ) {
-	require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-	// Require to make helper functions available.
-	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/load.php';
-	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/plugins.php';
-
-	$params = $request->get_json_params();
-
-	// Ensure the 'slug' parameter is present.
-	if ( ! isset( $params['slug'] ) ) {
-		return new WP_Error(
-			'missing_parameter',
-			__( 'Missing required parameter "slug".', 'performance-lab' ),
-			array( 'status' => 400 )
-		);
-	}
-
-	$plugin_slug = perflab_sanitize_plugin_slug( wp_unslash( $params['slug'] ) );
-	if ( null === $plugin_slug ) {
-		return new WP_Error(
-			'invalid_plugin',
-			__( 'Invalid plugin slug provided.', 'performance-lab' ),
-			array( 'status' => 400 )
-		);
-	}
-
-	$plugin_settings_url = perflab_get_plugin_settings_url( $plugin_slug );
+	$plugin_settings_url = perflab_get_plugin_settings_url( $request['slug'] );
 	if ( null === $plugin_settings_url ) {
-		return new WP_REST_Response(
-			array(
-				'success'           => true,
-				'pluginSettingsURL' => false,
-			)
+		return new WP_Error(
+			'no_settings_url',
+			__( 'No settings URL', 'performance-lab' ),
+			array( 'status' => 404 )
 		);
 	}
 
-	return new WP_REST_Response(
-		array(
-			'success'           => true,
-			'pluginSettingsURL' => esc_url_raw( $plugin_settings_url ),
-		)
-	);
+	return new WP_REST_Response( $plugin_settings_url );
 }

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -60,11 +60,12 @@ function perflab_register_endpoint(): void {
 			),
 			'callback'            => 'perflab_handle_feature_activation',
 			'permission_callback' => static function () {
-				if ( current_user_can( 'install_plugins' ) ) {
+				// Important: The endpoint calls perflab_install_and_activate_plugin() which does more granular capability checks.
+				if ( current_user_can( 'activate_plugins' ) ) {
 					return true;
 				}
 
-				return new WP_Error( 'cannot_install_plugin', __( 'Sorry, you are not allowed to install plugins on this site.', 'performance-lab' ) );
+				return new WP_Error( 'cannot_activate', __( 'Sorry, you are not allowed to activate this feature.', 'performance-lab' ) );
 			},
 		)
 	);

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -134,10 +134,21 @@ function perflab_handle_feature_activation( WP_REST_Request $request ) {
 	// Install and activate the plugin/feature and its dependencies.
 	$result = perflab_install_and_activate_plugin( $request['slug'] );
 	if ( is_wp_error( $result ) ) {
+		switch ( $result->get_error_code() ) {
+			case 'cannot_install_plugin':
+			case 'cannot_activate_plugin':
+				$response_code = rest_authorization_required_code();
+				break;
+			case 'plugin_not_found':
+				$response_code = 404;
+				break;
+			default:
+				$response_code = 500;
+		}
 		return new WP_Error(
-			'plugin_activation_failed',
+			$result->get_error_code(),
 			$result->get_error_message(),
-			array( 'status' => 500 )
+			array( 'status' => $response_code )
 		);
 	}
 

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Namespace for performance-lab REST API.
  *
+ * @since n.e.x.t
  * @var string
  */
 const PERFLAB_REST_API_NAMESPACE = 'performance-lab/v1';
@@ -23,6 +24,7 @@ const PERFLAB_REST_API_NAMESPACE = 'performance-lab/v1';
  * Note the `:activate` art of the endpoint follows Google's guidance in AIP-136 for the use of the POST method in a way
  * that does not strictly follow the standard usage.
  *
+ * @since n.e.x.t
  * @link https://google.aip.dev/136
  * @var string
  */
@@ -31,6 +33,7 @@ const PERFLAB_FEATURES_ACTIVATE_ROUTE = '/features/(?P<slug>[a-z0-9_-]+):activat
 /**
  * Route for fetching plugin/feature information.
  *
+ * @since n.e.x.t
  * @var string
  */
 const PERFLAB_FEATURES_INFORMATION_ROUTE = '/features/(?P<slug>[a-z0-9_-]+)';

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -339,3 +339,6 @@ if ( is_admin() ) {
 	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/server-timing.php';
 	require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/plugins.php';
 }
+
+// Load REST API.
+require_once PERFLAB_PLUGIN_DIR_PATH . 'includes/admin/rest-api.php';

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -22,7 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'PERFLAB_VERSION', '3.5.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
-define( 'PERFLAB_PLUGIN_DIR_URL', plugin_dir_url( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );
 
 // If the constant isn't defined yet, it means the Performance Lab object cache file is not loaded.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -22,6 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'PERFLAB_VERSION', '3.5.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
+define( 'PERFLAB_PLUGIN_DIR_URL', plugin_dir_url( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );
 
 // If the constant isn't defined yet, it means the Performance Lab object cache file is not loaded.

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -29,24 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * @param Closure $load            Callback that loads the plugin.
 	 */
 	static function ( string $global_var_name, string $version, Closure $load ): void {
-		$needs_bootstrap = ! isset( $GLOBALS[ $global_var_name ] );
-
-		// Register this copy of the plugin.
-		if (
-			// Register this copy if none has been registered yet.
-			! isset( $GLOBALS[ $global_var_name ]['version'] )
-			||
-			// Or register this copy if the version greater than what is currently registered.
-			version_compare( $version, $GLOBALS[ $global_var_name ]['version'], '>' )
-			||
-			// Otherwise, register this copy if it is actually the one installed in the directory for plugins.
-			rtrim( WP_PLUGIN_DIR, '/' ) === dirname( __DIR__ )
-		) {
-			$GLOBALS[ $global_var_name ]['version'] = $version;
-			$GLOBALS[ $global_var_name ]['load']    = $load;
-		}
-
-		if ( $needs_bootstrap ) {
+		if ( ! isset( $GLOBALS[ $global_var_name ] ) ) {
 			$bootstrap = static function () use ( $global_var_name ): void {
 				if (
 					isset( $GLOBALS[ $global_var_name ]['load'], $GLOBALS[ $global_var_name ]['version'] )
@@ -62,11 +45,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			// Wait until after the plugins have loaded and the theme has loaded. The after_setup_theme action is used
 			// because it is the first action that fires once the theme is loaded.
-			if ( (bool) did_action( 'after_setup_theme' ) ) {
-				$bootstrap();
-			} else {
-				add_action( 'after_setup_theme', $bootstrap, PHP_INT_MIN );
-			}
+			add_action( 'after_setup_theme', $bootstrap, PHP_INT_MIN );
+		}
+
+		// Register this copy of the plugin.
+		if (
+			// Register this copy if none has been registered yet.
+			! isset( $GLOBALS[ $global_var_name ]['version'] )
+			||
+			// Or register this copy if the version greater than what is currently registered.
+			version_compare( $version, $GLOBALS[ $global_var_name ]['version'], '>' )
+			||
+			// Otherwise, register this copy if it is actually the one installed in the directory for plugins.
+			rtrim( WP_PLUGIN_DIR, '/' ) === dirname( __DIR__ )
+		) {
+			$GLOBALS[ $global_var_name ]['version'] = $version;
+			$GLOBALS[ $global_var_name ]['load']    = $load;
 		}
 	}
 )(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes [#1583](https://github.com/WordPress/performance/issues/1583)

## Relevant technical choices

<!-- Please describe your changes. -->
1. Frontend / UX
    - Features / plugins in Performance Lab are now activated using AJAX improving user experience.
    - No page refresh when activating features / plugins.
    - Multiple plugin can be activated as each plugin activation sends different AJAX request.
    - The click event is added to the anchor link as if JavaScript is enabled then the default behaviour is prevented so it functions as a button else It behaves as a link.

2. Backend
    - Removed `perflab_print_plugin_progress_indicator_script` function as it was previously used for adding a progress indicator to the activate button on click. This functionality is now moved to the separate JavaScript file which handles the activation of plugin.
    - Added `perflab-plugin-activate-ajax` (script handle) script which handles activation of features / plugins using AJAX.
    - Updated `perflab_render_plugin_card` function to add data attribute `data-plugin-slug` in plugin activate link.
    - Added new REST API endpoints
        - `performance-lab/v1/features/(?P<slug>[a-z0-9_-]+):activate`
        - `performance-lab/v1/features/(?P<slug>[a-z0-9_-]+)`
  
3. Unable to Implement fully
   - Regarding the setting URL which is displayed in the admin notices and the plugin card.
   - I have implemented the settings URL part but it only works for the `Modern Image Formats` plugin.
   - Context: Currently only two plugins provide the settings URL  `Modern Image Formats` and `Speculative Loading`.
   - It does not work with the `Speculative Loading` because of how this plugin is loaded.
       - This plugin gets loaded ( loaded in this context is when are its helper files are loaded like `settings.php` ) on `after_setup_theme` hook.
       - But when the AJAX callback is triggered this hook has already been executed. As the plugin is activated later and which requries the `after_setup_theme` hook to fully load the plugin which includes the settings URL.
       - The function which is executed in the `after_setup_theme` calls a closure function which is stored in the global variable ( `plsr_pending_plugin_info` for the `Speculative Loading` plugin ) this closure function fully loads the plugin.
   - I tried and tested this could be fixed by calling the closure function in AJAX callback but we will be hardcoding the global variable name and will have to update the callback function if other plugins also add settings URL.
 
 4. Demo


https://github.com/user-attachments/assets/da3858aa-5359-4077-8015-b59b73c922a4





<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
