### PR TITLE
Prepare 3.6.0 release

### DIFF
--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -31,7 +31,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * a post available for cache purging. As seen in {@see od_can_optimize_response()}, when such a post ID is not
  * available for cache purging then it returns false, as it also does in another case like if is_404().
  *
- * @since n.e.x.t
+ * @since 0.8.0
  * @access private
  *
  * @return int|null Post ID or null if none found.

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 0.7.0
+ * Version: 0.8.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -70,7 +70,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.7.0',
+	'0.8.0',
 	static function ( string $version ): void {
 		if ( defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			return;

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -274,10 +274,10 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 **Bug Fixes**
 
-* Eliminate the detection time window. ([1640](https://github.com/WordPress/performance/pull/1640))
-* Fix phpstan errors. ([1627](https://github.com/WordPress/performance/pull/1627))
+* Eliminate the detection time window which prevented URL Metrics from being gathered when page caching is present. ([1640](https://github.com/WordPress/performance/pull/1640))
 * Revise the use of nonces in requests to store a URL Metric and block cross-origin requests. ([1637](https://github.com/WordPress/performance/pull/1637))
 * Send post ID of queried object or first post in loop in URL Metric storage request to schedule page cache validation. ([1641](https://github.com/WordPress/performance/pull/1641))
+* Fix phpstan errors. ([1627](https://github.com/WordPress/performance/pull/1627))
 
 = 0.7.0 =
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -270,6 +270,14 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 **Enhancements**
 
 * Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
+* Bump web-vitals from 4.2.3 to 4.2.4. ([1628](https://github.com/WordPress/performance/pull/1628))
+
+**Bug Fixes**
+
+* Eliminate the detection time window. ([1640](https://github.com/WordPress/performance/pull/1640))
+* Fix phpstan errors. ([1627](https://github.com/WordPress/performance/pull/1627))
+* Revise the use of nonces in requests to store a URL Metric and block cross-origin requests. ([1637](https://github.com/WordPress/performance/pull/1637))
+* Send post ID of queried object or first post in loop in URL Metric storage request to schedule page cache validation. ([1641](https://github.com/WordPress/performance/pull/1641))
 
 = 0.7.0 =
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   0.7.0
+Stable tag:   0.8.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -265,7 +265,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
-= n.e.x.t =
+= 0.8.0 =
 
 **Enhancements**
 

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -145,7 +145,7 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  *
  * This is used in the REST API to authenticate the storage of new URL Metrics from a given URL.
  *
- * @since n.e.x.t
+ * @since 0.8.0
  * @access private
  *
  * @see od_verify_url_metrics_storage_hmac()
@@ -165,7 +165,7 @@ function od_get_url_metrics_storage_hmac( string $slug, string $url, ?int $cache
 /**
  * Verifies HMAC for storing URL Metrics for a specific slug.
  *
- * @since n.e.x.t
+ * @since 0.8.0
  * @access private
  *
  * @see od_get_url_metrics_storage_hmac()

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -101,7 +101,7 @@ add_action( 'rest_api_init', 'od_register_endpoint' );
  * not account for the URL port (although there is a to-do comment committed in core to address this). Additionally,
  * the `is_allowed_http_origin()` function in core for some reason returns a string rather than a boolean.
  *
- * @since n.e.x.t
+ * @since 0.8.0
  * @access private
  *
  * @see is_allowed_http_origin()
@@ -249,7 +249,7 @@ function od_handle_rest_request( WP_REST_Request $request ) {
  * This is intended to flush any page cache for the URL after the new URL Metric was submitted so that the optimizations
  * which depend on that URL Metric can start to take effect.
  *
- * @since n.e.x.t
+ * @since 0.8.0
  * @access private
  *
  * @param int $cache_purge_post_id Cache purge post ID.

--- a/plugins/performance-lab/includes/admin/rest-api.php
+++ b/plugins/performance-lab/includes/admin/rest-api.php
@@ -3,7 +3,7 @@
  * REST API integration for the plugin.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Namespace for performance-lab REST API.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  * @var string
  */
 const PERFLAB_REST_API_NAMESPACE = 'performance-lab/v1';
@@ -24,7 +24,7 @@ const PERFLAB_REST_API_NAMESPACE = 'performance-lab/v1';
  * Note the `:activate` art of the endpoint follows Google's guidance in AIP-136 for the use of the POST method in a way
  * that does not strictly follow the standard usage.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  * @link https://google.aip.dev/136
  * @var string
  */
@@ -33,7 +33,7 @@ const PERFLAB_FEATURES_ACTIVATE_ROUTE = '/features/(?P<slug>[a-z0-9_-]+):activat
 /**
  * Route for fetching plugin/feature information.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  * @var string
  */
 const PERFLAB_FEATURES_INFORMATION_ROUTE = '/features/(?P<slug>[a-z0-9_-]+)';
@@ -41,7 +41,7 @@ const PERFLAB_FEATURES_INFORMATION_ROUTE = '/features/(?P<slug>[a-z0-9_-]+)';
 /**
  * Registers endpoint for performance-lab REST API.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  * @access private
  */
 function perflab_register_endpoint(): void {
@@ -102,7 +102,7 @@ add_action( 'rest_api_init', 'perflab_register_endpoint' );
  * Note that an enum is not being used because additional PHP files have to be required to access the necessary functions,
  * and this would not be ideal to do at rest_api_init.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  * @access private
  *
  * @param string $slug Plugin slug.
@@ -118,7 +118,7 @@ function perflab_validate_slug_endpoint_arg( string $slug ): bool {
 /**
  * Handles REST API request to activate plugin/feature.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  * @access private
  *
  * @phpstan-param WP_REST_Request<array<string, mixed>> $request
@@ -163,7 +163,7 @@ function perflab_handle_feature_activation( WP_REST_Request $request ) {
 /**
  * Handles REST API request to get plugin/feature information.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  * @access private
  *
  * @phpstan-param WP_REST_Request<array<string, mixed>> $request

--- a/plugins/performance-lab/includes/site-health/avif-headers/helper.php
+++ b/plugins/performance-lab/includes/site-health/avif-headers/helper.php
@@ -3,7 +3,7 @@
  * Helper function to detect and test AVIF header information.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Callback for avif_headers test.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  *
  * @return array{label: string, status: string, badge: array{label: string, color: string}, description: string, actions: string, test: string} Result.
  */
@@ -57,7 +57,7 @@ function avif_headers_check_avif_headers_test(): array {
 /**
  * Checks if AVIF headers are enabled.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  *
  * @return bool True if AVIF headers are enabled, false otherwise.
  */

--- a/plugins/performance-lab/includes/site-health/avif-headers/hooks.php
+++ b/plugins/performance-lab/includes/site-health/avif-headers/hooks.php
@@ -3,7 +3,7 @@
  * Hook callbacks used for AVIF Headers.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds tests to site health.
  *
- * @since n.e.x.t
+ * @since 3.6.0
  *
  * @param array{direct: array<string, array{label: string, test: string}>} $tests Site Health Tests.
  * @return array{direct: array<string, array{label: string, test: string}>} Amended tests.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 3.5.1
+ * Version: 3.6.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'PERFLAB_VERSION', '3.5.1' );
+define( 'PERFLAB_VERSION', '3.6.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -75,10 +75,9 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 **Enhancements**
 
-* Add unminified source JS files to builds. ([1643](https://github.com/WordPress/performance/pull/1643))
-* Install and activate Optimization Detective when the Embed Optimizer feature is activated from the Performance screen. ([1644](https://github.com/WordPress/performance/pull/1644))
-* Introduce AVIF header health check. ([1612](https://github.com/WordPress/performance/pull/1612))
 * Use AJAX for activating features / plugins in Performance Lab. ([1646](https://github.com/WordPress/performance/pull/1646))
+* Introduce AVIF header health check. ([1612](https://github.com/WordPress/performance/pull/1612))
+* Install and activate Optimization Detective when the Embed Optimizer feature is activated from the Performance screen. ([1644](https://github.com/WordPress/performance/pull/1644))
 
 **Bug Fixes**
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -73,6 +73,17 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.6.0 =
 
+**Enhancements**
+
+* Add unminified source JS files to builds. ([1643](https://github.com/WordPress/performance/pull/1643))
+* Install and activate Optimization Detective when the Embed Optimizer feature is activated from the Performance screen. ([1644](https://github.com/WordPress/performance/pull/1644))
+* Introduce AVIF header health check. ([1612](https://github.com/WordPress/performance/pull/1612))
+* Use AJAX for activating features / plugins in Performance Lab. ([1646](https://github.com/WordPress/performance/pull/1646))
+
+**Bug Fixes**
+
+* Fix uses of 'Plugin not found' string. ([1651](https://github.com/WordPress/performance/pull/1651))
+
 = 3.5.1 =
 
 **Bug Fixes**

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   3.5.1
+Stable tag:   3.6.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -70,6 +70,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.6.0 =
 
 = 3.5.1 =
 

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -477,7 +477,7 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
  * If that information is unavailable, it uses the MIME type from the attachment metadata.
  * If neither is available, it defaults to an empty string.
  *
- * @since n.e.x.t
+ * @since 2.3.0
  *
  * @param string $file          The path to the file.
  * @param int    $attachment_id The attachment ID.

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -474,10 +474,6 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
  *
  * If checking the file directly fails, the function falls back to the attachment's MIME type.
  *
- * The function attempts to determine the MIME type directly from the file.
- * If that information is unavailable, it uses the MIME type from the attachment metadata.
- * If neither is available, it defaults to an empty string.
- *
  * @since 2.3.0
  *
  * @param int    $attachment_id The attachment ID.

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.5
  * Requires PHP: 7.2
- * Version: 2.2.0
+ * Version: 2.3.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.2.0' );
+define( 'WEBP_UPLOADS_VERSION', '2.3.0' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -62,6 +62,11 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.3.0 =
 
+**Enhancements**
+
+* Introduce `webp_uploads_get_file_mime_type` helper function. ([1642](https://github.com/WordPress/performance/pull/1642))
+* Rename `webp_uploads_get_file_mime_type` to `webp_uploads_get_attachment_file_mime_type` to clarify scope. ([1662](https://github.com/WordPress/performance/pull/1662))
+
 **Bug Fixes**
 
 * Fix bug that would prevent uploaded images from being converted to the intended output format when having fallback formats enabled. ([1635](https://github.com/WordPress/performance/pull/1635))

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -62,10 +62,6 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.3.0 =
 
-**Enhancements**
-
-* Introduce `webp_uploads_get_file_mime_type` helper function. ([1642](https://github.com/WordPress/performance/pull/1642))
-
 **Bug Fixes**
 
 * Fix bug that would prevent uploaded images from being converted to the intended output format when having fallback formats enabled. ([1635](https://github.com/WordPress/performance/pull/1635))

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -62,6 +62,14 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.3.0 =
 
+**Enhancements**
+
+* Introduce `webp_uploads_get_file_mime_type` helper function. ([1642](https://github.com/WordPress/performance/pull/1642))
+
+**Bug Fixes**
+
+* Fix bug that would prevent uploaded images from being converted to the intended output format when having fallback formats enabled. ([1635](https://github.com/WordPress/performance/pull/1635))
+
 = 2.2.0 =
 
 **Enhancements**

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   2.2.0
+Stable tag:   2.3.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -59,6 +59,8 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.3.0 =
 
 = 2.2.0 =
 


### PR DESCRIPTION
See #1645
Previously #1609

- **Bump versions for 3.6.0 release**
- **Run npm run since**
- **Run npm run readme**

The following plugins are included in this release:

1. performance-lab 3.6.0
2. optimization-detective v0.8.0
3. webp-uploads v2.3.0