### PR TITLE
Add `fetchpriority=high` to `IMG` when it is the LCP element on desktop and mobile with other viewport groups empty

### DIFF
--- a/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups.php
+++ b/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups.php
@@ -1,0 +1,68 @@
+<?php
+return array(
+	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case ): void {
+		$breakpoint_max_widths = array( 480, 600, 782 );
+
+		add_filter(
+			'od_breakpoint_max_widths',
+			static function () use ( $breakpoint_max_widths ) {
+				return $breakpoint_max_widths;
+			}
+		);
+
+		OD_URL_Metrics_Post_Type::store_url_metric(
+			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
+			$test_case->get_sample_url_metric(
+				array(
+					'viewport_width' => 375,
+					'elements'       => array(
+						array(
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+							'isLCP' => true,
+						),
+					),
+				)
+			)
+		);
+
+		OD_URL_Metrics_Post_Type::store_url_metric(
+			od_get_url_metrics_slug( od_get_normalized_query_vars() ),
+			$test_case->get_sample_url_metric(
+				array(
+					'viewport_width' => 1000,
+					'elements'       => array(
+						array(
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+							'isLCP' => true,
+						),
+					),
+				)
+			)
+		);
+	},
+	'buffer'   => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+			</head>
+			<body>
+				<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" fetchpriority="high">
+			</body>
+		</html>
+	',
+	'expected' => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+				<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (max-width: 480px)">
+				<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (min-width: 783px)">
+			</head>
+			<body>
+				<img data-od-fetchpriority-already-added data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800" fetchpriority="high">
+				<script type="module">/* import detect ... */</script>
+			</body>
+		</html>
+	',
+);

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -427,6 +427,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * Gets common LCP element.
 	 *
 	 * @since 0.3.0
+	 * @since n.e.x.t An LCP element is also considered common if it is the same in the narrowest and widest viewport groups, and all intermediate groups are empty.
 	 *
 	 * @return OD_Element|null Common LCP element if it exists.
 	 */

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -456,19 +456,18 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 				||
 				$first_group_lcp_element->get_xpath() !== $last_group_lcp_element->get_xpath()
 			) {
-				return null;  // No common LCP element across the narrowest and widest viewports.
+				return null; // No common LCP element across the narrowest and widest viewports.
 			}
 
 			// Check intermediate viewport groups for conflicting LCP elements.
