### PR TITLE
Skip visiting any tags inside of `NOSCRIPT` elements

### DIFF
--- a/plugins/image-prioritizer/tests/test-cases/img-non-native-lazy-loading.php
+++ b/plugins/image-prioritizer/tests/test-cases/img-non-native-lazy-loading.php
@@ -46,7 +46,7 @@ return array(
 				<!-- Example with an adjoining NOSCRIPT > IMG tag which should be excluded from URL Metrics. -->
 				<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-src="https://example.com/bar.jpg" data-srcset="https://example.com/bar-large.jpg 1000w, https://example.com/bar-large.jpg 1000w" sizes="(max-width: 556px) 100vw, 556px" alt="Bar" class="attachment-large size-large wp-image-2 has-transparency lazyload" width="500" height="300">
 				<noscript>
-					<img data-od-unknown-tag data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[3][self::NOSCRIPT]/*[1][self::IMG]" src="https://example.com/bar.jpg" srcset="https://example.com/bar-large.jpg 1000w, https://example.com/bar-large.jpg 1000w" sizes="(max-width: 556px) 100vw, 556px" alt="Bar" class="attachment-large size-large wp-image-2 has-transparency lazyload" width="500" height="300">
+					<img src="https://example.com/bar.jpg" srcset="https://example.com/bar-large.jpg 1000w, https://example.com/bar-large.jpg 1000w" sizes="(max-width: 556px) 100vw, 556px" alt="Bar" class="attachment-large size-large wp-image-2 has-transparency lazyload" width="500" height="300">
 				</noscript>
 				<script type="module">/* import detect ... */</script>
 			</body>

--- a/plugins/image-prioritizer/tests/test-cases/img-non-native-lazy-loading.php
+++ b/plugins/image-prioritizer/tests/test-cases/img-non-native-lazy-loading.php
@@ -1,0 +1,55 @@
+<?php
+return array(
+	'set_up'   => static function ( Test_Image_Prioritizer_Helper $test_case ): void {
+		$slug = od_get_url_metrics_slug( od_get_normalized_query_vars() );
+
+		// Populate one URL Metric so that none of the IMG elements are unknown.
+		OD_URL_Metrics_Post_Type::store_url_metric(
+			$slug,
+			$test_case->get_sample_url_metric(
+				array(
+					'viewport_width' => 1000,
+					'elements'       => array(
+						array(
+							'xpath' => '/*[1][self::HTML]/*[2][self::BODY]/*[1][self::IMG]',
+							'isLCP' => true,
+						),
+					),
+				)
+			)
+		);
+	},
+	'buffer'   => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+				<script>/* custom lazy-loading */</script>
+			</head>
+			<body>
+				<!-- Example with an adjoining NOSCRIPT > IMG tag which should be excluded from URL Metrics. -->
+				<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-src="https://example.com/bar.jpg" data-srcset="https://example.com/bar-large.jpg 1000w, https://example.com/bar-large.jpg 1000w" sizes="(max-width: 556px) 100vw, 556px" alt="Bar" class="attachment-large size-large wp-image-2 has-transparency lazyload" width="500" height="300">
+				<noscript>
+					<img src="https://example.com/bar.jpg" srcset="https://example.com/bar-large.jpg 1000w, https://example.com/bar-large.jpg 1000w" sizes="(max-width: 556px) 100vw, 556px" alt="Bar" class="attachment-large size-large wp-image-2 has-transparency lazyload" width="500" height="300">
+				</noscript>
+			</body>
+		</html>
+	',
+	'expected' => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+				<script>/* custom lazy-loading */</script>
+			</head>
+			<body>
+				<!-- Example with an adjoining NOSCRIPT > IMG tag which should be excluded from URL Metrics. -->
+				<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" data-src="https://example.com/bar.jpg" data-srcset="https://example.com/bar-large.jpg 1000w, https://example.com/bar-large.jpg 1000w" sizes="(max-width: 556px) 100vw, 556px" alt="Bar" class="attachment-large size-large wp-image-2 has-transparency lazyload" width="500" height="300">
+				<noscript>
+					<img data-od-unknown-tag data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[3][self::NOSCRIPT]/*[1][self::IMG]" src="https://example.com/bar.jpg" srcset="https://example.com/bar-large.jpg 1000w, https://example.com/bar-large.jpg 1000w" sizes="(max-width: 556px) 100vw, 556px" alt="Bar" class="attachment-large size-large wp-image-2 has-transparency lazyload" width="500" height="300">
+				</noscript>
+				<script type="module">/* import detect ... */</script>
+			</body>
+		</html>
+	',
+);

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -227,6 +227,11 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	$needs_detection = ! $group_collection->is_every_group_complete();
 
 	do {
+		// Never process anything inside NOSCRIPT since it will never show up in the DOM when scripting is enabled, and thus it can never be detected nor measured.
+		if ( in_array( 'NOSCRIPT', $processor->get_breadcrumbs(), true ) ) {
+			continue;
+		}
+
 		$tracked_in_url_metrics = false;
 		$processor->set_bookmark( $current_tag_bookmark ); // TODO: Should we break if this returns false?
 

--- a/plugins/optimization-detective/tests/test-cases/noscript.php
+++ b/plugins/optimization-detective/tests/test-cases/noscript.php
@@ -1,0 +1,31 @@
+<?php
+return array(
+	'set_up'   => static function (): void {},
+	'buffer'   => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+			</head>
+			<body>
+				<noscript>
+					<img src="https://example.com/pixel.gif" alt="" width="1" height="1">
+				</noscript>
+			</body>
+		</html>
+	',
+	'expected' => '
+		<html lang="en">
+			<head>
+				<meta charset="utf-8">
+				<title>...</title>
+			</head>
+			<body>
+				<noscript>
+					<img data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::NOSCRIPT]/*[1][self::IMG]" src="https://example.com/pixel.gif" alt="" width="1" height="1">
+				</noscript>
+				<script type="module">/* import detect ... */</script>
+			</body>
+		</html>
+	',
+);

--- a/plugins/optimization-detective/tests/test-cases/noscript.php
+++ b/plugins/optimization-detective/tests/test-cases/noscript.php
@@ -22,7 +22,7 @@ return array(
 			</head>
 			<body>
 				<noscript>
-					<img data-od-xpath="/*[1][self::HTML]/*[2][self::BODY]/*[1][self::NOSCRIPT]/*[1][self::IMG]" src="https://example.com/pixel.gif" alt="" width="1" height="1">
+					<img src="https://example.com/pixel.gif" alt="" width="1" height="1">
 				</noscript>
 				<script type="module">/* import detect ... */</script>
 			</body>


### PR DESCRIPTION
Any tag which appears in a `NOSCRIPT` should always be excluded from visiting by any tag visitor. For example:

```html
<noscript>
	<img decoding="async" src="https://example.com/pixel.gif" alt="" width="1" height="1">
</noscript>
```

Currently this shows up on pages as:

```html
<noscript>
	<img data-od-unknown-tag src="https://example.com/pixel.gif" alt="" width="1" height="1">
</noscript>
```

Image Prioritizer adds the `data-od-unknown-tag` attribute to any visited tag `IMG` which is not located in URL Metrics. However, such an `IMG` can never be added to URL Metrics since it is not located in the DOM. 

This PR skips over visiting any tag which is inside of a `NOSCRIPT` element.

Such `NOSCRIPT` tags are often found with JS-based lazy-loading implementations.