### PR TITLE
Round viewport aspect ratio values to 2 decimal places.

### DIFF
--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -310,7 +310,7 @@ function od_get_minimum_viewport_aspect_ratio(): float {
 	 *
 	 * @param float $minimum_viewport_aspect_ratio Minimum viewport aspect ratio.
 	 */
-	return (float) apply_filters( 'od_minimum_viewport_aspect_ratio', 0.4 );
+	return round( (float) apply_filters( 'od_minimum_viewport_aspect_ratio', 0.4 ), 2 );
 }
 
 /**
@@ -332,7 +332,7 @@ function od_get_maximum_viewport_aspect_ratio(): float {
 	 *
 	 * @param float $maximum_viewport_aspect_ratio Maximum viewport aspect ratio.
 	 */
-	return (float) apply_filters( 'od_maximum_viewport_aspect_ratio', 2.5 );
+	return round( (float) apply_filters( 'od_maximum_viewport_aspect_ratio', 2.5 ), 2 );
 }
 
 /**


### PR DESCRIPTION
Modified the return values of minimum and maximum viewport aspect ratios to ensure they are rounded to 2 decimal places. This improves consistency and precision when handling these values.

Fixes #1765

## Relevant technical choices
It seems to be we can just round this value 