-			$num_groups = count( $this->groups );
-			for ( $i = 1; $i < $num_groups - 1; $i++ ) {
-				$group_lcp_element = $this->groups[ $i ]->get_lcp_element();
+			foreach ( array_slice( $this->groups, 1, -1 ) as $group ) {
+				$group_lcp_element = $group->get_lcp_element();
 				if (
 					$group_lcp_element instanceof OD_Element
 					&&
 					$group_lcp_element->get_xpath() !== $first_group_lcp_element->get_xpath()
 				) {
-					return null;  // Conflicting LCP element found in an intermediate group.
+					return null; // Conflicting LCP element found in an intermediate group.
 				}
 			}
 

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -730,7 +730,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		$xpath1 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[1]';
 		$xpath2 = '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]/*[2]';
 
-		$get_sample_url_metric = function ( int $viewport_width, string $lcp_element_xpath, bool $is_lcp ): OD_URL_Metric {
+		$get_sample_url_metric = function ( int $viewport_width, string $lcp_element_xpath, bool $is_lcp = true ): OD_URL_Metric {
 			return $this->get_sample_url_metric(
 				array(
 					'viewport_width' => $viewport_width,
@@ -745,9 +745,9 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		return array(
 			'all_groups_have_common_lcp'             => array(
 				'url_metrics' => array(
-					$get_sample_url_metric( 400, $xpath1, true ),
-					$get_sample_url_metric( 600, $xpath1, true ),
-					$get_sample_url_metric( 1000, $xpath1, true ),
+					$get_sample_url_metric( 400, $xpath1 ),
+					$get_sample_url_metric( 600, $xpath1 ),
+					$get_sample_url_metric( 1000, $xpath1 ),
 				),
 				'expected'    => array(
 					'type'  => OD_Element::class,
@@ -760,22 +760,22 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 			),
 			'empty_first_group'                      => array(
 				'url_metrics' => array(
-					$get_sample_url_metric( 600, $xpath1, true ),
-					$get_sample_url_metric( 1000, $xpath1, true ),
+					$get_sample_url_metric( 600, $xpath1 ),
+					$get_sample_url_metric( 1000, $xpath1 ),
 				),
 				'expected'    => null,
 			),
 			'empty_last_group'                       => array(
 				'url_metrics' => array(
-					$get_sample_url_metric( 400, $xpath1, true ),
-					$get_sample_url_metric( 600, $xpath1, true ),
+					$get_sample_url_metric( 400, $xpath1 ),
+					$get_sample_url_metric( 600, $xpath1 ),
 				),
 				'expected'    => null,
 			),
 			'first_and_last_common_lcp_others_empty' => array(
 				'url_metrics' => array(
-					$get_sample_url_metric( 400, $xpath1, true ),
-					$get_sample_url_metric( 1000, $xpath1, true ),
+					$get_sample_url_metric( 400, $xpath1 ),
+					$get_sample_url_metric( 1000, $xpath1 ),
 				),
 				'expected'    => array(
 					'type'  => OD_Element::class,
@@ -784,17 +784,17 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 			),
 			'intermediate_groups_conflict'           => array(
 				'url_metrics' => array(
-					$get_sample_url_metric( 400, $xpath1, true ),
-					$get_sample_url_metric( 600, $xpath2, true ),
-					$get_sample_url_metric( 1000, $xpath1, true ),
+					$get_sample_url_metric( 400, $xpath1 ),
+					$get_sample_url_metric( 600, $xpath2 ),
+					$get_sample_url_metric( 1000, $xpath1 ),
 				),
 				'expected'    => null,
 			),
 			'first_and_last_lcp_mismatch'            => array(
 				'url_metrics' => array(
-					$get_sample_url_metric( 400, $xpath1, true ),
-					$get_sample_url_metric( 600, $xpath1, true ),
-					$get_sample_url_metric( 1000, $xpath2, true ),
+					$get_sample_url_metric( 400, $xpath1 ),
+					$get_sample_url_metric( 600, $xpath1 ),
+					$get_sample_url_metric( 1000, $xpath2 ),
 				),
 				'expected'    => null,
 			),

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -749,10 +749,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					$get_sample_url_metric( 600, $xpath1 ),
 					$get_sample_url_metric( 1000, $xpath1 ),
 				),
-				'expected'    => array(
-					'type'  => OD_Element::class,
-					'xpath' => $xpath1,
-				),
+				'expected'    => $xpath1,
 			),
 			'no_url_metrics'                         => array(
 				'url_metrics' => array(),
@@ -777,10 +774,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					$get_sample_url_metric( 400, $xpath1 ),
 					$get_sample_url_metric( 1000, $xpath1 ),
 				),
-				'expected'    => array(
-					'type'  => OD_Element::class,
-					'xpath' => $xpath1,
-				),
+				'expected'    => $xpath1,
 			),
 			'intermediate_groups_conflict'           => array(
 				'url_metrics' => array(
@@ -817,9 +811,9 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 	 * @dataProvider data_provider_test_get_common_lcp_element
 	 *
 	 * @param OD_URL_Metric[] $url_metrics URL Metrics.
-	 * @param mixed           $expected    Expected.
+	 * @param string|null     $expected    Expected.
 	 */
-	public function test_get_common_lcp_element( array $url_metrics, $expected ): void {
+	public function test_get_common_lcp_element( array $url_metrics, ?string $expected ): void {
 		$breakpoints      = array( 480, 800 );
 		$sample_size      = 3;
 		$current_etag     = md5( '' );
@@ -834,9 +828,9 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		$this->assertCount( 3, $group_collection );
 
 		$common_lcp_element = $group_collection->get_common_lcp_element();
-		if ( is_array( $expected ) ) {
-			$this->assertInstanceOf( $expected['type'], $common_lcp_element );
-			$this->assertSame( $expected['xpath'], $common_lcp_element->get_xpath() );
+		if ( is_string( $expected ) ) {
+			$this->assertInstanceOf( OD_Element::class, $common_lcp_element );
+			$this->assertSame( $expected, $common_lcp_element->get_xpath() );
 		} else {
 			$this->assertNull( $common_lcp_element );
 		}


### PR DESCRIPTION
## Summary

Fixes #1710 

## Relevant technical choices

- Updated `OD_URL_Metric_Group_Collection::get_common_lcp_element()` to also consider an LCP element as common if it is identical in the narrowest and widest viewport groups, with all intermediate groups remaining empty.