### PR TITLE
Accurate sizes: Disable layout calculations for classic themes

### DIFF
--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -140,6 +140,11 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
  * @return string|false An improved sizes attribute or false if a better size cannot be calculated.
  */
 function auto_sizes_calculate_better_sizes( int $id, $size, string $align, int $resize_width, string $max_alignment ) {
+	// Bail early if not a block theme.
+	if ( ! wp_is_block_theme() ) {
+		return false;
+	}
+
 	// Without an image ID or a resize width, we cannot calculate a better size.
 	if ( 0 === $id && 0 === $resize_width ) {
 		return false;

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -615,6 +615,38 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the image block with different alignment in classic theme.
+	 *
+	 * @dataProvider data_image_blocks_with_relative_alignment_for_classic_theme
+	 *
+	 * @param string $image_alignment Image alignment.
+	 */
+	public function test_image_block_with_different_alignment_in_classic_theme( string $image_alignment ): void {
+		switch_theme( 'twentytwentyone' );
+
+		$block_content = $this->get_image_block_markup( self::$image_id, 'large', $image_alignment );
+
+		$result = apply_filters( 'the_content', $block_content );
+
+		$this->assertStringContainsString( 'sizes="(max-width: 1024px) 100vw, 1024px" ', $result );
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<array<string>> The ancestor and image alignments.
+	 */
+	public function data_image_blocks_with_relative_alignment_for_classic_theme(): array {
+		return array(
+			array( '' ),
+			array( 'wide' ),
+			array( 'left' ),
+			array( 'center' ),
+			array( 'right' ),
+		);
+	}
+
+	/**
 	 * Filter the theme.json data to include relative layout sizes.
 	 *
 	 * @param WP_Theme_JSON_Data $theme_json Theme JSON object.


### PR DESCRIPTION
## Summary

This PR Checks the functionality of the image block in classic themes. After merging #1738, the `sizes` attribute for the classic theme has been producing incorrect values.  

**Issue Example:**  
When selecting the `wide` alignment for an image block, the `sizes` attribute is rendered as: `sizes="(max-width: ) 100vw, "`, This is incorrect. The expected output should be: `sizes="(max-width: 1024px) 100vw, 1024px"`  

This PR aims to fix this issue and ensure the `sizes` attribute is generated correctly for classic themes.

### Steps to reproduce the issue
- Activate classic theme (TT1)
- Add image block and select `wide` alignment
- Check frontend.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
