### PR TITLE
Rename `webp_uploads_get_file_mime_type` to `webp_uploads_get_attachment_file_mime_type` to clarify scope

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -488,7 +488,7 @@ function webp_uploads_get_attachment_file_mime_type( int $attachment_id, string 
 	if ( '' === $file ) {
 		$file = get_attached_file( $attachment_id, true );
 		// File does not exist.
-		if ( false === $file || ! file_exists( $file ) ) {
+		if ( false === $file ) {
 			return '';
 		}
 	}

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -479,11 +479,19 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
  *
  * @since n.e.x.t
  *
- * @param string $file          The path to the file.
  * @param int    $attachment_id The attachment ID.
+ * @param string $file          Optional. The path to the file.
  * @return string The MIME type of the file, or an empty string if not found.
  */
-function webp_uploads_get_file_mime_type( string $file, int $attachment_id ): string {
+function webp_uploads_get_attachment_file_mime_type( int $attachment_id, string $file = '' ): string {
+	if ( '' === $file ) {
+		$file = get_attached_file( $attachment_id, true );
+		// File does not exist.
+		if ( false === $file || ! file_exists( $file ) ) {
+			return '';
+		}
+	}
+
 	/*
 	 * We need to get the MIME type ideally from the file, as WordPress Core may have already altered it.
 	 * The post MIME type is typically not updated during that process.

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -470,8 +470,9 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
 }
 
 /**
- * Retrieves the MIME type of a file, checking the file directly if possible,
- * and falling back to the attachment's MIME type if needed.
+ * Retrieves the MIME type of an attachment file, checking the file directly if possible.
+ *
+ * If checking the file directly fails, the function falls back to the attachment's MIME type.
  *
  * The function attempts to determine the MIME type directly from the file.
  * If that information is unavailable, it uses the MIME type from the attachment metadata.

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -58,7 +58,7 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 		return $metadata;
 	}
 
-	$mime_type = webp_uploads_get_file_mime_type( $file, $attachment_id );
+	$mime_type = webp_uploads_get_attachment_file_mime_type( $attachment_id, $file );
 	if ( '' === $mime_type ) {
 		return $metadata;
 	}

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -23,13 +23,7 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		return $image;
 	}
 
-	$file = get_attached_file( $attachment_id, true );
-	// File does not exist.
-	if ( false === $file || ! file_exists( $file ) ) {
-		return $image;
-	}
-
-	$original_file_mime_type = webp_uploads_get_file_mime_type( $file, $attachment_id );
+	$original_file_mime_type = webp_uploads_get_attachment_file_mime_type( $attachment_id );
 	if ( '' === $original_file_mime_type ) {
 		return $image;
 	}


### PR DESCRIPTION
## Summary

These PR address the feedback for https://github.com/WordPress/performance/pull/1642#discussion_r1836955274.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
