### PR TITLE
Ensure optimization is performed in the wp-env local environment and log debug messages to console when disabled

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -86,7 +86,7 @@ function od_maybe_add_template_output_buffer_filter(): void {
 			'reason' => __( 'Page is not optimized because od_can_optimize_response() returned false. This can be overridden with the od_can_optimize_response filter.', 'optimization-detective' ),
 		),
 		array(
-			'test'   => ! od_is_rest_api_unavailable() || ( wp_get_environment_type() === 'local' && ! class_exists( 'Test_OD_Optimization' ) ),
+			'test'   => ! od_is_rest_api_unavailable() || ( wp_get_environment_type() === 'local' && ! function_exists( 'tests_add_filter' ) ),
 			'reason' => __( 'Page is not optimized because the REST API for storing URL Metrics is not available.', 'optimization-detective' ),
 		),
 		array(

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -108,7 +108,7 @@ function od_maybe_add_template_output_buffer_filter(): void {
 					foreach ( $reasons as $reason ) {
 						wp_print_inline_script_tag(
 							sprintf(
-								'console.log( %s );',
+								'console.info( %s );',
 								(string) wp_json_encode( '[Optimization Detective] ' . $reason )
 							),
 							array( 'type' => 'module' )

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -105,20 +105,13 @@ function od_maybe_add_template_output_buffer_filter(): void {
 			add_action(
 				'wp_print_footer_scripts',
 				static function () use ( $reasons ): void {
-					foreach ( $reasons as $reason ) {
-						wp_print_inline_script_tag(
-							sprintf(
-								'console.info( %s );',
-								(string) wp_json_encode( '[Optimization Detective] ' . $reason )
-							),
-							array( 'type' => 'module' )
-						);
-					}
+					od_print_disabled_reasons( $reasons );
 				}
 			);
 		}
 		return;
 	}
+
 	$callback = 'od_optimize_template_output_buffer';
 	if (
 		function_exists( 'perflab_wrap_server_timing' )
@@ -130,6 +123,28 @@ function od_maybe_add_template_output_buffer_filter(): void {
 		$callback = perflab_wrap_server_timing( $callback, 'optimization-detective', 'exist' );
 	}
 	add_filter( 'od_template_output_buffer', $callback );
+}
+
+/**
+ * Prints the reasons why Optimization Detective is not optimizing the current page.
+ *
+ * This is only used when WP_DEBUG is enabled.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @param string[] $reasons Reason messages.
+ */
+function od_print_disabled_reasons( array $reasons ): void {
+	foreach ( $reasons as $reason ) {
+		wp_print_inline_script_tag(
+			sprintf(
+				'console.info( %s );',
+				(string) wp_json_encode( '[Optimization Detective] ' . $reason )
+			),
+			array( 'type' => 'module' )
+		);
+	}
 }
 
 /**

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -82,9 +82,8 @@ function od_buffer_output( $passthrough ) {
 function od_maybe_add_template_output_buffer_filter(): void {
 	if (
 		! od_can_optimize_response() ||
-		od_is_rest_api_unavailable() ||
+		( od_is_rest_api_unavailable() && ( wp_get_environment_type() !== 'local' || class_exists( 'Test_OD_Optimization' ) ) ) ||
 		isset( $_GET['optimization_detective_disabled'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
 	) {
 		return;
 	}

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -86,7 +86,7 @@ function od_maybe_add_template_output_buffer_filter(): void {
 			'reason' => __( 'Page is not optimized because od_can_optimize_response() returned false. This can be overridden with the od_can_optimize_response filter.', 'optimization-detective' ),
 		),
 		array(
-			'test'   => ! ( od_is_rest_api_unavailable() && ( wp_get_environment_type() !== 'local' || class_exists( 'Test_OD_Optimization' ) ) ),
+			'test'   => ! od_is_rest_api_unavailable() || ( wp_get_environment_type() === 'local' && ! class_exists( 'Test_OD_Optimization' ) ),
 			'reason' => __( 'Page is not optimized because the REST API for storing URL Metrics is not available.', 'optimization-detective' ),
 		),
 		array(

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -216,6 +216,25 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test od_print_disabled_reasons().
+	 *
+	 * @covers ::od_print_disabled_reasons
+	 */
+	public function test_od_print_disabled_reasons(): void {
+		$this->assertSame( '', get_echo( 'od_print_disabled_reasons', array( array() ) ) );
+		$foo_message = get_echo( 'od_print_disabled_reasons', array( array( 'Foo' ) ) );
+		$this->assertStringContainsString( '<script', $foo_message );
+		$this->assertStringContainsString( 'console.info(', $foo_message );
+		$this->assertStringContainsString( '[Optimization Detective] Foo', $foo_message );
+
+		$foo_and_bar_messages = get_echo( 'od_print_disabled_reasons', array( array( 'Foo', 'Bar' ) ) );
+		$this->assertStringContainsString( '<script', $foo_and_bar_messages );
+		$this->assertStringContainsString( 'console.info(', $foo_and_bar_messages );
+		$this->assertStringContainsString( '[Optimization Detective] Foo', $foo_and_bar_messages );
+		$this->assertStringContainsString( '[Optimization Detective] Bar', $foo_and_bar_messages );
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array<string, mixed> Data.


### PR DESCRIPTION
I was testing Optimization Detective and I was confused why it wasn't working. Pages which normally had been optimized were being served as if Optimization Detective wasn't even active. It turns out that this is a side effect of #1762 where we prevent any page processing when the REST API for storing URL Metrics is unavailable. Since loopback requests don't work in wp-env (https://github.com/WordPress/gutenberg/issues/20569), neither does the Site Health test for checking whether the REST API is available. 

Without the patch in this PR, a plugin can force optimization to apply even when the REST API isn't available via code like the following:

```php
// The wp-env environment does not support loopback requests, so we need to pretend that everything is good.
add_filter(
	'pre_option_od_rest_api_unavailable',
	static function ( $pre ): string {
		if ( ! is_admin() ) {
			return '0';
		}
		return $pre;
	}
);
```

This could be added to the [`od-dev-mode`](https://github.com/westonruter/od-dev-mode/tree/main) plugin. But this plugin shouldn't have to be installed in order to test Optimization Detective in wp-env.

So this PR adds a condition (a7cedce60a559cfc43fa433fc70bd1c200b6954c) so that `od_is_rest_api_unavailable()` is checked alongside `( wp_get_environment_type() !== 'local' || class_exists( 'Test_OD_Optimization' ) )`. Only if both are true will it short-circuit.

Additionally, to assist with helping users understand why Optimization Detective isn't doing anything, this PR includes the reasons for optimization being disabled in the console when `WP_DEBUG` is enabled.