### PR TITLE
Centralize and Automate Plugin Asset Minification in Webpack

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -16,6 +16,7 @@ on:
       - 'tests/multisite.xml'
       - 'composer.json'
       - 'composer.lock'
+      - 'webpack.config.js'
   pull_request:
     # Only run if PHP-related files changed.
     paths:
@@ -28,6 +29,7 @@ on:
       - 'tests/multisite.xml'
       - 'composer.json'
       - 'composer.lock'
+      - 'webpack.config.js'
     types:
       - opened
       - reopened

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -218,7 +218,7 @@ const buildPlugin = ( env ) => {
 	const dependencies = [ 'minify-plugin-assets' ];
 
 	if ( pluginsWithBuild.includes( env.plugin ) ) {
-		dependencies.push( `${ env.plugin }` );
+		dependencies.push( env.plugin );
 	}
 
 	return {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -197,9 +197,11 @@ const buildPlugin = ( env ) => {
 	const buildDir = path.resolve( __dirname, 'build' );
 	const to = path.resolve( buildDir, env.plugin );
 	const from = path.resolve( __dirname, 'plugins', env.plugin );
-	const dependencies = pluginsWithBuild.includes( env.plugin )
-		? [ `${ env.plugin }` ]
-		: [];
+	const dependencies = [ 'minify-plugin-assets' ];
+
+	if ( pluginsWithBuild.includes( env.plugin ) ) {
+		dependencies.push( `${ env.plugin }` );
+	}
 
 	return {
 		...sharedConfig,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,18 +62,19 @@ const minifyPluginAssets = ( env ) => {
 			new CopyWebpackPlugin( {
 				patterns: [
 					{
+						// NOTE: Automatically minifies JavaScript files with Terser during the copy process.
 						from: `${ sourcePath }/**/*.js`,
-						noErrorOnMissing: true,
 						to: ( { absoluteFilename } ) =>
 							absoluteFilename.replace( /\.js$/, '.min.js' ),
 						// Exclude already-minified files and those in the build directory
 						globOptions: {
 							ignore: [ '**/build/**', '**/*.min.js' ],
 						},
+						// Prevents errors for plugins without JavaScript files.
+						noErrorOnMissing: true,
 					},
 					{
 						from: `${ sourcePath }/**/*.css`,
-						noErrorOnMissing: true,
 						to: ( { absoluteFilename } ) =>
 							absoluteFilename.replace( /\.css$/, '.min.css' ),
 						transform: {
@@ -83,6 +84,7 @@ const minifyPluginAssets = ( env ) => {
 						globOptions: {
 							ignore: [ '**/build/**', '**/*.min.css' ],
 						},
+						noErrorOnMissing: true,
 					},
 				],
 			} ),
@@ -120,6 +122,7 @@ const optimizationDetective = ( env ) => {
 					{
 						from: `${ source }/dist/web-vitals.js`,
 						to: `${ destination }/build/web-vitals.js`,
+						// Ensures the file is copied without minification, preserving its original form.
 						info: { minimized: true },
 					},
 					{
@@ -211,6 +214,7 @@ const buildPlugin = ( env ) => {
 	const buildDir = path.resolve( __dirname, 'build' );
 	const to = path.resolve( buildDir, env.plugin );
 	const from = path.resolve( __dirname, 'plugins', env.plugin );
+	// Ensures minification and the plugin's build process (if defined) run before building the plugin.
 	const dependencies = [ 'minify-plugin-assets' ];
 
 	if ( pluginsWithBuild.includes( env.plugin ) ) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,9 +40,21 @@ const pluginsWithBuild = [ 'optimization-detective', 'web-worker-offloading' ];
 /**
  * Webpack Config: Minify Plugin Assets
  *
+ * @param {*} env Webpack environment
  * @return {Object} Webpack configuration
  */
-const minifyPluginAssets = () => {
+const minifyPluginAssets = ( env ) => {
+	if ( env.plugin && ! standalonePlugins.includes( env.plugin ) ) {
+		// eslint-disable-next-line no-console
+		console.error( `Plugin "${ env.plugin }" not found. Aborting.` );
+
+		return defaultBuildConfig;
+	}
+
+	const sourcePath = env.plugin
+		? path.resolve( __dirname, 'plugins', env.plugin )
+		: path.resolve( __dirname, 'plugins' );
+
 	return {
 		...sharedConfig,
 		name: 'minify-plugin-assets',
@@ -50,7 +62,7 @@ const minifyPluginAssets = () => {
 			new CopyWebpackPlugin( {
 				patterns: [
 					{
-						from: `plugins/**/*.js`,
+						from: `${ sourcePath }/**/*.js`,
 						to: ( { absoluteFilename } ) =>
 							absoluteFilename.replace( /\.js$/, '.min.js' ),
 						// Exclude already-minified files and those in the build directory
@@ -59,7 +71,7 @@ const minifyPluginAssets = () => {
 						},
 					},
 					{
-						from: `plugins/**/*.css`,
+						from: `${ sourcePath }/**/*.css`,
 						to: ( { absoluteFilename } ) =>
 							absoluteFilename.replace( /\.css$/, '.min.css' ),
 						transform: {
@@ -73,7 +85,7 @@ const minifyPluginAssets = () => {
 				],
 			} ),
 			new WebpackBar( {
-				name: `Minifying Plugin Assets`,
+				name: `Minifying Assets for ${ env.plugin ?? 'All Plugins' }`,
 				color: '#f5e0dc',
 			} ),
 		],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,7 @@ const minifyPluginAssets = ( env ) => {
 				patterns: [
 					{
 						from: `${ sourcePath }/**/*.js`,
+						noErrorOnMissing: true,
 						to: ( { absoluteFilename } ) =>
 							absoluteFilename.replace( /\.js$/, '.min.js' ),
 						// Exclude already-minified files and those in the build directory
@@ -72,6 +73,7 @@ const minifyPluginAssets = ( env ) => {
 					},
 					{
 						from: `${ sourcePath }/**/*.css`,
+						noErrorOnMissing: true,
 						to: ( { absoluteFilename } ) =>
 							absoluteFilename.replace( /\.css$/, '.min.css' ),
 						transform: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,124 +35,46 @@ const sharedConfig = {
 };
 
 // Store plugins that require build process.
-const pluginsWithBuild = [
-	'performance-lab',
-	'embed-optimizer',
-	'image-prioritizer',
-	'optimization-detective',
-	'web-worker-offloading',
-];
+const pluginsWithBuild = [ 'optimization-detective', 'web-worker-offloading' ];
 
 /**
- * Webpack Config: Performance Lab
+ * Webpack Config: Minify Plugin Assets
  *
- * @param {*} env Webpack environment
  * @return {Object} Webpack configuration
  */
-const performanceLab = ( env ) => {
-	if ( env.plugin && env.plugin !== 'performance-lab' ) {
-		return defaultBuildConfig;
-	}
-
-	const pluginDir = path.resolve( __dirname, 'plugins/performance-lab' );
-
+const minifyPluginAssets = () => {
 	return {
 		...sharedConfig,
-		name: 'performance-lab',
+		name: 'minify-plugin-assets',
 		plugins: [
 			new CopyWebpackPlugin( {
 				patterns: [
 					{
-						from: `${ pluginDir }/includes/admin/plugin-activate-ajax.js`,
-						to: `${ pluginDir }/includes/admin/plugin-activate-ajax.min.js`,
-					},
-				],
-			} ),
-			new WebpackBar( {
-				name: 'Building Performance Lab Assets',
-				color: '#2196f3',
-			} ),
-		],
-	};
-};
-
-/**
- * Webpack Config: Embed Optimizer
- *
- * @param {*} env Webpack environment
- * @return {Object} Webpack configuration
- */
-const embedOptimizer = ( env ) => {
-	if ( env.plugin && env.plugin !== 'embed-optimizer' ) {
-		return defaultBuildConfig;
-	}
-
-	const pluginDir = path.resolve( __dirname, 'plugins/embed-optimizer' );
-
-	return {
-		...sharedConfig,
-		name: 'embed-optimizer',
-		plugins: [
-			new CopyWebpackPlugin( {
-				patterns: [
-					{
-						from: `${ pluginDir }/detect.js`,
-						to: `${ pluginDir }/detect.min.js`,
+						from: `plugins/**/*.js`,
+						to: ( { absoluteFilename } ) =>
+							absoluteFilename.replace( /\.js$/, '.min.js' ),
+						// Exclude already-minified files and those in the build directory
+						globOptions: {
+							ignore: [ '**/build/**', '**/*.min.js' ],
+						},
 					},
 					{
-						from: `${ pluginDir }/lazy-load.js`,
-						to: `${ pluginDir }/lazy-load.min.js`,
-					},
-				],
-			} ),
-			new WebpackBar( {
-				name: 'Building Embed Optimizer Assets',
-				color: '#2196f3',
-			} ),
-		],
-	};
-};
-
-/**
- * Webpack Config: Image Prioritizer
- *
- * @param {*} env Webpack environment
- * @return {Object} Webpack configuration
- */
-const imagePrioritizer = ( env ) => {
-	if ( env.plugin && env.plugin !== 'image-prioritizer' ) {
-		return defaultBuildConfig;
-	}
-
-	const pluginDir = path.resolve( __dirname, 'plugins/image-prioritizer' );
-
-	return {
-		...sharedConfig,
-		name: 'image-prioritizer',
-		plugins: [
-			new CopyWebpackPlugin( {
-				patterns: [
-					{
-						from: `${ pluginDir }/lazy-load-video.js`,
-						to: `${ pluginDir }/lazy-load-video.min.js`,
-					},
-					{
-						from: `${ pluginDir }/lazy-load-bg-image.js`,
-						to: `${ pluginDir }/lazy-load-bg-image.min.js`,
-					},
-					{
-						from: `${ pluginDir }/lazy-load-bg-image.css`,
-						to: `${ pluginDir }/lazy-load-bg-image.min.css`,
+						from: `plugins/**/*.css`,
+						to: ( { absoluteFilename } ) =>
+							absoluteFilename.replace( /\.css$/, '.min.css' ),
 						transform: {
 							transformer: cssMinifyTransformer,
 							cache: false,
+						},
+						globOptions: {
+							ignore: [ '**/build/**', '**/*.min.css' ],
 						},
 					},
 				],
 			} ),
 			new WebpackBar( {
-				name: 'Building Image Prioritizer Assets',
-				color: '#2196f3',
+				name: `Minifying Plugin Assets`,
+				color: '#f5e0dc',
 			} ),
 		],
 	};
@@ -193,10 +115,6 @@ const optimizationDetective = ( env ) => {
 							transformer: assetDataTransformer,
 							cache: false,
 						},
-					},
-					{
-						from: `${ destination }/detect.js`,
-						to: `${ destination }/detect.min.js`,
 					},
 				],
 			} ),
@@ -333,9 +251,7 @@ const buildPlugin = ( env ) => {
 };
 
 module.exports = [
-	performanceLab,
-	embedOptimizer,
-	imagePrioritizer,
+	minifyPluginAssets,
 	optimizationDetective,
 	webWorkerOffloading,
 	buildPlugin,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1711 

This is also an attempt to improve the solution introduced in #1643 by further streamlining the process of generating minified asset files.

## Relevant technical choices

- Removed Webpack configurations for Performance Lab, Embed Optimizer, and Image Prioritizer that existed solely for asset minification, making them redundant with the new centralized approach.
- Implemented plugin-specific minification:
    - When running `npm run build:plugin:optimization-detective` (or any specific plugin), only assets for that plugin are minified.
    - This prevents redundant minification when using `npm run build-plugins` script, which would otherwise re-minify the same assets multiple times (while the overhead may be minimal, this approach avoids redundancy.)
- When `npm run build` is executed, it generates minified versions of assets across all plugins.
