### PR TITLE
Add custom PHPCS sniff to warn against usage of `empty()`

### DIFF
--- a/plugins/dominant-color-images/phpcs.xml.dist
+++ b/plugins/dominant-color-images/phpcs.xml.dist
@@ -2,7 +2,9 @@
 <ruleset name="WPP-DominantColorImages">
 	<description>WordPress Coding Standards for Image Placeholders Plugin</description>
 
-	<rule ref="../../tools/phpcs/phpcs.ruleset.xml"/>
+	<rule ref="../../tools/phpcs/phpcs.ruleset.xml">
+		<exclude name="WPP.PHP.RestrictedEmptyConstruct.EmptyConstructUsage" />
+	</rule>
 
 	<config name="text_domain" value="dominant-color-images,default"/>
 

--- a/plugins/performance-lab/phpcs.xml.dist
+++ b/plugins/performance-lab/phpcs.xml.dist
@@ -1,7 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="WPP-PerformanceLab">
 	<description>WordPress Coding Standards for the Performance Lab Plugin</description>
-	<rule ref="../../tools/phpcs/phpcs.ruleset.xml"/>
+
+	<rule ref="../../tools/phpcs/phpcs.ruleset.xml">
+		<exclude name="WPP.PHP.RestrictedEmptyConstruct.EmptyConstructUsage" />
+	</rule>
 
 	<config name="text_domain" value="performance-lab,default"/>
 

--- a/plugins/webp-uploads/phpcs.xml.dist
+++ b/plugins/webp-uploads/phpcs.xml.dist
@@ -2,7 +2,9 @@
 <ruleset name="WPP-WebPUploads">
 	<description>WordPress Coding Standards for Modern Image Formats Plugin</description>
 
-	<rule ref="../../tools/phpcs/phpcs.ruleset.xml"/>
+	<rule ref="../../tools/phpcs/phpcs.ruleset.xml">
+		<exclude name="WPP.PHP.RestrictedEmptyConstruct.EmptyConstructUsage" />
+	</rule>
 
 	<config name="text_domain" value="webp-uploads"/>
 

--- a/tools/phpcs/Sniffs/PHP/RestrictedEmptyConstructSniff.php
+++ b/tools/phpcs/Sniffs/PHP/RestrictedEmptyConstructSniff.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Sniff to restrict usage of the empty() construct.
+ *
+ * @package performance
+ */
+
+namespace WPPCS\WPP\Sniffs\PHP;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+// phpcs:ignoreFile WordPress.NamingConventions.ValidVariableName -- required by the interface.
+
+/**
+ * Restricts usage of empty().
+ */
+class RestrictedEmptyConstructSniff implements Sniff {
+
+	/**
+	 * Registers the tokens that this sniff wants to listen for.
+	 */
+	public function register(): array {
+		return array( \T_EMPTY );
+	}
+
+	/**
+	 * Processes this sniff, when one of its tokens is encountered.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack.
+	 */
+	public function process( File $phpcsFile, $stackPtr ): void { // phpcs:ignore SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint -- required by the interface.
+		$phpcsFile->addWarning(
+			'Usage of empty() can mask code problems. Consider explicit checks instead.',
+			$stackPtr,
+			'EmptyConstructUsage'
+		);
+	}
+}

--- a/tools/phpcs/phpcs.ruleset.xml
+++ b/tools/phpcs/phpcs.ruleset.xml
@@ -113,6 +113,14 @@
 		<exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification" /><!-- TODO: Investigate this -->
 	</rule>
 
+	<!-- Do no apply for custom sniffs. -->
+	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
+		<exclude-pattern>./Sniffs/*</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>./Sniffs/*</exclude-pattern>
+	</rule>
+
 	<!-- Exclude built plugins and built assets in plugins. -->
 	<exclude-pattern>./build/*</exclude-pattern>
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1219 

## Relevant Technical Choices

The `dominant-color-images`, `performance-lab`, and `webp-uploads` plugins have been ignored by the custom PHPCS sniff configuration, similar to the approach used for PHPStan.