### PR TITLE
Disable URL Metric storage locking by default for administrators

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -366,15 +366,12 @@ export default async function detect( {
 	}
 
 	// Abort if the client already submitted a URL Metric for this URL and viewport group.
-	// TODO: Remove the console timing.
-	console.time( 'sha1' ); // eslint-disable-line no-console
 	const alreadySubmittedSessionStorageKey =
 		await getAlreadySubmittedSessionStorageKey(
 			currentETag,
 			currentUrl,
 			urlMetricGroupStatus
 		);
-	console.timeEnd( 'sha1' ); // eslint-disable-line no-console
 	if ( alreadySubmittedSessionStorageKey in sessionStorage ) {
 		const previousVisitTime = parseInt(
 			sessionStorage.getItem( alreadySubmittedSessionStorageKey ),

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -253,6 +253,7 @@ function extendElementData( xpath, properties ) {
  * @param {number}                 args.maxViewportAspectRatio     Maximum aspect ratio allowed for the viewport.
  * @param {boolean}                args.isDebug                    Whether to show debug messages.
  * @param {string}                 args.restApiEndpoint            URL for where to send the detection data.
+ * @param {string}                 [args.restApiNonce]             Nonce for the REST API when the user is logged-in.
  * @param {string}                 args.currentETag                Current ETag.
  * @param {string}                 args.currentUrl                 Current URL.
  * @param {string}                 args.urlMetricSlug              Slug for URL Metric.
@@ -269,6 +270,7 @@ export default async function detect( {
 	isDebug,
 	extensionModuleUrls,
 	restApiEndpoint,
+	restApiNonce,
 	currentETag,
 	currentUrl,
 	urlMetricSlug,
@@ -664,6 +666,9 @@ export default async function detect( {
 	}
 
 	const url = new URL( restApiEndpoint );
+	if ( typeof restApiNonce === 'string' ) {
+		url.searchParams.set( '_wpnonce', restApiNonce );
+	}
 	url.searchParams.set( 'slug', urlMetricSlug );
 	url.searchParams.set( 'current_etag', currentETag );
 	if ( typeof cachePurgePostId === 'number' ) {

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -96,33 +96,65 @@ function error( ...message ) {
 }
 
 /**
- * Checks whether the URL Metric(s) for the provided viewport width is needed.
+ * Gets the status for the URL Metric group for the provided viewport width.
  *
  * The comparison logic here corresponds with the PHP logic in `OD_URL_Metric_Group::is_viewport_width_in_range()`.
+ * This function is also similar to the PHP logic in `\OD_URL_Metric_Group_Collection::get_group_for_viewport_width()`.
  *
  * @param {number}                 viewportWidth          - Current viewport width.
  * @param {URLMetricGroupStatus[]} urlMetricGroupStatuses - Viewport group statuses.
- * @return {boolean} Whether URL Metrics are needed.
+ * @return {URLMetricGroupStatus} The URL metric group for the viewport width.
  */
-function isViewportNeeded( viewportWidth, urlMetricGroupStatuses ) {
-	if ( viewportWidth === 0 ) {
-		return false;
-	}
-
-	for ( const {
-		minimumViewportWidth,
-		maximumViewportWidth,
-		complete,
-	} of urlMetricGroupStatuses ) {
+function getGroupForViewportWidth( viewportWidth, urlMetricGroupStatuses ) {
+	for ( const urlMetricGroupStatus of urlMetricGroupStatuses ) {
 		if (
-			viewportWidth > minimumViewportWidth &&
-			( null === maximumViewportWidth ||
-				viewportWidth <= maximumViewportWidth )
+			viewportWidth > urlMetricGroupStatus.minimumViewportWidth &&
+			( null === urlMetricGroupStatus.maximumViewportWidth ||
+				viewportWidth <= urlMetricGroupStatus.maximumViewportWidth )
 		) {
-			return complete;
+			return urlMetricGroupStatus;
 		}
 	}
-	return false;
+	throw new Error(
+		`${ consoleLogPrefix } Unexpectedly unable to locate group for the current viewport width.`
+	);
+}
+
+/**
+ * Gets the sessionStorage key for keeping track of whether the current client session already submitted a URL Metric.
+ *
+ * @param {string}               currentETag          - Current ETag.
+ * @param {string}               currentUrl           - Current URL.
+ * @param {URLMetricGroupStatus} urlMetricGroupStatus - URL Metric group status.
+ * @return {Promise<string>} Session storage key.
+ */
+async function getAlreadySubmittedSessionStorageKey(
+	currentETag,
+	currentUrl,
+	urlMetricGroupStatus
+) {
+	const message = [
+		currentETag,
+		currentUrl,
+		urlMetricGroupStatus.minimumViewportWidth,
+		urlMetricGroupStatus.maximumViewportWidth || '',
+	].join( '-' );
+
+	/*
+	 * Note that the components are hashed for a couple of reasons:
+	 *
+	 * 1. It results in a consistent length string devoid of any special characters that could cause problems.
+	 * 2. Since the key includes the URL, hashing it avoids potential privacy concerns where the sessionStorage is
+	 *    examined to see which URLs the client went to.
+	 *
+	 * The SHA-1 algorithm is chosen since it is the fastest and there is no need for cryptographic security.
+	 */
+	const msgBuffer = new TextEncoder().encode( message );
+	const hashBuffer = await crypto.subtle.digest( 'SHA-1', msgBuffer );
+	const hashHex = Array.from( new Uint8Array( hashBuffer ) )
+		.map( ( b ) => b.toString( 16 ).padStart( 2, '0' ) )
+		.join( '' );
+	return `odSubmitted-${ hashHex }`;
 }
 
 /**
@@ -272,6 +304,7 @@ function extendElementData( xpath, properties ) {
  * @param {string}                 args.urlMetricHMAC              HMAC for URL Metric storage.
  * @param {URLMetricGroupStatus[]} args.urlMetricGroupStatuses     URL Metric group statuses.
  * @param {number}                 args.storageLockTTL             The TTL (in seconds) for the URL Metric storage lock.
+ * @param {number}                 args.freshnessTTL               The freshness age (TTL) for a given URL Metric.
  * @param {string}                 args.webVitalsLibrarySrc        The URL for the web-vitals library.
  * @param {CollectionDebugData}    [args.urlMetricGroupCollection] URL Metric group collection, when in debug mode.
  */
@@ -289,6 +322,7 @@ export default async function detect( {
 	urlMetricHMAC,
 	urlMetricGroupStatuses,
 	storageLockTTL,
+	freshnessTTL,
 	webVitalsLibrarySrc,
 	urlMetricGroupCollection,
 } ) {
@@ -310,12 +344,53 @@ export default async function detect( {
 		);
 	}
 
+	if ( win.innerWidth === 0 || win.innerHeight === 0 ) {
+		if ( isDebug ) {
+			log(
+				'Window must have non-zero dimensions for URL Metric collection.'
+			);
+		}
+		return;
+	}
+
 	// Abort if the current viewport is not among those which need URL Metrics.
-	if ( ! isViewportNeeded( win.innerWidth, urlMetricGroupStatuses ) ) {
+	const urlMetricGroupStatus = getGroupForViewportWidth(
+		win.innerWidth,
+		urlMetricGroupStatuses
+	);
+	if ( urlMetricGroupStatus.complete ) {
 		if ( isDebug ) {
 			log( 'No need for URL Metrics from the current viewport.' );
 		}
 		return;
+	}
+
+	// Abort if the client already submitted a URL Metric for this URL and viewport group.
+	// TODO: Remove the console timing.
+	console.time( 'sha1' ); // eslint-disable-line no-console
+	const alreadySubmittedSessionStorageKey =
+		await getAlreadySubmittedSessionStorageKey(
+			currentETag,
+			currentUrl,
+			urlMetricGroupStatus
+		);
+	console.timeEnd( 'sha1' ); // eslint-disable-line no-console
+	if ( alreadySubmittedSessionStorageKey in sessionStorage ) {
+		const previousVisitTime = parseInt(
+			sessionStorage.getItem( alreadySubmittedSessionStorageKey ),
+			10
+		);
+		if (
+			! isNaN( previousVisitTime ) &&
+			( getCurrentTime() - previousVisitTime ) / 1000 < freshnessTTL
+		) {
+			if ( isDebug ) {
+				log(
+					'The current client session already submitted a fresh URL Metric for this URL so a new one will not be collected now.'
+				);
+				return;
+			}
+		}
 	}
 
 	// Abort if the viewport aspect ratio is not in a common range.
@@ -671,6 +746,12 @@ export default async function detect( {
 	// Even though the server may reject the REST API request, we still have to set the storage lock
 	// because we can't look at the response when sending a beacon.
 	setStorageLock( getCurrentTime() );
+
+	// Remember that the URL Metric was submitted for this URL to avoid having multiple entries submitted by the same client.
+	sessionStorage.setItem(
+		alreadySubmittedSessionStorageKey,
+		String( getCurrentTime() )
+	);
 
 	if ( isDebug ) {
 		log( 'Sending URL Metric:', urlMetric );

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -138,6 +138,7 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 			iterator_to_array( $group_collection )
 		),
 		'storageLockTTL'         => OD_Storage_Lock::get_ttl(),
+		'freshnessTTL'           => od_get_url_metric_freshness_ttl(),
 		'webVitalsLibrarySrc'    => $web_vitals_lib_src,
 	);
 	if ( is_user_logged_in() ) {

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -137,6 +137,9 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		'storageLockTTL'         => OD_Storage_Lock::get_ttl(),
 		'webVitalsLibrarySrc'    => $web_vitals_lib_src,
 	);
+	if ( is_user_logged_in() ) {
+		$detect_args['restApiNonce'] = wp_create_nonce( 'wp_rest' );
+	}
 	if ( WP_DEBUG ) {
 		$detect_args['urlMetricGroupCollection'] = $group_collection;
 	}

--- a/plugins/optimization-detective/docs/hooks.md
+++ b/plugins/optimization-detective/docs/hooks.md
@@ -102,7 +102,7 @@ add_filter( 'od_url_metrics_breakpoint_sample_size', function (): int {
 } );
 ```
 
-### Filter: `od_url_metric_storage_lock_ttl` (default: 60 seconds, except 0 for admins)
+### Filter: `od_url_metric_storage_lock_ttl` (default: 60 seconds, except 0 for authorized logged-in users)
 
 Filters how long the current IP is locked from submitting another URL metric storage REST API request.
 
@@ -114,7 +114,7 @@ add_filter( 'od_metrics_storage_lock_ttl', function ( int $ttl ): int {
 } );
 ```
 
-By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else. Whether the current user is an administrator is determined by whether the user has the `od_store_url_metric_now` capability. This meta capability by default maps to the `manage_options` capability via the `map_meta_cap` filter.
+By default, the TTL is zero (0) for authorized users and sixty (60) for everyone else. Whether the current user is authorized is determined by whether the user has the `od_store_url_metric_now` capability. This meta capability by default maps to the `manage_options` primitive capability via the `map_meta_cap` filter.
 
 During development this is useful to set to zero so you can quickly collect new URL Metrics by reloading the page without having to wait for the storage lock to release:
 

--- a/plugins/optimization-detective/docs/hooks.md
+++ b/plugins/optimization-detective/docs/hooks.md
@@ -114,7 +114,7 @@ add_filter( 'od_metrics_storage_lock_ttl', function ( int $ttl ): int {
 } );
 ```
 
-By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else.
+By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else. Whether the current user is an administrator is determined by whether the user has the `od_store_url_metric_now` capability. This meta capability by default maps to the `manage_options` capability via the `map_meta_cap` filter.
 
 During development this is useful to set to zero so you can quickly collect new URL Metrics by reloading the page without having to wait for the storage lock to release:
 

--- a/plugins/optimization-detective/docs/hooks.md
+++ b/plugins/optimization-detective/docs/hooks.md
@@ -114,7 +114,7 @@ add_filter( 'od_metrics_storage_lock_ttl', function ( int $ttl ): int {
 } );
 ```
 
-By default, the TTL is zero (0) for authorized users and sixty (60) for everyone else. Whether the current user is authorized is determined by whether the user has the `od_store_url_metric_now` capability. This meta capability by default maps to the `manage_options` primitive capability via the `map_meta_cap` filter.
+By default, the TTL is zero (0) for authorized users and sixty (60) for everyone else. Whether the current user is authorized is determined by whether the user has the `od_store_url_metric_now` capability. This custom capability by default maps to the `manage_options` primitive capability via the `user_has_cap` filter.
 
 During development this is useful to set to zero so you can quickly collect new URL Metrics by reloading the page without having to wait for the storage lock to release:
 

--- a/plugins/optimization-detective/docs/hooks.md
+++ b/plugins/optimization-detective/docs/hooks.md
@@ -102,15 +102,19 @@ add_filter( 'od_url_metrics_breakpoint_sample_size', function (): int {
 } );
 ```
 
-### Filter: `od_url_metric_storage_lock_ttl` (default: 1 minute in seconds)
+### Filter: `od_url_metric_storage_lock_ttl` (default: 60 seconds, except 0 for admins)
 
-Filters how long a given IP is locked from submitting another metric-storage REST API request. Filtering the TTL to zero will disable any metric storage locking. This is useful, for example, to disable locking when a user is logged-in with code like the following:
+Filters how long the current IP is locked from submitting another URL metric storage REST API request.
+
+Filtering the TTL to zero will disable any URL Metric storage locking. This is useful, for example, to disable locking when a user is logged-in with code like the following:
 
 ```php
 add_filter( 'od_metrics_storage_lock_ttl', function ( int $ttl ): int {
 	return is_user_logged_in() ? 0 : $ttl;
 } );
 ```
+
+By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else.
 
 During development this is useful to set to zero so you can quickly collect new URL Metrics by reloading the page without having to wait for the storage lock to release:
 

--- a/plugins/optimization-detective/hooks.php
+++ b/plugins/optimization-detective/hooks.php
@@ -18,6 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 add_action( 'init', 'od_initialize_extensions', PHP_INT_MAX );
 add_filter( 'template_include', 'od_buffer_output', PHP_INT_MAX );
 OD_URL_Metrics_Post_Type::add_hooks();
+OD_Storage_Lock::add_hooks();
 add_action( 'wp', 'od_maybe_add_template_output_buffer_filter' );
 add_action( 'wp_head', 'od_render_generator_meta_tag' );
 add_filter( 'site_status_tests', 'od_add_rest_api_availability_test' );

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -21,6 +21,49 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class OD_Storage_Lock {
 
 	/**
+	 * Capability for being able to store a URL Metric now.
+	 *
+	 * @since n.e.x.t
+	 * @access private
+	 * @var string
+	 */
+	const STORE_URL_METRIC_NOW_CAPABILITY = 'od_store_url_metric_now';
+
+	/**
+	 * Adds hooks.
+	 *
+	 * @since n.e.x.t
+	 * @access private
+	 */
+	public static function add_hooks(): void {
+		add_filter( 'map_meta_cap', array( __CLASS__, 'filter_map_meta_cap' ), 10, 3 );
+	}
+
+	/**
+	 * Filters map_meta_cap to grant the `od_store_url_metric_now` capability to administrators by default.
+	 *
+	 * @since n.e.x.t
+	 * @access private
+	 *
+	 * @param string[]|mixed $caps    Capabilities.
+	 * @param string         $cap     Capability.
+	 * @param int            $user_id User ID.
+	 * @return string[] Granted capabilities.
+	 */
+	public static function filter_map_meta_cap( $caps, string $cap, int $user_id ): array {
+		if ( ! is_array( $caps ) ) {
+			$caps = array();
+		}
+
+		$primitive_cap = 'manage_options';
+		if ( 'od_store_url_metric_now' === $cap && user_can( $user_id, $primitive_cap ) ) {
+			$caps = array( $primitive_cap );
+		}
+
+		return $caps;
+	}
+
+	/**
 	 * Gets the TTL (in seconds) for the URL Metric storage lock.
 	 *
 	 * @since 0.1.0
@@ -29,7 +72,7 @@ final class OD_Storage_Lock {
 	 * @return int<0, max> TTL in seconds, greater than or equal to zero. A value of zero means that the storage lock should be disabled and thus that transients must not be used.
 	 */
 	public static function get_ttl(): int {
-		$ttl = current_user_can( 'manage_options' ) ? 0 : MINUTE_IN_SECONDS;
+		$ttl = current_user_can( self::STORE_URL_METRIC_NOW_CAPABILITY ) ? 0 : MINUTE_IN_SECONDS;
 
 		/**
 		 * Filters how long the current IP is locked from submitting another URL metric storage REST API request.
@@ -41,7 +84,9 @@ final class OD_Storage_Lock {
 		 *         return is_user_logged_in() ? 0 : $ttl;
 		 *     } );
 		 *
-		 * By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else.
+		 * By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else. Whether the current
+		 * user is an administrator is determined by whether the user has the `od_store_url_metric_now` capability. This
+		 * meta capability by default maps to the `manage_options` capability via the `map_meta_cap` filter.
 		 *
 		 * @since 0.1.0
 		 * @since 1.0.0 This now defaults to zero (0) for administrator users.

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -26,25 +26,29 @@ final class OD_Storage_Lock {
 	 * @since 0.1.0
 	 * @access private
 	 *
-	 * @return int TTL in seconds, greater than or equal to zero. A value of zero means that the storage lock should be disabled and thus that transients must not be used.
+	 * @return int<0, max> TTL in seconds, greater than or equal to zero. A value of zero means that the storage lock should be disabled and thus that transients must not be used.
 	 */
 	public static function get_ttl(): int {
+		$ttl = current_user_can( 'manage_options' ) ? 0 : MINUTE_IN_SECONDS;
 
 		/**
-		 * Filters how long a given IP is locked from submitting another metric-storage REST API request.
+		 * Filters how long the current IP is locked from submitting another URL metric storage REST API request.
 		 *
-		 * Filtering the TTL to zero will disable any metric storage locking. This is useful, for example, to disable
+		 * Filtering the TTL to zero will disable any URL Metric storage locking. This is useful, for example, to disable
 		 * locking when a user is logged-in with code like the following:
 		 *
 		 *     add_filter( 'od_metrics_storage_lock_ttl', static function ( int $ttl ): int {
 		 *         return is_user_logged_in() ? 0 : $ttl;
 		 *     } );
 		 *
-		 * @since 0.1.0
+		 * By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else.
 		 *
-		 * @param int $ttl TTL.
+		 * @since 0.1.0
+		 * @since 1.0.0 This now defaults to zero (0) for administrator users.
+		 *
+		 * @param int $ttl TTL. Defaults to 0 for administrators, and 60 for everyone else.
 		 */
-		$ttl = (int) apply_filters( 'od_url_metric_storage_lock_ttl', MINUTE_IN_SECONDS );
+		$ttl = (int) apply_filters( 'od_url_metric_storage_lock_ttl', $ttl );
 		return max( 0, $ttl );
 	}
 

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -56,7 +56,10 @@ final class OD_Storage_Lock {
 
 		$primitive_cap = 'manage_options';
 		if ( self::STORE_URL_METRIC_NOW_CAPABILITY === $cap ) {
-			$caps = array( $primitive_cap );
+			$i = array_search( self::STORE_URL_METRIC_NOW_CAPABILITY, $caps, true );
+			if ( false !== $i ) {
+				$caps[ $i ] = $primitive_cap;
+			}
 		}
 		return $caps;
 	}

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -36,30 +36,28 @@ final class OD_Storage_Lock {
 	 * @access private
 	 */
 	public static function add_hooks(): void {
-		add_filter( 'map_meta_cap', array( __CLASS__, 'filter_map_meta_cap' ), 10, 3 );
+		add_filter( 'map_meta_cap', array( __CLASS__, 'filter_map_meta_cap' ), 10, 2 );
 	}
 
 	/**
-	 * Filters map_meta_cap to grant the `od_store_url_metric_now` capability to administrators by default.
+	 * Filters map_meta_cap to grant the `od_store_url_metric_now` capability to `manage_options` by default.
 	 *
 	 * @since n.e.x.t
 	 * @access private
 	 *
-	 * @param string[]|mixed $caps    Primitive capabilities required of the user.
-	 * @param string         $cap     Capability being checked.
-	 * @param int            $user_id The user ID.
+	 * @param string[]|mixed $caps Primitive capabilities required of the user.
+	 * @param string         $cap  Capability being checked.
 	 * @return string[] Primitive capabilities required of the user.
 	 */
-	public static function filter_map_meta_cap( $caps, string $cap, int $user_id ): array {
+	public static function filter_map_meta_cap( $caps, string $cap ): array {
 		if ( ! is_array( $caps ) ) {
 			$caps = array();
 		}
 
 		$primitive_cap = 'manage_options';
-		if ( self::STORE_URL_METRIC_NOW_CAPABILITY === $cap && user_can( $user_id, $primitive_cap ) ) {
+		if ( self::STORE_URL_METRIC_NOW_CAPABILITY === $cap ) {
 			$caps = array( $primitive_cap );
 		}
-
 		return $caps;
 	}
 

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -81,12 +81,12 @@ final class OD_Storage_Lock {
 		 *
 		 * By default, the TTL is zero (0) for authorized users and sixty (60) for everyone else. Whether the current
 		 * user is authorized is determined by whether the user has the `od_store_url_metric_now` capability. This
-		 * meta capability by default maps to the `manage_options` primitive capability via the `map_meta_cap` filter.
+		 * custom capability by default maps to the `manage_options` primitive capability via the `user_has_cap` filter.
 		 *
 		 * @since 0.1.0
-		 * @since 1.0.0 This now defaults to zero (0) for administrator users.
+		 * @since 1.0.0 This now defaults to zero (0) for authorized users.
 		 *
-		 * @param int $ttl TTL. Defaults to 0 for administrators, and 60 for everyone else.
+		 * @param int $ttl TTL. Defaults to 60, except zero (0) for authorized users.
 		 */
 		$ttl = (int) apply_filters( 'od_url_metric_storage_lock_ttl', $ttl );
 		return max( 0, $ttl );

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -36,29 +36,26 @@ final class OD_Storage_Lock {
 	 * @access private
 	 */
 	public static function add_hooks(): void {
-		add_filter( 'map_meta_cap', array( __CLASS__, 'filter_map_meta_cap' ), 10, 2 );
+		add_filter( 'user_has_cap', array( __CLASS__, 'filter_user_has_cap' ) );
 	}
 
 	/**
-	 * Filters map_meta_cap to grant the `od_store_url_metric_now` capability to `manage_options` by default.
+	 * Filters `user_has_cap` to grant the `od_store_url_metric_now` capability to users who can `manage_options` by default.
 	 *
 	 * @since n.e.x.t
 	 * @access private
 	 *
-	 * @param string[]|mixed $caps Primitive capabilities required of the user.
-	 * @param string         $cap  Capability being checked.
-	 * @return string[] Primitive capabilities required of the user.
+	 * @param array<string, bool>|mixed $allcaps Capability names mapped to boolean values for whether the user has that capability.
+	 * @return array<string, bool> Capability names mapped to boolean values for whether the user has that capability.
 	 */
-	public static function filter_map_meta_cap( $caps, string $cap ): array {
-		if ( ! is_array( $caps ) ) {
-			$caps = array();
+	public static function filter_user_has_cap( $allcaps ): array {
+		if ( ! is_array( $allcaps ) ) {
+			$allcaps = array();
 		}
-
-		$primitive_cap = 'manage_options';
-		if ( self::STORE_URL_METRIC_NOW_CAPABILITY === $cap ) {
-			$caps = array( $primitive_cap );
+		if ( isset( $allcaps['manage_options'] ) ) {
+			$allcaps['od_store_url_metric_now'] = $allcaps['manage_options'];
 		}
-		return $caps;
+		return $allcaps;
 	}
 
 	/**

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -45,10 +45,10 @@ final class OD_Storage_Lock {
 	 * @since n.e.x.t
 	 * @access private
 	 *
-	 * @param string[]|mixed $caps    Capabilities.
-	 * @param string         $cap     Capability.
-	 * @param int            $user_id User ID.
-	 * @return string[] Granted capabilities.
+	 * @param string[]|mixed $caps    Primitive capabilities required of the user.
+	 * @param string         $cap     Capability being checked.
+	 * @param int            $user_id The user ID.
+	 * @return string[] Primitive capabilities required of the user.
 	 */
 	public static function filter_map_meta_cap( $caps, string $cap, int $user_id ): array {
 		if ( ! is_array( $caps ) ) {
@@ -56,7 +56,7 @@ final class OD_Storage_Lock {
 		}
 
 		$primitive_cap = 'manage_options';
-		if ( 'od_store_url_metric_now' === $cap && user_can( $user_id, $primitive_cap ) ) {
+		if ( self::STORE_URL_METRIC_NOW_CAPABILITY === $cap && user_can( $user_id, $primitive_cap ) ) {
 			$caps = array( $primitive_cap );
 		}
 

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -56,10 +56,7 @@ final class OD_Storage_Lock {
 
 		$primitive_cap = 'manage_options';
 		if ( self::STORE_URL_METRIC_NOW_CAPABILITY === $cap ) {
-			$i = array_search( self::STORE_URL_METRIC_NOW_CAPABILITY, $caps, true );
-			if ( false !== $i ) {
-				$caps[ $i ] = $primitive_cap;
-			}
+			$caps = array( $primitive_cap );
 		}
 		return $caps;
 	}

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -84,9 +84,9 @@ final class OD_Storage_Lock {
 		 *         return is_user_logged_in() ? 0 : $ttl;
 		 *     } );
 		 *
-		 * By default, the TTL is zero (0) for administrator users and sixty (60) for everyone else. Whether the current
-		 * user is an administrator is determined by whether the user has the `od_store_url_metric_now` capability. This
-		 * meta capability by default maps to the `manage_options` capability via the `map_meta_cap` filter.
+		 * By default, the TTL is zero (0) for authorized users and sixty (60) for everyone else. Whether the current
+		 * user is authorized is determined by whether the user has the `od_store_url_metric_now` capability. This
+		 * meta capability by default maps to the `manage_options` primitive capability via the `map_meta_cap` filter.
 		 *
 		 * @since 0.1.0
 		 * @since 1.0.0 This now defaults to zero (0) for administrator users.

--- a/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
@@ -28,6 +28,12 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 				'set_up'   => static function (): void {},
 				'expected' => MINUTE_IN_SECONDS,
 			),
+			'unfiltered_admin'  => array(
+				'set_up'   => static function (): void {
+					wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+				},
+				'expected' => 0,
+			),
 			'filtered_hour'     => array(
 				'set_up'   => static function (): void {
 					add_filter(

--- a/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
@@ -23,13 +23,13 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	 * @covers ::add_hooks
 	 */
 	public function test_add_hooks(): void {
-		remove_all_filters( 'map_meta_cap' );
+		remove_all_filters( 'user_has_cap' );
 
 		OD_Storage_Lock::add_hooks();
 
 		$this->assertSame(
 			10,
-			has_filter( 'map_meta_cap', array( OD_Storage_Lock::class, 'filter_map_meta_cap' ) )
+			has_filter( 'user_has_cap', array( OD_Storage_Lock::class, 'filter_user_has_cap' ) )
 		);
 	}
 
@@ -39,44 +39,52 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	 *
 	 * @return array<string, mixed>
 	 */
-	public function data_filter_map_meta_cap(): array {
+	public function data_filter_user_has_cap(): array {
 		return array(
-			'caps_null_irrelevant' => array(
-				'caps'     => null,
-				'cap'      => 'edit_posts',
+			'caps_null_irrelevant'     => array(
+				'allcaps'  => null,
 				'expected' => array(),
 			),
-			'caps_irrelevant'      => array(
-				'caps'     => array( 'edit_posts' ),
-				'cap'      => 'edit_posts',
-				'expected' => array( 'edit_posts' ),
+			'caps_irrelevant'          => array(
+				'allcaps'  => array( 'edit_posts' => true ),
+				'expected' => array( 'edit_posts' => true ),
 			),
-			'caps_null_relevant'   => array(
-				'caps'     => null,
-				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'expected' => array( 'manage_options' ),
+			'caps_relevant_allowed'    => array(
+				'allcaps'  => array(
+					'edit_posts'     => true,
+					'manage_options' => true,
+				),
+				'expected' => array(
+					'edit_posts'     => true,
+					'manage_options' => true,
+					OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY => true,
+				),
 			),
-			'caps_normal_relevant' => array(
-				'caps'     => array( OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY ),
-				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'expected' => array( 'manage_options' ),
+			'caps_relevant_disallowed' => array(
+				'allcaps'  => array(
+					'edit_posts'     => true,
+					'manage_options' => false,
+				),
+				'expected' => array(
+					'edit_posts'     => true,
+					'manage_options' => false,
+					OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY => false,
+				),
 			),
 		);
 	}
 
 	/**
-	 * Test filter_map_meta_cap().
+	 * Test filter_user_has_cap().
 	 *
-	 * @dataProvider data_filter_map_meta_cap
-	 * @covers ::filter_map_meta_cap
+	 * @dataProvider data_filter_user_has_cap
+	 * @covers ::filter_user_has_cap
 	 *
-	 * @param string[]|mixed $caps      Primitive capabilities required of the user.
-	 * @param string         $cap       Capability being checked.
-	 * @param string[]       $expected  Expected primitive capabilities required of the user.
+	 * @param array<string, bool>|null $allcaps  Existing capabilities.
+	 * @param array<string, bool>      $expected Expected capabilities.
 	 */
-	public function test_filter_map_meta_cap( $caps, string $cap, array $expected ): void {
-		$return = OD_Storage_Lock::filter_map_meta_cap( $caps, $cap );
-		$this->assertSame( $expected, $return );
+	public function test_filter_user_has_cap( ?array $allcaps, array $expected ): void {
+		$this->assertSame( $expected, OD_Storage_Lock::filter_user_has_cap( $allcaps ) );
 	}
 
 	/**
@@ -142,7 +150,7 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	 * Test get_ttl().
 	 *
 	 * @covers ::get_ttl
-	 * @covers ::filter_map_meta_cap
+	 * @covers ::filter_user_has_cap
 	 *
 	 * @dataProvider data_provider_get_ttl
 	 *

--- a/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
@@ -41,35 +41,25 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	 */
 	public function data_filter_map_meta_cap(): array {
 		return array(
-			'bad_caps_relevant'   => array(
-				'caps'      => null,
-				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'user_role' => 'administrator',
-				'expected'  => array( 'manage_options' ),
+			'caps_null_irrelevant' => array(
+				'caps'     => null,
+				'cap'      => 'edit_posts',
+				'expected' => array(),
 			),
-			'bad_caps_irrelevant' => array(
-				'caps'      => null,
-				'cap'       => 'edit_posts',
-				'user_role' => 'administrator',
-				'expected'  => array(),
+			'caps_irrelevant'      => array(
+				'caps'     => array( 'edit_posts' ),
+				'cap'      => 'edit_posts',
+				'expected' => array( 'edit_posts' ),
 			),
-			'caps_authorized'     => array(
-				'caps'      => array(),
-				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'user_role' => 'administrator',
-				'expected'  => array( 'manage_options' ),
+			'caps_null_relevant'   => array(
+				'caps'     => null,
+				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
+				'expected' => array( 'manage_options' ),
 			),
-			'caps_unauthorized'   => array(
-				'caps'      => array(),
-				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'user_role' => 'subscriber',
-				'expected'  => array(),
-			),
-			'caps_anonymous'      => array(
-				'caps'      => array(),
-				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'user_role' => null,
-				'expected'  => array(),
+			'caps_normal_relevant' => array(
+				'caps'     => array( OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY ),
+				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
+				'expected' => array( 'manage_options' ),
 			),
 		);
 	}
@@ -82,14 +72,10 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	 *
 	 * @param string[]|mixed $caps      Primitive capabilities required of the user.
 	 * @param string         $cap       Capability being checked.
-	 * @param string|null    $user_role Current user role.
 	 * @param string[]       $expected  Expected primitive capabilities required of the user.
 	 */
-	public function test_filter_map_meta_cap( $caps, string $cap, ?string $user_role, array $expected ): void {
-		if ( null !== $user_role ) {
-			wp_set_current_user( self::factory()->user->create( array( 'role' => $user_role ) ) );
-		}
-		$return = OD_Storage_Lock::filter_map_meta_cap( $caps, $cap, wp_get_current_user()->ID );
+	public function test_filter_map_meta_cap( $caps, string $cap, array $expected ): void {
+		$return = OD_Storage_Lock::filter_map_meta_cap( $caps, $cap );
 		$this->assertSame( $expected, $return );
 	}
 

--- a/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
@@ -54,12 +54,17 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 			'caps_null_relevant'   => array(
 				'caps'     => null,
 				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'expected' => array( 'manage_options' ),
+				'expected' => array(),
 			),
 			'caps_normal_relevant' => array(
 				'caps'     => array( OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY ),
 				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
 				'expected' => array( 'manage_options' ),
+			),
+			'caps_extra_relevant'  => array(
+				'caps'     => array( 'edit_posts', OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY ),
+				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
+				'expected' => array( 'edit_posts', 'manage_options' ),
 			),
 		);
 	}

--- a/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
@@ -54,17 +54,12 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 			'caps_null_relevant'   => array(
 				'caps'     => null,
 				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'expected' => array(),
+				'expected' => array( 'manage_options' ),
 			),
 			'caps_normal_relevant' => array(
 				'caps'     => array( OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY ),
 				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
 				'expected' => array( 'manage_options' ),
-			),
-			'caps_extra_relevant'  => array(
-				'caps'     => array( 'edit_posts', OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY ),
-				'cap'      => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
-				'expected' => array( 'edit_posts', 'manage_options' ),
 			),
 		);
 	}

--- a/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
@@ -18,6 +18,22 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test add_hooks().
+	 *
+	 * @covers ::add_hooks
+	 */
+	public function test_add_hooks(): void {
+		remove_all_filters( 'map_meta_cap' );
+
+		OD_Storage_Lock::add_hooks();
+
+		$this->assertSame(
+			10,
+			has_filter( 'map_meta_cap', array( OD_Storage_Lock::class, 'filter_map_meta_cap' ) )
+		);
+	}
+
+	/**
 	 * Data provider.
 	 *
 	 * @return array<string, array{set_up: Closure, expected: int}>

--- a/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-storage-lock.php
@@ -33,6 +33,66 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 		);
 	}
 
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function data_filter_map_meta_cap(): array {
+		return array(
+			'bad_caps_relevant'   => array(
+				'caps'      => null,
+				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
+				'user_role' => 'administrator',
+				'expected'  => array( 'manage_options' ),
+			),
+			'bad_caps_irrelevant' => array(
+				'caps'      => null,
+				'cap'       => 'edit_posts',
+				'user_role' => 'administrator',
+				'expected'  => array(),
+			),
+			'caps_authorized'     => array(
+				'caps'      => array(),
+				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
+				'user_role' => 'administrator',
+				'expected'  => array( 'manage_options' ),
+			),
+			'caps_unauthorized'   => array(
+				'caps'      => array(),
+				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
+				'user_role' => 'subscriber',
+				'expected'  => array(),
+			),
+			'caps_anonymous'      => array(
+				'caps'      => array(),
+				'cap'       => OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY,
+				'user_role' => null,
+				'expected'  => array(),
+			),
+		);
+	}
+
+	/**
+	 * Test filter_map_meta_cap().
+	 *
+	 * @dataProvider data_filter_map_meta_cap
+	 * @covers ::filter_map_meta_cap
+	 *
+	 * @param string[]|mixed $caps      Primitive capabilities required of the user.
+	 * @param string         $cap       Capability being checked.
+	 * @param string|null    $user_role Current user role.
+	 * @param string[]       $expected  Expected primitive capabilities required of the user.
+	 */
+	public function test_filter_map_meta_cap( $caps, string $cap, ?string $user_role, array $expected ): void {
+		if ( null !== $user_role ) {
+			wp_set_current_user( self::factory()->user->create( array( 'role' => $user_role ) ) );
+		}
+		$return = OD_Storage_Lock::filter_map_meta_cap( $caps, $cap, wp_get_current_user()->ID );
+		$this->assertSame( $expected, $return );
+	}
+
 	/**
 	 * Data provider.
 	 *
@@ -40,17 +100,17 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	 */
 	public function data_provider_get_ttl(): array {
 		return array(
-			'unfiltered'        => array(
+			'unfiltered'         => array(
 				'set_up'   => static function (): void {},
 				'expected' => MINUTE_IN_SECONDS,
 			),
-			'unfiltered_admin'  => array(
+			'unfiltered_admin'   => array(
 				'set_up'   => static function (): void {
 					wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
 				},
 				'expected' => 0,
 			),
-			'filtered_hour'     => array(
+			'filtered_hour'      => array(
 				'set_up'   => static function (): void {
 					add_filter(
 						'od_url_metric_storage_lock_ttl',
@@ -61,13 +121,30 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 				},
 				'expected' => HOUR_IN_SECONDS,
 			),
-			'filtered_negative' => array(
+			'filtered_negative'  => array(
 				'set_up'   => static function (): void {
 					add_filter(
 						'od_url_metric_storage_lock_ttl',
 						static function (): int {
 							return -100;
 						}
+					);
+				},
+				'expected' => 0,
+			),
+			'granted_subscriber' => array(
+				'set_up'   => static function (): void {
+					add_filter(
+						'map_meta_cap',
+						static function ( array $caps, string $cap, int $user_id ): array {
+							$primitive_cap = 'exist';
+							if ( OD_Storage_Lock::STORE_URL_METRIC_NOW_CAPABILITY === $cap && user_can( $user_id, $primitive_cap ) ) {
+								$caps = array( $primitive_cap );
+							}
+							return $caps;
+						},
+						10,
+						3
 					);
 				},
 				'expected' => 0,
@@ -79,6 +156,7 @@ class Test_OD_Storage_Lock extends WP_UnitTestCase {
 	 * Test get_ttl().
 	 *
 	 * @covers ::get_ttl
+	 * @covers ::filter_map_meta_cap
 	 *
 	 * @dataProvider data_provider_get_ttl
 	 *

--- a/plugins/optimization-detective/tests/test-detection.php
+++ b/plugins/optimization-detective/tests/test-detection.php
@@ -210,5 +210,10 @@ class Test_OD_Detection extends WP_UnitTestCase {
 		$this->assertStringContainsString( '"minimumViewportWidth":601', $script );
 		$this->assertStringContainsString( '"minimumViewportWidth":783', $script );
 		$this->assertStringContainsString( '"complete":false', $script );
+		if ( is_user_logged_in() ) {
+			$this->assertStringContainsString( '"restApiNonce":', $script );
+		} else {
+			$this->assertStringNotContainsString( '"restApiNonce":', $script );
+		}
 	}
 }

--- a/plugins/optimization-detective/tests/test-detection.php
+++ b/plugins/optimization-detective/tests/test-detection.php
@@ -90,6 +90,7 @@ class Test_OD_Detection extends WP_UnitTestCase {
 					'storageLockTTL'      => MINUTE_IN_SECONDS,
 					'extensionModuleUrls' => array(),
 					'cachePurgePostId'    => null,
+					'freshnessTTL'        => DAY_IN_SECONDS,
 				),
 				'expected_standard_build' => true,
 			),
@@ -138,9 +139,16 @@ class Test_OD_Detection extends WP_UnitTestCase {
 							return DAY_IN_SECONDS;
 						}
 					);
+					add_filter(
+						'od_url_metric_freshness_ttl',
+						static function () {
+							return WEEK_IN_SECONDS;
+						}
+					);
 				},
 				'expected_exports'        => array(
 					'storageLockTTL'         => DAY_IN_SECONDS,
+					'freshnessTTL'           => WEEK_IN_SECONDS,
 					'extensionModuleUrls'    => array( home_url( '/my-extension.js', 'https' ) ),
 					'minViewportAspectRatio' => 0,
 					'maxViewportAspectRatio' => 2,
@@ -184,6 +192,7 @@ class Test_OD_Detection extends WP_UnitTestCase {
 				'currentUrl'             => od_get_current_url(),
 				'urlMetricSlug'          => $slug,
 				'cachePurgePostId'       => od_get_cache_purge_post_id(),
+				'freshnessTTL'           => od_get_url_metric_freshness_ttl(),
 			),
 			$expected_exports
 		);

--- a/plugins/optimization-detective/tests/test-detection.php
+++ b/plugins/optimization-detective/tests/test-detection.php
@@ -84,15 +84,27 @@ class Test_OD_Detection extends WP_UnitTestCase {
 	 */
 	public function data_provider_od_get_detection_script(): array {
 		return array(
-			'unfiltered' => array(
+			'unfiltered'       => array(
 				'set_up'                  => static function (): void {},
 				'expected_exports'        => array(
 					'storageLockTTL'      => MINUTE_IN_SECONDS,
 					'extensionModuleUrls' => array(),
+					'cachePurgePostId'    => null,
 				),
 				'expected_standard_build' => true,
 			),
-			'filtered'   => array(
+			'unfiltered_admin' => array(
+				'set_up'                  => static function (): void {
+					wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+				},
+				'expected_exports'        => array(
+					'storageLockTTL'      => 0,
+					'extensionModuleUrls' => array(),
+					'cachePurgePostId'    => null,
+				),
+				'expected_standard_build' => true,
+			),
+			'filtered'         => array(
 				'set_up'                  => static function (): void {
 					add_filter(
 						'od_url_metric_storage_lock_ttl',
@@ -107,11 +119,31 @@ class Test_OD_Detection extends WP_UnitTestCase {
 							return $urls;
 						}
 					);
+					add_filter(
+						'od_minimum_viewport_aspect_ratio',
+						static function () {
+							return 0;
+						}
+					);
+					add_filter(
+						'od_maximum_viewport_aspect_ratio',
+						static function () {
+							return 2;
+						}
+					);
 					add_filter( 'od_use_web_vitals_attribution_build', '__return_true' );
+					add_filter(
+						'od_url_metric_storage_lock_ttl',
+						static function () {
+							return DAY_IN_SECONDS;
+						}
+					);
 				},
 				'expected_exports'        => array(
-					'storageLockTTL'      => HOUR_IN_SECONDS,
-					'extensionModuleUrls' => array( home_url( '/my-extension.js', 'https' ) ),
+					'storageLockTTL'         => DAY_IN_SECONDS,
+					'extensionModuleUrls'    => array( home_url( '/my-extension.js', 'https' ) ),
+					'minViewportAspectRatio' => 0,
+					'maxViewportAspectRatio' => 2,
 				),
 				'expected_standard_build' => false,
 			),
@@ -123,6 +155,15 @@ class Test_OD_Detection extends WP_UnitTestCase {
 	 *
 	 * @covers ::od_get_detection_script
 	 * @covers ::od_get_asset_path
+	 * @covers OD_Storage_Lock::get_ttl
+	 * @covers ::od_get_cache_purge_post_id
+	 * @covers ::od_get_minimum_viewport_aspect_ratio
+	 * @covers ::od_get_maximum_viewport_aspect_ratio
+	 * @covers ::od_get_current_url
+	 * @covers ::od_get_url_metrics_storage_hmac
+	 * @covers OD_URL_Metric_Group::get_minimum_viewport_width
+	 * @covers OD_URL_Metric_Group::is_complete
+	 * @covers OD_URL_Metric_Group_Collection::get_current_etag
 	 *
 	 * @dataProvider data_provider_od_get_detection_script
 	 *
@@ -132,8 +173,20 @@ class Test_OD_Detection extends WP_UnitTestCase {
 	 */
 	public function test_od_get_detection_script_returns_script( Closure $set_up, array $expected_exports, bool $expected_standard_build ): void {
 		$set_up();
-		$slug         = od_get_url_metrics_slug( array( 'p' => '1' ) );
+		$slug         = od_get_url_metrics_slug( array() );
 		$current_etag = md5( '' );
+
+		$expected_exports = array_merge(
+			array(
+				'minViewportAspectRatio' => od_get_minimum_viewport_aspect_ratio(),
+				'maxViewportAspectRatio' => od_get_maximum_viewport_aspect_ratio(),
+				'isDebug'                => WP_DEBUG,
+				'currentUrl'             => od_get_current_url(),
+				'urlMetricSlug'          => $slug,
+				'cachePurgePostId'       => od_get_cache_purge_post_id(),
+			),
+			$expected_exports
+		);
 
 		$breakpoints      = array( 480, 600, 782 );
 		$group_collection = new OD_URL_Metric_Group_Collection( array(), $current_etag, $breakpoints, 3, HOUR_IN_SECONDS );
@@ -145,6 +198,7 @@ class Test_OD_Detection extends WP_UnitTestCase {
 		foreach ( $expected_exports as $key => $value ) {
 			$this->assertStringContainsString( sprintf( '%s:%s', wp_json_encode( $key ), wp_json_encode( $value ) ), $script );
 		}
+		$this->assertStringContainsString( '"urlMetricHMAC":', $script );
 		$this->assertSame( 1, preg_match( '/"webVitalsLibrarySrc":("[^"]+?")/', $script, $matches ) );
 		$web_vitals_library_src = json_decode( $matches[1] );
 		$this->assertStringContainsString(


### PR DESCRIPTION
<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1829

This changes the default value passed into the `od_url_metric_storage_lock_ttl` from `60` to `0` when the current user is an administrator. Additionally, a new `od_store_url_metric_now` meta capability is introduced which maps to `manage_options` by default. This gives sites the ability to customize which users have access to that capability.

In practice this will eliminate the need for the following code in the [Optimization Detective Dev Mode plugin](https://github.com/westonruter/od-dev-mode) as long as the developer is testing while being logged-in as an administrator:

```php
// During development, this can be useful to set to zero so that you don't have to wait for new URL Metrics to be requested when engineering a new optimization.
add_filter(
	'od_url_metric_freshness_ttl',
	static function () {
		return 0;
	}
);
```