### PR TITLE
Add meta attributes to preloaded tags and preload links for Image Prioritizer

### DIFF
--- a/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-background-image-styled-tag-visitor.php
@@ -88,7 +88,7 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 
 		// If this element is the LCP (for a breakpoint group), add a preload link for it.
 		foreach ( $context->url_metric_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
-			$this->add_image_preload_link( $context->link_collection, $group, $background_image_url );
+			$this->add_image_preload_link( $context, $group, $background_image_url );
 		}
 
 		$this->lazy_load_bg_images( $context );
@@ -171,7 +171,7 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 				&&
 				$processor->get_attribute( 'class' ) === $common['class'] // May be checking equality with null.
 			) {
-				$this->add_image_preload_link( $context->link_collection, $group, $common['url'] );
+				$this->add_image_preload_link( $context, $group, $common['url'] );
 
 				// Now that the preload link has been added, eliminate the entry to stop looking for it while iterating over the rest of the document.
 				unset( $this->group_common_lcp_element_external_background_images[ $i ] );
@@ -184,22 +184,24 @@ final class Image_Prioritizer_Background_Image_Styled_Tag_Visitor extends Image_
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param OD_Link_Collection  $link_collection Link collection.
-	 * @param OD_URL_Metric_Group $group           URL Metric group.
-	 * @param non-empty-string    $url             Image URL.
+	 * @param OD_Tag_Visitor_Context $context Context.
+	 * @param OD_URL_Metric_Group    $group   URL Metric group.
+	 * @param non-empty-string       $url     Image URL.
 	 */
-	private function add_image_preload_link( OD_Link_Collection $link_collection, OD_URL_Metric_Group $group, string $url ): void {
-		$link_collection->add_link(
+	private function add_image_preload_link( OD_Tag_Visitor_Context $context, OD_URL_Metric_Group $group, string $url ): void {
+		$context->link_collection->add_link(
 			array(
-				'rel'           => 'preload',
-				'fetchpriority' => 'high',
-				'as'            => 'image',
-				'href'          => $url,
-				'media'         => 'screen',
+				'rel'                          => 'preload',
+				'fetchpriority'                => 'high',
+				'as'                           => 'image',
+				'href'                         => $url,
+				'media'                        => 'screen',
+				'data-od-related-tag-selector' => $this->get_css_selector( $context->processor ),
 			),
 			$group->get_minimum_viewport_width(),
 			$group->get_maximum_viewport_width()
 		);
+		$context->processor->set_meta_attribute( 'preloaded', true );
 	}
 
 	/**

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -339,13 +339,20 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 			)
 		);
 
+		// Construct CSS selector to assist with identifying the related tag.
+		$selector = $this->get_css_selector( $context->processor );
+
 		foreach ( $context->url_metric_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
+			$attributes['data-od-related-tag-selector'] = $selector;
+
 			$context->link_collection->add_link(
 				$attributes,
 				$group->get_minimum_viewport_width(),
 				$group->get_maximum_viewport_width()
 			);
 		}
+
+		$context->processor->set_meta_attribute( 'preloaded', true );
 	}
 
 	/**

--- a/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-tag-visitor.php
@@ -66,4 +66,36 @@ abstract class Image_Prioritizer_Tag_Visitor {
 		}
 		return $value;
 	}
+
+	/**
+	 * Constructs a CSS selector for the current tag.
+	 *
+	 * @since n.e.x.t
+	 * @todo Move this into OD_HTML_Tag_Processor itself.
+	 *
+	 * @param OD_HTML_Tag_Processor $processor Processor.
+	 * @return string Selector.
+	 */
+	protected function get_css_selector( OD_HTML_Tag_Processor $processor ): string {
+		$selector = join( ' > ', $processor->get_breadcrumbs() );
+		$id       = $processor->get_attribute( 'id' );
+		if ( is_string( $id ) ) {
+			$selector .= '#' . $id;
+		}
+		$class_attr = $processor->get_attribute( 'class' );
+		if ( is_string( $class_attr ) ) {
+			$selector .= join(
+				'',
+				array_map(
+					static function ( string $class_name ): string {
+						return '.' . $class_name;
+					},
+					array_filter(
+						(array) preg_split( '/\s+/', trim( $class_attr ) )
+					)
+				)
+			);
+		}
+		return $selector;
+	}
 }

--- a/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-video-tag-visitor.php
@@ -137,6 +137,9 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 
 		$xpath = $processor->get_xpath();
 
+		// Construct CSS selector to assist with identifying the related tag.
+		$selector = $this->get_css_selector( $context->processor );
+
 		// If this element is the LCP (for a breakpoint group), add a preload link for the poster image.
 		foreach ( $context->url_metric_group_collection->get_groups_by_lcp_element( $xpath ) as $group ) {
 			$link_attributes = array(
@@ -151,6 +154,9 @@ final class Image_Prioritizer_Video_Tag_Visitor extends Image_Prioritizer_Tag_Vi
 			if ( null !== $crossorigin ) {
 				$link_attributes['crossorigin'] = 'use-credentials' === $crossorigin ? 'use-credentials' : 'anonymous';
 			}
+
+			$link_attributes['data-od-related-tag-selector'] = $selector;
+			$context->processor->set_meta_attribute( 'preloaded', true );
 
 			$context->link_collection->add_link(
 				$link_attributes,

--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -52,9 +52,9 @@ final class OD_Link_Collection implements Countable {
 	 *
 	 * @phpstan-param LinkAttributes $attributes
 	 *
-	 * @param array             $attributes             Attributes.
-	 * @param int<0, max>|null  $minimum_viewport_width Minimum width or null if not bounded or relevant.
-	 * @param positive-int|null $maximum_viewport_width Maximum width or null if not bounded (i.e. infinity) or relevant.
+	 * @param array<string, string> $attributes             Attributes.
+	 * @param int<0, max>|null      $minimum_viewport_width Minimum width or null if not bounded or relevant.
+	 * @param positive-int|null     $maximum_viewport_width Maximum width or null if not bounded (i.e. infinity) or relevant.
 	 *
 	 * @throws InvalidArgumentException When invalid arguments are provided.
 	 */


### PR DESCRIPTION
> [!IMPORTANT]
> This is a sub-PR of #1713 and should not be merged before that is merged.

Debugging optimizations applied by Image Prioritizer involves identifying why a given preload link is added or attempting to connect a preload link with the underlying element that caused the preload link to be added in the first place. This can be done by implicitly by looking at attributes like connecting a preload link's `imagesrcset` attribute with the `srcset` attribute of some `IMG` on the page. However, this gets more complicated with #1713 where background images applied with stylesheets are preloaded since there is no reference to the image URL in the HTML source. To assist with this, I'm considering whether we should add `data-od-preloaded` attributes to tags which have associated preload links, and conversely for the preload links to have `data-od-related-tag-selector` which helps to identify the element that the preload link was added for.

For example, the following change would be applied to the `lcp-element-external-background-image-present-in-document-and-fully-populated-samples` test case:

```diff
--- Before
+++ After
 <meta charset="utf-8">
 <title>...</title>
 <link rel="stylesheet" href="/style.css">
-<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop.jpg" media="screen and (min-width: 783px)">
-<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile.jpg" media="screen and (max-width: 480px)">
-<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/phablet.jpg" media="screen and (min-width: 601px) and (max-width: 782px)">
-<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/tablet.jpg" media="screen and (min-width: 481px) and (max-width: 600px)">
+<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop.jpg" media="screen and (min-width: 783px)" data-od-related-tag-selector="HTML &gt; BODY &gt; HEADER#masthead.banner">
+<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile.jpg" media="screen and (max-width: 480px)" data-od-related-tag-selector="HTML &gt; BODY &gt; HEADER#masthead.banner">
+<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/phablet.jpg" media="screen and (min-width: 601px) and (max-width: 782px)" data-od-related-tag-selector="HTML &gt; BODY &gt; HEADER#masthead.banner">
+<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/tablet.jpg" media="screen and (min-width: 481px) and (max-width: 600px)" data-od-related-tag-selector="HTML &gt; BODY &gt; HEADER#masthead.banner">
 </head>
 <body>
-<header id="masthead" class="banner">
+<header data-od-preloaded id="masthead" class="banner">
 <h1>Example</h1>
 </header>
 </body>
 </html>
```

The work to update all of the test cases with these new changes would be tedious, so I haven't updated them yet. This would be a good opportunity to implement #1418 to eliminate this tediousness here and in the future.

Using a CSS selector as opposed to the already-made XPath is just something I was considering. By not including the element index which is present in the XPath it could make it easier to locate the element after JS has manipulated the DOM structure after page load.