### PR TITLE
Remove `no-cache` and `max-age=0` from bfcache failure conditions

### DIFF
--- a/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
+++ b/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
@@ -29,7 +29,7 @@ function perflab_bfcache_compatibility_headers_check(): array {
 			'color' => 'blue',
 		),
 		'description' => '<p>' . wp_kses(
-			__( 'If the <code>Cache-Control</code> page response header includes directives like <code>no-store</code>, <code>no-cache</code>, or <code>max-age=0</code> then it can prevent instant back/forward navigations (using the browser bfcache). These are not present for unauthenticated requests on your site, so it is configured properly. Note that WordPress adds these directives for logged-in page responses.', 'performance-lab' ),
+			__( "If the <code>Cache-Control</code> page response header includes the <code>no-store</code> directive then it can prevent instant back/forward navigations (using the browser's bfcache). This is not present for unauthenticated requests on your site, so it is configured properly. Note that there are other ways that bfcache can be disabled (e.g. you have JavaScript which uses a <code>unload</code> event listener). Also note that WordPress adds this directive for logged-in page responses for privacy/security reasons.", 'performance-lab' ),
 			array( 'code' => array() )
 		) . '</p>',
 		'actions'     => '',
@@ -66,41 +66,15 @@ function perflab_bfcache_compatibility_headers_check(): array {
 	}
 
 	foreach ( (array) $cache_control_headers as $cache_control_header ) {
-		$cache_control_header = strtolower( $cache_control_header );
-		$found_directives     = array();
-		foreach ( array( 'no-store' ) as $directive ) {
-			if ( str_contains( $cache_control_header, $directive ) ) {
-				$found_directives[] = $directive;
-			}
-		}
-
-		if ( count( $found_directives ) > 0 ) {
+		if ( str_contains( strtolower( $cache_control_header ), 'no-store' ) ) {
 			$result['label']       = __( 'The Cache-Control page header is preventing fast back/forward navigations', 'performance-lab' );
 			$result['status']      = 'recommended';
 			$result['description'] = sprintf(
-				'<p>%s %s</p>',
+				'<p>%s</p>',
 				wp_kses(
-					sprintf(
-						/* translators: %s: problematic directive(s) */
-						_n(
-							'The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directive: %s.',
-							'The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directives: %s.',
-							count( $found_directives ),
-							'performance-lab'
-						),
-						implode(
-							', ',
-							array_map(
-								static function ( $header ) {
-									return "<code>$header</code>";
-								},
-								$found_directives
-							)
-						)
-					),
+					__( "The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the <code>no-store</code> directive. This can affect the performance of your site by preventing fast back/forward navigations (via the browser's bfcache).", 'performance-lab' ),
 					array( 'code' => array() )
-				),
-				esc_html__( 'This can affect the performance of your site by preventing fast back/forward navigations (via browser bfcache).', 'performance-lab' )
+				)
 			);
 			break;
 		}

--- a/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
+++ b/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
@@ -68,7 +68,7 @@ function perflab_bfcache_compatibility_headers_check(): array {
 	foreach ( (array) $cache_control_headers as $cache_control_header ) {
 		$cache_control_header = strtolower( $cache_control_header );
 		$found_directives     = array();
-		foreach ( array( 'no-store', 'no-cache', 'max-age=0' ) as $directive ) {
+		foreach ( array( 'no-store' ) as $directive ) {
 			if ( str_contains( $cache_control_header, $directive ) ) {
 				$found_directives[] = $directive;
 			}

--- a/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
+++ b/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
@@ -71,9 +71,11 @@ function perflab_bfcache_compatibility_headers_check(): array {
 			$result['status']      = 'recommended';
 			$result['description'] = sprintf(
 				'<p>%s</p>',
-				wp_kses(
-					__( "The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the <code>no-store</code> directive. This can affect the performance of your site by preventing fast back/forward navigations (via the browser's bfcache).", 'performance-lab' ),
-					array( 'code' => array() )
+				sprintf(
+					/* translators: 1: Cache-Control, 2: no-store */
+					esc_html__( 'The %1$s response header for an unauthenticated request to the home page includes the %2$s directive. This can affect the performance of your site by preventing fast back/forward navigations (via the browser\'s bfcache).', 'performance-lab' ),
+					'<code>Cache-Control</code>',
+					'<code>no-store</code>'
 				)
 			);
 			break;

--- a/plugins/performance-lab/tests/includes/site-health/bfcache-compatibility-headers/test-bfcache-compatibility-headers.php
+++ b/plugins/performance-lab/tests/includes/site-health/bfcache-compatibility-headers/test-bfcache-compatibility-headers.php
@@ -91,18 +91,18 @@ class Test_BFCache_Compatibility_Headers extends WP_UnitTestCase {
 			),
 			'no_cache'           => array(
 				$this->build_response( 200, array( 'cache-control' => 'no-cache' ) ),
-				'recommended',
-				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directive: <code>no-cache</code>',
+				'good',
+				'If the <code>Cache-Control</code> page response header includes directives like',
 			),
 			'max_age_0'          => array(
-				$this->build_response( 200, array( 'cache-control' => 'max-age=0' ) ),
-				'recommended',
-				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directive: <code>max-age=0</code>',
+				$this->build_response( 200, array( 'cache-control' => 'no-cache' ) ),
+				'good',
+				'If the <code>Cache-Control</code> page response header includes directives like',
 			),
 			'max_age_0_no_store' => array(
 				$this->build_response( 200, array( 'cache-control' => 'max-age=0, no-store' ) ),
 				'recommended',
-				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directives: <code>no-store</code>, <code>max-age=0</code>',
+				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directive: <code>no-store</code>',
 			),
 			'error'              => array(
 				new WP_Error( 'http_request_failed', 'HTTP request failed' ),

--- a/plugins/performance-lab/tests/includes/site-health/bfcache-compatibility-headers/test-bfcache-compatibility-headers.php
+++ b/plugins/performance-lab/tests/includes/site-health/bfcache-compatibility-headers/test-bfcache-compatibility-headers.php
@@ -82,27 +82,27 @@ class Test_BFCache_Compatibility_Headers extends WP_UnitTestCase {
 			'headers_not_set'    => array(
 				$this->build_response( 200, array( 'cache-control' => '' ) ),
 				'good',
-				'If the <code>Cache-Control</code> page response header includes directives like',
+				'If the <code>Cache-Control</code> page response header includes',
 			),
 			'no_store'           => array(
 				$this->build_response( 200, array( 'cache-control' => 'no-store' ) ),
 				'recommended',
-				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directive: <code>no-store</code>',
+				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes',
 			),
 			'no_cache'           => array(
 				$this->build_response( 200, array( 'cache-control' => 'no-cache' ) ),
 				'good',
-				'If the <code>Cache-Control</code> page response header includes directives like',
+				'If the <code>Cache-Control</code> page response header includes',
 			),
 			'max_age_0'          => array(
 				$this->build_response( 200, array( 'cache-control' => 'no-cache' ) ),
 				'good',
-				'If the <code>Cache-Control</code> page response header includes directives like',
+				'If the <code>Cache-Control</code> page response header includes',
 			),
 			'max_age_0_no_store' => array(
 				$this->build_response( 200, array( 'cache-control' => 'max-age=0, no-store' ) ),
 				'recommended',
-				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes the following directive: <code>no-store</code>',
+				'<p>The <code>Cache-Control</code> response header for an unauthenticated request to the home page includes',
 			),
 			'error'              => array(
 				new WP_Error( 'http_request_failed', 'HTTP request failed' ),


### PR DESCRIPTION
## Summary

Fixes #1825
