### PR TITLE
Automatically opt into 1536x1536 and 2048x2048 sizes when generating fallback images

### DIFF
--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -780,3 +780,31 @@ function webp_uploads_init(): void {
 	}
 }
 add_action( 'init', 'webp_uploads_init' );
+
+/**
+ * Automatically opt into extra image sizes when generating fallback images.
+ *
+ * @since n.e.x.t
+ */
+function webp_uploads_opt_in_extra_image_sizes(): void {
+	if ( ! webp_uploads_is_fallback_enabled() ) {
+		return;
+	}
+
+	global $_wp_additional_image_sizes;
+
+	if ( ! is_array( $_wp_additional_image_sizes ) ) {
+		return;
+	}
+
+	// NOTE: Modifying global to mimic the "hypothetical" WP core API behavior.
+
+	if ( isset( $_wp_additional_image_sizes['1536x1536'] ) && ! isset( $_wp_additional_image_sizes['1536x1536']['provide_additional_mime_types'] ) ) {
+		$_wp_additional_image_sizes['1536x1536']['provide_additional_mime_types'] = true; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+
+	if ( isset( $_wp_additional_image_sizes['2048x2048'] ) && ! isset( $_wp_additional_image_sizes['2048x2048']['provide_additional_mime_types'] ) ) {
+		$_wp_additional_image_sizes['2048x2048']['provide_additional_mime_types'] = true; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	}
+}
+add_action( 'plugins_loaded', 'webp_uploads_opt_in_extra_image_sizes' );

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -785,6 +785,8 @@ add_action( 'init', 'webp_uploads_init' );
  * Automatically opt into extra image sizes when generating fallback images.
  *
  * @since n.e.x.t
+ *
+ * @global array $_wp_additional_image_sizes Associative array of additional image sizes.
  */
 function webp_uploads_opt_in_extra_image_sizes(): void {
 	if ( ! webp_uploads_is_fallback_enabled() ) {
@@ -793,11 +795,7 @@ function webp_uploads_opt_in_extra_image_sizes(): void {
 
 	global $_wp_additional_image_sizes;
 
-	if ( ! is_array( $_wp_additional_image_sizes ) ) {
-		return;
-	}
-
-	// NOTE: Modifying global to mimic the "hypothetical" WP core API behavior.
+	// Modify global to mimic the "hypothetical" WP core API behavior via an additional `add_image_size()` parameter.
 
 	if ( isset( $_wp_additional_image_sizes['1536x1536'] ) && ! isset( $_wp_additional_image_sizes['1536x1536']['provide_additional_mime_types'] ) ) {
 		$_wp_additional_image_sizes['1536x1536']['provide_additional_mime_types'] = true; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1512 

## Relevant technical choices

<!-- Please describe your changes. -->

This PR automatically opt into 1536x1536 and 2048x2048 sizes when generating fallback images. This only happens when the "generate fallback images" is enabled.

The opt in is done by modifying the `$_wp_additional_image_sizes` global which is the array containing extra image sizes. The `provide_additional_mime_types` property is set to true for the 1536x1536 and 2048x2048 image sizes so that the selected modern image format of these sizes is also generated.

### Before 
For the demo img these images were generated ( fallback images is enabled )
![Screenshot 2024-11-20 at 1 58 21 PM](https://github.com/user-attachments/assets/d43eeecd-d6ce-4e89-a43d-a89c0d5452d7)


### After
For the demo img these images are now generated ( fallback images is enabled )
![Screenshot 2024-11-20 at 1 58 55 PM](https://github.com/user-attachments/assets/53f89c64-4524-481d-9179-98967c6c2c60)


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
