### PR TITLE
Add support for pre-release version syntax to all relevant tools

### DIFF
--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -54,7 +54,7 @@ function updateReadmeChangelog( readmeFile, changelog ) {
 	const fileContent = fs.readFileSync( readmeFile, 'utf-8' );
 
 	const stableTagVersionMatches = fileContent.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+)$/m
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
 		throw new Error( `Unable to locate stable tag in ${ readmeFile }` );
@@ -112,7 +112,7 @@ function getStableTag( readmeFilePath ) {
 	const readmeContents = fs.readFileSync( readmeFilePath, 'utf-8' );
 
 	const stableTagVersionMatches = readmeContents.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+)$/m
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
 		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -61,7 +61,7 @@ exports.handler = async ( opt ) => {
 		const readmeFile = path.resolve( pluginDirectory, 'readme.txt' );
 		const readmeContent = fs.readFileSync( readmeFile, 'utf-8' );
 		const readmeContentMatches = readmeContent.match(
-			/^Stable tag:\s+(\d+\.\d+\.\d+)$/m
+			/^Stable tag:\s+(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
 		);
 		if ( ! readmeContentMatches ) {
 			throw new Error(

--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -38,7 +38,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const readmeContents = fs.readFileSync( readmeFilePath, 'utf-8' );
 
 	const stableTagVersionMatches = readmeContents.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-\w+)?)$/m
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
 		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );
@@ -46,7 +46,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const stableTagVersion = stableTagVersionMatches[ 1 ];
 
 	const latestChangelogMatches = readmeContents.match(
-		/^== Changelog ==\n+= (\d+\.\d+\.\d+(?:-\w+)?) =$/m
+		/^== Changelog ==\n+= (\d+\.\d+\.\d+(?:-[\w\.]+)?) =$/m
 	);
 	if ( ! latestChangelogMatches ) {
 		throw new Error(
@@ -71,7 +71,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	}
 
 	const headerVersionMatches = phpBootstrapFileContents.match(
-		/^ \* Version:\s+(\d+\.\d+\.\d+(?:-\w+)?)$/m
+		/^ \* Version:\s+(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
 	);
 	if ( ! headerVersionMatches ) {
 		throw new Error(
@@ -81,7 +81,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const headerVersion = headerVersionMatches[ 1 ];
 
 	const phpLiteralVersionMatches = phpBootstrapFileContents.match(
-		/'(\d+\.\d+\.\d+(?:-\w+)?)'/
+		/'(\d+\.\d+\.\d+(?:-[\w\.]+)?)'/
 	);
 	if ( ! phpLiteralVersionMatches ) {
 		throw new Error( 'Unable to locate the PHP literal version.' );

--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -50,7 +50,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	);
 	if ( ! latestChangelogMatches ) {
 		throw new Error(
-			'Unable to latest version entry in readme changelog.'
+			'Unable to locate latest version entry in readme changelog.'
 		);
 	}
 	const latestChangelogVersion = latestChangelogMatches[ 1 ];

--- a/tools/webpack/utils.js
+++ b/tools/webpack/utils.js
@@ -37,7 +37,7 @@ const getPluginVersion = ( pluginPath ) => {
 	const readmePath = path.resolve( pluginPath, 'readme.txt' );
 
 	const fileContent = fs.readFileSync( readmePath, 'utf-8' );
-	const versionRegex = /(?:Stable tag|v)\s*:\s*(\d+\.\d+\.\d+)/i;
+	const versionRegex = /(?:Stable tag|v)\s*:\s*(\d+\.\d+\.\d+(?:-[\w\.]+)?)/i;
 	const match = versionRegex.exec( fileContent );
 
 	if ( match ) {


### PR DESCRIPTION
## Summary

In order to support release versions like the upcoming Optimization Detective `1.0.0-beta.1`, we need to make sure our tooling supports such versions.

The `versions` command was already checking for pre-release identifiers, however it was flawed because it would not accept periods in the suffix, which are commonly used. This PR updates all relevant regexes to support version suffixes, using a uniform approach.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
