### PR TITLE
Convert WebP to AVIF on upload

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -28,7 +28,7 @@ function webp_uploads_get_upload_image_mime_transforms(): array {
 
 	$default_transforms = array(
 		'image/jpeg' => array( 'image/' . $output_format ),
-		'image/webp' => array( 'image/webp' ),
+		'image/webp' => array( 'image/' . $output_format ),
 		'image/avif' => array( 'image/avif' ),
 		'image/png'  => array( 'image/' . $output_format ),
 	);

--- a/plugins/webp-uploads/tests/test-helper.php
+++ b/plugins/webp-uploads/tests/test-helper.php
@@ -365,14 +365,14 @@ class Test_WebP_Uploads_Helper extends TestCase {
 			$this->set_image_output_type( 'avif' );
 			$default_transforms = array(
 				'image/jpeg' => array( 'image/avif' ),
-				'image/webp' => array( 'image/webp' ),
+				'image/webp' => array( 'image/avif' ),
 				'image/avif' => array( 'image/avif' ),
 				'image/png'  => array( 'image/avif' ),
 			);
 		} else {
 			$default_transforms = array(
 				'image/jpeg' => array( 'image/webp' ),
-				'image/webp' => array( 'image/webp' ),
+				'image/webp' => array( 'image/avif' ),
 				'image/avif' => array( 'image/avif' ),
 				'image/png'  => array( 'image/webp' ),
 			);

--- a/plugins/webp-uploads/tests/test-helper.php
+++ b/plugins/webp-uploads/tests/test-helper.php
@@ -372,7 +372,7 @@ class Test_WebP_Uploads_Helper extends TestCase {
 		} else {
 			$default_transforms = array(
 				'image/jpeg' => array( 'image/webp' ),
-				'image/webp' => array( 'image/avif' ),
+				'image/webp' => array( 'image/webp' ),
 				'image/avif' => array( 'image/avif' ),
 				'image/png'  => array( 'image/webp' ),
 			);

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1089,7 +1089,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 	}
 
 	/**
-	 * Create the original mime type for WebP images.
+	 * Convert WebP to AVIF on uploads.
 	 */
 	public function test_that_it_should_convert_webp_to_avif_on_upload(): void {
 		// Ensure the AVIF MIME type is supported; skip the test if not.

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1087,4 +1087,38 @@ class Test_WebP_Uploads_Load extends TestCase {
 
 		wp_delete_attachment( $attachment_id );
 	}
+
+	/**
+	 * Create the original mime type for WebP images.
+	 */
+	public function test_that_it_should_convert_webp_to_avif_on_upload(): void {
+		$mime_type = 'image/avif';
+
+		// Ensure the MIME type is supported; skip the test if not.
+		if ( ! webp_uploads_mime_type_supported( $mime_type ) ) {
+			$this->markTestSkipped( 'Mime type ' . $mime_type . ' is not supported.' );
+		}
+
+		$this->set_image_output_type( 'avif' );
+
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/balloons.webp' );
+
+		// There should be a AVIF source, but no WebP source for the full image.
+		$this->assertImageNotHasSource( $attachment_id, 'image/webp' );
+		$this->assertImageHasSource( $attachment_id, 'image/avif' );
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		// The full image should be a AVIF.
+		$this->assertArrayHasKey( 'file', $metadata );
+		$this->assertStringEndsWith( $metadata['sources']['image/avif']['file'], $metadata['file'] );
+		$this->assertStringEndsWith( $metadata['sources']['image/avif']['file'], get_attached_file( $attachment_id ) );
+
+		// There should be a WebP source, but no JPEG source for all sizes.
+		foreach ( array_keys( $metadata['sizes'] ) as $size_name ) {
+			$this->assertImageNotHasSizeSource( $attachment_id, $size_name, 'image/webp' );
+			$this->assertImageHasSizeSource( $attachment_id, $size_name, 'image/avif' );
+		}
+		wp_delete_attachment( $attachment_id );
+	}
 }

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1092,11 +1092,9 @@ class Test_WebP_Uploads_Load extends TestCase {
 	 * Create the original mime type for WebP images.
 	 */
 	public function test_that_it_should_convert_webp_to_avif_on_upload(): void {
-		$mime_type = 'image/avif';
-
-		// Ensure the MIME type is supported; skip the test if not.
-		if ( ! webp_uploads_mime_type_supported( $mime_type ) ) {
-			$this->markTestSkipped( 'Mime type ' . $mime_type . ' is not supported.' );
+		// Ensure the AVIF MIME type is supported; skip the test if not.
+		if ( ! webp_uploads_mime_type_supported( 'image/avif' ) ) {
+			$this->markTestSkipped( 'Mime type image/avif is not supported.' );
 		}
 
 		$this->set_image_output_type( 'avif' );

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1114,7 +1114,7 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$this->assertStringEndsWith( $metadata['sources']['image/avif']['file'], $metadata['file'] );
 		$this->assertStringEndsWith( $metadata['sources']['image/avif']['file'], get_attached_file( $attachment_id ) );
 
-		// There should be a WebP source, but no JPEG source for all sizes.
+		// There should be a AVIF source, but no WebP source for all sizes.
 		foreach ( array_keys( $metadata['sizes'] ) as $size_name ) {
 			$this->assertImageNotHasSizeSource( $attachment_id, $size_name, 'image/webp' );
 			$this->assertImageHasSizeSource( $attachment_id, $size_name, 'image/avif' );


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1557

## Relevant technical choices

- Take a pull in your local to get latest changes from the PR.
- Open WP admin, Go to `Settings > Media > Modern Image Formats > Image output format (Select "AVIF")`
- Upload `WebP` Image.
- Check the frontend.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
