### PR TITLE
Prepare 3.8.0 release

### DIFF
--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -210,7 +210,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	 * not end up being the load balanced domain used for the embed. Lastly, these domains are only for the URLs
 	 * for GET requests, as POST requests are not likely to be part of the critical rendering path.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.4.1
 	 *
 	 * @param OD_HTML_Tag_Processor $processor Processor, with the cursor currently at an embed block.
 	 * @return array<non-empty-string> Array of URLs to preconnect to.
@@ -270,7 +270,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	/**
 	 * Adds preconnect links for embed resources.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.4.1
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
 	 */
@@ -299,7 +299,7 @@ final class Embed_Optimizer_Tag_Visitor {
 	/**
 	 * Optimizes an embed based on whether it is displayed in any initial viewport.
 	 *
-	 * @since n.e.x.t
+	 * @since 0.4.1
 	 *
 	 * @param OD_Tag_Visitor_Context $context Tag visitor context, with the cursor currently at an embed block.
 	 */

--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -5,7 +5,7 @@
  * Description: Optimizes the performance of embeds through lazy-loading, preconnecting, and reserving space to reduce layout shifts.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 0.4.0
+ * Version: 0.4.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'embed_optimizer_pending_plugin',
-	'0.4.0',
+	'0.4.1',
 	static function ( string $version ): void {
 		if ( defined( 'EMBED_OPTIMIZER_VERSION' ) ) {
 			return;

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   0.4.0
+Stable tag:   0.4.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, embeds
@@ -66,6 +66,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.4.1 =
 
 = 0.4.0 =
 

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -69,6 +69,10 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.4.1 =
 
+**Bug Fixes**
+
+* Remove requirement for both mobile and desktop URL metrics to be collected for `preconnect` links to be added. ([1764](https://github.com/WordPress/performance/pull/1764))
+
 = 0.4.0 =
 
 **Enhancements**

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.6
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.3.0
+ * Version: 0.3.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -72,7 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.3.0',
+	'0.3.1',
 	static function ( string $version ): void {
 		if ( defined( 'IMAGE_PRIORITIZER_VERSION' ) ) {
 			return;

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   0.3.0
+Stable tag:   0.3.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -69,6 +69,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 0.3.1 =
 
 = 0.3.0 =
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -72,6 +72,10 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 0.3.1 =
 
+**Bug Fixes**
+
+* Remove erroneous check for resource initiator type when considering whether to submit LCP background image. ([1760](https://github.com/WordPress/performance/pull/1760))
+
 = 0.3.0 =
 
 **Enhancements**

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -36,7 +36,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Transitional XPath.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 * @todo Remove logic related to transitional_xpath in a subsequent release once URL Metrics have been collected with the new format.
 	 * @var non-empty-string|null
 	 */
@@ -131,7 +131,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * Gets XPath for element.
 	 *
 	 * @since 0.7.0
-	 * @since n.e.x.t Returns the transitional XPath format. To access the underlying raw XPath, access the 'xpath' key of the jsonSerialize response.
+	 * @since 1.0.0-beta1 Returns the transitional XPath format. To access the underlying raw XPath, access the 'xpath' key of the jsonSerialize response.
 	 * @todo Remove logic related to transitional_xpath in a subsequent release once URL Metrics have been collected with the new format.
 	 *
 	 * @return non-empty-string XPath.

--- a/plugins/optimization-detective/class-od-element.php
+++ b/plugins/optimization-detective/class-od-element.php
@@ -36,7 +36,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	/**
 	 * Transitional XPath.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 * @todo Remove logic related to transitional_xpath in a subsequent release once URL Metrics have been collected with the new format.
 	 * @var non-empty-string|null
 	 */
@@ -131,7 +131,7 @@ class OD_Element implements ArrayAccess, JsonSerializable {
 	 * Gets XPath for element.
 	 *
 	 * @since 0.7.0
-	 * @since 1.0.0-beta1 Returns the transitional XPath format. To access the underlying raw XPath, access the 'xpath' key of the jsonSerialize response.
+	 * @since 1.0.0 Returns the transitional XPath format. To access the underlying raw XPath, access the 'xpath' key of the jsonSerialize response.
 	 * @todo Remove logic related to transitional_xpath in a subsequent release once URL Metrics have been collected with the new format.
 	 *
 	 * @return non-empty-string XPath.

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -159,7 +159,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Note that currently only the third item will currently be populated (index 2), as this corresponds to tags which
 	 * are children of the `BODY` tag. This is used in {@see self::get_xpath()}.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 * @var array<array<string, string>>
 	 */
 	private $open_stack_attributes = array();
@@ -204,7 +204,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * This is used to store the old XPath format in a transitional period until which new URL Metrics are expected to
 	 * have been collected to purge out references to the old format.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 * @var string|null
 	 */
 	private $current_xpath = null;
@@ -582,7 +582,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Themes utilize the 'wp-site-blocks' class name in the root `DIV`. Only one attribute is currently returned,
 	 * although potentially more could be returned if additional disambiguation is needed in the future.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 *
 	 * @return array<string, string> Disambiguating attributes.
 	 */
@@ -682,7 +682,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * can simply be an alias for that one. See related logic in {@see OD_Element::get_xpath()}. This function is only
 	 * used internally by Optimization Detective in {@see od_optimize_template_output_buffer()}.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 * @todo Move the logic in this method to the get_xpath() method and let this be an alias for that method once the transitional period is over.
 	 * @access private
 	 *
@@ -715,7 +715,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Returns whether the processor is currently at or inside the admin bar.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 *
 	 * @return bool Whether at or inside the admin bar.
 	 */

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -159,7 +159,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Note that currently only the third item will currently be populated (index 2), as this corresponds to tags which
 	 * are children of the `BODY` tag. This is used in {@see self::get_xpath()}.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 * @var array<array<string, string>>
 	 */
 	private $open_stack_attributes = array();
@@ -204,7 +204,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * This is used to store the old XPath format in a transitional period until which new URL Metrics are expected to
 	 * have been collected to purge out references to the old format.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 * @var string|null
 	 */
 	private $current_xpath = null;
@@ -582,7 +582,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Themes utilize the 'wp-site-blocks' class name in the root `DIV`. Only one attribute is currently returned,
 	 * although potentially more could be returned if additional disambiguation is needed in the future.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 *
 	 * @return array<string, string> Disambiguating attributes.
 	 */
@@ -682,7 +682,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * can simply be an alias for that one. See related logic in {@see OD_Element::get_xpath()}. This function is only
 	 * used internally by Optimization Detective in {@see od_optimize_template_output_buffer()}.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 * @todo Move the logic in this method to the get_xpath() method and let this be an alias for that method once the transitional period is over.
 	 * @access private
 	 *
@@ -715,7 +715,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Returns whether the processor is currently at or inside the admin bar.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 *
 	 * @return bool Whether at or inside the admin bar.
 	 */

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -51,7 +51,7 @@ final class OD_Tag_Visitor_Context {
 	/**
 	 * Visited tag state.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 * @var OD_Visited_Tag_State
 	 */
 	private $visited_tag_state;
@@ -78,7 +78,7 @@ final class OD_Tag_Visitor_Context {
 	 *
 	 * Calling this method from a tag visitor has the same effect as a tag visitor returning `true`.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 */
 	public function track_tag(): void {
 		$this->visited_tag_state->track_tag();

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -51,7 +51,7 @@ final class OD_Tag_Visitor_Context {
 	/**
 	 * Visited tag state.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 * @var OD_Visited_Tag_State
 	 */
 	private $visited_tag_state;
@@ -78,7 +78,7 @@ final class OD_Tag_Visitor_Context {
 	 *
 	 * Calling this method from a tag visitor has the same effect as a tag visitor returning `true`.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 */
 	public function track_tag(): void {
 		$this->visited_tag_state->track_tag();

--- a/plugins/optimization-detective/class-od-visited-tag-state.php
+++ b/plugins/optimization-detective/class-od-visited-tag-state.php
@@ -3,7 +3,7 @@
  * Optimization Detective: OD_Visited_Tag_State class
  *
  * @package optimization-detective
- * @since 1.0.0-beta1
+ * @since 1.0.0
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * State for a tag visitation when visited by tag visitors while walking over a document.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  */
 final class OD_Visited_Tag_State {
@@ -23,7 +23,7 @@ final class OD_Visited_Tag_State {
 	/**
 	 * Whether the tag should be tracked among the elements in URL Metrics.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 * @var bool
 	 */
 	private $should_track_tag;
@@ -38,7 +38,7 @@ final class OD_Visited_Tag_State {
 	/**
 	 * Marks the tag for being tracked in URL Metrics.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 */
 	public function track_tag(): void {
 		$this->should_track_tag = true;
@@ -47,7 +47,7 @@ final class OD_Visited_Tag_State {
 	/**
 	 * Whether the tag should be tracked among the elements in URL Metrics.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 * @return bool Whether tracked.
 	 */
 	public function is_tag_tracked(): bool {
@@ -59,7 +59,7 @@ final class OD_Visited_Tag_State {
 	 *
 	 * This should be called after tag visitors have been invoked on a tag.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 */
 	public function reset(): void {
 		$this->should_track_tag = false;

--- a/plugins/optimization-detective/class-od-visited-tag-state.php
+++ b/plugins/optimization-detective/class-od-visited-tag-state.php
@@ -3,7 +3,7 @@
  * Optimization Detective: OD_Visited_Tag_State class
  *
  * @package optimization-detective
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * State for a tag visitation when visited by tag visitors while walking over a document.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  */
 final class OD_Visited_Tag_State {
@@ -23,7 +23,7 @@ final class OD_Visited_Tag_State {
 	/**
 	 * Whether the tag should be tracked among the elements in URL Metrics.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 * @var bool
 	 */
 	private $should_track_tag;
@@ -38,7 +38,7 @@ final class OD_Visited_Tag_State {
 	/**
 	 * Marks the tag for being tracked in URL Metrics.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 */
 	public function track_tag(): void {
 		$this->should_track_tag = true;
@@ -47,7 +47,7 @@ final class OD_Visited_Tag_State {
 	/**
 	 * Whether the tag should be tracked among the elements in URL Metrics.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 * @return bool Whether tracked.
 	 */
 	public function is_tag_tracked(): bool {
@@ -59,7 +59,7 @@ final class OD_Visited_Tag_State {
 	 *
 	 * This should be called after tag visitors have been invoked on a tag.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 */
 	public function reset(): void {
 		$this->should_track_tag = false;

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -87,7 +87,7 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 	 * Note that the attribution build is slightly larger than the standard build, so this is why it is not used by default.
 	 * The additional attribution data is made available to client-side extension script modules registered via the `od_extension_module_urls` filter.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0-beta1
 	 *
 	 * @param bool $use_attribution_build Whether to use the attribution build.
 	 */

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -87,7 +87,7 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 	 * Note that the attribution build is slightly larger than the standard build, so this is why it is not used by default.
 	 * The additional attribution data is made available to client-side extension script modules registered via the `od_extension_module_urls` filter.
 	 *
-	 * @since 1.0.0-beta1
+	 * @since 1.0.0
 	 *
 	 * @param bool $use_attribution_build Whether to use the attribution build.
 	 */

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 0.9.0
+ * Version: 1.0.0-beta1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'0.9.0',
+	'1.0.0-beta1',
 	static function ( string $version ): void {
 		if ( defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			return;

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -130,7 +130,7 @@ function od_maybe_add_template_output_buffer_filter(): void {
  *
  * This is only used when WP_DEBUG is enabled.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @param string[] $reasons Reason messages.

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -130,7 +130,7 @@ function od_maybe_add_template_output_buffer_filter(): void {
  *
  * This is only used when WP_DEBUG is enabled.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @param string[] $reasons Reason messages.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -57,6 +57,26 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 1.0.0-beta1 =
 
+**Enhancements**
+
+* Add site health check to detect blocked REST API and short-circuit optimization when unavailable. ([1762](https://github.com/WordPress/performance/pull/1762))
+* Allow extensions to opt in to using the web-vitals attribution build via the `od_use_web_vitals_attribution_build` filter. ([1759](https://github.com/WordPress/performance/pull/1759))
+* Disambiguate XPaths for children of `BODY` with `id`, `class`, or `role` attributes. ([1797](https://github.com/WordPress/performance/pull/1797))
+* Eliminate varying URL Metrics by logged-in state and discontinue disabling optimization by default for admins. ([1788](https://github.com/WordPress/performance/pull/1788))
+* Improve test coverage for Optimization Detective. ([1817](https://github.com/WordPress/performance/pull/1817))
+* Introduce `OD_Tag_Visitor_Context::track_tag()` method as alternative for returning `true` in tag visitor callback. ([1821](https://github.com/WordPress/performance/pull/1821))
+* Omit element node index in XPaths up to children of BODY. ([1790](https://github.com/WordPress/performance/pull/1790))
+* Skip visiting tags in the Admin Bar when optimizing a page. ([1816](https://github.com/WordPress/performance/pull/1816))
+
+**Bug Fixes**
+
+* Ensure optimization is performed in the wp-env local environment and log debug messages to console when disabled. ([1822](https://github.com/WordPress/performance/pull/1822))
+* Skip visiting any tags inside of `NOSCRIPT` elements. ([1783](https://github.com/WordPress/performance/pull/1783))
+
+**Documentation**
+
+* Move Optimization Detective docs into [`README.md`](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective/docs). ([1763](https://github.com/WordPress/performance/pull/1763))
+
 = 0.9.0 =
 
 **Enhancements**

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   0.9.0
+Stable tag:   1.0.0-beta1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -54,6 +54,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 1.0.0-beta1 =
 
 = 0.9.0 =
 

--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -3,7 +3,7 @@
  * Site Health checks.
  *
  * @package optimization-detective
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds the Optimization Detective REST API check to site health tests.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @param array{direct: array<string, array{label: string, test: string}>}|mixed $tests Site Health Tests.
@@ -39,7 +39,7 @@ function od_add_rest_api_availability_test( $tests ): array {
 /**
  * Tests availability of the Optimization Detective REST API endpoint.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @return array{label: string, status: string, badge: array{label: string, color: string}, description: string, actions: string, test: string} Result.
@@ -68,7 +68,7 @@ function od_test_rest_api_availability(): array {
  * the admin. The reason for storing the negative unavailable state as opposed to the positive available state is that
  * when an option does not exist then `get_option()` returns `false` which is the same falsy value as the stored `'0'`.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @return bool Whether unavailable.
@@ -80,7 +80,7 @@ function od_is_rest_api_unavailable(): bool {
 /**
  * Tests availability of the Optimization Detective REST API endpoint.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @param array<string, mixed>|WP_Error $response REST API response.
@@ -165,7 +165,7 @@ function od_compose_site_health_result( $response ): array {
 /**
  * Gets the response to an Optimization Detective REST API store request to confirm it is available to unauthenticated requests.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @param bool $use_cached Whether to use a previous response cached in a transient.
@@ -195,7 +195,7 @@ function od_get_rest_api_health_check_response( bool $use_cached ) {
 /**
  * Renders an admin notice if the REST API health check fails.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @param bool $in_plugin_row Whether the notice is to be printed in the plugin row.
@@ -251,7 +251,7 @@ function od_maybe_render_rest_api_health_check_admin_notice( bool $in_plugin_row
 /**
  * Displays an admin notice on the plugin row if the REST API health check fails.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  *
  * @param string $plugin_file Plugin file.
@@ -273,7 +273,7 @@ function od_render_rest_api_health_check_admin_notice_in_plugin_row( string $plu
  * shown at the `admin_notices` action once, the notice will only be displayed inline with the plugin row thereafter
  * via {@see od_render_rest_api_health_check_admin_notice_in_plugin_row()}.
  *
- * @since n.e.x.t
+ * @since 1.0.0-beta1
  * @access private
  */
 function od_maybe_run_rest_api_health_check(): void {

--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -3,7 +3,7 @@
  * Site Health checks.
  *
  * @package optimization-detective
- * @since 1.0.0-beta1
+ * @since 1.0.0
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds the Optimization Detective REST API check to site health tests.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @param array{direct: array<string, array{label: string, test: string}>}|mixed $tests Site Health Tests.
@@ -39,7 +39,7 @@ function od_add_rest_api_availability_test( $tests ): array {
 /**
  * Tests availability of the Optimization Detective REST API endpoint.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @return array{label: string, status: string, badge: array{label: string, color: string}, description: string, actions: string, test: string} Result.
@@ -68,7 +68,7 @@ function od_test_rest_api_availability(): array {
  * the admin. The reason for storing the negative unavailable state as opposed to the positive available state is that
  * when an option does not exist then `get_option()` returns `false` which is the same falsy value as the stored `'0'`.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @return bool Whether unavailable.
@@ -80,7 +80,7 @@ function od_is_rest_api_unavailable(): bool {
 /**
  * Tests availability of the Optimization Detective REST API endpoint.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @param array<string, mixed>|WP_Error $response REST API response.
@@ -165,7 +165,7 @@ function od_compose_site_health_result( $response ): array {
 /**
  * Gets the response to an Optimization Detective REST API store request to confirm it is available to unauthenticated requests.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @param bool $use_cached Whether to use a previous response cached in a transient.
@@ -195,7 +195,7 @@ function od_get_rest_api_health_check_response( bool $use_cached ) {
 /**
  * Renders an admin notice if the REST API health check fails.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @param bool $in_plugin_row Whether the notice is to be printed in the plugin row.
@@ -251,7 +251,7 @@ function od_maybe_render_rest_api_health_check_admin_notice( bool $in_plugin_row
 /**
  * Displays an admin notice on the plugin row if the REST API health check fails.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  *
  * @param string $plugin_file Plugin file.
@@ -273,7 +273,7 @@ function od_render_rest_api_health_check_admin_notice_in_plugin_row( string $plu
  * shown at the `admin_notices` action once, the notice will only be displayed inline with the plugin row thereafter
  * via {@see od_render_rest_api_health_check_admin_notice_in_plugin_row()}.
  *
- * @since 1.0.0-beta1
+ * @since 1.0.0
  * @access private
  */
 function od_maybe_run_rest_api_health_check(): void {

--- a/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
+++ b/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/helper.php
@@ -3,7 +3,7 @@
  * Helper functions used for Cache-Control headers for bfcache compatibility site health check.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.8.0
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Tests the Cache-Control headers for bfcache compatibility.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @return array{label: string, status: string, badge: array{label: string, color: string}, description: string, actions: string, test: string} Result.

--- a/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/hooks.php
+++ b/plugins/performance-lab/includes/site-health/bfcache-compatibility-headers/hooks.php
@@ -3,7 +3,7 @@
  * Hook callbacks used for cache-control headers.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.8.0
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Add the bfcache compatibility check to site health tests.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @param array{direct: array<string, array{label: string, test: string}>} $tests Site Health Tests.

--- a/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/helper.php
+++ b/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/helper.php
@@ -3,7 +3,7 @@
  * Helper function to detect if static assets have effective caching headers.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.8.0
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Callback for the effective caching headers test.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @return array{label: string, status: string, badge: array{label: string, color: string}, description: string, actions: string, test: string} Result.
@@ -50,7 +50,7 @@ function perflab_effective_asset_cache_headers_assets_test(): array {
 	/**
 	 * Filters the list of assets to check for effective caching headers.
 	 *
-	 * @since n.e.x.t
+	 * @since 3.8.0
 	 *
 	 * @param string[] $assets List of asset URLs to check.
 	 */
@@ -84,7 +84,7 @@ function perflab_effective_asset_cache_headers_assets_test(): array {
 /**
  * Checks if effective caching headers are enabled for a list of assets.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @param  string[] $assets List of asset URLs to check.
@@ -163,7 +163,7 @@ function perflab_effective_asset_cache_headers_check_assets( array $assets ): ar
 /**
  * Checks if effective caching headers are enabled.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @param WpOrg\Requests\Utility\CaseInsensitiveDictionary|array<string, string|array<string>> $headers Response headers.
@@ -173,7 +173,7 @@ function perflab_effective_asset_cache_headers_check_headers( $headers ): array 
 	/**
 	 * Filters the threshold for effective caching headers.
 	 *
-	 * @since n.e.x.t
+	 * @since 3.8.0
 	 *
 	 * @param int $threshold Threshold in seconds.
 	 */
@@ -266,7 +266,7 @@ function perflab_effective_asset_cache_headers_check_headers( $headers ): array 
 /**
  * Attempt a conditional request with ETag/Last-Modified.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @param string                                                                               $url     The asset URL.
@@ -304,7 +304,7 @@ function perflab_effective_asset_cache_headers_try_conditional_request( string $
 /**
  * Generate a table listing files that need effective caching headers, including reasons.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @param array<array{filename: string, reason: string}> $fail_details Array of arrays with 'filename' and 'reason'.

--- a/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
+++ b/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
@@ -3,7 +3,7 @@
  * Hook callbacks used for effective caching headers.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 3.8.0
  */
 
 // @codeCoverageIgnoreStart
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Adds tests to site health.
  *
- * @since n.e.x.t
+ * @since 3.8.0
  * @access private
  *
  * @param array{direct: array<string, array{label: string, test: string}>} $tests Site Health Tests.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 3.7.0
+ * Version: 3.8.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 // @codeCoverageIgnoreEnd
 
-define( 'PERFLAB_VERSION', '3.7.0' );
+define( 'PERFLAB_VERSION', '3.8.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -75,7 +75,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 **Enhancements**
 
-* Add Site Health check for `Cache-Control: no-store` page response header which disables bfcache. ([1807](https://github.com/WordPress/performance/pull/1807))
+* Add Site Health test for `Cache-Control: no-store` page response header which disables bfcache. ([1807](https://github.com/WordPress/performance/pull/1807))
 * Add Site Health test to verify that static assets are served with far-future expires. ([1727](https://github.com/WordPress/performance/pull/1727))
 * Enqueue scripts using `plugins_url()` instead of `plugin_dir_url()`. ([1761](https://github.com/WordPress/performance/pull/1761))
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -73,6 +73,12 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.8.0 =
 
+**Enhancements**
+
+* Add Site Health check for `Cache-Control: no-store` page response header which disables bfcache. ([1807](https://github.com/WordPress/performance/pull/1807))
+* Add Site Health test to verify that static assets are served with far-future expires. ([1727](https://github.com/WordPress/performance/pull/1727))
+* Enqueue scripts using `plugins_url()` instead of `plugin_dir_url()`. ([1761](https://github.com/WordPress/performance/pull/1761))
+
 = 3.7.0 =
 
 **Enhancements**

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   3.7.0
+Stable tag:   3.8.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -70,6 +70,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.8.0 =
 
 = 3.7.0 =
 

--- a/plugins/speculation-rules/hooks.php
+++ b/plugins/speculation-rules/hooks.php
@@ -37,7 +37,7 @@ function plsr_print_speculation_rules(): void {
 		 * For site owners of sites without pretty permalinks that are certain their site is not using such a pattern,
 		 * this filter can be used to still enable speculative loading at their own risk.
 		 *
-		 * @since n.e.x.t
+		 * @since 1.4.0
 		 *
 		 * @param bool $enabled Whether speculative loading is enabled even without pretty permalinks.
 		 */

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -5,7 +5,7 @@
  * Description: Enables browsers to speculatively prerender or prefetch pages to achieve near-instant loads based on user interaction.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.3.1
+ * Version: 1.4.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'plsr_pending_plugin_info',
-	'1.3.1',
+	'1.4.0',
 	static function ( string $version ): void {
 
 		// Define the constant.

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -121,6 +121,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.4.0 =
 
+**Enhancements**
+
+* Implement speculative loading considerations for safer behavior. ([1784](https://github.com/WordPress/performance/pull/1784))
+
 = 1.3.1 =
 
 **Bug Fixes**

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   1.3.1
+Stable tag:   1.4.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, javascript, speculation rules, prerender, prefetch
@@ -118,6 +118,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.4.0 =
 
 = 1.3.1 =
 

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -63,7 +63,7 @@ function plsr_get_setting_default(): array {
 /**
  * Returns the stored setting value for Speculative Loading configuration.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  *
  * @return array{ mode: 'prefetch'|'prerender', eagerness: 'conservative'|'moderate'|'eager' } {
  *     Stored setting value.

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -514,7 +514,7 @@ add_action( 'delete_attachment', 'webp_uploads_remove_sources_files', 10, 1 );
 /**
  * Filters `wp_content_img_tag` to update images so that they use the preferred MIME type where possible.
  *
- * @since n.e.x.t
+ * @since 2.5.0
  *
  * @param string $filtered_image Full img tag with attributes that will replace the source img tag.
  * @param string $context        Additional context, like the current filter name or the function name from where this was called.

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 2.4.0
+ * Version: 2.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.4.0' );
+define( 'WEBP_UPLOADS_VERSION', '2.5.0' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   2.4.0
+Stable tag:   2.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -59,6 +59,8 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.5.0 =
 
 = 2.4.0 =
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -62,6 +62,10 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.5.0 =
 
+**Enhancements**
+
+* Switch to `wp_content_img_tag` filter for improved image handling. ([1772](https://github.com/WordPress/performance/pull/1772))
+
 = 2.4.0 =
 
 **Enhancements**


### PR DESCRIPTION
Fixes #1796. 
Previously #1754.

- **Bump plugin versions**
- **Run npm run since**
- **Remove -beta1 from 1.0.0 since tags**
- **Generate changelogs**

The following plugins are included in this release:

1. `speculation-rules`: v1.4.0
1. `optimization-detective`: v1.0.0-beta1
1. `webp-uploads`: v2.5.0
1. `embed-optimizer`: v0.4.1
1. `image-prioritizer`: v0.3.1
1. `performance-lab`: v3.8.0
