### PR TITLE
Github workflow: Sticky to ubuntu 24.04 for CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       security-events: write
     steps:

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   pre-run:
     name: Pre-run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.plugins }}
     steps:
@@ -49,7 +49,7 @@ jobs:
   deploy:
     name: "Deploy Plugin: ${{ matrix.plugin }}"
     needs: pre-run
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: write
       deployments: write
@@ -160,7 +160,7 @@ jobs:
   release-assets:
     name: Add release assets
     needs: [ pre-run, deploy ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -21,7 +21,7 @@ permissions: {}
 jobs:
   pre-run:
     name: Pre-run
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.plugins }}
     steps:
@@ -49,7 +49,7 @@ jobs:
   deploy:
     name: "Deploy Plugin: ${{ matrix.plugin }}"
     needs: pre-run
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
       deployments: write
@@ -160,7 +160,7 @@ jobs:
   release-assets:
     name: Add release assets
     needs: [ pre-run, deploy ]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   js-lint:
     name: JS Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   js-lint:
     name: JS Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   php-lint:
     name: PHP
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   php-lint:
     name: PHP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
       - uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   php-test-plugins:
     name: "PHP ${{ matrix.php }} / WP ${{ matrix.wp }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -36,7 +36,7 @@ on:
 jobs:
   php-test-plugins:
     name: "PHP ${{ matrix.php }} / WP ${{ matrix.wp }}"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,13 +20,13 @@ env:
 jobs:
   check-type-label:
     name: Check [Type] Label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - if: contains( env.LABELS, '[Type]' ) == false
         run: exit 1
   check-milestone:
     name: Check Milestone
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no milestone' ) == false
         run: exit 1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -20,13 +20,13 @@ env:
 jobs:
   check-type-label:
     name: Check [Type] Label
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - if: contains( env.LABELS, '[Type]' ) == false
         run: exit 1
   check-milestone:
     name: Check Milestone
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no milestone' ) == false
         run: exit 1

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -48,7 +48,7 @@ jobs:
   # - Removes the props-bot label, if necessary.
   props-bot:
     name: Generate a list of props
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       # The action needs permission `write` permission for PRs in order to add a comment.
       pull-requests: write

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -48,7 +48,7 @@ jobs:
   # - Removes the props-bot label, if necessary.
   props-bot:
     name: Generate a list of props
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # The action needs permission `write` permission for PRs in order to add a comment.
       pull-requests: write

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   spell-checker:
     name: Spell Check with Typos
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Search for misspellings

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   spell-checker:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Search for misspellings


### PR DESCRIPTION
## Summary

Sticky to ubuntu version 24.04 as ubuntu-latest will start to use 24.04 mentioned [here](https://github.com/actions/runner-images/issues/10636)

## Screenshot
<img width="1003" alt="Screenshot 2024-12-11 at 10 35 11 AM" src="https://github.com/user-attachments/assets/5b44ca0f-2920-4eef-b1b7-5f5557754ad2">


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
