### PR TITLE
Remove problematic n.e.x.t readme changelog entries

### DIFF
--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -67,12 +67,6 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
-= n.e.x.t =
-
-**Enhancements**
-
-* Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
-
 = 0.3.0 =
 
 **Enhancements**

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -62,12 +62,6 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
-= n.e.x.t =
-
-**Enhancements**
-
-* Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
-
 = 0.2.0 =
 
 **Enhancements**

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -94,12 +94,6 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
-= n.e.x.t =
-
-**Enhancements**
-
-* Serve unminified scripts when `SCRIPT_DEBUG` is enabled. ([1643](https://github.com/WordPress/performance/pull/1643))
-
 = 0.1.1 =
 
 **Enhancements**


### PR DESCRIPTION
## Summary

This fixes the problems encountered during https://github.com/WordPress/performance/actions/runs/11898594316/job/33155426118.

See https://wordpress.slack.com/archives/C02KGN5K076/p1731954235710569
