### PR TITLE
Fix uses of 'Plugin not found' string

### DIFF
--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -359,7 +359,7 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
 		}
 
 		$plugins = get_plugins( '/' . $plugin_slug );
-		if ( empty( $plugins ) ) {
+		if ( count( $plugins ) === 0 ) {
 			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
 		}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -25,7 +25,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	if ( is_array( $plugins ) ) {
 		// If the specific plugin_slug is not in the cache, return an error.
 		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
-			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
+			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
 		}
 		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
 	}
@@ -83,7 +83,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	set_transient( $transient_key, $plugins, HOUR_IN_SECONDS );
 
 	if ( ! isset( $plugins[ $plugin_slug ] ) ) {
-		return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'performance-lab' ) );
+		return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
 	}
 
 	/**

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -29,7 +29,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 				'plugin_not_found',
 				__( 'Plugin not found.', 'default' ) . ' ' .
 				/* translators: %s is error code */
-				sprintf( '(Error code: %d)', __LINE__ )
+				sprintf( '(Error line: %d)', __LINE__ )
 			);
 		}
 		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
@@ -92,7 +92,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 			'plugin_not_found',
 			__( 'Plugin not found.', 'default' ) . ' ' .
 			/* translators: %s is error code */
-			sprintf( '(Error code: %d)', __LINE__ )
+			sprintf( '(Error line: %d)', __LINE__ )
 		);
 	}
 
@@ -374,7 +374,7 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
 				'plugin_not_found',
 				__( 'Plugin not found.', 'default' ) . ' ' .
 				/* translators: %s is error code */
-				sprintf( '(Error code: %d)', __LINE__ )
+				sprintf( '(Error line: %d)', __LINE__ )
 			);
 		}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -27,9 +27,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
 			return new WP_Error(
 				'plugin_not_found',
-				__( 'Plugin not found.', 'default' ) . ' ' .
-				/* translators: %s is error code */
-				sprintf( '(Error line: %d)', __LINE__ )
+				__( 'Plugin not found in cached API response.', 'performance-lab' )
 			);
 		}
 		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
@@ -90,9 +88,7 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	if ( ! isset( $plugins[ $plugin_slug ] ) ) {
 		return new WP_Error(
 			'plugin_not_found',
-			__( 'Plugin not found.', 'default' ) . ' ' .
-			/* translators: %s is error code */
-			sprintf( '(Error line: %d)', __LINE__ )
+			__( 'Plugin not found in API response.', 'performance-lab' )
 		);
 	}
 
@@ -372,9 +368,7 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
 		if ( count( $plugins ) === 0 ) {
 			return new WP_Error(
 				'plugin_not_found',
-				__( 'Plugin not found.', 'default' ) . ' ' .
-				/* translators: %s is error code */
-				sprintf( '(Error line: %d)', __LINE__ )
+				__( 'Plugin not found among installed plugins.', 'performance-lab' )
 			);
 		}
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array{name: string, slug: string, short_description: string, requires: string|false, requires_php: string|false, requires_plugins: string[], download_link: string, version: string}|WP_Error Array of plugin data or WP_Error if failed.
  */
 function perflab_query_plugin_info( string $plugin_slug ) {
-	$transient_key = 'perflab_plugins_info-v2';
+	$transient_key = 'perflab_plugins_info';
 	$plugins       = get_transient( $transient_key );
 
 	if ( is_array( $plugins ) ) {

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -25,7 +25,12 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	if ( is_array( $plugins ) ) {
 		// If the specific plugin_slug is not in the cache, return an error.
 		if ( ! isset( $plugins[ $plugin_slug ] ) ) {
-			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
+			return new WP_Error(
+				'plugin_not_found',
+				__( 'Plugin not found.', 'default' ) . ' ' .
+				/* translators: %s is error code */
+				sprintf( '(Error code: %d)', __LINE__ )
+			);
 		}
 		return $plugins[ $plugin_slug ]; // Return cached plugin info if found.
 	}
@@ -83,7 +88,12 @@ function perflab_query_plugin_info( string $plugin_slug ) {
 	set_transient( $transient_key, $plugins, HOUR_IN_SECONDS );
 
 	if ( ! isset( $plugins[ $plugin_slug ] ) ) {
-		return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
+		return new WP_Error(
+			'plugin_not_found',
+			__( 'Plugin not found.', 'default' ) . ' ' .
+			/* translators: %s is error code */
+			sprintf( '(Error code: %d)', __LINE__ )
+		);
 	}
 
 	/**
@@ -360,7 +370,12 @@ function perflab_install_and_activate_plugin( string $plugin_slug, array &$proce
 
 		$plugins = get_plugins( '/' . $plugin_slug );
 		if ( count( $plugins ) === 0 ) {
-			return new WP_Error( 'plugin_not_found', __( 'Plugin not found.', 'default' ) );
+			return new WP_Error(
+				'plugin_not_found',
+				__( 'Plugin not found.', 'default' ) . ' ' .
+				/* translators: %s is error code */
+				sprintf( '(Error code: %d)', __LINE__ )
+			);
 		}
 
 		$plugin_file_names = array_keys( $plugins );


### PR DESCRIPTION
I [replied](https://wordpress.org/support/topic/plugin-not-found-9/#post-18130638) to a [comment](https://wordpress.org/support/topic/plugin-not-found-9/#post-18130597) from @gordonrjones (maybe the same GitHub username?) on the WordPress support forum:

> There are three possible locations where this error could be coming from:
> https://github.com/WordPress/performance/blob/7c6aa818b5c9707d7619a91614548ef51efba033/plugins/performance-lab/includes/admin/plugins.php#L28
> https://github.com/WordPress/performance/blob/7c6aa818b5c9707d7619a91614548ef51efba033/plugins/performance-lab/includes/admin/plugins.php#L86
> https://github.com/WordPress/performance/blob/7c6aa818b5c9707d7619a91614548ef51efba033/plugins/performance-lab/includes/admin/plugins.php#L363
> 
> All three are in that same file: includes/admin/plugins.php. Unfortunately we’re reusing the same string for each error. Are you comfortable editing the strings in the plugin file editor in WordPress to, for example, add `__LINE__` after the strings so we can differentiate between them? This will help us debug where the error is coming from.
> 
> Aside: I also see that we’re using the string with the default text domain once, but with the performance-lab text domain twice. That’s not good either. I’ll open a PR to fix this for the next release, as well as to make the strings unique.

This PR seeks to improve the usage of the strings, including their disambiguation.

The error message now includes an "error code" which is the line number from where the error originated:

![image](https://github.com/user-attachments/assets/051ce8dd-7d49-4c72-b999-0ddf0b3f352a)