### PR TITLE
Prevent submitting URL Metric if viewport size changed

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -127,6 +127,12 @@ function recursiveFreeze( obj ) {
 	Object.freeze( obj );
 }
 
+// This needs to be captured early in case the user later resizes the window.
+const viewport = {
+	width: win.innerWidth,
+	height: win.innerHeight,
+};
+
 /**
  * URL Metric being assembled for submission.
  *
@@ -443,10 +449,7 @@ export default async function detect( {
 
 	urlMetric = {
 		url: currentUrl,
-		viewport: {
-			width: win.innerWidth,
-			height: win.innerHeight,
-		},
+		viewport,
 		elements: [],
 	};
 
@@ -506,6 +509,20 @@ export default async function detect( {
 			{ once: true }
 		);
 	} );
+
+	// Only proceed with submitting the URL Metric if viewport stayed the same size. Changing the viewport size (e.g. due
+	// to resizing a window or changing the orientation of a device) will result in unexpected metrics being collected.
+	if (
+		window.innerWidth !== urlMetric.viewport.width ||
+		window.innerHeight !== urlMetric.viewport.height
+	) {
+		if ( isDebug ) {
+			log(
+				'Aborting URL Metric collection due to viewport size change.'
+			);
+		}
+		return;
+	}
 
 	if ( extensions.size > 0 ) {
 		for ( const [


### PR DESCRIPTION
This is cherry-picked from a75b94f803ff51b0eacf0122aa011d04b76db1d1 in https://github.com/WordPress/performance/pull/1697.

Only proceed with submitting the URL Metric if the viewport stayed the same size from when the page first loaded until it was closed. Changing the viewport size (e.g. due to resizing a window or changing the orientation of a device) will result in unexpected metrics being collected.