### PR TITLE
Add guidance for managing Performance feature plugins

### DIFF
--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -291,8 +291,11 @@ function perflab_render_plugins_ui(): void {
 		</div>
 		<div class="clear"></div>
 	</div>
-	<p>
-		<?php
+	<?php
+	if ( current_user_can( 'activate_plugins' ) ) {
+		?>
+		<p>
+			<?php
 			$plugins_url = add_query_arg(
 				array(
 					's'             => 'WordPress Performance Team',
@@ -310,8 +313,10 @@ function perflab_render_plugins_ui(): void {
 					'a' => array( 'href' => true ),
 				)
 			);
-		?>
-	</p>
+			?>
+		</p>
+		<?php
+	}
 	<?php
 }
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -291,6 +291,16 @@ function perflab_render_plugins_ui(): void {
 		</div>
 		<div class="clear"></div>
 	</div>
+	<p>
+		<?php
+		printf(
+			/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
+			esc_html__( 'Performance features are installed as plugins. To update features or remove them, %1$s manage them on the plugins screen. %2$s', 'performance-lab' ),
+			'<a href="' . esc_url( admin_url( 'plugins.php?s=WordPress%20Performance%20Team&plugin_status=all' ) ) . '">',
+			'</a>'
+		);
+		?>
+	</p>
 	<?php
 }
 

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -296,7 +296,15 @@ function perflab_render_plugins_ui(): void {
 		printf(
 			/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
 			esc_html__( 'Performance features are installed as plugins. To update features or remove them, %1$s manage them on the plugins screen. %2$s', 'performance-lab' ),
-			'<a href="' . esc_url( admin_url( 'plugins.php?s=WordPress%20Performance%20Team&plugin_status=all' ) ) . '">',
+			'<a href="' . esc_url(
+				add_query_arg(
+					array(
+						's'             => 'WordPress Performance Team',
+						'plugin_status' => 'all',
+					),
+					admin_url( 'plugins.php' )
+				)
+			) . '">',
 			'</a>'
 		);
 		?>

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -293,20 +293,23 @@ function perflab_render_plugins_ui(): void {
 	</div>
 	<p>
 		<?php
-		printf(
-			/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
-			esc_html__( 'Performance features are installed as plugins. To update features or remove them, %1$s manage them on the plugins screen. %2$s', 'performance-lab' ),
-			'<a href="' . esc_url(
-				add_query_arg(
-					array(
-						's'             => 'WordPress Performance Team',
-						'plugin_status' => 'all',
-					),
-					admin_url( 'plugins.php' )
+			$plugins_url = add_query_arg(
+				array(
+					's'             => 'WordPress Performance Team',
+					'plugin_status' => 'all',
+				),
+				admin_url( 'plugins.php' )
+			);
+			echo wp_kses(
+				sprintf(
+					/* translators: %s is the URL to the plugins screen */
+					__( 'Performance features are installed as plugins. To update features or remove them, <a href="%s">manage them on the plugins screen</a>.', 'performance-lab' ),
+					esc_url( $plugins_url )
+				),
+				array(
+					'a' => array( 'href' => true ),
 				)
-			) . '">',
-			'</a>'
-		);
+			);
 		?>
 	</p>
 	<?php

--- a/plugins/performance-lab/includes/admin/plugins.php
+++ b/plugins/performance-lab/includes/admin/plugins.php
@@ -317,7 +317,6 @@ function perflab_render_plugins_ui(): void {
 		</p>
 		<?php
 	}
-	<?php
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1695

## Relevant technical choices

Added an informative paragraph to the bottom of the Performance Features screen as seen in the screenshot below:
![image](https://github.com/user-attachments/assets/8459290c-a4e2-4627-9141-2b32ede27542)
