### PR TITLE
Disable codecov since currently broken

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -51,7 +51,7 @@ jobs:
             wp: 'trunk'
           - php: '8.2'
             wp: 'latest'
-            coverage: true
+            # coverage: true # TODO: Uncomment once coverage reports are fixed. See <https://github.com/WordPress/performance/pull/1586#issuecomment-2474498387>.
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
       WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}


### PR DESCRIPTION
See https://github.com/WordPress/performance/issues/1284

Disables Codecov as introduced in https://github.com/WordPress/performance/pull/1586

For what needs to be done to re-enable, see https://github.com/WordPress/performance/pull/1586#issuecomment-2474498387