### PR TITLE
Fix tracking events like add_to_cart in WooCommerce integration

### DIFF
--- a/plugins/web-worker-offloading/third-party/woocommerce.php
+++ b/plugins/web-worker-offloading/third-party/woocommerce.php
@@ -29,17 +29,14 @@ function plwwo_woocommerce_configure( $configuration ): array {
 	$configuration['forward'][] = 'dataLayer.push';
 	$configuration['forward'][] = 'gtag';
 
-	$configuration['mainWindowAccessors'][] = 'wp';   // Because woocommerce-google-analytics-integration needs to access wp.i18n.
-	$configuration['mainWindowAccessors'][] = 'ga4w'; // Because woocommerce-google-analytics-integration needs to access window.ga4w.
-
 	return $configuration;
 }
 add_filter( 'plwwo_configuration', 'plwwo_woocommerce_configure' );
 
 plwwo_mark_scripts_for_offloading(
+	// Note: 'woocommerce-google-analytics-integration' is intentionally not included because for some reason events like add_to_cart don't get tracked.
 	array(
 		'google-tag-manager',
-		'woocommerce-google-analytics-integration',
 		'woocommerce-google-analytics-integration-gtag',
 	)
 );


### PR DESCRIPTION
>[!IMPORTANT]
> This is a sub-PR of #1686 

While testing Web Worker Offloading, I discovered that `add_to_cart` events weren't getting sent to GA when clicking the Add To Cart button. It seems I should not have included the `woocommerce-google-analytics-integration` script among those which are offloaded because then it's not picking up on the button click event for some reason. Only the initial `view_item_list` event was getting sent. So in this PR I've undone that so that the `add_to_cart` event can be sent to GA:

Before:

[Screen recording 2024-12-13 15.18.54.webm](https://github.com/user-attachments/assets/a9409a0d-aa4d-499f-b7c2-6e862707fec2)

After:

[Screen recording 2024-12-13 15.19.56.webm](https://github.com/user-attachments/assets/2eff82aa-de06-4aa6-ad40-e709b64cc635)
