### PR TITLE
Accurate sizes: Support relative alignment widths

### DIFF
--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -220,14 +220,14 @@ function auto_sizes_calculate_better_sizes( int $id, $size, string $align, int $
 	return $layout_width;
 }
 
-	/**
-	 * Retrieves the layout width for an alignment defined in theme.json.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param string $alignment The alignment value.
-	 * @return string The alignment width based.
-	 */
+/**
+ * Retrieves the layout width for an alignment defined in theme.json.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $alignment The alignment value.
+ * @return string The alignment width based.
+ */
 function auto_sizes_get_layout_width( string $alignment ): string {
 	$layout = auto_sizes_get_layout_settings();
 
@@ -240,15 +240,15 @@ function auto_sizes_get_layout_width( string $alignment ): string {
 	return $layout_widths[ $alignment ] ?? '';
 }
 
-	/**
-	 * Filters the context keys that a block type uses.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param string[]      $uses_context Array of registered uses context for a block type.
-	 * @param WP_Block_Type $block_type   The full block type object.
-	 * @return string[] The filtered context keys used by the block type.
-	 */
+/**
+ * Filters the context keys that a block type uses.
+ *
+ * @since n.e.x.t
+ *
+ * @param string[]      $uses_context Array of registered uses context for a block type.
+ * @param WP_Block_Type $block_type   The full block type object.
+ * @return string[] The filtered context keys used by the block type.
+ */
 function auto_sizes_filter_uses_context( array $uses_context, WP_Block_Type $block_type ): array {
 	// The list of blocks that can consume outer layout context.
 	$consumer_blocks = array(
@@ -263,15 +263,15 @@ function auto_sizes_filter_uses_context( array $uses_context, WP_Block_Type $blo
 	return $uses_context;
 }
 
-	/**
-	 * Modifies the block context during rendering to blocks.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @param array<string, mixed> $context Current block context.
-	 * @param array<string, mixed> $block   The block being rendered.
-	 * @return array<string, mixed> Modified block context.
-	 */
+/**
+ * Modifies the block context during rendering to blocks.
+ *
+ * @since n.e.x.t
+ *
+ * @param array<string, mixed> $context Current block context.
+ * @param array<string, mixed> $block   The block being rendered.
+ * @return array<string, mixed> Modified block context.
+ */
 function auto_sizes_filter_render_block_context( array $context, array $block ): array {
 	// When no max alignment is set, the maximum is assumed to be 'full'.
 	$context['max_alignment'] = $context['max_alignment'] ?? 'full';
@@ -296,13 +296,13 @@ function auto_sizes_filter_render_block_context( array $context, array $block ):
 	return $context;
 }
 
-	/**
-	 * Retrieves the layout settings defined in theme.json.
-	 *
-	 * @since n.e.x.t
-	 *
-	 * @return array<string, mixed> Associative array of layout settings.
-	 */
+/**
+ * Retrieves the layout settings defined in theme.json.
+ *
+ * @since n.e.x.t
+ *
+ * @return array<string, mixed> Associative array of layout settings.
+ */
 function auto_sizes_get_layout_settings(): array {
 	static $layout = array();
 	if ( count( $layout ) === 0 ) {

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -304,9 +304,5 @@ function auto_sizes_filter_render_block_context( array $context, array $block ):
  * @return array<string, mixed> Associative array of layout settings.
  */
 function auto_sizes_get_layout_settings(): array {
-	static $layout = array();
-	if ( count( $layout ) === 0 ) {
-		$layout = wp_get_global_settings( array( 'layout' ) );
-	}
-	return $layout;
+	return wp_get_global_settings( array( 'layout' ) );
 }

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -194,13 +194,21 @@ function auto_sizes_calculate_better_sizes( int $id, $size, string $align, int $
 
 		case 'left':
 		case 'right':
-			$layout_width = sprintf( '%1$spx', $image_width );
-			break;
-
 		case 'center':
 		default:
-			$alignment    = auto_sizes_get_layout_width( 'default' );
-			$layout_width = sprintf( '%1$spx', min( (int) $alignment, $image_width ) );
+			$layout_alignment = in_array( $alignment, array( 'left', 'right' ), true ) ? 'wide' : 'default';
+			$layout_width     = auto_sizes_get_layout_width( $layout_alignment );
+
+			/*
+			 * If the layout width is in pixels, we can compare against the image width
+			 * on the server. Otherwise, we need to rely on CSS functions.
+			 */
+			if ( str_ends_with( $layout_width, 'px' ) ) {
+				$layout_width = sprintf( '%1$spx', min( (int) $layout_width, $image_width ) );
+			} else {
+				$layout_width = sprintf( 'min(%1$s, %2$spx)', $layout_width, $image_width );
+			}
+
 			break;
 	}
 
@@ -212,14 +220,14 @@ function auto_sizes_calculate_better_sizes( int $id, $size, string $align, int $
 	return $layout_width;
 }
 
-/**
- * Retrieves the layout width for an alignment defined in theme.json.
- *
- * @since n.e.x.t
- *
- * @param string $alignment The alignment value.
- * @return string The alignment width based.
- */
+	/**
+	 * Retrieves the layout width for an alignment defined in theme.json.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $alignment The alignment value.
+	 * @return string The alignment width based.
+	 */
 function auto_sizes_get_layout_width( string $alignment ): string {
 	$layout = auto_sizes_get_layout_settings();
 
@@ -232,15 +240,15 @@ function auto_sizes_get_layout_width( string $alignment ): string {
 	return $layout_widths[ $alignment ] ?? '';
 }
 
-/**
- * Filters the context keys that a block type uses.
- *
- * @since n.e.x.t
- *
- * @param string[]      $uses_context Array of registered uses context for a block type.
- * @param WP_Block_Type $block_type   The full block type object.
- * @return string[] The filtered context keys used by the block type.
- */
+	/**
+	 * Filters the context keys that a block type uses.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string[]      $uses_context Array of registered uses context for a block type.
+	 * @param WP_Block_Type $block_type   The full block type object.
+	 * @return string[] The filtered context keys used by the block type.
+	 */
 function auto_sizes_filter_uses_context( array $uses_context, WP_Block_Type $block_type ): array {
 	// The list of blocks that can consume outer layout context.
 	$consumer_blocks = array(
@@ -255,15 +263,15 @@ function auto_sizes_filter_uses_context( array $uses_context, WP_Block_Type $blo
 	return $uses_context;
 }
 
-/**
- * Modifies the block context during rendering to blocks.
- *
- * @since n.e.x.t
- *
- * @param array<string, mixed> $context Current block context.
- * @param array<string, mixed> $block   The block being rendered.
- * @return array<string, mixed> Modified block context.
- */
+	/**
+	 * Modifies the block context during rendering to blocks.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param array<string, mixed> $context Current block context.
+	 * @param array<string, mixed> $block   The block being rendered.
+	 * @return array<string, mixed> Modified block context.
+	 */
 function auto_sizes_filter_render_block_context( array $context, array $block ): array {
 	// When no max alignment is set, the maximum is assumed to be 'full'.
 	$context['max_alignment'] = $context['max_alignment'] ?? 'full';
@@ -288,13 +296,13 @@ function auto_sizes_filter_render_block_context( array $context, array $block ):
 	return $context;
 }
 
-/**
- * Retrieves the layout settings defined in theme.json.
- *
- * @since n.e.x.t
- *
- * @return array<string, mixed> Associative array of layout settings.
- */
+	/**
+	 * Retrieves the layout settings defined in theme.json.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @return array<string, mixed> Associative array of layout settings.
+	 */
 function auto_sizes_get_layout_settings(): array {
 	static $layout = array();
 	if ( count( $layout ) === 0 ) {

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -204,7 +204,7 @@ function auto_sizes_calculate_better_sizes( int $id, $size, string $align, int $
 			 * on the server. Otherwise, we need to rely on CSS functions.
 			 */
 			if ( str_ends_with( $layout_width, 'px' ) ) {
-				$layout_width = sprintf( '%1$spx', min( (int) $layout_width, $image_width ) );
+				$layout_width = sprintf( '%dpx', min( (int) $layout_width, $image_width ) );
 			} else {
 				$layout_width = sprintf( 'min(%1$s, %2$spx)', $layout_width, $image_width );
 			}


### PR DESCRIPTION
## Summary

This is an initial concept for supporting relative alignment widths as described in https://github.com/WordPress/performance/issues/1511#issuecomment-2539842267.

## Relevant technical choices

<!-- Please describe your changes. -->
If the layout setting ends in a px value, compare directly with the image width. If the layout setting uses any other value, use a CSS `min()` function in `sizes`.

This also improves the logic for left/right alignment values so they are constrained by `wide` layouts if the image width is larger than the container.

## To test
1. Visit the site editor
2. Edit Styles > Layout
3. Set content width to a relative value, like `30rem`
4. Add an image block with default alignment to a post
5. Inspect that the generated `sizes` value looks similar to `sizes="(max-width: min(20rem, 1024px)) 100vw, min(20rem, 1024px)"`

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
