### PR TITLE
Remove `auto_sizes_get_layout_settings()`

### DIFF
--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -229,7 +229,7 @@ function auto_sizes_calculate_better_sizes( int $id, $size, string $align, int $
  * @return string The alignment width based.
  */
 function auto_sizes_get_layout_width( string $alignment ): string {
-	$layout = auto_sizes_get_layout_settings();
+	$layout = wp_get_global_settings( array( 'layout' ) );
 
 	$layout_widths = array(
 		'full'    => '100vw', // Todo: incorporate useRootPaddingAwareAlignments.
@@ -294,15 +294,4 @@ function auto_sizes_filter_render_block_context( array $context, array $block ):
 	}
 
 	return $context;
-}
-
-/**
- * Retrieves the layout settings defined in theme.json.
- *
- * @since n.e.x.t
- *
- * @return array<string, mixed> Associative array of layout settings.
- */
-function auto_sizes_get_layout_settings(): array {
-	return wp_get_global_settings( array( 'layout' ) );
 }


### PR DESCRIPTION
## Summary

Follow-up on #1737  

In https://github.com/WordPress/performance/pull/1737/commits/35988a41382022cdccd22433f1d6f1cdb5f70f5b, we removed the static cache. Since the function was originally created for cache implementation and is now removed, it’s no longer needed. Instead, we can directly incorporate the one-line global setting code into the function where it is used.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
