### PR TITLE
Fix race condition bug where activating multiple features sequentially could fail to activate some features

### DIFF
--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -7,21 +7,20 @@
 	const { i18n, a11y, apiFetch } = wp;
 	const { __ } = i18n;
 
-	/**
-	 * Handles click events on elements with the class 'perflab-install-active-plugin'.
-	 *
-	 * This asynchronous function listens for click events on the document and executes
-	 * the provided callback function if triggered.
-	 *
-	 * @param {MouseEvent} event - The click event object that is triggered when the user clicks on the document.
-	 *
-	 * @return {Promise<void>} The asynchronous function returns a promise that resolves to void.
-	 */
-	async function handlePluginActivationClick( event ) {
-		const target = /** @type {HTMLElement} */ ( event.target );
+	// Queue to hold pending activation requests.
+	const activationQueue = [];
+	let isProcessingActivation = false;
 
+	/**
+	 * Enqueues plugin activation requests and starts processing if not already in progress.
+	 *
+	 * @param {MouseEvent} event - The click event object.
+	 */
+	function enqueuePluginActivation( event ) {
 		// Prevent the default link behavior.
 		event.preventDefault();
+
+		const target = /** @type {HTMLElement} */ ( event.target );
 
 		if (
 			target.classList.contains( 'updating-message' ) ||
@@ -30,12 +29,37 @@
 			return;
 		}
 
+		target.textContent = __( 'Waiting…', 'performance-lab' );
+
+		const pluginSlug = target.dataset.pluginSlug;
+
+		activationQueue.push( { target, pluginSlug } );
+
+		// Start processing the queue if not already doing so.
+		if ( ! isProcessingActivation ) {
+			handlePluginActivation();
+		}
+	}
+
+	/**
+	 * Handles activation of feature/plugin using queue based approach.
+	 *
+	 * @return {Promise<void>} The asynchronous function returns a promise that resolves to void.
+	 */
+	async function handlePluginActivation() {
+		if ( 0 === activationQueue.length ) {
+			isProcessingActivation = false;
+			return;
+		}
+
+		isProcessingActivation = true;
+
+		const { target, pluginSlug } = activationQueue.shift();
+
 		target.classList.add( 'updating-message' );
 		target.textContent = __( 'Activating…', 'performance-lab' );
 
 		a11y.speak( __( 'Activating…', 'performance-lab' ) );
-
-		const pluginSlug = target.dataset.pluginSlug;
 
 		try {
 			// Activate the plugin/feature via the REST API.
@@ -76,6 +100,8 @@
 
 			target.classList.remove( 'updating-message' );
 			target.textContent = __( 'Activate', 'performance-lab' );
+		} finally {
+			handlePluginActivation();
 		}
 	}
 
@@ -83,6 +109,6 @@
 	document
 		.querySelectorAll( '.perflab-install-active-plugin' )
 		.forEach( ( item ) => {
-			item.addEventListener( 'click', handlePluginActivationClick );
+			item.addEventListener( 'click', enqueuePluginActivation );
 		} );
 } )();

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -29,6 +29,7 @@
 			return;
 		}
 
+		target.classList.add( 'updating-message' );
 		target.textContent = __( 'Waiting…', 'performance-lab' );
 
 		const pluginSlug = target.dataset.pluginSlug;
@@ -56,7 +57,6 @@
 
 		const { target, pluginSlug } = activationQueue.shift();
 
-		target.classList.add( 'updating-message' );
 		target.textContent = __( 'Activating…', 'performance-lab' );
 
 		a11y.speak( __( 'Activating…', 'performance-lab' ) );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1660 

## Relevant technical choices

<!-- Please describe your changes. -->
Implemented a queue based approach for activation of features / plugins using the AJAX in JavaScript.

Now only one features / plugin sends a request at a time other request are processed after previous request is finished.

## Demo


https://github.com/user-attachments/assets/6d6c3b9d-6f33-4b4b-a882-aa3d6c1f7fe1

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
