### PR TITLE
Account for $meta arg in wp_prepare_attachment_for_js not being an array

### DIFF
--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -251,14 +251,17 @@ add_action( 'admin_print_footer_scripts', 'dominant_color_admin_script' );
  *
  * @since n.e.x.t
  *
- * @param array<mixed>|mixed $response   The current response array for the attachment.
- * @param WP_Post            $attachment The attachment post object.
- * @param array<mixed>       $meta       The attachment metadata.
- * @return array<mixed> The modified response array with added dominant color and transparency information.
+ * @param array<string, mixed>|mixed $response   The current response array for the attachment.
+ * @param WP_Post                    $attachment The attachment post object.
+ * @param array<string, mixed>|false $meta       The attachment metadata.
+ * @return array<string, mixed> The modified response array with added dominant color and transparency information.
  */
-function dominant_color_prepare_attachment_for_js( $response, WP_Post $attachment, array $meta ): array {
+function dominant_color_prepare_attachment_for_js( $response, WP_Post $attachment, $meta ): array {
 	if ( ! is_array( $response ) ) {
 		$response = array();
+	}
+	if ( ! is_array( $meta ) ) {
+		return $response;
 	}
 
 	$response['dominantColor'] = '';


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1755

This is a follow-up to #1719.

## Relevant technical choices

The `dominant_color_prepare_attachment_for_js()` function depends on there being metadata associated with an attachment, since this metadata is where the dominant color information comes from. In addition to allowing `$meta` to be passed as `false` instead of an `array` (which fixes the fatal error), if it is passed as `false` then the function now short-circuits since there is nothing for it to do.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
