### PR TITLE
Introduce `OD_Tag_Visitor_Context::track_tag()` method as alternative for returning `true` in tag visitor callback

### DIFF
--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -16,7 +16,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Context for tag visitors invoked for each tag while walking over a document.
  *
  * @since 0.4.0
- * @access private
  *
  * @property-read OD_URL_Metric_Group_Collection $url_metrics_group_collection Deprecated property accessed via magic getter. Use the url_metric_group_collection property instead.
  */
@@ -25,6 +24,7 @@ final class OD_Tag_Visitor_Context {
 	/**
 	 * HTML tag processor.
 	 *
+	 * @since 0.4.0
 	 * @var OD_HTML_Tag_Processor
 	 * @readonly
 	 */
@@ -33,6 +33,7 @@ final class OD_Tag_Visitor_Context {
 	/**
 	 * URL Metric group collection.
 	 *
+	 * @since 0.4.0
 	 * @var OD_URL_Metric_Group_Collection
 	 * @readonly
 	 */
@@ -41,6 +42,7 @@ final class OD_Tag_Visitor_Context {
 	/**
 	 * Link collection.
 	 *
+	 * @since 0.4.0
 	 * @var OD_Link_Collection
 	 * @readonly
 	 */
@@ -48,6 +50,8 @@ final class OD_Tag_Visitor_Context {
 
 	/**
 	 * Constructor.
+	 *
+	 * @since 0.4.0
 	 *
 	 * @param OD_HTML_Tag_Processor          $processor                   HTML tag processor.
 	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL Metric group collection.

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -49,6 +49,14 @@ final class OD_Tag_Visitor_Context {
 	public $link_collection;
 
 	/**
+	 * Visited tag state.
+	 *
+	 * @since n.e.x.t
+	 * @var OD_Visited_Tag_State
+	 */
+	private $visited_tag_state;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since 0.4.0
@@ -56,11 +64,24 @@ final class OD_Tag_Visitor_Context {
 	 * @param OD_HTML_Tag_Processor          $processor                   HTML tag processor.
 	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL Metric group collection.
 	 * @param OD_Link_Collection             $link_collection             Link collection.
+	 * @param OD_Visited_Tag_State           $visited_tag_state           Visited tag state.
 	 */
-	public function __construct( OD_HTML_Tag_Processor $processor, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_Link_Collection $link_collection ) {
+	public function __construct( OD_HTML_Tag_Processor $processor, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_Link_Collection $link_collection, OD_Visited_Tag_State $visited_tag_state ) {
 		$this->processor                   = $processor;
 		$this->url_metric_group_collection = $url_metric_group_collection;
 		$this->link_collection             = $link_collection;
+		$this->visited_tag_state           = $visited_tag_state;
+	}
+
+	/**
+	 * Marks the tag for being tracked in URL Metrics.
+	 *
+	 * Calling this method from a tag visitor has the same effect as a tag visitor returning `true`.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function track_tag(): void {
+		$this->visited_tag_state->track_tag();
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-tag-visitor-registry.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-registry.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Registry for tag visitors invoked for each tag while walking over a document.
  *
- * @phpstan-type TagVisitorCallback callable( OD_Tag_Visitor_Context ): bool
+ * @phpstan-type TagVisitorCallback callable( OD_Tag_Visitor_Context ): ( bool | void )
  *
  * @implements IteratorAggregate<string, TagVisitorCallback>
  *

--- a/plugins/optimization-detective/class-od-visited-tag-state.php
+++ b/plugins/optimization-detective/class-od-visited-tag-state.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Optimization Detective: OD_Visited_Tag_State class
+ *
+ * @package optimization-detective
+ * @since n.e.x.t
+ */
+
+// @codeCoverageIgnoreStart
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+// @codeCoverageIgnoreEnd
+
+/**
+ * State for a tag visitation when visited by tag visitors while walking over a document.
+ *
+ * @since n.e.x.t
+ * @access private
+ */
+final class OD_Visited_Tag_State {
+
+	/**
+	 * Whether the tag should be tracked among the elements in URL Metrics.
+	 *
+	 * @since n.e.x.t
+	 * @var bool
+	 */
+	private $should_track_tag;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->reset();
+	}
+
+	/**
+	 * Marks the tag for being tracked in URL Metrics.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function track_tag(): void {
+		$this->should_track_tag = true;
+	}
+
+	/**
+	 * Whether the tag should be tracked among the elements in URL Metrics.
+	 *
+	 * @since n.e.x.t
+	 * @return bool Whether tracked.
+	 */
+	public function is_tag_tracked(): bool {
+		return $this->should_track_tag;
+	}
+
+	/**
+	 * Resets state.
+	 *
+	 * This should be called after tag visitors have been invoked on a tag.
+	 *
+	 * @since n.e.x.t
+	 */
+	public function reset(): void {
+		$this->should_track_tag = false;
+	}
+}

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -123,6 +123,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		// Optimization logic.
 		require_once __DIR__ . '/class-od-link-collection.php';
 		require_once __DIR__ . '/class-od-tag-visitor-registry.php';
+		require_once __DIR__ . '/class-od-visited-tag-state.php';
 		require_once __DIR__ . '/class-od-tag-visitor-context.php';
 		require_once __DIR__ . '/optimization.php';
 

--- a/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/buffer.html
@@ -1,0 +1,14 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+	</head>
+	<body>
+		<div id="page">
+			<div id="not-tracked-by-any"></div>
+			<div id="tracked-by-return-true"></div>
+			<div id="tracked-by-track-tag-method"></div>
+			<div id="tracked-by-return-value-and-track-tag-method"></div>
+		</div>
+	</body>
+</html>

--- a/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/expected.html
@@ -1,0 +1,15 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+	</head>
+	<body>
+		<div id="page">
+			<div id="not-tracked-by-any"></div>
+			<div data-od-xpath="/HTML/BODY/DIV[@id=&#039;page&#039;]/*[2][self::DIV]" id="tracked-by-return-true"></div>
+			<div data-od-xpath="/HTML/BODY/DIV[@id=&#039;page&#039;]/*[3][self::DIV]" id="tracked-by-track-tag-method"></div>
+			<div data-od-xpath="/HTML/BODY/DIV[@id=&#039;page&#039;]/*[4][self::DIV]" id="tracked-by-return-value-and-track-tag-method"></div>
+		</div>
+	<script type="module">/* import detect ... */</script>
+</body>
+</html>

--- a/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/set-up.php
+++ b/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/set-up.php
@@ -1,0 +1,50 @@
+<?php
+return static function (): void {
+	add_action(
+		'od_register_tag_visitors',
+		static function ( OD_Tag_Visitor_Registry $registry ): void {
+			$registry->register(
+				'not-tracking-anything-return-false',
+				static function (): bool {
+					return false;
+				}
+			);
+
+			$registry->register(
+				'not-tracking-anything-return-void',
+				static function ( OD_Tag_Visitor_Context $context ): void {}
+			);
+
+			$registry->register(
+				'track-by-return-true',
+				static function ( OD_Tag_Visitor_Context $context ): bool {
+					return in_array(
+						$context->processor->get_attribute( 'id' ),
+						array(
+							'tracked-by-return-true',
+							'tracked-by-return-value-and-track-tag-method',
+						),
+						true
+					);
+				}
+			);
+
+			$registry->register(
+				'track-by-track-tag-method',
+				static function ( OD_Tag_Visitor_Context $context ): void {
+					$should_track = in_array(
+						$context->processor->get_attribute( 'id' ),
+						array(
+							'tracked-by-track-tag-method',
+							'tracked-by-return-value-and-track-tag-method',
+						),
+						true
+					);
+					if ( $should_track ) {
+						$context->track_tag();
+					}
+				}
+			);
+		}
+	);
+};

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -337,6 +337,11 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 	 * @covers ::od_is_response_html_content_type
 	 * @covers OD_Tag_Visitor_Context::__construct
 	 * @covers OD_Tag_Visitor_Context::__get
+	 * @covers OD_Tag_Visitor_Context::track_tag
+	 * @covers OD_Visited_Tag_State::__construct
+	 * @covers OD_Visited_Tag_State::track_tag
+	 * @covers OD_Visited_Tag_State::is_tag_tracked
+	 * @covers OD_Visited_Tag_State::reset
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 *
@@ -379,9 +384,11 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 			function ( OD_Tag_Visitor_Registry $tag_visitor_registry ): void {
 				$tag_visitor_registry->register(
 					'video',
-					function ( OD_Tag_Visitor_Context $context ): bool {
+					function ( OD_Tag_Visitor_Context $context ): void {
 						$this->assertFalse( $context->processor->is_tag_closer() );
-						return $context->processor->get_tag() === 'VIDEO';
+						if ( $context->processor->get_tag() === 'VIDEO' ) {
+							$context->track_tag();
+						}
 					}
 				);
 			}


### PR DESCRIPTION
Something that has bugged me for awhile with how tag visitor callbacks work is the aspect of returning a boolean for whether or not the currently-visited tag should be tracked in the `elements` of the stored URL Metrics. For simple cases, the boolean works fine but it can get hard to _track_ when the callback returns in multiple places. If you have to short-circuit anywhere, then you have to remember which return value is appropriate at a given time. 

The other problem with returning a boolean is having to remember what the boolean means. This was difficult to explain when reviews were performed when developing Optimization Detective, and it never totally felt right. Additionally, when developing a tag visitor which doesn't actually need URL Metrics to perform its optimizations, it is confusing that in this case there is no need to `return true` since there is no need to refer to the URL Metrics to apply the optimization. For example:

```php
function add_decoding_async_to_img_tags( OD_Tag_Visitor_Context $context ): bool {
	if ( $context->processor->get_tag() !== 'IMG' ) {
		return false;
	}
	$context->processor->set_attribute( 'decoding', 'async' );
	return false;
}
```

So this PR retains the ability to return a boolean, but it also introduces a new `track_tag` method exposed on the supplied `OD_Tag_Visitor_Context` object which is equivalent to `return true`. Having a method makes the decision to opt-in to tracking much more explicit. This simplifies the above to:

```php
function add_decoding_async_to_img_tags( OD_Tag_Visitor_Context $context ): void {
	if ( $context->processor->get_tag() !== 'IMG' ) {
		return;
	}
	$context->processor->set_attribute( 'decoding', 'async' );
}
```
And these are equivalent tag visitors:

```php
function optimize_img( OD_Tag_Visitor_Context $context ): bool {
	if ( $context->processor->get_tag() !== 'IMG' ) {
		return false;
	}
	
	// Do optimizations based on $context->url_metric_group_collection...
	return true;
}
```

```php
function optimize_img( OD_Tag_Visitor_Context $context ) {
	if ( $context->processor->get_tag() !== 'IMG' ) {
		return;
	}

	$context->track_tag();

	// Do optimizations based on $context->url_metric_group_collection...
}
```

For a bigger example of how this improves the DX, see this PR for the Intrinsic Dimensions PR: https://github.com/westonruter/od-intrinsic-dimensions/pull/1/files (cf. #10)