### PR TITLE
Fix logic inversion in od_can_optimize_response()

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -123,7 +123,7 @@ function od_can_optimize_response(): bool {
 		current_user_can( 'customize' ) ||
 		// Page caching plugins can only reliably be told to invalidate a cached page when a post is available to trigger
 		// the relevant actions on.
-		null !== od_get_cache_purge_post_id()
+		null === od_get_cache_purge_post_id()
 	);
 
 	/**


### PR DESCRIPTION
I was testing the latest plugins on my blog and I was perplexed to find that Optimization Detective wasn't working on any URL. I found out it was due to a logic inversion I introduced in #1641. I didn't notice the issue when testing locally because I have the following dev-mode plugin code running, including:

```php
add_filter( 'od_can_optimize_response', '__return_true' );
```

This means that the checking for `od_get_cache_purge_post_id()` I added to `od_can_optimize_response()` wasn't having any effect. Note that each of the conditions in that function are meant to be _negative_ conditions for which responses should _not_ be optimized. The entire boolean chain of conditions is then negated. So this is why the logic looks correct at first glance, but not if you look at the other conditions in the boolean chain.

The issue also was not detected in unit tests because (1) there are no posts created initially when unit tests run so `null !== od_get_cache_purge_post_id()` was always returning `false`, and (2) I hadn't explicitly checked the condition for when this is expected to return `null`. 

These are rectified in this PR.