### PR TITLE
Fix Lightbox trigger BUTTON visibility issue on an Image lightbox when Picture Element is enabled

### DIFF
--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -172,16 +172,26 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 /**
  * Adds CSS to make Lightbox trigger BUTTON visible on an Image lightbox when Picture Element is enabled.
  *
- * @since 2.4.0
- * 
+ * @since n.e.x.t
+ *
+ * @return void
  */
-function webp_make_lightbox_trigger_button_visible() {
-    if ( has_filter( 'render_block_core/image', 'block_core_image_render_lightbox' ) ) {
-		echo '<style>
-			.wp-lightbox-container > :hover {
-				opacity: 1;
-			}
-		</style>';
+function webp_make_lightbox_trigger_button_visible(): void {
+	if ( has_filter( 'render_block_core/image', 'block_core_image_render_lightbox' ) ) {
+		echo '<style> .wp-lightbox-container > picture + button { opacity: 1 } </style>';
 	}
 }
-add_action( 'wp_footer', 'webp_make_lightbox_trigger_button_visible' );
+
+/**
+ * Add an action to wp_footer conditionally for lighbox trigger button visibility.
+ * 
+ * @since n.e.x.t
+ *
+ * @return void
+ */
+function webp_add_footer_action_for_lightbox_button_visibility() {
+	if ( webp_uploads_is_picture_element_enabled() ) {
+		add_action( 'wp_footer', 'webp_make_lightbox_trigger_button_visible' );
+	}
+}
+add_action( 'init', 'webp_add_footer_action_for_lightbox_button_visibility' );

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -174,7 +174,6 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
  *
  * @since n.e.x.t
  *
- * @return void
  */
 function webp_make_lightbox_trigger_button_visible(): void {
 	if ( has_filter( 'render_block_core/image', 'block_core_image_render_lightbox' ) ) {
@@ -184,10 +183,9 @@ function webp_make_lightbox_trigger_button_visible(): void {
 
 /**
  * Add an action to wp_footer conditionally for lighbox trigger button visibility.
- * 
+ *
  * @since n.e.x.t
  *
- * @return void
  */
 function webp_add_footer_action_for_lightbox_button_visibility(): void {
 	if ( webp_uploads_is_picture_element_enabled() ) {

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -189,7 +189,7 @@ function webp_make_lightbox_trigger_button_visible(): void {
  *
  * @return void
  */
-function webp_add_footer_action_for_lightbox_button_visibility() {
+function webp_add_footer_action_for_lightbox_button_visibility(): void {
 	if ( webp_uploads_is_picture_element_enabled() ) {
 		add_action( 'wp_footer', 'webp_make_lightbox_trigger_button_visible' );
 	}

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -168,3 +168,20 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 		$image
 	);
 }
+
+/**
+ * Adds CSS to make Lightbox trigger BUTTON visible on an Image lightbox when Picture Element is enabled.
+ *
+ * @since 2.4.0
+ * 
+ */
+function webp_make_lightbox_trigger_button_visible() {
+    if ( has_filter( 'render_block_core/image', 'block_core_image_render_lightbox' ) ) {
+		echo '<style>
+			.wp-lightbox-container > :hover {
+				opacity: 1;
+			}
+		</style>';
+	}
+}
+add_action( 'wp_footer', 'webp_make_lightbox_trigger_button_visible' );

--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -173,7 +173,6 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
  * Adds CSS to make Lightbox trigger BUTTON visible on an Image lightbox when Picture Element is enabled.
  *
  * @since n.e.x.t
- *
  */
 function webp_make_lightbox_trigger_button_visible(): void {
 	if ( has_filter( 'render_block_core/image', 'block_core_image_render_lightbox' ) ) {
@@ -185,7 +184,6 @@ function webp_make_lightbox_trigger_button_visible(): void {
  * Add an action to wp_footer conditionally for lighbox trigger button visibility.
  *
  * @since n.e.x.t
- *
  */
 function webp_add_footer_action_for_lightbox_button_visibility(): void {
 	if ( webp_uploads_is_picture_element_enabled() ) {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1805

## Relevant technical choices

<!-- Please describe your changes. -->
- To fix the button visibility issue, we have conditionally added the custom CSS from the Modern Image Formats plugin when there is a Image block that has lightbox enabled.
- Used filter - `render_block_core/image` to detect the above conditions. [Ref](https://github.com/WordPress/wordpress-develop/blob/7fe8f1cc6f2722d773c738bbe0811bef2a07756e/src/wp-includes/blocks/image.php#L67-L83).


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
