### PR TITLE
Incorporate page state into ETag computation

### DIFF
--- a/plugins/embed-optimizer/tests/test-optimization-detective.php
+++ b/plugins/embed-optimizer/tests/test-optimization-detective.php
@@ -18,21 +18,12 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 		if ( ! defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			$this->markTestSkipped( 'Optimization Detective is not active.' );
 		}
-		$GLOBALS['template'] = '/path/to/theme/index.php';
 
 		// Normalize the data for computing the current URL Metrics ETag to work around the issue where there is no
 		// global variable storing the OD_Tag_Visitor_Registry instance along with any registered tag visitors, so
 		// during set up we do not know what the ETag will look like. The current ETag is only established when
 		// the output begins to be processed by od_optimize_template_output_buffer().
 		add_filter( 'od_current_url_metrics_etag_data', '__return_empty_array' );
-	}
-
-	/**
-	 * Runs the routine after each test is executed.
-	 */
-	public function tear_down(): void {
-		unset( $GLOBALS['template'] );
-		parent::tear_down();
 	}
 
 	/**

--- a/plugins/embed-optimizer/tests/test-optimization-detective.php
+++ b/plugins/embed-optimizer/tests/test-optimization-detective.php
@@ -18,12 +18,21 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 		if ( ! defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			$this->markTestSkipped( 'Optimization Detective is not active.' );
 		}
+		$GLOBALS['template'] = '/path/to/theme/index.php';
 
 		// Normalize the data for computing the current URL Metrics ETag to work around the issue where there is no
 		// global variable storing the OD_Tag_Visitor_Registry instance along with any registered tag visitors, so
 		// during set up we do not know what the ETag will look like. The current ETag is only established when
 		// the output begins to be processed by od_optimize_template_output_buffer().
 		add_filter( 'od_current_url_metrics_etag_data', '__return_empty_array' );
+	}
+
+	/**
+	 * Runs the routine after each test is executed.
+	 */
+	public function tear_down(): void {
+		unset( $GLOBALS['template'] );
+		parent::tear_down();
 	}
 
 	/**
@@ -101,7 +110,6 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ): void {
-		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$set_up( $this );
 
 		$buffer = od_optimize_template_output_buffer( $buffer );
@@ -123,7 +131,5 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
-
-		unset( $GLOBALS['template'] );
 	}
 }

--- a/plugins/embed-optimizer/tests/test-optimization-detective.php
+++ b/plugins/embed-optimizer/tests/test-optimization-detective.php
@@ -101,6 +101,7 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ): void {
+		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$set_up( $this );
 
 		$buffer = od_optimize_template_output_buffer( $buffer );
@@ -122,5 +123,7 @@ class Test_Embed_Optimizer_Optimization_Detective extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
+
+		unset( $GLOBALS['template'] );
 	}
 }

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -98,6 +98,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 * @param callable|string $expected Expected content after.
 	 */
 	public function test_image_prioritizer_register_tag_visitors( callable $set_up, $buffer, $expected ): void {
+		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$set_up( $this, $this::factory() );
 
 		$buffer = is_string( $buffer ) ? $buffer : $buffer();
@@ -125,6 +126,8 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
+
+		unset( $GLOBALS['template'] );
 	}
 
 	/**
@@ -220,6 +223,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 * @phpstan-param array{ xpath: string, isLCP: bool, intersectionRatio: int } $element_metrics
 	 */
 	public function test_auto_sizes( array $element_metrics, string $buffer, string $expected ): void {
+		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$this->populate_url_metrics( array( $element_metrics ) );
 
 		$html_start_doc = '<html lang="en"><head><meta charset="utf-8"><title>...</title></head><body>';
@@ -234,6 +238,8 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
+
+		unset( $GLOBALS['template'] );
 	}
 
 	/**

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -15,12 +15,21 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
+		$GLOBALS['template'] = '/path/to/theme/index.php';
 
 		// Normalize the data for computing the current URL Metrics ETag to work around the issue where there is no
 		// global variable storing the OD_Tag_Visitor_Registry instance along with any registered tag visitors, so
 		// during set up we do not know what the ETag will look like. The current ETag is only established when
 		// the output begins to be processed by od_optimize_template_output_buffer().
 		add_filter( 'od_current_url_metrics_etag_data', '__return_empty_array' );
+	}
+
+	/**
+	 * Runs the routine after each test is executed.
+	 */
+	public function tear_down(): void {
+		unset( $GLOBALS['template'] );
+		parent::tear_down();
 	}
 
 	/**
@@ -98,7 +107,6 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 * @param callable|string $expected Expected content after.
 	 */
 	public function test_end_to_end( callable $set_up, $buffer, $expected ): void {
-		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$set_up( $this, $this::factory() );
 
 		$buffer = is_string( $buffer ) ? $buffer : $buffer();
@@ -126,8 +134,6 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
-
-		unset( $GLOBALS['template'] );
 	}
 
 	/**
@@ -223,7 +229,6 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 * @phpstan-param array{ xpath: string, isLCP: bool, intersectionRatio: int } $element_metrics
 	 */
 	public function test_auto_sizes_end_to_end( array $element_metrics, string $buffer, string $expected ): void {
-		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$this->populate_url_metrics( array( $element_metrics ) );
 
 		$html_start_doc = '<html lang="en"><head><meta charset="utf-8"><title>...</title></head><body>';
@@ -238,8 +243,6 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
-
-		unset( $GLOBALS['template'] );
 	}
 
 	/**

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -15,21 +15,12 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
-		$GLOBALS['template'] = '/path/to/theme/index.php';
 
 		// Normalize the data for computing the current URL Metrics ETag to work around the issue where there is no
 		// global variable storing the OD_Tag_Visitor_Registry instance along with any registered tag visitors, so
 		// during set up we do not know what the ETag will look like. The current ETag is only established when
 		// the output begins to be processed by od_optimize_template_output_buffer().
 		add_filter( 'od_current_url_metrics_etag_data', '__return_empty_array' );
-	}
-
-	/**
-	 * Runs the routine after each test is executed.
-	 */
-	public function tear_down(): void {
-		unset( $GLOBALS['template'] );
-		parent::tear_down();
 	}
 
 	/**

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -170,6 +170,10 @@ function od_is_response_html_content_type(): bool {
  * @since 0.1.0
  * @access private
  *
+ * @global WP_Query $wp_the_query            WP_Query object.
+ * @global string   $_wp_current_template_id Current template ID.
+ * @global string   $template                Template file path.
+ *
  * @param string $buffer Template output buffer.
  * @return string Filtered template output buffer.
  */
@@ -206,7 +210,15 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	 */
 	do_action( 'od_register_tag_visitors', $tag_visitor_registry );
 
