### PR TITLE
Minify script used for ajax activation of features; warn if absent and serve original file when SCRIPT_DEBUG is enabled 

### DIFF
--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -121,7 +121,7 @@ function embed_optimizer_filter_extension_module_urls( $extension_module_urls ):
 	if ( ! is_array( $extension_module_urls ) ) {
 		$extension_module_urls = array();
 	}
-	$extension_module_urls[] = add_query_arg( 'ver', EMBED_OPTIMIZER_VERSION, plugin_dir_url( __FILE__ ) . sprintf( 'detect%s.js', wp_scripts_get_suffix() ) );
+	$extension_module_urls[] = add_query_arg( 'ver', EMBED_OPTIMIZER_VERSION, plugin_dir_url( __FILE__ ) . embed_optimizer_get_asset_path( 'detect.js' ) );
 	return $extension_module_urls;
 }
 
@@ -326,7 +326,7 @@ function embed_optimizer_lazy_load_scripts(): void {
  * @since 0.2.0
  */
 function embed_optimizer_get_lazy_load_script(): string {
-	$script = file_get_contents( __DIR__ . sprintf( '/lazy-load%s.js', wp_scripts_get_suffix() ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
+	$script = file_get_contents( __DIR__ . '/' . embed_optimizer_get_asset_path( 'lazy-load.js' ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
 
 	if ( false === $script ) {
 		return '';
@@ -423,4 +423,40 @@ add_action( 'after_plugin_row_meta', 'embed_optimizer_print_row_meta_install_not
 function embed_optimizer_render_generator(): void {
 	// Use the plugin slug as it is immutable.
 	echo '<meta name="generator" content="embed-optimizer ' . esc_attr( EMBED_OPTIMIZER_VERSION ) . '">' . "\n";
+}
+
+/**
+ * Gets the path to a script or stylesheet.
+ *
+ * @since n.e.x.t
+ *
+ * @param string      $src_path Source path, relative to plugin root.
+ * @param string|null $min_path Minified path. If not supplied, then '.min' is injected before the file extension in the source path.
+ * @return string URL to script or stylesheet.
+ */
+function embed_optimizer_get_asset_path( string $src_path, ?string $min_path = null ): string {
+	if ( null === $min_path ) {
+		// Note: wp_scripts_get_suffix() is not used here because we need access to both the source and minified paths.
+		$min_path = (string) preg_replace( '/(?=\.\w+$)/', '.min', $src_path );
+	}
+
+	$force_src = false;
+	if ( WP_DEBUG && ! file_exists( trailingslashit( __DIR__ ) . $min_path ) ) {
+		$force_src = true;
+		wp_trigger_error(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s is the minified asset path */
+				__( 'Minified asset has not been built: %s', 'embed-optimizer' ),
+				$min_path
+			),
+			E_USER_WARNING
+		);
+	}
+
+	if ( SCRIPT_DEBUG || $force_src ) {
+		return $src_path;
+	}
+
+	return $min_path;
 }

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -76,3 +76,39 @@ function image_prioritizer_register_tag_visitors( OD_Tag_Visitor_Registry $regis
 	$video_visitor = new Image_Prioritizer_Video_Tag_Visitor();
 	$registry->register( 'image-prioritizer/video', $video_visitor );
 }
+
+/**
+ * Gets the path to a script or stylesheet.
+ *
+ * @since n.e.x.t
+ *
+ * @param string      $src_path Source path, relative to plugin root.
+ * @param string|null $min_path Minified path. If not supplied, then '.min' is injected before the file extension in the source path.
+ * @return string URL to script or stylesheet.
+ */
+function image_prioritizer_get_asset_path( string $src_path, ?string $min_path = null ): string {
+	if ( null === $min_path ) {
+		// Note: wp_scripts_get_suffix() is not used here because we need access to both the source and minified paths.
+		$min_path = (string) preg_replace( '/(?=\.\w+$)/', '.min', $src_path );
+	}
+
+	$force_src = false;
+	if ( WP_DEBUG && ! file_exists( trailingslashit( __DIR__ ) . $min_path ) ) {
+		$force_src = true;
+		wp_trigger_error(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s is the minified asset path */
+				__( 'Minified asset has not been built: %s', 'image-prioritizer' ),
+				$min_path
+			),
+			E_USER_WARNING
+		);
+	}
+
+	if ( SCRIPT_DEBUG || $force_src ) {
+		return $src_path;
+	}
+
+	return $min_path;
+}

--- a/plugins/image-prioritizer/hooks.php
+++ b/plugins/image-prioritizer/hooks.php
@@ -22,7 +22,8 @@ add_action( 'od_init', 'image_prioritizer_init' );
  * @since 0.2.0
  */
 function image_prioritizer_get_lazy_load_script(): string {
-	$script = file_get_contents( __DIR__ . sprintf( '/lazy-load%s.js', wp_scripts_get_suffix() ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
+	$path   = image_prioritizer_get_asset_path( 'lazy-load.js' );
+	$script = file_get_contents( __DIR__ . '/' . $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- It's a local filesystem path not a remote request.
 
 	if ( false === $script ) {
 		return '';

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -112,7 +112,7 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 	return wp_get_inline_script_tag(
 		sprintf(
 			'import detect from %s; detect( %s );',
-			wp_json_encode( add_query_arg( 'ver', OPTIMIZATION_DETECTIVE_VERSION, plugin_dir_url( __FILE__ ) . sprintf( 'detect%s.js', wp_scripts_get_suffix() ) ) ),
+			wp_json_encode( add_query_arg( 'ver', OPTIMIZATION_DETECTIVE_VERSION, plugin_dir_url( __FILE__ ) . od_get_asset_path( 'detect.js' ) ) ),
 			wp_json_encode( $detect_args )
 		),
 		array( 'type' => 'module' )

--- a/plugins/optimization-detective/helper.php
+++ b/plugins/optimization-detective/helper.php
@@ -64,3 +64,39 @@ function od_render_generator_meta_tag(): void {
 	// Use the plugin slug as it is immutable.
 	echo '<meta name="generator" content="optimization-detective ' . esc_attr( OPTIMIZATION_DETECTIVE_VERSION ) . '">' . "\n";
 }
+
+/**
+ * Gets the path to a script or stylesheet.
+ *
+ * @since n.e.x.t
+ *
+ * @param string      $src_path Source path, relative to plugin root.
+ * @param string|null $min_path Minified path. If not supplied, then '.min' is injected before the file extension in the source path.
+ * @return string URL to script or stylesheet.
+ */
+function od_get_asset_path( string $src_path, ?string $min_path = null ): string {
+	if ( null === $min_path ) {
+		// Note: wp_scripts_get_suffix() is not used here because we need access to both the source and minified paths.
+		$min_path = (string) preg_replace( '/(?=\.\w+$)/', '.min', $src_path );
+	}
+
+	$force_src = false;
+	if ( WP_DEBUG && ! file_exists( trailingslashit( __DIR__ ) . $min_path ) ) {
+		$force_src = true;
+		wp_trigger_error(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s is the minified asset path */
+				__( 'Minified asset has not been built: %s', 'optimization-detective' ),
+				$min_path
+			),
+			E_USER_WARNING
+		);
+	}
+
+	if ( SCRIPT_DEBUG || $force_src ) {
+		return $src_path;
+	}
+
+	return $min_path;
+}

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -229,7 +229,7 @@ function perflab_get_asset_path( string $src_path, ?string $min_path = null ): s
 	}
 
 	$force_src = false;
-	if ( WP_DEBUG && ! file_exists( PERFLAB_PLUGIN_DIR_PATH . $min_path ) ) {
+	if ( WP_DEBUG && ! file_exists( trailingslashit( PERFLAB_PLUGIN_DIR_PATH ) . $min_path ) ) {
 		$force_src = true;
 		wp_trigger_error(
 			__FUNCTION__,

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -214,7 +214,7 @@ function perflab_dismiss_wp_pointer_wrapper(): void {
 add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 0 );
 
 /**
- * Gets the URL to a script or stylesheet.
+ * Gets the path to a script or stylesheet.
  *
  * @since n.e.x.t
  *
@@ -222,12 +222,10 @@ add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 
  * @param string|null $min_path Minified path. If not supplied, then '.min' is injected before the file extension in the source path.
  * @return string URL to script or stylesheet.
  */
-function perflab_get_asset_src( string $src_path, ?string $min_path = null ): string {
-	$dir_url = plugin_dir_url( PERFLAB_MAIN_FILE );
-
+function perflab_get_asset_path( string $src_path, ?string $min_path = null ): string {
 	if ( null === $min_path ) {
 		// Note: wp_scripts_get_suffix() is not used here because we need access to both the source and minified paths.
-		$min_path = preg_replace( '/(?=\.\w+$)/', '.min', $src_path );
+		$min_path = (string) preg_replace( '/(?=\.\w+$)/', '.min', $src_path );
 	}
 
 	$force_src = false;
@@ -249,10 +247,10 @@ function perflab_get_asset_src( string $src_path, ?string $min_path = null ): st
 	}
 
 	if ( SCRIPT_DEBUG || $force_src ) {
-		return $dir_url . $src_path;
+		return $src_path;
 	}
 
-	return $dir_url . $min_path;
+	return $min_path;
 }
 
 /**
@@ -270,7 +268,7 @@ function perflab_enqueue_features_page_scripts(): void {
 	// Enqueue plugin activate AJAX script and localize script data.
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',
-		perflab_get_asset_src( 'includes/admin/plugin-activate-ajax.js' ),
+		plugin_dir_url( PERFLAB_MAIN_FILE ) . perflab_get_asset_path( 'includes/admin/plugin-activate-ajax.js' ),
 		array( 'wp-i18n', 'wp-a11y', 'wp-api-fetch' ),
 		PERFLAB_VERSION,
 		true

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -229,11 +229,7 @@ function perflab_get_asset_path( string $src_path, ?string $min_path = null ): s
 	}
 
 	$force_src = false;
-	if (
-		( WP_DEBUG || wp_get_environment_type() === 'local' )
-		&&
-		! file_exists( PERFLAB_PLUGIN_DIR_PATH . $min_path )
-	) {
+	if ( WP_DEBUG && ! file_exists( PERFLAB_PLUGIN_DIR_PATH . $min_path ) ) {
 		$force_src = true;
 		wp_trigger_error(
 			__FUNCTION__,

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -228,7 +228,7 @@ function perflab_enqueue_features_page_scripts(): void {
 	// Enqueue plugin activate AJAX script and localize script data.
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',
-		plugin_dir_url( PERFLAB_MAIN_FILE ) . 'includes/admin/plugin-activate-ajax.js',
+		plugin_dir_url( PERFLAB_MAIN_FILE ) . 'includes/admin/plugin-activate-ajax' . wp_scripts_get_suffix() . '.js',
 		array( 'wp-i18n', 'wp-a11y', 'wp-api-fetch' ),
 		PERFLAB_VERSION,
 		true

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -214,6 +214,48 @@ function perflab_dismiss_wp_pointer_wrapper(): void {
 add_action( 'wp_ajax_dismiss-wp-pointer', 'perflab_dismiss_wp_pointer_wrapper', 0 );
 
 /**
+ * Gets the URL to a script or stylesheet.
+ *
+ * @since n.e.x.t
+ *
+ * @param string      $src_path Source path.
+ * @param string|null $min_path Minified path. If not supplied, then '.min' is injected before the file extension in the source path.
+ * @return string URL to script or stylesheet.
+ */
+function perflab_get_asset_src( string $src_path, ?string $min_path = null ): string {
+	$dir_url = plugin_dir_url( PERFLAB_MAIN_FILE );
+
+	if ( null === $min_path ) {
+		// Note: wp_scripts_get_suffix() is not used here because we need access to both the source and minified paths.
+		$min_path = preg_replace( '/(?=\.\w+$)/', '.min', $src_path );
+	}
+
+	$force_src = false;
+	if (
+		( WP_DEBUG || wp_get_environment_type() === 'local' )
+		&&
+		! file_exists( PERFLAB_PLUGIN_DIR_PATH . $min_path )
+	) {
+		$force_src = true;
+		wp_trigger_error(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s is the minified asset path */
+				__( 'Minified asset has not been built: %s', 'performance-lab' ),
+				$min_path
+			),
+			E_USER_WARNING
+		);
+	}
+
+	if ( SCRIPT_DEBUG || $force_src ) {
+		return $dir_url . $src_path;
+	}
+
+	return $dir_url . $min_path;
+}
+
+/**
  * Callback function to handle admin scripts.
  *
  * @since 2.8.0
@@ -228,7 +270,7 @@ function perflab_enqueue_features_page_scripts(): void {
 	// Enqueue plugin activate AJAX script and localize script data.
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',
-		plugin_dir_url( PERFLAB_MAIN_FILE ) . 'includes/admin/plugin-activate-ajax' . wp_scripts_get_suffix() . '.js',
+		perflab_get_asset_src( 'includes/admin/plugin-activate-ajax.js' ),
 		array( 'wp-i18n', 'wp-a11y', 'wp-api-fetch' ),
 		PERFLAB_VERSION,
 		true

--- a/tools/phpstan/constants.php
+++ b/tools/phpstan/constants.php
@@ -17,3 +17,5 @@ define( 'OPTIMIZATION_DETECTIVE_MAIN_FILE', 'plugins/optimization-detective/load
 define( 'IMAGE_PRIORITIZER_VERSION', '0.0.0' );
 
 define( 'EMBED_OPTIMIZER_VERSION', '0.0.0' );
+
+define( 'PERFLAB_PLUGIN_DIR_PATH', __DIR__ . '/../../plugins/performance-lab/' );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,11 +35,45 @@ const sharedConfig = {
 
 // Store plugins that require build process.
 const pluginsWithBuild = [
+	'performance-lab',
 	'embed-optimizer',
 	'image-prioritizer',
 	'optimization-detective',
 	'web-worker-offloading',
 ];
+
+/**
+ * Webpack Config: Performance Lab
+ *
+ * @param {*} env Webpack environment
+ * @return {Object} Webpack configuration
+ */
+const performanceLab = ( env ) => {
+	if ( env.plugin && env.plugin !== 'performance-lab' ) {
+		return defaultBuildConfig;
+	}
+
+	const pluginDir = path.resolve( __dirname, 'plugins/performance-lab' );
+
+	return {
+		...sharedConfig,
+		name: 'performance-lab',
+		plugins: [
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						from: `${ pluginDir }/includes/admin/plugin-activate-ajax.js`,
+						to: `${ pluginDir }/includes/admin/plugin-activate-ajax.min.js`,
+					},
+				],
+			} ),
+			new WebpackBar( {
+				name: 'Building Performance Lab Assets',
+				color: '#2196f3',
+			} ),
+		],
+	};
+};
 
 /**
  * Webpack Config: Embed Optimizer
@@ -286,6 +320,7 @@ const buildPlugin = ( env ) => {
 };
 
 module.exports = [
+	performanceLab,
 	embedOptimizer,
 	imagePrioritizer,
 	optimizationDetective,


### PR DESCRIPTION
This is a follow-up to #1643 and #1646. 

This adds minification of the `plugin-activate-ajax.js` file that was introduced in https://github.com/WordPress/performance/pull/1646, and it ensures the non-minified version is also distributed according to #1643.

This is not a critical PR to include in the 3.6.0 release since the JS file in question is small and it's only served in the admin.