### PR TITLE
Remove erroneous check for resource initiator type when considering whether to submit LCP background image

### DIFF
--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -78,27 +78,6 @@ export async function initialize( { isDebug, onLCP } ) {
 }
 
 /**
- * Gets the performance resource entry for a given URL.
- *
- * @since 0.3.0
- *
- * @param {string} url - Resource URL.
- * @return {PerformanceResourceTiming|null} Resource entry or null.
- */
-function getPerformanceResourceByURL( url ) {
-	const entries =
-		/** @type PerformanceResourceTiming[] */ performance.getEntriesByType(
-			'resource'
-		);
-	for ( const entry of entries ) {
-		if ( entry.name === url ) {
-			return entry;
-		}
-	}
-	return null;
-}
-
-/**
  * Handles a new LCP metric being reported.
  *
  * @since 0.3.0
@@ -127,21 +106,6 @@ function handleLCPMetric( metric, isDebug ) {
 		// These are handled by Image_Prioritizer_Background_Image_Styled_Tag_Visitor.
 		if ( entry.element.style.backgroundImage ) {
 			continue;
-		}
-
-		// Now only consider proceeding with the URL if its loading was initiated with stylesheet or preload link.
-		const resourceEntry = getPerformanceResourceByURL( entry.url );
-		if (
-			! resourceEntry ||
-			! [ 'css', 'link' ].includes( resourceEntry.initiatorType )
-		) {
-			if ( isDebug ) {
-				warn(
-					`Skipped considering URL (${ entry.url }) due to unexpected performance resource timing entry:`,
-					resourceEntry
-				);
-			}
-			return;
 		}
 
 		// Skip URLs that are excessively long. This is the maxLength defined in image_prioritizer_add_element_item_schema_properties().

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -44,18 +44,6 @@ function log( ...message ) {
 }
 
 /**
- * Logs a warning.
- *
- * @since 0.3.0
- *
- * @param {...*} message
- */
-function warn( ...message ) {
-	// eslint-disable-next-line no-console
-	console.warn( consoleLogPrefix, ...message );
-}
-
-/**
  * Initializes extension.
  *
  * @since 0.3.0


### PR DESCRIPTION
## Summary

When setting up a demo site with Optimization Detective, I was confused when I wasn't getting the `lcpElementExternalBackgroundImage` data submitted with the URL Metric. In looking at the console, I saw:

![image](https://github.com/user-attachments/assets/8ebd3aa7-fa88-49ea-b06c-f371649d526b)

This was strange because the LCP element was definitely using a `background-image` coming from a stylesheet:

![image](https://github.com/user-attachments/assets/897cbe70-d660-46c6-b037-013d1ef4a11e)

Nevertheless, the `initiatorType` of the resource was coming through as an `img` and not as `css`. Then I looked further down the page and I found the same image _was_ being used in an `IMG` tag:

![image](https://github.com/user-attachments/assets/c7c7552f-58f0-4b01-862d-5016df22faea)

This actually reveals an interesting performance fact: even though the image is being used as a background image for the LCP element, there is an image way further down the page which is actually initiating the loading of this image before the stylesheet is initiating the load. Even more surprising, this `IMG` has `loading=lazy`. This highlights the need for adding a preload link for this image URL so that it is properly prioritized!

Granted, it may be unlikely for the exact same image used as the LCP element's background to also appear further down the page in non-example content. In any case, checking the `initiatorType` for the resource was redundant because it's already aborting if the LCP element is an `IMG` tag:

https://github.com/WordPress/performance/blob/2033d448b25012ce9134b6fc329e851ca852e1fc/plugins/image-prioritizer/detect.js#L90-L98

Therefore, there is no need for the additional check.