-	$current_etag         = od_get_current_url_metrics_etag( $tag_visitor_registry );
+	if ( wp_is_block_theme() ) {
+		// Extract the template slug from $_wp_current_template_id, which has the format 'theme_slug//template_slug'.
+		$parts            = explode( '//', $GLOBALS['_wp_current_template_id'] );
+		$current_template = ( 2 === count( $parts ) ) ? $parts[1] : '';
+	} else {
+		$current_template = basename( $GLOBALS['template'] );
+	}
+
+	$current_etag         = od_get_current_url_metrics_etag( $tag_visitor_registry, $GLOBALS['wp_the_query'], $current_template );
 	$group_collection     = new OD_URL_Metric_Group_Collection(
 		$post instanceof WP_Post ? OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post ) : array(),
 		$current_etag,

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -211,9 +211,8 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	do_action( 'od_register_tag_visitors', $tag_visitor_registry );
 
 	if ( wp_is_block_theme() ) {
-		// Extract the template slug from $_wp_current_template_id, which has the format 'theme_slug//template_slug'.
-		$parts            = explode( '//', $GLOBALS['_wp_current_template_id'] );
-		$current_template = ( 2 === count( $parts ) ) ? $parts[1] : '';
+		$current_template = get_block_template( $GLOBALS['_wp_current_template_id'], 'wp_template' );
+		$current_template = $current_template ?? basename( $GLOBALS['template'] );
 	} else {
 		$current_template = basename( $GLOBALS['template'] );
 	}

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -170,15 +170,13 @@ function od_is_response_html_content_type(): bool {
  * @since 0.1.0
  * @access private
  *
- * @global WP_Query $wp_the_query            WP_Query object.
- * @global string   $_wp_current_template_id Current template ID.
- * @global string   $template                Template file path.
+ * @global WP_Query $wp_the_query WP_Query object.
  *
  * @param string $buffer Template output buffer.
  * @return string Filtered template output buffer.
  */
 function od_optimize_template_output_buffer( string $buffer ): string {
-	global $wp_the_query, $_wp_current_template_id, $template;
+	global $wp_the_query;
 
 	// If the content-type is not HTML or the output does not start with '<', then abort since the buffer is definitely not HTML.
 	if (
@@ -212,15 +210,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	 */
 	do_action( 'od_register_tag_visitors', $tag_visitor_registry );
 
-	$current_template = null;
-	if ( wp_is_block_theme() && isset( $_wp_current_template_id ) ) {
-		$current_template = get_block_template( $_wp_current_template_id, 'wp_template' );
-	}
-	if ( null === $current_template && isset( $template ) && is_string( $template ) ) {
-		$current_template = basename( $template );
-	}
-
-	$current_etag         = od_get_current_url_metrics_etag( $tag_visitor_registry, $wp_the_query, $current_template );
+	$current_etag         = od_get_current_url_metrics_etag( $tag_visitor_registry, $wp_the_query, od_get_current_theme_template() );
 	$group_collection     = new OD_URL_Metric_Group_Collection(
 		$post instanceof WP_Post ? OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post ) : array(),
 		$current_etag,

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -210,10 +210,11 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	 */
 	do_action( 'od_register_tag_visitors', $tag_visitor_registry );
 
-	if ( wp_is_block_theme() ) {
+	$current_template = null;
+	if ( wp_is_block_theme() && isset( $GLOBALS['_wp_current_template_id'] ) ) {
 		$current_template = get_block_template( $GLOBALS['_wp_current_template_id'], 'wp_template' );
-		$current_template = $current_template ?? basename( $GLOBALS['template'] );
-	} else {
+	}
+	if ( null === $current_template && isset( $GLOBALS['template'] ) && is_string( $GLOBALS['template'] ) ) {
 		$current_template = basename( $GLOBALS['template'] );
 	}
 

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -178,6 +178,8 @@ function od_is_response_html_content_type(): bool {
  * @return string Filtered template output buffer.
  */
 function od_optimize_template_output_buffer( string $buffer ): string {
+	global $wp_the_query, $_wp_current_template_id, $template;
+
 	// If the content-type is not HTML or the output does not start with '<', then abort since the buffer is definitely not HTML.
 	if (
 		! od_is_response_html_content_type() ||
@@ -211,14 +213,14 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	do_action( 'od_register_tag_visitors', $tag_visitor_registry );
 
 	$current_template = null;
-	if ( wp_is_block_theme() && isset( $GLOBALS['_wp_current_template_id'] ) ) {
-		$current_template = get_block_template( $GLOBALS['_wp_current_template_id'], 'wp_template' );
+	if ( wp_is_block_theme() && $_wp_current_template_id ) {
+		$current_template = get_block_template( $_wp_current_template_id, 'wp_template' );
 	}
-	if ( null === $current_template && isset( $GLOBALS['template'] ) && is_string( $GLOBALS['template'] ) ) {
-		$current_template = basename( $GLOBALS['template'] );
+	if ( null === $current_template && $template && is_string( $template ) ) {
+		$current_template = basename( $template );
 	}
 
-	$current_etag         = od_get_current_url_metrics_etag( $tag_visitor_registry, $GLOBALS['wp_the_query'], $current_template );
+	$current_etag         = od_get_current_url_metrics_etag( $tag_visitor_registry, $wp_the_query, $current_template );
 	$group_collection     = new OD_URL_Metric_Group_Collection(
 		$post instanceof WP_Post ? OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post ) : array(),
 		$current_etag,

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -213,10 +213,10 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	do_action( 'od_register_tag_visitors', $tag_visitor_registry );
 
 	$current_template = null;
-	if ( wp_is_block_theme() && $_wp_current_template_id ) {
+	if ( wp_is_block_theme() && isset( $_wp_current_template_id ) ) {
 		$current_template = get_block_template( $_wp_current_template_id, 'wp_template' );
 	}
-	if ( null === $current_template && $template && is_string( $template ) ) {
+	if ( null === $current_template && isset( $template ) && is_string( $template ) ) {
 		$current_template = basename( $template );
 	}
 

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -150,12 +150,12 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  * @since n.e.x.t
  * @access private
  *
- * @param OD_Tag_Visitor_Registry $tag_visitor_registry Tag visitor registry.
- * @param WP_Query                $wp_query             The WP_Query instance.
- * @param string                  $current_template     The current template being used.
+ * @param OD_Tag_Visitor_Registry  $tag_visitor_registry Tag visitor registry.
+ * @param WP_Query                 $wp_query             The WP_Query instance.
+ * @param string|WP_Block_Template $current_template     The current template being used.
  * @return non-empty-string Current ETag.
  */
-function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, string $current_template ): string {
+function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, $current_template ): string {
 	$active_theme = array(
 		'template'   => array(
 			'name'    => get_template(),

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -156,9 +156,30 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  * @return non-empty-string Current ETag.
  */
 function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, $current_template ): string {
+	$queried_object      = $wp_query->get_queried_object();
+	$queried_object_data = array(
+		'id'            => null,
+		'type'          => null,
+		'last_modified' => null,
+	);
+
+	if ( $queried_object instanceof WP_Post ) {
+		$queried_object_data['id']            = $queried_object->ID;
+		$queried_object_data['type']          = 'post';
+		$queried_object_data['last_modified'] = $queried_object->post_modified_gmt;
+	} elseif ( $queried_object instanceof WP_Term ) {
+		$queried_object_data['id']   = $queried_object->term_id;
+		$queried_object_data['type'] = 'term';
+	} elseif ( $queried_object instanceof WP_User ) {
+		$queried_object_data['id']   = $queried_object->ID;
+		$queried_object_data['type'] = 'user';
+	} elseif ( $wp_query->is_post_type_archive() ) {
+		$queried_object_data['type'] = get_query_var( 'post_type' );
+	}
+
 	$data = array(
 		'tag_visitors'     => array_keys( iterator_to_array( $tag_visitor_registry ) ),
-		'queried_object'   => $wp_query->get_queried_object(),
+		'queried_object'   => $queried_object_data,
 		'queried_posts'    => wp_list_pluck( $wp_query->posts, 'post_modified_gmt', 'ID' ),
 		'active_theme'     => array(
 			'template'   => array(

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -150,8 +150,8 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  * @since n.e.x.t
  * @access private
  *
- * @param OD_Tag_Visitor_Registry      $tag_visitor_registry Tag visitor registry.
- * @param WP_Query                     $wp_query             The WP_Query instance.
+ * @param OD_Tag_Visitor_Registry       $tag_visitor_registry Tag visitor registry.
+ * @param WP_Query                      $wp_query             The WP_Query instance.
  * @param string|WP_Block_Template|null $current_template     The current template being used.
  * @return non-empty-string Current ETag.
  */

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -232,7 +232,7 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 				'version' => wp_get_theme()->get( 'Version' ),
 			),
 		),
-		'current_template' => $current_template,
+		'current_template' => $current_template instanceof WP_Block_Template ? get_object_vars( $current_template ) : $current_template,
 	);
 
 	/**

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -158,15 +158,14 @@ function od_get_url_metrics_slug( array $query_vars ): string {
 function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, $current_template ): string {
 	$queried_object      = $wp_query->get_queried_object();
 	$queried_object_data = array(
-		'id'            => null,
-		'type'          => null,
-		'last_modified' => null,
+		'id'   => null,
+		'type' => null,
 	);
 
 	if ( $queried_object instanceof WP_Post ) {
-		$queried_object_data['id']            = $queried_object->ID;
-		$queried_object_data['type']          = 'post';
-		$queried_object_data['last_modified'] = $queried_object->post_modified_gmt;
+		$queried_object_data['id']                = $queried_object->ID;
+		$queried_object_data['type']              = 'post';
+		$queried_object_data['post_modified_gmt'] = $queried_object->post_modified_gmt;
 	} elseif ( $queried_object instanceof WP_Term ) {
 		$queried_object_data['id']   = $queried_object->term_id;
 		$queried_object_data['type'] = 'term';

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -174,7 +174,7 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 		$queried_object_data['id']   = $queried_object->ID;
 		$queried_object_data['type'] = 'user';
 	} elseif ( $wp_query->is_post_type_archive() ) {
-		$queried_object_data['type'] = get_query_var( 'post_type' );
+		$queried_object_data['type'] = $wp_query->get( 'post_type' );
 	}
 
 	$data = array(

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -156,16 +156,31 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  * @return non-empty-string Current ETag.
  */
 function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, string $current_template ): string {
+	$active_theme = array(
+		'template'   => array(
+			'name'    => get_template(),
+			'version' => wp_get_theme( get_template() )->get( 'Version' ),
+		),
+		'stylesheet' => array(
+			'name'    => get_stylesheet(),
+			'version' => wp_get_theme()->get( 'Version' ),
+		),
+	);
+
+	/**
+	 * Filters the active theme details used for computing the current ETag.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array<string, array<string, string|false>> $active_theme Active theme details.
+	 */
+	$active_theme = apply_filters( 'od_current_url_metrics_etag_active_theme', $active_theme );
+
 	$data = array(
 		'tag_visitors'     => array_keys( iterator_to_array( $tag_visitor_registry ) ),
 		'queried_object'   => $wp_query->get_queried_object(),
 		'queried_posts'    => wp_list_pluck( $wp_query->posts, 'post_modified_gmt', 'ID' ),
-		'active_theme'     => array(
-			'template'           => get_template(),
-			'template_version'   => wp_get_theme( get_template() )->get( 'Version' ),
-			'stylesheet'         => get_stylesheet(),
-			'stylesheet_version' => wp_get_theme()->get( 'Version' ),
-		),
+		'active_theme'     => $active_theme,
 		'current_template' => $current_template,
 	);
 

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -156,31 +156,20 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  * @return non-empty-string Current ETag.
  */
 function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, $current_template ): string {
-	$active_theme = array(
-		'template'   => array(
-			'name'    => get_template(),
-			'version' => wp_get_theme( get_template() )->get( 'Version' ),
-		),
-		'stylesheet' => array(
-			'name'    => get_stylesheet(),
-			'version' => wp_get_theme()->get( 'Version' ),
-		),
-	);
-
-	/**
-	 * Filters the active theme details used for computing the current ETag.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param array<string, array<string, string|false>> $active_theme Active theme details.
-	 */
-	$active_theme = apply_filters( 'od_current_url_metrics_etag_active_theme', $active_theme );
-
 	$data = array(
 		'tag_visitors'     => array_keys( iterator_to_array( $tag_visitor_registry ) ),
 		'queried_object'   => $wp_query->get_queried_object(),
 		'queried_posts'    => wp_list_pluck( $wp_query->posts, 'post_modified_gmt', 'ID' ),
-		'active_theme'     => $active_theme,
+		'active_theme'     => array(
+			'template'   => array(
+				'name'    => get_template(),
+				'version' => wp_get_theme( get_template() )->get( 'Version' ),
+			),
+			'stylesheet' => array(
+				'name'    => get_stylesheet(),
+				'version' => wp_get_theme()->get( 'Version' ),
+			),
+		),
 		'current_template' => $current_template,
 	);
 

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -141,6 +141,32 @@ function od_get_url_metrics_slug( array $query_vars ): string {
 }
 
 /**
+ * Gets the current template for a block theme or a classic theme.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @global string|null $_wp_current_template_id Current template ID.
+ * @global string|null $template                Template file path.
+ *
+ * @return string|WP_Block_Template|null Template.
+ */
+function od_get_current_theme_template() {
+	global $template, $_wp_current_template_id;
+
+	if ( wp_is_block_theme() && isset( $_wp_current_template_id ) ) {
+		$block_template = get_block_template( $_wp_current_template_id, 'wp_template' );
+		if ( $block_template instanceof WP_Block_Template ) {
+			return $block_template;
+		}
+	}
+	if ( isset( $template ) && is_string( $template ) ) {
+		return basename( $template );
+	}
+	return null;
+}
+
+/**
  * Gets the current ETag for URL Metrics.
  *
  * Generates a hash based on the IDs of registered tag visitors, the queried object,

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -177,12 +177,12 @@ function od_get_current_theme_template() {
  * @access private
  *
  * @param OD_Tag_Visitor_Registry       $tag_visitor_registry Tag visitor registry.
- * @param WP_Query                      $wp_query             The WP_Query instance.
+ * @param WP_Query|null                 $wp_query             The WP_Query instance.
  * @param string|WP_Block_Template|null $current_template     The current template being used.
  * @return non-empty-string Current ETag.
  */
-function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, $current_template ): string {
-	$queried_object      = $wp_query->get_queried_object();
+function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, ?WP_Query $wp_query, $current_template ): string {
+	$queried_object      = $wp_query instanceof WP_Query ? $wp_query->get_queried_object() : null;
 	$queried_object_data = array(
 		'id'   => null,
 		'type' => null,
@@ -219,7 +219,7 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 						'post_modified_gmt' => $post->post_modified_gmt,
 					);
 				},
-				0 === $wp_query->post_count ? array() : $wp_query->posts // Needed in case WP_Query has not been initialized.
+				( $wp_query instanceof WP_Query && $wp_query->post_count > 0 ) ? $wp_query->posts : array()
 			)
 		),
 		'active_theme'     => array(

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -155,18 +155,8 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  */
 function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry ): string {
 	$data = array(
-		'tag_visitors' => array_keys( iterator_to_array( $tag_visitor_registry ) ),
-	);
-
-	if ( is_singular() ) {
-		$queried_object = get_queried_object();
-
-		$data['queried_object'] = array(
-			'ID'            => $queried_object->ID,
-			'last_modified' => $queried_object->post_modified_gmt,
-		);
-	} else {
-		$data['queried_posts'] = array_map(
+		'tag_visitors'  => array_keys( iterator_to_array( $tag_visitor_registry ) ),
+		'queried_posts' => array_map(
 			static function ( WP_Post $post ): array {
 				return array(
 					'ID'            => $post->ID,
@@ -174,8 +164,8 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 				);
 			},
 			$GLOBALS['wp_the_query']->posts
-		);
-	}
+		),
+	);
 
 	/**
 	 * Filters the data that goes into computing the current ETag for URL Metrics.

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -205,7 +205,23 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 	$data = array(
 		'tag_visitors'     => array_keys( iterator_to_array( $tag_visitor_registry ) ),
 		'queried_object'   => $queried_object_data,
-		'queried_posts'    => wp_list_pluck( $wp_query->posts, 'post_modified_gmt', 'ID' ),
+		'queried_posts'    => array_filter(
+			array_map(
+				static function ( $post ): ?array {
+					if ( is_int( $post ) ) {
+						$post = get_post( $post );
+					}
+					if ( ! ( $post instanceof WP_Post ) ) {
+						return null;
+					}
+					return array(
+						'id'                => $post->ID,
+						'post_modified_gmt' => $post->post_modified_gmt,
+					);
+				},
+				0 === $wp_query->post_count ? array() : $wp_query->posts // Needed in case WP_Query has not been initialized.
+			)
+		),
 		'active_theme'     => array(
 			'template'   => array(
 				'name'    => get_template(),

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -143,12 +143,16 @@ function od_get_url_metrics_slug( array $query_vars ): string {
 /**
  * Gets the current ETag for URL Metrics.
  *
- * The ETag is a hash based on the IDs of the registered tag visitors
- * in the current environment. It is used for marking the URL Metrics as stale
- * when its value changes.
+ * Generates a hash based on the IDs of registered tag visitors, queried posts,
+ * and theme information in the current environment. This ETag is used to assess
+ * if the URL Metrics are stale when its value changes.
  *
  * @since n.e.x.t
  * @access private
+ *
+ * @global WP_Query $wp_the_query            Global WP_Query instance.
+ * @global string   $_wp_current_template_id Current template ID.
+ * @global string   $template                Template file path.
  *
  * @param OD_Tag_Visitor_Registry $tag_visitor_registry Tag visitor registry.
  * @return non-empty-string Current ETag.

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -172,8 +172,8 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 	} elseif ( $queried_object instanceof WP_User ) {
 		$queried_object_data['id']   = $queried_object->ID;
 		$queried_object_data['type'] = 'user';
-	} elseif ( $wp_query->is_post_type_archive() ) {
-		$queried_object_data['type'] = $wp_query->get( 'post_type' );
+	} elseif ( $queried_object instanceof WP_Post_Type ) {
+		$queried_object_data['type'] = $queried_object->name;
 	}
 
 	$data = array(

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -166,7 +166,15 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 			'last_modified' => $queried_object->post_modified_gmt,
 		);
 	} else {
-		$data['queried_post_ids'] = join( ',', wp_list_pluck( $GLOBALS['wp_query']->posts, 'ID' ) );
+		$data['queried_posts'] = array_map(
+			static function ( WP_Post $post ): array {
+				return array(
+					'ID'            => $post->ID,
+					'last_modified' => $post->post_modified_gmt,
+				);
+			},
+			$GLOBALS['wp_the_query']->posts
+		);
 	}
 
 	/**

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -165,7 +165,20 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 			},
 			$GLOBALS['wp_the_query']->posts
 		),
+		'active_theme'  => array(
+			'template'           => get_template(),
+			'template_version'   => wp_get_theme( get_template() )->get( 'Version' ),
+			'stylesheet'         => get_stylesheet(),
+			'stylesheet_version' => wp_get_theme()->get( 'Version' ),
+		),
 	);
+
+	if ( wp_is_block_theme() ) {
+		// Extract the template slug from $_wp_current_template_id, which has the format 'theme_slug//template_slug'.
+		$data['current_template'] = explode( '//', $GLOBALS['_wp_current_template_id'] )[1];
+	} else {
+		$data['current_template'] = basename( $GLOBALS['template'] );
+	}
 
 	/**
 	 * Filters the data that goes into computing the current ETag for URL Metrics.

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -150,9 +150,9 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  * @since n.e.x.t
  * @access private
  *
- * @param OD_Tag_Visitor_Registry  $tag_visitor_registry Tag visitor registry.
- * @param WP_Query                 $wp_query             The WP_Query instance.
- * @param string|WP_Block_Template $current_template     The current template being used.
+ * @param OD_Tag_Visitor_Registry      $tag_visitor_registry Tag visitor registry.
+ * @param WP_Query                     $wp_query             The WP_Query instance.
+ * @param string|WP_Block_Template|null $current_template     The current template being used.
  * @return non-empty-string Current ETag.
  */
 function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry, WP_Query $wp_query, $current_template ): string {

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -158,6 +158,17 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 		'tag_visitors' => array_keys( iterator_to_array( $tag_visitor_registry ) ),
 	);
 
+	if ( is_singular() ) {
+		$queried_object = get_queried_object();
+
+		$data['queried_object'] = array(
+			'ID'            => $queried_object->ID,
+			'last_modified' => $queried_object->post_modified_gmt,
+		);
+	} else {
+		$data['queried_post_ids'] = join( ',', wp_list_pluck( $GLOBALS['wp_query']->posts, 'ID' ) );
+	}
+
 	/**
 	 * Filters the data that goes into computing the current ETag for URL Metrics.
 	 *

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -143,9 +143,9 @@ function od_get_url_metrics_slug( array $query_vars ): string {
 /**
  * Gets the current ETag for URL Metrics.
  *
- * Generates a hash based on the IDs of registered tag visitors, queried posts,
- * and theme information in the current environment. This ETag is used to assess
- * if the URL Metrics are stale when its value changes.
+ * Generates a hash based on the IDs of registered tag visitors, the queried object,
+ * posts in The Loop, and theme information in the current environment. This ETag
+ * is used to assess if the URL Metrics are stale when its value changes.
  *
  * @since n.e.x.t
  * @access private
@@ -173,9 +173,10 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 	}
 
 	$data = array(
-		'tag_visitors'  => array_keys( iterator_to_array( $tag_visitor_registry ) ),
-		'queried_posts' => $queried_posts,
-		'active_theme'  => array(
+		'tag_visitors'   => array_keys( iterator_to_array( $tag_visitor_registry ) ),
+		'queried_object' => get_queried_object(),
+		'queried_posts'  => $queried_posts,
+		'active_theme'   => array(
 			'template'           => get_template(),
 			'template_version'   => wp_get_theme( get_template() )->get( 'Version' ),
 			'stylesheet'         => get_stylesheet(),

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -158,9 +158,8 @@ function od_get_url_metrics_slug( array $query_vars ): string {
  * @return non-empty-string Current ETag.
  */
 function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_registry ): string {
-	$data = array(
-		'tag_visitors'  => array_keys( iterator_to_array( $tag_visitor_registry ) ),
-		'queried_posts' => array_map(
+	if ( isset( $GLOBALS['wp_the_query']->posts ) && is_array( $GLOBALS['wp_the_query']->posts ) ) {
+		$queried_posts = array_map(
 			static function ( WP_Post $post ): array {
 				return array(
 					'ID'            => $post->ID,
@@ -168,7 +167,14 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 				);
 			},
 			$GLOBALS['wp_the_query']->posts
-		),
+		);
+	} else {
+		$queried_posts = array();
+	}
+
+	$data = array(
+		'tag_visitors'  => array_keys( iterator_to_array( $tag_visitor_registry ) ),
+		'queried_posts' => $queried_posts,
 		'active_theme'  => array(
 			'template'           => get_template(),
 			'template_version'   => wp_get_theme( get_template() )->get( 'Version' ),
@@ -179,9 +185,9 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 
 	if ( wp_is_block_theme() ) {
 		// Extract the template slug from $_wp_current_template_id, which has the format 'theme_slug//template_slug'.
-		$data['current_template'] = explode( '//', $GLOBALS['_wp_current_template_id'] )[1];
+		$data['current_template'] = explode( '//', $GLOBALS['_wp_current_template_id'] ?? '' )[1] ?? '';
 	} else {
-		$data['current_template'] = basename( $GLOBALS['template'] );
+		$data['current_template'] = basename( $GLOBALS['template'] ?? '' );
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/data/themes/block-theme/style.css
+++ b/plugins/optimization-detective/tests/data/themes/block-theme/style.css
@@ -1,0 +1,7 @@
+/*
+Theme Name: Block Theme
+Theme URI: https://wordpress.org/
+Description: For testing purposes only.
+Version: 1.0.0
+Text Domain: block-theme
+*/

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -321,10 +321,14 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 				'queried_object'   => null,
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
-					'template'           => 'default',
-					'template_version'   => '1.6',
-					'stylesheet'         => 'default',
-					'stylesheet_version' => '1.6',
+					'template'   => array(
+						'name'    => 'default',
+						'version' => '1.6',
+					),
+					'stylesheet' => array(
+						'name'    => 'default',
+						'version' => '1.6',
+					),
 				),
 				'current_template' => 'index.php',
 			),
@@ -363,10 +367,14 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 				'queried_object'   => null,
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
-					'template'           => 'default',
-					'template_version'   => '1.6',
-					'stylesheet'         => 'default',
-					'stylesheet_version' => '1.6',
+					'template'   => array(
+						'name'    => 'default',
+						'version' => '1.6',
+					),
+					'stylesheet' => array(
+						'name'    => 'default',
+						'version' => '1.6',
+					),
 				),
 				'current_template' => 'index.php',
 			),
@@ -396,10 +404,14 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 				),
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
-					'template'           => 'default',
-					'template_version'   => '1.6',
-					'stylesheet'         => 'default',
-					'stylesheet_version' => '1.6',
+					'template'   => array(
+						'name'    => 'default',
+						'version' => '1.6',
+					),
+					'stylesheet' => array(
+						'name'    => 'default',
+						'version' => '1.6',
+					),
 				),
 				'current_template' => 'index.php',
 			),

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -334,7 +334,11 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'tag_visitors'     => array(),
-				'queried_object'   => null,
+				'queried_object'   => array(
+					'id'            => null,
+					'type'          => null,
+					'last_modified' => null,
+				),
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
 					'template'   => array(
@@ -382,7 +386,11 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
-				'queried_object'   => null,
+				'queried_object'   => array(
+					'id'            => null,
+					'type'          => null,
+					'last_modified' => null,
+				),
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
 					'template'   => array(
@@ -414,7 +422,11 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
-				'queried_object'   => null,
+				'queried_object'   => array(
+					'id'            => null,
+					'type'          => null,
+					'last_modified' => null,
+				),
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
 					'template'   => array(

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -333,8 +333,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertSame( $captured_etag_data[ count( $captured_etag_data ) - 2 ], $captured_etag_data[ count( $captured_etag_data ) - 1 ] );
 
 		// Add new post.
-		$new_post_id = self::factory()->post->create();
-		$post_ids[]  = $new_post_id;
+		$post_ids[] = self::factory()->post->create();
 		$wp_the_query->query( array() );
 		$etag3 = od_get_current_url_metrics_etag( $registry, $wp_the_query, $current_template );
 		$this->assertNotEquals( $etag2, $etag3 ); // Etag should change.

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -309,7 +309,20 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$etag2 = od_get_current_url_metrics_etag( $registry );
 		$this->assertSame( $etag1, $etag2 );
 		$this->assertCount( 2, $captured_etag_data );
-		$this->assertSame( array( 'tag_visitors' => array() ), $captured_etag_data[0] );
+		$this->assertSame(
+			array(
+				'tag_visitors'     => array(),
+				'queried_posts'    => array(),
+				'active_theme'     => array(
+					'template'           => 'default',
+					'template_version'   => '1.6',
+					'stylesheet'         => 'default',
+					'stylesheet_version' => '1.6',
+				),
+				'current_template' => '',
+			),
+			$captured_etag_data[0]
+		);
 		$this->assertSame( $captured_etag_data[ count( $captured_etag_data ) - 2 ], $captured_etag_data[ count( $captured_etag_data ) - 1 ] );
 
 		$registry->register( 'foo', static function (): void {} );
@@ -318,11 +331,29 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$etag3 = od_get_current_url_metrics_etag( $registry );
 		$this->assertNotEquals( $etag2, $etag3 );
 		$this->assertNotEquals( $captured_etag_data[ count( $captured_etag_data ) - 2 ], $captured_etag_data[ count( $captured_etag_data ) - 1 ] );
-		$this->assertSame( array( 'tag_visitors' => array( 'foo', 'bar', 'baz' ) ), $captured_etag_data[ count( $captured_etag_data ) - 1 ] );
+		$this->assertSame(
+			array(
+				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
+				'queried_posts'    => array(),
+				'active_theme'     => array(
+					'template'           => 'default',
+					'template_version'   => '1.6',
+					'stylesheet'         => 'default',
+					'stylesheet_version' => '1.6',
+				),
+				'current_template' => '',
+			),
+			$captured_etag_data[ count( $captured_etag_data ) - 1 ]
+		);
 		add_filter(
 			'od_current_url_metrics_etag_data',
 			static function ( $data ): array {
-				$data['last_modified'] = '2024-03-02T01:00:00';
+				$data['queried_posts'] = array(
+					array(
+						'ID'            => 99,
+						'last_modified' => '2024-03-02T01:00:00',
+					),
+				);
 				return $data;
 			}
 		);
@@ -331,8 +362,20 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertNotEquals( $captured_etag_data[ count( $captured_etag_data ) - 2 ], $captured_etag_data[ count( $captured_etag_data ) - 1 ] );
 		$this->assertSame(
 			array(
-				'tag_visitors'  => array( 'foo', 'bar', 'baz' ),
-				'last_modified' => '2024-03-02T01:00:00',
+				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
+				'queried_posts'    => array(
+					array(
+						'ID'            => 99,
+						'last_modified' => '2024-03-02T01:00:00',
+					),
+				),
+				'active_theme'     => array(
+					'template'           => 'default',
+					'template_version'   => '1.6',
+					'stylesheet'         => 'default',
+					'stylesheet_version' => '1.6',
+				),
+				'current_template' => '',
 			),
 			$captured_etag_data[ count( $captured_etag_data ) - 1 ]
 		);

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -389,14 +389,14 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 
 			'user_archive'                => array(
 				'set_up' => function (): Closure {
-					$user = self::factory()->user->create_and_get();
-					$this->assertInstanceOf( WP_User::class, $user );
-					$post_ids = self::factory()->post->create_many( 3, array( 'post_author' => $user->ID ) );
-					$this->go_to( get_author_posts_url( $user->ID ) );
+					$user_id = self::factory()->user->create();
+					$this->assertIsInt( $user_id );
+					$post_ids = self::factory()->post->create_many( 3, array( 'post_author' => $user_id ) );
+					$this->go_to( get_author_posts_url( $user_id ) );
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'author.php';
 
-					return function ( array $etag_data ) use ( $user, $post_ids ): void {
-						$this->assertSame( $user->ID, $etag_data['queried_object']['id'] );
+					return function ( array $etag_data ) use ( $user_id, $post_ids ): void {
+						$this->assertSame( $user_id, $etag_data['queried_object']['id'] );
 						$this->assertSame( 'user', $etag_data['queried_object']['type'] );
 						$this->assertCount( 3, $etag_data['queried_posts'] );
 						$this->assertEqualSets( $post_ids, wp_list_pluck( $etag_data['queried_posts'], 'id' ) );

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -342,9 +342,8 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 			array(
 				'tag_visitors'     => array(),
 				'queried_object'   => array(
-					'id'            => null,
-					'type'          => null,
-					'last_modified' => null,
+					'id'   => null,
+					'type' => null,
 				),
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
@@ -394,9 +393,8 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 			array(
 				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
 				'queried_object'   => array(
-					'id'            => null,
-					'type'          => null,
-					'last_modified' => null,
+					'id'   => null,
+					'type' => null,
 				),
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(
@@ -430,9 +428,8 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 			array(
 				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
 				'queried_object'   => array(
-					'id'            => null,
-					'type'          => null,
-					'last_modified' => null,
+					'id'   => null,
+					'type' => null,
 				),
 				'queried_posts'    => wp_list_pluck( $wp_the_query->posts, 'post_modified_gmt', 'ID' ),
 				'active_theme'     => array(

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -293,7 +293,9 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 	 */
 	public function test_od_get_current_url_metrics_etag(): void {
 		remove_all_filters( 'od_current_url_metrics_etag_data' );
-		$registry = new OD_Tag_Visitor_Registry();
+		$registry         = new OD_Tag_Visitor_Registry();
+		$wp_the_query     = new WP_Query();
+		$current_template = 'index.php';
 
 		$captured_etag_data = array();
 		add_filter(
@@ -304,9 +306,9 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 			},
 			PHP_INT_MAX
 		);
-		$etag1 = od_get_current_url_metrics_etag( $registry );
+		$etag1 = od_get_current_url_metrics_etag( $registry, $wp_the_query, $current_template );
 		$this->assertMatchesRegularExpression( '/^[a-z0-9]{32}\z/', $etag1 );
-		$etag2 = od_get_current_url_metrics_etag( $registry );
+		$etag2 = od_get_current_url_metrics_etag( $registry, $wp_the_query, $current_template );
 		$this->assertSame( $etag1, $etag2 );
 		$this->assertCount( 2, $captured_etag_data );
 		$this->assertSame(
@@ -320,7 +322,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					'stylesheet'         => 'default',
 					'stylesheet_version' => '1.6',
 				),
-				'current_template' => '',
+				'current_template' => 'index.php',
 			),
 			$captured_etag_data[0]
 		);
@@ -329,7 +331,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$registry->register( 'foo', static function (): void {} );
 		$registry->register( 'bar', static function (): void {} );
 		$registry->register( 'baz', static function (): void {} );
-		$etag3 = od_get_current_url_metrics_etag( $registry );
+		$etag3 = od_get_current_url_metrics_etag( $registry, $wp_the_query, $current_template );
 		$this->assertNotEquals( $etag2, $etag3 );
 		$this->assertNotEquals( $captured_etag_data[ count( $captured_etag_data ) - 2 ], $captured_etag_data[ count( $captured_etag_data ) - 1 ] );
 		$this->assertSame(
@@ -343,7 +345,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					'stylesheet'         => 'default',
 					'stylesheet_version' => '1.6',
 				),
-				'current_template' => '',
+				'current_template' => 'index.php',
 			),
 			$captured_etag_data[ count( $captured_etag_data ) - 1 ]
 		);
@@ -359,7 +361,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 				return $data;
 			}
 		);
-		$etag4 = od_get_current_url_metrics_etag( $registry );
+		$etag4 = od_get_current_url_metrics_etag( $registry, $wp_the_query, $current_template );
 		$this->assertNotEquals( $etag3, $etag4 );
 		$this->assertNotEquals( $captured_etag_data[ count( $captured_etag_data ) - 2 ], $captured_etag_data[ count( $captured_etag_data ) - 1 ] );
 		$this->assertSame(
@@ -378,7 +380,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					'stylesheet'         => 'default',
 					'stylesheet_version' => '1.6',
 				),
-				'current_template' => '',
+				'current_template' => 'index.php',
 			),
 			$captured_etag_data[ count( $captured_etag_data ) - 1 ]
 		);

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -396,6 +396,16 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$user_id = self::factory()->user->create();
 					$this->assertIsInt( $user_id );
 					$post_ids = self::factory()->post->create_many( 3, array( 'post_author' => $user_id ) );
+
+					// This is a workaround because the author URL pretty permalink is failing for some reason only on GHA.
+					add_filter(
+						'author_link',
+						static function ( $link, $author_id ) {
+							return add_query_arg( 'author', $author_id, home_url( '/' ) );
+						},
+						10,
+						2
+					);
 					$this->go_to( get_author_posts_url( $user_id ) );
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'author.php';
 

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -300,7 +300,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$post = self::factory()->post->create_and_get();
 					$this->assertInstanceOf( WP_Post::class, $post );
 					$this->go_to( '/' );
-					$GLOBALS['template'] = 'home.php';
+					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'home.php';
 
 					return function ( array $etag_data, Closure $get_etag ) use ( $post ): void {
 						$this->assertNull( $etag_data['queried_object']['id'] );
@@ -337,7 +337,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$this->assertInstanceOf( WP_Post::class, $post );
 					remove_filter( 'wp_insert_post_data', $force_old_post_modified_data );
 					$this->go_to( get_permalink( $post ) );
-					$GLOBALS['template'] = 'single.php';
+					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'single.php';
 
 					return function ( array $etag_data, Closure $get_etag ) use ( $post ): void {
 						$this->assertSame( $post->ID, $etag_data['queried_object']['id'] );
@@ -375,7 +375,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 						wp_set_post_terms( $post_id, array( $term->term_id ), 'category' );
 					}
 					$this->go_to( get_category_link( $term ) );
-					$GLOBALS['template'] = 'category.php';
+					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'category.php';
 
 					return function ( array $etag_data ) use ( $term, $post_ids ): void {
 						$this->assertSame( $term->term_id, $etag_data['queried_object']['id'] );
@@ -393,7 +393,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$this->assertInstanceOf( WP_User::class, $user );
 					$post_ids = self::factory()->post->create_many( 3, array( 'post_author' => $user->ID ) );
 					$this->go_to( get_author_posts_url( $user->ID ) );
-					$GLOBALS['template'] = 'author.php';
+					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'author.php';
 
 					return function ( array $etag_data ) use ( $user, $post_ids ): void {
 						$this->assertSame( $user->ID, $etag_data['queried_object']['id'] );
@@ -416,7 +416,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					);
 					$post_ids = self::factory()->post->create_many( 4, array( 'post_type' => 'book' ) );
 					$this->go_to( get_post_type_archive_link( 'book' ) );
-					$GLOBALS['template'] = 'archive-book.php';
+					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'archive-book.php';
 
 					return function ( array $etag_data ) use ( $post_ids ): void {
 						$this->assertNull( $etag_data['queried_object']['id'] );
@@ -436,7 +436,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 
 					$post_ids = self::factory()->post->create_many( 5 );
 					$this->go_to( get_page_link( $page_id ) );
-					$GLOBALS['template'] = 'home.php';
+					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'home.php';
 
 					return function ( array $etag_data ) use ( $page_id, $post_ids ): void {
 						$this->assertSame( $page_id, $etag_data['queried_object']['id'] );
@@ -478,9 +478,6 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 	 * @covers ::od_get_current_theme_template
 	 */
 	public function test_od_get_current_url_metrics_etag( Closure $set_up ): void {
-		global $template;
-		$template = 'index.php';
-
 		$captured_etag_data = null;
 		add_filter(
 			'od_current_url_metrics_etag_data',

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -308,9 +308,9 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 			PHP_INT_MAX
 		);
 		add_filter(
-			'od_current_url_metrics_etag_active_theme',
-			static function ( $active_theme ) {
-				$active_theme = array(
+			'od_current_url_metrics_etag_data',
+			static function ( $data ) {
+				$data['active_theme'] = array(
 					'template'   => array(
 						'name'    => 'od-theme',
 						'version' => '1.0.0',
@@ -320,7 +320,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 						'version' => '1.0.0',
 					),
 				);
-				return $active_theme;
+				return $data;
 			}
 		);
 
@@ -401,11 +401,11 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 
 		// Modify data using filters.
 		add_filter(
-			'od_current_url_metrics_etag_active_theme',
-			static function ( $active_theme ) {
-				$active_theme['template']['version']   = '2.0.0';
-				$active_theme['stylesheet']['version'] = '2.0.0';
-				return $active_theme;
+			'od_current_url_metrics_etag_data',
+			static function ( $data ) {
+				$data['active_theme']['template']['version']   = '2.0.0';
+				$data['active_theme']['stylesheet']['version'] = '2.0.0';
+				return $data;
 			}
 		);
 		$etag6 = od_get_current_url_metrics_etag( $registry, $wp_the_query, $current_template );

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -303,6 +303,8 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'home.php';
 
 					return function ( array $etag_data, Closure $get_etag ) use ( $post ): void {
+						$this->assertTrue( is_home() );
+						$this->assertTrue( is_front_page() );
 						$this->assertNull( $etag_data['queried_object']['id'] );
 						$this->assertNull( $etag_data['queried_object']['type'] );
 						$this->assertCount( 1, $etag_data['queried_posts'] );
@@ -340,6 +342,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'single.php';
 
 					return function ( array $etag_data, Closure $get_etag ) use ( $post ): void {
+						$this->assertTrue( is_single( $post ) );
 						$this->assertSame( $post->ID, $etag_data['queried_object']['id'] );
 						$this->assertSame( 'post', $etag_data['queried_object']['type'] );
 						$this->assertArrayHasKey( 'post_modified_gmt', $etag_data['queried_object'] );
@@ -378,6 +381,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'category.php';
 
 					return function ( array $etag_data ) use ( $term, $post_ids ): void {
+						$this->assertTrue( is_category( $term ) );
 						$this->assertSame( $term->term_id, $etag_data['queried_object']['id'] );
 						$this->assertSame( 'term', $etag_data['queried_object']['type'] );
 						$this->assertCount( 2, $etag_data['queried_posts'] );
@@ -396,6 +400,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'author.php';
 
 					return function ( array $etag_data ) use ( $user_id, $post_ids ): void {
+						$this->assertTrue( is_author( $user_id ), 'Expected is_author() after having gone to ' . get_author_posts_url( $user_id ) );
 						$this->assertSame( $user_id, $etag_data['queried_object']['id'] );
 						$this->assertSame( 'user', $etag_data['queried_object']['type'] );
 						$this->assertCount( 3, $etag_data['queried_posts'] );
@@ -419,6 +424,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'archive-book.php';
 
 					return function ( array $etag_data ) use ( $post_ids ): void {
+						$this->assertTrue( is_post_type_archive( 'book' ) );
 						$this->assertNull( $etag_data['queried_object']['id'] );
 						$this->assertSame( 'book', $etag_data['queried_object']['type'] );
 						$this->assertCount( 4, $etag_data['queried_posts'] );
@@ -439,6 +445,8 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					$GLOBALS['template'] = trailingslashit( get_template_directory() ) . 'home.php';
 
 					return function ( array $etag_data ) use ( $page_id, $post_ids ): void {
+						$this->assertTrue( is_home() );
+						$this->assertFalse( is_front_page() );
 						$this->assertSame( $page_id, $etag_data['queried_object']['id'] );
 						$this->assertSame( 'post', $etag_data['queried_object']['type'] );
 						$this->assertCount( 5, $etag_data['queried_posts'] );
@@ -455,6 +463,8 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					update_option( 'template', 'block-theme' );
 					update_option( 'stylesheet', 'block-theme' );
 					$this->go_to( '/' );
+					$this->assertTrue( is_home() );
+					$this->assertTrue( is_front_page() );
 					$GLOBALS['_wp_current_template_id'] = 'block-theme//index';
 
 					return function ( array $etag_data ): void {

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -312,6 +312,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'tag_visitors'     => array(),
+				'queried_object'   => null,
 				'queried_posts'    => array(),
 				'active_theme'     => array(
 					'template'           => 'default',
@@ -334,6 +335,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
+				'queried_object'   => null,
 				'queried_posts'    => array(),
 				'active_theme'     => array(
 					'template'           => 'default',
@@ -363,6 +365,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 		$this->assertSame(
 			array(
 				'tag_visitors'     => array( 'foo', 'bar', 'baz' ),
+				'queried_object'   => null,
 				'queried_posts'    => array(
 					array(
 						'ID'            => 99,

--- a/plugins/optimization-detective/tests/test-helper.php
+++ b/plugins/optimization-detective/tests/test-helper.php
@@ -25,6 +25,8 @@ class Test_OD_Helper extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider.
+	 *
 	 * @return array<string, array<string, mixed>>
 	 */
 	public function data_to_test_od_generate_media_query(): array {

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -31,7 +31,6 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 		$this->original_request_uri    = $_SERVER['REQUEST_URI'];
 		$this->original_request_method = $_SERVER['REQUEST_METHOD'];
 		$this->default_mimetype        = (string) ini_get( 'default_mimetype' );
-		$GLOBALS['template']           = '/path/to/theme/index.php';
 	}
 
 	public function tear_down(): void {
@@ -39,7 +38,6 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 		$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
 		ini_set( 'default_mimetype', $this->default_mimetype ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		unset( $GLOBALS['wp_customize'] );
-		unset( $GLOBALS['template'] );
 		parent::tear_down();
 	}
 

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -291,6 +291,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ): void {
+		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$set_up( $this );
 
 		add_action(
@@ -336,5 +337,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
+
+		unset( $GLOBALS['template'] );
 	}
 }

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -27,10 +27,11 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 	private $default_mimetype;
 
 	public function set_up(): void {
+		parent::set_up();
 		$this->original_request_uri    = $_SERVER['REQUEST_URI'];
 		$this->original_request_method = $_SERVER['REQUEST_METHOD'];
 		$this->default_mimetype        = (string) ini_get( 'default_mimetype' );
-		parent::set_up();
+		$GLOBALS['template']           = '/path/to/theme/index.php';
 	}
 
 	public function tear_down(): void {
@@ -38,6 +39,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 		$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
 		ini_set( 'default_mimetype', $this->default_mimetype ); // phpcs:ignore WordPress.PHP.IniSet.Risky
 		unset( $GLOBALS['wp_customize'] );
+		unset( $GLOBALS['template'] );
 		parent::tear_down();
 	}
 
@@ -291,7 +293,6 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 */
 	public function test_od_optimize_template_output_buffer( Closure $set_up, string $buffer, string $expected ): void {
-		$GLOBALS['template'] = '/path/to/theme/index.php';
 		$set_up( $this );
 
 		add_action(
@@ -337,7 +338,5 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 			$this->remove_initial_tabs( $buffer ),
 			"Buffer snapshot:\n$buffer"
 		);
-
-		unset( $GLOBALS['template'] );
 	}
 }

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -27,7 +27,7 @@ trait Optimization_Detective_Test_Helpers {
 	 */
 	public function populate_url_metrics( array $elements, bool $complete = true ): void {
 		$slug        = od_get_url_metrics_slug( od_get_normalized_query_vars() );
-		$etag        = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), 'index.php' ); // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
+		$etag        = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), trailingslashit( get_template_directory() ) . 'index.php' ); // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
 		$sample_size = $complete ? od_get_url_metrics_breakpoint_sample_size() : 1;
 		foreach ( array_merge( od_get_breakpoint_max_widths(), array( 1000 ) ) as $viewport_width ) {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
@@ -81,7 +81,7 @@ trait Optimization_Detective_Test_Helpers {
 	public function get_sample_url_metric( array $params ): OD_URL_Metric {
 		$params = array_merge(
 			array(
-				'etag'           => od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), 'index.php' ), // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
+				'etag'           => od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), trailingslashit( get_template_directory() ) . 'index.php' ), // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
 				'url'            => home_url( '/' ),
 				'viewport_width' => 480,
 				'elements'       => array(),

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -27,7 +27,7 @@ trait Optimization_Detective_Test_Helpers {
 	 */
 	public function populate_url_metrics( array $elements, bool $complete = true ): void {
 		$slug        = od_get_url_metrics_slug( od_get_normalized_query_vars() );
-		$etag        = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), trailingslashit( get_template_directory() ) . 'index.php' ); // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
+		$etag        = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), null, null ); // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
 		$sample_size = $complete ? od_get_url_metrics_breakpoint_sample_size() : 1;
 		foreach ( array_merge( od_get_breakpoint_max_widths(), array( 1000 ) ) as $viewport_width ) {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
@@ -81,7 +81,7 @@ trait Optimization_Detective_Test_Helpers {
 	public function get_sample_url_metric( array $params ): OD_URL_Metric {
 		$params = array_merge(
 			array(
-				'etag'           => od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), trailingslashit( get_template_directory() ) . 'index.php' ), // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
+				'etag'           => od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), null, null ), // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
 				'url'            => home_url( '/' ),
 				'viewport_width' => 480,
 				'elements'       => array(),

--- a/tests/class-optimization-detective-test-helpers.php
+++ b/tests/class-optimization-detective-test-helpers.php
@@ -27,7 +27,7 @@ trait Optimization_Detective_Test_Helpers {
 	 */
 	public function populate_url_metrics( array $elements, bool $complete = true ): void {
 		$slug        = od_get_url_metrics_slug( od_get_normalized_query_vars() );
-		$etag        = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry() ); // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
+		$etag        = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), 'index.php' ); // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
 		$sample_size = $complete ? od_get_url_metrics_breakpoint_sample_size() : 1;
 		foreach ( array_merge( od_get_breakpoint_max_widths(), array( 1000 ) ) as $viewport_width ) {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
@@ -81,7 +81,7 @@ trait Optimization_Detective_Test_Helpers {
 	public function get_sample_url_metric( array $params ): OD_URL_Metric {
 		$params = array_merge(
 			array(
-				'etag'           => od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry() ), // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
+				'etag'           => od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), new WP_Query(), 'index.php' ), // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
 				'url'            => home_url( '/' ),
 				'viewport_width' => 480,
 				'elements'       => array(),


### PR DESCRIPTION
## Summary

Fixes #1466 

## Relevant technical choices

Factored the following into the ETag computation:
  - The queried object
  - The post IDs and last modified of posts in The Loop
  - The active theme (stylesheet, template, and their versions)
  - The current theme template, with the base name of of the template PHP file (e.g. `single.php` for classic themes, or else the `WP_Block_Template` attributes in case of block themes.