### PR TITLE
Change minimum viewport width to be exclusive whereas the maximum width remains inclusive

### DIFF
--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -149,7 +149,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Open stack tags.
 	 *
 	 * @since 0.4.0
-	 * @var string[]
+	 * @var non-empty-string[]
 	 */
 	private $open_stack_tags = array();
 
@@ -160,7 +160,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * are children of the `BODY` tag. This is used in {@see self::get_xpath()}.
 	 *
 	 * @since 1.0.0
-	 * @var array<array<string, string>>
+	 * @var array<array<non-empty-string, string>>
 	 */
 	private $open_stack_attributes = array();
 
@@ -168,7 +168,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Open stack indices.
 	 *
 	 * @since 0.4.0
-	 * @var int[]
+	 * @var non-negative-int[]
 	 */
 	private $open_stack_indices = array();
 
@@ -181,7 +181,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * populated back into `$this->open_stack_tags` and `$this->open_stack_indices`.
 	 *
 	 * @since 0.4.0
-	 * @var array<string, array{tags: string[], attributes: array<array<string, string>>, indices: int[]}>
+	 * @var array<string, array{tags: non-empty-string[], attributes: array<array<non-empty-string, string>>, indices: non-negative-int[]}>
 	 */
 	private $bookmarked_open_stacks = array();
 
@@ -221,7 +221,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Mapping of bookmark name to a list of HTML strings which will be inserted at the time get_updated_html() is called.
 	 *
 	 * @since 0.4.0
-	 * @var array<string, string[]>
+	 * @var array<non-empty-string, string[]>
 	 */
 	private $buffered_text_replacements = array();
 
@@ -238,7 +238,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Count for the number of times that the cursor was moved.
 	 *
 	 * @since 0.6.0
-	 * @var int
+	 * @var non-negative-int
 	 * @see self::next_token()
 	 * @see self::seek()
 	 */
@@ -292,7 +292,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * @see WP_HTML_Processor::expects_closer()
 	 * @since 0.4.0
 	 *
-	 * @param string|null $tag_name Tag name, if not provided then the current tag is used. Optional.
+	 * @param non-empty-string|null $tag_name Tag name, if not provided then the current tag is used. Optional.
 	 * @return bool Whether to expect a closer for the tag.
 	 */
 	public function expects_closer( ?string $tag_name = null ): bool {
@@ -336,6 +336,11 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 		if ( null === $tag_name || $this->get_token_type() !== '#tag' ) {
 			return true;
 		}
+		/**
+		 * Tag name.
+		 *
+		 * @var non-empty-string $tag_name
+		 */
 
 		if ( $this->previous_tag_without_closer ) {
 			array_pop( $this->open_stack_tags );
@@ -422,7 +427,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * @see self::next_token()
 	 * @see self::seek()
 	 *
-	 * @return int Count of times the cursor has moved.
+	 * @return non-negative-int Count of times the cursor has moved.
 	 */
 	public function get_cursor_move_count(): int {
 		return $this->cursor_move_count;
@@ -458,8 +463,8 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 0.4.0
 	 *
-	 * @param string      $name  Meta attribute name.
-	 * @param string|true $value Value.
+	 * @param non-empty-string $name  Meta attribute name.
+	 * @param string|true      $value Value.
 	 * @return bool Whether an attribute was set.
 	 */
 	public function set_meta_attribute( string $name, $value ): bool {
@@ -489,7 +494,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * @since 0.4.0
 	 * @see WP_HTML_Processor::get_current_depth()
 	 *
-	 * @return int Nesting-depth of current location in the document.
+	 * @return non-negative-int Nesting-depth of current location in the document.
 	 */
 	public function get_current_depth(): int {
 		return count( $this->open_stack_tags );
@@ -565,7 +570,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * @since 0.4.0
 	 * @since 0.9.0 Renamed from get_breadcrumbs() to get_indexed_breadcrumbs().
 	 *
-	 * @return Generator<array{string, int, array<string, string>}> Breadcrumb.
+	 * @return Generator<array{non-empty-string, non-negative-int, array<non-empty-string, string>}> Breadcrumb.
 	 */
 	private function get_indexed_breadcrumbs(): Generator {
 		foreach ( $this->open_stack_tags as $i => $breadcrumb_tag_name ) {
@@ -584,7 +589,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array<string, string> Disambiguating attributes.
+	 * @return array<non-empty-string, string> Disambiguating attributes.
 	 */
 	private function get_disambiguating_attributes(): array {
 		$attributes = array();
@@ -617,7 +622,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * @since 0.9.0
 	 * @see WP_HTML_Processor::get_breadcrumbs()
 	 *
-	 * @return string[] Array of tag names representing path to matched node.
+	 * @return non-empty-string[] Array of tag names representing path to matched node.
 	 */
 	public function get_breadcrumbs(): array {
 		return $this->open_stack_tags;

--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -196,7 +196,7 @@ final class OD_Link_Collection implements Countable {
 					&&
 					$last_link['maximum_viewport_width'] === $link['minimum_viewport_width']
 				) {
-					$last_link['maximum_viewport_width'] = max( $last_link['maximum_viewport_width'], $link['maximum_viewport_width'] );
+					$last_link['maximum_viewport_width'] = null === $link['maximum_viewport_width'] ? null : max( $last_link['maximum_viewport_width'], $link['maximum_viewport_width'] );
 
 					// Update the last link with the new maximum viewport width.
 					$carry[ count( $carry ) - 1 ] = $last_link;

--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @phpstan-type Link array{
  *                   attributes: LinkAttributes,
  *                   minimum_viewport_width: int<0, max>|null,
- *                   maximum_viewport_width: positive-int|null
+ *                   maximum_viewport_width: int<1, max>|null
  *               }
  *
  * @phpstan-type LinkAttributes array{
@@ -53,9 +53,9 @@ final class OD_Link_Collection implements Countable {
 	 *
 	 * @phpstan-param LinkAttributes $attributes
 	 *
-	 * @param array             $attributes             Attributes.
-	 * @param int<0, max>|null  $minimum_viewport_width Minimum width or null if not bounded or relevant.
-	 * @param positive-int|null $maximum_viewport_width Maximum width or null if not bounded (i.e. infinity) or relevant.
+	 * @param array            $attributes             Attributes.
+	 * @param int<0, max>|null $minimum_viewport_width Minimum width (exclusive) or null if not bounded or relevant.
+	 * @param int<1, max>|null $maximum_viewport_width Maximum width (inclusive) or null if not bounded (i.e. infinity) or relevant.
 	 *
 	 * @throws InvalidArgumentException When invalid arguments are provided.
 	 */
@@ -194,7 +194,7 @@ final class OD_Link_Collection implements Countable {
 					&&
 					is_int( $last_link['maximum_viewport_width'] )
 					&&
-					$last_link['maximum_viewport_width'] + 1 === $link['minimum_viewport_width']
+					$last_link['maximum_viewport_width'] === $link['minimum_viewport_width']
 				) {
 					$last_link['maximum_viewport_width'] = max( $last_link['maximum_viewport_width'], $link['maximum_viewport_width'] );
 

--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -249,7 +249,7 @@ final class OD_Link_Collection implements Countable {
 	/**
 	 * Constructs the Link HTTP response header.
 	 *
-	 * @return string|null Link HTTP response header, or null if there are none.
+	 * @return non-empty-string|null Link HTTP response header, or null if there are none.
 	 */
 	public function get_response_header(): ?string {
 		$link_headers = array();

--- a/plugins/optimization-detective/class-od-tag-visitor-registry.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-registry.php
@@ -27,7 +27,7 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	/**
 	 * Visitors.
 	 *
-	 * @var array<string, TagVisitorCallback>
+	 * @var array<non-empty-string, TagVisitorCallback>
 	 */
 	private $visitors = array();
 
@@ -36,8 +36,8 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	 *
 	 * @phpstan-param TagVisitorCallback $tag_visitor_callback
 	 *
-	 * @param string   $id                   Identifier for the tag visitor.
-	 * @param callable $tag_visitor_callback Tag visitor callback.
+	 * @param non-empty-string $id                   Identifier for the tag visitor.
+	 * @param callable         $tag_visitor_callback Tag visitor callback.
 	 */
 	public function register( string $id, callable $tag_visitor_callback ): void {
 		$this->visitors[ $id ] = $tag_visitor_callback;
@@ -46,7 +46,7 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	/**
 	 * Determines if a visitor has been registered.
 	 *
-	 * @param string $id Identifier for the tag visitor.
+	 * @param non-empty-string $id Identifier for the tag visitor.
 	 * @return bool Whether registered.
 	 */
 	public function is_registered( string $id ): bool {
@@ -56,7 +56,7 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	/**
 	 * Gets a registered visitor.
 	 *
-	 * @param string $id Identifier for the tag visitor.
+	 * @param non-empty-string $id Identifier for the tag visitor.
 	 * @return TagVisitorCallback|null Whether registered.
 	 */
 	public function get_registered( string $id ): ?callable {
@@ -69,7 +69,7 @@ final class OD_Tag_Visitor_Registry implements Countable, IteratorAggregate {
 	/**
 	 * Unregisters a tag visitor.
 	 *
-	 * @param string $id Identifier for the tag visitor.
+	 * @param non-empty-string $id Identifier for the tag visitor.
 	 * @return bool Whether a tag visitor was unregistered.
 	 */
 	public function unregister( string $id ): bool {

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -57,16 +57,14 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * This array may be empty in which case there are no responsive breakpoints and all URL Metrics are collected in a
 	 * single group.
 	 *
-	 * @var int[]
-	 * @phpstan-var positive-int[]
+	 * @var positive-int[]
 	 */
 	private $breakpoints;
 
 	/**
 	 * Sample size for URL Metrics for a given breakpoint.
 	 *
-	 * @var int
-	 * @phpstan-var positive-int
+	 * @var int<1, max>
 	 */
 	private $sample_size;
 
@@ -75,8 +73,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *
 	 * A freshness age of zero means a URL Metric will always be considered stale.
 	 *
-	 * @var int
-	 * @phpstan-var 0|positive-int
+	 * @var int<0, max>
 	 */
 	private $freshness_ttl;
 
@@ -91,7 +88,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *          get_groups_by_lcp_element?: array<string, OD_URL_Metric_Group[]>,
 	 *          get_common_lcp_element?: OD_Element|null,
 	 *          get_all_element_max_intersection_ratios?: array<string, float>,
-	 *          get_xpath_elements_map?: array<string, non-empty-array<int, OD_Element>>,
+	 *          get_xpath_elements_map?: array<string, non-empty-array<non-negative-int, OD_Element>>,
 	 *          get_all_elements_positioned_in_any_initial_viewport?: array<string, bool>,
 	 *      }
 	 */
@@ -101,6 +98,10 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * Constructor.
 	 *
 	 * @throws InvalidArgumentException When an invalid argument is supplied.
+	 *
+	 * @phpstan-param positive-int[] $breakpoints
+	 * @phpstan-param int<1, max>    $sample_size
+	 * @phpstan-param int<0, max>    $freshness_ttl
 	 *
 	 * @param OD_URL_Metric[]  $url_metrics   URL Metrics.
 	 * @param non-empty-string $current_etag  The current ETag.
@@ -495,7 +496,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *
 	 * @since 0.7.0
 	 *
-	 * @return array<string, non-empty-array<int, OD_Element>> Keys are XPaths and values are the element instances.
+	 * @return array<string, non-empty-array<non-negative-int, OD_Element>> Keys are XPaths and values are the element instances.
 	 */
 	public function get_xpath_elements_map(): array {
 		if ( array_key_exists( __FUNCTION__, $this->result_cache ) ) {

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -244,13 +244,13 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * @return OD_URL_Metric_Group[] Groups.
 	 */
 	private function create_groups(): array {
-		$groups    = array();
-		$min_width = 0;
-		foreach ( $this->breakpoints as $max_width ) {
-			$groups[]  = new OD_URL_Metric_Group( array(), $min_width, $max_width, $this->sample_size, $this->freshness_ttl, $this );
-			$min_width = $max_width + 1;
+		$groups              = array();
+		$min_width_exclusive = 0;
+		foreach ( $this->breakpoints as $max_width_inclusive ) {
+			$groups[]            = new OD_URL_Metric_Group( array(), $min_width_exclusive, $max_width_inclusive, $this->sample_size, $this->freshness_ttl, $this );
+			$min_width_exclusive = $max_width_inclusive;
 		}
-		$groups[] = new OD_URL_Metric_Group( array(), $min_width, PHP_INT_MAX, $this->sample_size, $this->freshness_ttl, $this );
+		$groups[] = new OD_URL_Metric_Group( array(), $min_width_exclusive, PHP_INT_MAX, $this->sample_size, $this->freshness_ttl, $this );
 		return $groups;
 	}
 
@@ -285,7 +285,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 * @since 0.1.0
 	 * @throws InvalidArgumentException When there is no group for the provided viewport width. This would only happen if a negative width is provided.
 	 *
-	 * @param int $viewport_width Viewport width.
+	 * @param positive-int $viewport_width Viewport width.
 	 * @return OD_URL_Metric_Group URL Metric group for the viewport width.
 	 */
 	public function get_group_for_viewport_width( int $viewport_width ): OD_URL_Metric_Group {

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -47,12 +47,9 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	/**
 	 * Breakpoints in max widths.
 	 *
-	 * Valid values are from 1 to PHP_INT_MAX - 1. This is because:
-	 *
-	 * 1. It doesn't make sense for there to be a viewport width of zero, so the first breakpoint (max width) must be at least 1.
-	 * 2. After the last breakpoint, the final breakpoint group is set to be spanning one plus the last breakpoint max width up
-	 *    until PHP_INT_MAX. So a breakpoint cannot be PHP_INT_MAX because then the minimum viewport width for the final group
-	 *    would end up being larger than PHP_INT_MAX.
+	 * A breakpoint must be greater than zero because a viewport group's maximum viewport width has a minimum (inclusive)
+	 * value of 1, and the breakpoints are used as the maximum viewport widths for the viewport groups, with the addition of
+	 * a final viewport group which has a maximum viewport width of infinity.
 	 *
 	 * This array may be empty in which case there are no responsive breakpoints and all URL Metrics are collected in a
 	 * single group.
@@ -128,13 +125,13 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 		sort( $breakpoints );
 		$breakpoints = array_values( array_unique( $breakpoints, SORT_NUMERIC ) );
 		foreach ( $breakpoints as $breakpoint ) {
-			if ( ! is_int( $breakpoint ) || $breakpoint < 1 || PHP_INT_MAX === $breakpoint ) {
+			if ( ! is_int( $breakpoint ) || $breakpoint < 1 ) {
 				throw new InvalidArgumentException(
 					esc_html(
 						sprintf(
 							/* translators: %d is the invalid breakpoint */
 							__(
-								'Each of the breakpoints must be greater than zero and less than PHP_INT_MAX, but encountered: %d',
+								'Each of the breakpoints must be greater than zero, but encountered: %d',
 								'optimization-detective'
 							),
 							$breakpoint
@@ -216,7 +213,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *
 	 * This group normally represents viewports for desktop devices.  This group always has a minimum viewport width
 	 * defined as one greater than the largest breakpoint returned by {@see od_get_breakpoint_max_widths()}.
-	 * The maximum viewport is always `PHP_INT_MAX`, or in other words it is unbounded.
+	 * The maximum viewport width of this group is always `null`, or in other words it is unbounded.
 	 *
 	 * @since 0.7.0
 	 *
@@ -251,7 +248,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 			$groups[]            = new OD_URL_Metric_Group( array(), $min_width_exclusive, $max_width_inclusive, $this->sample_size, $this->freshness_ttl, $this );
 			$min_width_exclusive = $max_width_inclusive;
 		}
-		$groups[] = new OD_URL_Metric_Group( array(), $min_width_exclusive, PHP_INT_MAX, $this->sample_size, $this->freshness_ttl, $this );
+		$groups[] = new OD_URL_Metric_Group( array(), $min_width_exclusive, null, $this->sample_size, $this->freshness_ttl, $this );
 		return $groups;
 	}
 
@@ -273,7 +270,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 			}
 		}
 		// @codeCoverageIgnoreStart
-		// In practice this exception should never get thrown because create_groups() creates groups from a minimum of 0 to a maximum of PHP_INT_MAX.
+		// In practice this exception should never get thrown because create_groups() creates groups from a minimum of 0 to an unbounded maximum.
 		throw new InvalidArgumentException(
 			esc_html__( 'No group available to add URL Metric to.', 'optimization-detective' )
 		);
@@ -301,7 +298,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 				}
 			}
 			// @codeCoverageIgnoreStart
-			// In practice this exception should never get thrown because create_groups() creates groups from a minimum of 0 to a maximum of PHP_INT_MAX.
+			// In practice this exception should never get thrown because create_groups() creates groups from a minimum of 0 to an unbounded maximum.
 			throw new InvalidArgumentException(
 				esc_html(
 					sprintf(
@@ -668,8 +665,8 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	 *             every_group_populated: bool,
 	 *             groups: array<int, array{
 	 *                 lcp_element: ?OD_Element,
-	 *                 minimum_viewport_width: 0|positive-int,
-	 *                 maximum_viewport_width: positive-int,
+	 *                 minimum_viewport_width: int<0, max>,
+	 *                 maximum_viewport_width: int<1, max>|null,
 	 *                 complete: bool,
 	 *                 url_metrics: OD_URL_Metric[]
 	 *             }>

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -41,11 +41,11 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	private $minimum_viewport_width;
 
 	/**
-	 * Maximum possible viewport width for the group (inclusive).
+	 * Maximum possible viewport width for the group (inclusive), where null means it is unbounded.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @var int<1, max>
+	 * @var int<1, max>|null
 	 */
 	private $maximum_viewport_width;
 
@@ -98,33 +98,35 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * @access private
 	 * @throws InvalidArgumentException If arguments are invalid.
 	 *
-	 * @phpstan-param int<0, max> $minimum_viewport_width
-	 * @phpstan-param int<1, max> $maximum_viewport_width
-	 * @phpstan-param int<1, max> $sample_size
-	 * @phpstan-param int<0, max> $freshness_ttl
+	 * @phpstan-param int<0, max>      $minimum_viewport_width
+	 * @phpstan-param int<1, max>|null $maximum_viewport_width
+	 * @phpstan-param int<1, max>      $sample_size
+	 * @phpstan-param int<0, max>      $freshness_ttl
 	 *
 	 * @param OD_URL_Metric[]                $url_metrics            URL Metrics to add to the group.
 	 * @param int                            $minimum_viewport_width Minimum possible viewport width (exclusive) for the group. Must be zero or greater.
-	 * @param int                            $maximum_viewport_width Maximum possible viewport width (inclusive) for the group. Must be greater than zero and the minimum viewport width.
+	 * @param int|null                       $maximum_viewport_width Maximum possible viewport width (inclusive) for the group. Must be greater than zero and the minimum viewport width. Null means unbounded.
 	 * @param int                            $sample_size            Sample size for the maximum number of viewports in a group between breakpoints.
 	 * @param int                            $freshness_ttl          Freshness age (TTL) for a given URL Metric.
 	 * @param OD_URL_Metric_Group_Collection $collection             Collection that this instance belongs to.
 	 */
-	public function __construct( array $url_metrics, int $minimum_viewport_width, int $maximum_viewport_width, int $sample_size, int $freshness_ttl, OD_URL_Metric_Group_Collection $collection ) {
+	public function __construct( array $url_metrics, int $minimum_viewport_width, ?int $maximum_viewport_width, int $sample_size, int $freshness_ttl, OD_URL_Metric_Group_Collection $collection ) {
 		if ( $minimum_viewport_width < 0 ) {
 			throw new InvalidArgumentException(
 				esc_html__( 'The minimum viewport width must be at least zero.', 'optimization-detective' )
 			);
 		}
-		if ( $maximum_viewport_width < 1 ) {
-			throw new InvalidArgumentException(
-				esc_html__( 'The maximum viewport width must be greater than zero.', 'optimization-detective' )
-			);
-		}
-		if ( $minimum_viewport_width >= $maximum_viewport_width ) {
-			throw new InvalidArgumentException(
-				esc_html__( 'The minimum viewport width must be smaller than the maximum viewport width.', 'optimization-detective' )
-			);
+		if ( isset( $maximum_viewport_width ) ) {
+			if ( $maximum_viewport_width < 1 ) {
+				throw new InvalidArgumentException(
+					esc_html__( 'The maximum viewport width must be greater than zero.', 'optimization-detective' )
+				);
+			}
+			if ( $minimum_viewport_width >= $maximum_viewport_width ) {
+				throw new InvalidArgumentException(
+					esc_html__( 'The minimum viewport width must be smaller than the maximum viewport width.', 'optimization-detective' )
+				);
+			}
 		}
 		$this->minimum_viewport_width = $minimum_viewport_width;
 		$this->maximum_viewport_width = $maximum_viewport_width;
@@ -176,9 +178,9 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * @since 0.1.0
 	 *
 	 * @todo Eliminate in favor of readonly public property.
-	 * @return int<1, max> Minimum viewport width (inclusive).
+	 * @return int<1, max>|null Minimum viewport width (inclusive). Null means unbounded.
 	 */
-	public function get_maximum_viewport_width(): int {
+	public function get_maximum_viewport_width(): ?int {
 		return $this->maximum_viewport_width;
 	}
 
@@ -219,7 +221,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	public function is_viewport_width_in_range( int $viewport_width ): bool {
 		return (
 			$viewport_width > $this->minimum_viewport_width &&
-			$viewport_width <= $this->maximum_viewport_width
+			( null === $this->maximum_viewport_width || $viewport_width <= $this->maximum_viewport_width )
 		);
 	}
 
@@ -485,8 +487,8 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * @return array{
 	 *             freshness_ttl: 0|positive-int,
 	 *             sample_size: positive-int,
-	 *             minimum_viewport_width: 0|positive-int,
-	 *             maximum_viewport_width: positive-int,
+	 *             minimum_viewport_width: int<0, max>,
+	 *             maximum_viewport_width: int<1, max>|null,
 	 *             lcp_element: ?OD_Element,
 	 *             complete: bool,
 	 *             url_metrics: OD_URL_Metric[]

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -32,12 +32,11 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	private $url_metrics;
 
 	/**
-	 * Minimum possible viewport width for the group (inclusive).
+	 * Minimum possible viewport width for the group (exclusive).
 	 *
 	 * @since 0.1.0
 	 *
-	 * @var int
-	 * @phpstan-var 0|positive-int
+	 * @var int<0, max>
 	 */
 	private $minimum_viewport_width;
 
@@ -46,8 +45,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 *
 	 * @since 0.1.0
 	 *
-	 * @var int
-	 * @phpstan-var positive-int
+	 * @var int<1, max>
 	 */
 	private $maximum_viewport_width;
 
@@ -103,8 +101,8 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * @throws InvalidArgumentException If arguments are invalid.
 	 *
 	 * @param OD_URL_Metric[]                $url_metrics            URL Metrics to add to the group.
-	 * @param int                            $minimum_viewport_width Minimum possible viewport width for the group. Must be zero or greater.
-	 * @param int                            $maximum_viewport_width Maximum possible viewport width for the group. Must be greater than zero and the minimum viewport width.
+	 * @param int                            $minimum_viewport_width Minimum possible viewport width (exclusive) for the group. Must be zero or greater.
+	 * @param int                            $maximum_viewport_width Maximum possible viewport width (inclusive) for the group. Must be greater than zero and the minimum viewport width.
 	 * @param int                            $sample_size            Sample size for the maximum number of viewports in a group between breakpoints.
 	 * @param int                            $freshness_ttl          Freshness age (TTL) for a given URL Metric.
 	 * @param OD_URL_Metric_Group_Collection $collection             Collection that this instance belongs to.
@@ -158,12 +156,12 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	}
 
 	/**
-	 * Gets the minimum possible viewport width (inclusive).
+	 * Gets the minimum possible viewport width (exclusive).
 	 *
 	 * @since 0.1.0
 	 *
 	 * @todo Eliminate in favor of readonly public property.
-	 * @return int<0, max> Minimum viewport width.
+	 * @return int<0, max> Minimum viewport width (exclusive).
 	 */
 	public function get_minimum_viewport_width(): int {
 		return $this->minimum_viewport_width;
@@ -175,7 +173,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * @since 0.1.0
 	 *
 	 * @todo Eliminate in favor of readonly public property.
-	 * @return int<1, max> Minimum viewport width.
+	 * @return int<1, max> Minimum viewport width (inclusive).
 	 */
 	public function get_maximum_viewport_width(): int {
 		return $this->maximum_viewport_width;
@@ -208,16 +206,18 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	}
 
 	/**
-	 * Checks whether the provided viewport width is within the minimum/maximum range for.
+	 * Checks whether the provided viewport width is between the minimum (exclusive) and maximum (inclusive).
 	 *
 	 * @since 0.1.0
+	 *
+	 * @phpstan-param int<1, max> $viewport_width
 	 *
 	 * @param int $viewport_width Viewport width.
 	 * @return bool Whether the viewport width is in range.
 	 */
 	public function is_viewport_width_in_range( int $viewport_width ): bool {
 		return (
-			$viewport_width >= $this->minimum_viewport_width &&
+			$viewport_width > $this->minimum_viewport_width &&
 			$viewport_width <= $this->maximum_viewport_width
 		);
 	}

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -54,8 +54,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 *
 	 * @since 0.1.0
 	 *
-	 * @var int
-	 * @phpstan-var positive-int
+	 * @var int<1, max>
 	 */
 	private $sample_size;
 
@@ -64,8 +63,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 *
 	 * @since 0.1.0
 	 *
-	 * @var int
-	 * @phpstan-var 0|positive-int
+	 * @var int<0, max>
 	 */
 	private $freshness_ttl;
 
@@ -99,6 +97,11 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 *
 	 * @access private
 	 * @throws InvalidArgumentException If arguments are invalid.
+	 *
+	 * @phpstan-param int<0, max> $minimum_viewport_width
+	 * @phpstan-param int<1, max> $maximum_viewport_width
+	 * @phpstan-param int<1, max> $sample_size
+	 * @phpstan-param int<0, max> $freshness_ttl
 	 *
 	 * @param OD_URL_Metric[]                $url_metrics            URL Metrics to add to the group.
 	 * @param int                            $minimum_viewport_width Minimum possible viewport width (exclusive) for the group. Must be zero or greater.
@@ -185,8 +188,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * @since 0.9.0
 	 *
 	 * @todo Eliminate in favor of readonly public property.
-	 * @phpstan-return positive-int
-	 * @return int Sample size.
+	 * @return int<1, max> Sample size.
 	 */
 	public function get_sample_size(): int {
 		return $this->sample_size;
@@ -198,8 +200,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 * @since 0.9.0
 	 *
 	 * @todo Eliminate in favor of readonly public property.
-	 * @phpstan-return 0|positive-int
-	 * @return int Freshness age.
+	 * @return int<0, max> Freshness age.
 	 */
 	public function get_freshness_ttl(): int {
 		return $this->freshness_ttl;
@@ -324,14 +325,14 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 			/**
 			 * Seen breadcrumbs counts.
 			 *
-			 * @var array<int, string> $seen_breadcrumbs
+			 * @var array<int, non-empty-string> $seen_breadcrumbs
 			 */
 			$seen_breadcrumbs = array();
 
 			/**
 			 * Breadcrumb counts.
 			 *
-			 * @var array<int, int> $breadcrumb_counts
+			 * @var array<int, non-negative-int> $breadcrumb_counts
 			 */
 			$breadcrumb_counts = array();
 

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -16,8 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Representation of the measurements taken from a single client's visit to a specific URL.
  *
  * @phpstan-type ViewportRect array{
- *                                width: int,
- *                                height: int
+ *                                width: positive-int,
+ *                                height: positive-int
  *                            }
  * @phpstan-type DOMRect      array{
  *                                width: float,
@@ -249,12 +249,12 @@ class OD_URL_Metric implements JsonSerializable {
 						'width'  => array(
 							'type'     => 'integer',
 							'required' => true,
-							'minimum'  => 0,
+							'minimum'  => 1,
 						),
 						'height' => array(
 							'type'     => 'integer',
 							'required' => true,
-							'minimum'  => 0,
+							'minimum'  => 1,
 						),
 					),
 					'additionalProperties' => false,
@@ -482,7 +482,7 @@ class OD_URL_Metric implements JsonSerializable {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return int Viewport width.
+	 * @return positive-int Viewport width.
 	 */
 	public function get_viewport_width(): int {
 		return $this->data['viewport']['width'];

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -437,7 +437,7 @@ class OD_URL_Metric implements JsonSerializable {
 	 *
 	 * @since 0.6.0
 	 *
-	 * @return string UUID.
+	 * @return non-empty-string UUID.
 	 */
 	public function get_uuid(): string {
 		return $this->data['uuid'];
@@ -460,7 +460,7 @@ class OD_URL_Metric implements JsonSerializable {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @return string URL.
+	 * @return non-empty-string URL.
 	 */
 	public function get_url(): string {
 		return $this->data['url'];

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -116,7 +116,8 @@ function isViewportNeeded( viewportWidth, urlMetricGroupStatuses ) {
 	} of urlMetricGroupStatuses ) {
 		if (
 			viewportWidth > minimumViewportWidth &&
-			viewportWidth <= maximumViewportWidth
+			( null === maximumViewportWidth ||
+				viewportWidth <= maximumViewportWidth )
 		) {
 			return complete;
 		}

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -98,20 +98,30 @@ function error( ...message ) {
 /**
  * Checks whether the URL Metric(s) for the provided viewport width is needed.
  *
+ * The comparison logic here corresponds with the PHP logic in `OD_URL_Metric_Group::is_viewport_width_in_range()`.
+ *
  * @param {number}                 viewportWidth          - Current viewport width.
  * @param {URLMetricGroupStatus[]} urlMetricGroupStatuses - Viewport group statuses.
  * @return {boolean} Whether URL Metrics are needed.
  */
 function isViewportNeeded( viewportWidth, urlMetricGroupStatuses ) {
-	let lastWasLacking = false;
-	for ( const { minimumViewportWidth, complete } of urlMetricGroupStatuses ) {
-		if ( viewportWidth >= minimumViewportWidth ) {
-			lastWasLacking = ! complete;
-		} else {
-			break;
+	if ( viewportWidth === 0 ) {
+		return false;
+	}
+
+	for ( const {
+		minimumViewportWidth,
+		maximumViewportWidth,
+		complete,
+	} of urlMetricGroupStatuses ) {
+		if (
+			viewportWidth > minimumViewportWidth &&
+			viewportWidth <= maximumViewportWidth
+		) {
+			return complete;
 		}
 	}
-	return lastWasLacking;
+	return false;
 }
 
 /**

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -38,11 +38,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @global WP_Query $wp_query WordPress Query object.
  *
- * @return int|null Post ID or null if none found.
+ * @return positive-int|null Post ID or null if none found.
  */
 function od_get_cache_purge_post_id(): ?int {
 	$queried_object = get_queried_object();
-	if ( $queried_object instanceof WP_Post ) {
+	if ( $queried_object instanceof WP_Post && $queried_object->ID > 0 ) {
 		return $queried_object->ID;
 	}
 
@@ -55,6 +55,8 @@ function od_get_cache_purge_post_id(): ?int {
 		isset( $wp_query->posts[0] )
 		&&
 		$wp_query->posts[0] instanceof WP_Post
+		&&
+		$wp_query->posts[0]->ID > 0
 	) {
 		return $wp_query->posts[0]->ID;
 	}
@@ -68,7 +70,7 @@ function od_get_cache_purge_post_id(): ?int {
  * @since 0.1.0
  * @access private
  *
- * @param string                         $slug             URL Metrics slug.
+ * @param non-empty-string               $slug             URL Metrics slug.
  * @param OD_URL_Metric_Group_Collection $group_collection URL Metric group collection.
  */
 function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $group_collection ): string {

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -129,10 +129,9 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		'urlMetricHMAC'          => od_get_url_metrics_storage_hmac( $slug, $current_etag, $current_url, $cache_purge_post_id ),
 		'urlMetricGroupStatuses' => array_map(
 			static function ( OD_URL_Metric_Group $group ): array {
-				$max = $group->get_maximum_viewport_width();
 				return array(
 					'minimumViewportWidth' => $group->get_minimum_viewport_width(), // Exclusive.
-					'maximumViewportWidth' => PHP_INT_MAX === $max ? null : $max, // Inclusive.
+					'maximumViewportWidth' => $group->get_maximum_viewport_width(), // Inclusive.
 					'complete'             => $group->is_complete(),
 				);
 			},

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -128,7 +128,8 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		'urlMetricGroupStatuses' => array_map(
 			static function ( OD_URL_Metric_Group $group ): array {
 				return array(
-					'minimumViewportWidth' => $group->get_minimum_viewport_width(),
+					'minimumViewportWidth' => $group->get_minimum_viewport_width(), // Exclusive.
+					'maximumViewportWidth' => $group->get_maximum_viewport_width(), // Inclusive.
 					'complete'             => $group->is_complete(),
 				);
 			},

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -129,9 +129,10 @@ function od_get_detection_script( string $slug, OD_URL_Metric_Group_Collection $
 		'urlMetricHMAC'          => od_get_url_metrics_storage_hmac( $slug, $current_etag, $current_url, $cache_purge_post_id ),
 		'urlMetricGroupStatuses' => array_map(
 			static function ( OD_URL_Metric_Group $group ): array {
+				$max = $group->get_maximum_viewport_width();
 				return array(
 					'minimumViewportWidth' => $group->get_minimum_viewport_width(), // Exclusive.
-					'maximumViewportWidth' => $group->get_maximum_viewport_width(), // Inclusive.
+					'maximumViewportWidth' => PHP_INT_MAX === $max ? null : $max, // Inclusive.
 					'complete'             => $group->is_complete(),
 				);
 			},

--- a/plugins/optimization-detective/helper.php
+++ b/plugins/optimization-detective/helper.php
@@ -37,18 +37,18 @@ function od_initialize_extensions(): void {
  *
  * @since 0.7.0
  *
- * @param int|null $minimum_viewport_width Minimum viewport width.
- * @param int|null $maximum_viewport_width Maximum viewport width.
+ * @param int<0, max>|null $minimum_viewport_width Minimum viewport width (exclusive).
+ * @param int<1, max>|null $maximum_viewport_width Maximum viewport width (inclusive).
  * @return non-empty-string|null Media query, or null if the min/max were both unspecified or invalid.
  */
 function od_generate_media_query( ?int $minimum_viewport_width, ?int $maximum_viewport_width ): ?string {
-	if ( is_int( $minimum_viewport_width ) && is_int( $maximum_viewport_width ) && $minimum_viewport_width > $maximum_viewport_width ) {
-		_doing_it_wrong( __FUNCTION__, esc_html__( 'The minimum width cannot be greater than the maximum width.', 'optimization-detective' ), 'Optimization Detective 0.7.0' );
+	if ( is_int( $minimum_viewport_width ) && is_int( $maximum_viewport_width ) && $minimum_viewport_width >= $maximum_viewport_width ) {
+		_doing_it_wrong( __FUNCTION__, esc_html__( 'The minimum width cannot be greater than or equal to the maximum width.', 'optimization-detective' ), 'Optimization Detective 0.7.0' );
 		return null;
 	}
 	$media_attributes = array();
 	if ( null !== $minimum_viewport_width && $minimum_viewport_width > 0 ) {
-		$media_attributes[] = sprintf( '(min-width: %dpx)', $minimum_viewport_width );
+		$media_attributes[] = sprintf( '(min-width: %dpx)', $minimum_viewport_width + 1 );
 	}
 	if ( null !== $maximum_viewport_width && PHP_INT_MAX !== $maximum_viewport_width ) {
 		$media_attributes[] = sprintf( '(max-width: %dpx)', $maximum_viewport_width );

--- a/plugins/optimization-detective/helper.php
+++ b/plugins/optimization-detective/helper.php
@@ -50,7 +50,7 @@ function od_generate_media_query( ?int $minimum_viewport_width, ?int $maximum_vi
 	if ( null !== $minimum_viewport_width && $minimum_viewport_width > 0 ) {
 		$media_attributes[] = sprintf( '(min-width: %dpx)', $minimum_viewport_width + 1 );
 	}
-	if ( null !== $maximum_viewport_width && PHP_INT_MAX !== $maximum_viewport_width ) {
+	if ( null !== $maximum_viewport_width && PHP_INT_MAX !== $maximum_viewport_width ) { // Note: The use of PHP_INT_MAX is obsolete.
 		$media_attributes[] = sprintf( '(max-width: %dpx)', $maximum_viewport_width );
 	}
 	if ( count( $media_attributes ) === 0 ) {

--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -254,7 +254,7 @@ function od_maybe_render_rest_api_health_check_admin_notice( bool $in_plugin_row
  * @since 1.0.0
  * @access private
  *
- * @param string $plugin_file Plugin file.
+ * @param non-empty-string $plugin_file Plugin file.
  */
 function od_render_rest_api_health_check_admin_notice_in_plugin_row( string $plugin_file ): void {
 	if ( 'optimization-detective/load.php' !== $plugin_file ) { // TODO: What if a different plugin slug is used?

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -26,7 +26,7 @@ final class OD_Storage_Lock {
 	 * @since 0.1.0
 	 * @access private
 	 *
-	 * @return int TTL in seconds, greater than or equal to zero. A value of zero means that the storage lock should be disabled and thus that transients must not be used.
+	 * @return int<0, max> TTL in seconds, greater than or equal to zero. A value of zero means that the storage lock should be disabled and thus that transients must not be used.
 	 */
 	public static function get_ttl(): int {
 
@@ -52,7 +52,7 @@ final class OD_Storage_Lock {
 	 * Gets transient key for locking URL Metric storage (for the current IP).
 	 *
 	 * @todo Should the URL be included in the key? Or should a user only be allowed to store one metric?
-	 * @return string Transient key.
+	 * @return non-empty-string Transient key.
 	 */
 	public static function get_transient_key(): string {
 		$ip_address = $_SERVER['HTTP_X_FORWARDED_FOR'] ?? $_SERVER['REMOTE_ADDR'];

--- a/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
+++ b/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
@@ -31,7 +31,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	/**
 	 * ID for the URL Metric post.
 	 *
-	 * @var int
+	 * @var positive-int
 	 * @readonly
 	 */
 	public $post_id;
@@ -66,7 +66,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @param WP_REST_Request                $request                     REST API request.
-	 * @param int                            $post_id                     ID for the URL Metric post.
+	 * @param positive-int                   $post_id                     ID for the URL Metric post.
 	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL Metric group collection.
 	 * @param OD_URL_Metric_Group            $url_metric_group            URL Metric group.
 	 * @param OD_URL_Metric                  $url_metric                  URL Metric.

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -84,7 +84,7 @@ class OD_URL_Metrics_Post_Type {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param string $slug URL Metrics slug.
+	 * @param non-empty-string $slug URL Metrics slug.
 	 * @return WP_Post|null Post object if exists.
 	 */
 	public static function get_post( string $slug ): ?WP_Post {
@@ -202,9 +202,9 @@ class OD_URL_Metrics_Post_Type {
 	 * @since 0.1.0
 	 * @todo There is duplicate logic here with od_handle_rest_request().
 	 *
-	 * @param string        $slug           Slug (hash of normalized query vars).
-	 * @param OD_URL_Metric $new_url_metric New URL Metric.
-	 * @return int|WP_Error Post ID or WP_Error otherwise.
+	 * @param non-empty-string $slug Slug (hash of normalized query vars).
+	 * @param OD_URL_Metric    $new_url_metric New URL Metric.
+	 * @return positive-int|WP_Error Post ID or WP_Error otherwise.
 	 */
 	public static function store_url_metric( string $slug, OD_URL_Metric $new_url_metric ) {
 		$post_data = array(

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -243,13 +243,8 @@ class OD_URL_Metrics_Post_Type {
 		}
 
 		$post_data['post_content'] = wp_json_encode(
-			array_map(
-				static function ( OD_URL_Metric $url_metric ): array {
-					return $url_metric->jsonSerialize();
-				},
-				$group_collection->get_flattened_url_metrics()
-			),
-			JSON_UNESCAPED_SLASHES // No need for escaped slashes since not printed to frontend.
+			$group_collection->get_flattened_url_metrics(),
+			JSON_UNESCAPED_SLASHES // No need for escaping slashes since this JSON is not embedded in HTML.
 		);
 		if ( ! is_string( $post_data['post_content'] ) ) {
 			return new WP_Error( 'json_encode_error', json_last_error_msg() );

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -377,20 +377,7 @@ function od_get_breakpoint_max_widths(): array {
 	$breakpoint_max_widths = array_map(
 		static function ( $original_breakpoint ) use ( $function_name ): int {
 			$breakpoint = $original_breakpoint;
-			if ( PHP_INT_MAX === $breakpoint ) {
-				$breakpoint = PHP_INT_MAX - 1;
-				_doing_it_wrong(
-					esc_html( $function_name ),
-					esc_html(
-						sprintf(
-							/* translators: %s is the actual breakpoint max width */
-							__( 'Breakpoint must be less than PHP_INT_MAX, but saw "%s".', 'optimization-detective' ),
-							$original_breakpoint
-						)
-					),
-					''
-				);
-			} elseif ( $breakpoint <= 0 ) {
+			if ( $breakpoint <= 0 ) {
 				$breakpoint = 1;
 				_doing_it_wrong(
 					esc_html( $function_name ),
@@ -409,12 +396,12 @@ function od_get_breakpoint_max_widths(): array {
 		/**
 		 * Filters the breakpoint max widths to group URL Metrics for various viewports.
 		 *
-		 * A breakpoint must be greater than zero and less than PHP_INT_MAX. This array may be empty in which case there
+		 * A breakpoint must be greater than zero. This array may be empty in which case there
 		 * are no responsive breakpoints and all URL Metrics are collected in a single group.
 		 *
 		 * @since 0.1.0
 		 *
-		 * @param int[] $breakpoint_max_widths Max widths for viewport breakpoints. Defaults to [480, 600, 782].
+		 * @param positive-int[] $breakpoint_max_widths Max widths for viewport breakpoints. Defaults to [480, 600, 782].
 		 */
 		array_map( 'intval', (array) apply_filters( 'od_breakpoint_max_widths', array( 480, 600, 782 ) ) )
 	);

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.1.0
  * @access private
  *
- * @return int Expiration TTL in seconds.
+ * @return int<0, max> Expiration TTL in seconds.
  */
 function od_get_url_metric_freshness_ttl(): int {
 	/**
@@ -117,6 +117,8 @@ function od_get_current_url(): string {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$current_url .= ltrim( wp_unslash( $_SERVER['REQUEST_URI'] ), '/' );
 	}
+
+	// TODO: We should be able to assert that this returns an non-empty-string.
 	return esc_url_raw( $current_url );
 }
 
@@ -131,7 +133,7 @@ function od_get_current_url(): string {
  * @see od_get_normalized_query_vars()
  *
  * @param array<string, mixed> $query_vars Normalized query vars.
- * @return string Slug.
+ * @return non-empty-string Slug.
  */
 function od_get_url_metrics_slug( array $query_vars ): string {
 	return md5( (string) wp_json_encode( $query_vars ) );
@@ -257,15 +259,22 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
  * @see od_verify_url_metrics_storage_hmac()
  * @see od_get_url_metrics_slug()
  *
- * @param string           $slug                Slug (hash of normalized query vars).
- * @param non-empty-string $current_etag        Current ETag.
- * @param string           $url                 URL.
- * @param int|null         $cache_purge_post_id Cache purge post ID.
- * @return string HMAC.
+ * @param non-empty-string  $slug                Slug (hash of normalized query vars).
+ * @param non-empty-string  $current_etag        Current ETag.
+ * @param string            $url                 URL.
+ * @param positive-int|null $cache_purge_post_id Cache purge post ID.
+ * @return non-empty-string HMAC.
  */
 function od_get_url_metrics_storage_hmac( string $slug, string $current_etag, string $url, ?int $cache_purge_post_id = null ): string {
 	$action = "store_url_metric:$slug:$current_etag:$url:$cache_purge_post_id";
-	return wp_hash( $action, 'nonce' );
+
+	/**
+	 * HMAC.
+	 *
+	 * @var non-empty-string $hmac
+	 */
+	$hmac = wp_hash( $action, 'nonce' );
+	return $hmac;
 }
 
 /**
@@ -278,11 +287,11 @@ function od_get_url_metrics_storage_hmac( string $slug, string $current_etag, st
  * @see od_get_url_metrics_storage_hmac()
  * @see od_get_url_metrics_slug()
  *
- * @param string           $hmac                HMAC.
- * @param string           $slug                Slug (hash of normalized query vars).
- * @param non-empty-string $current_etag        Current ETag.
- * @param string           $url                 URL.
- * @param int|null         $cache_purge_post_id Cache purge post ID.
+ * @param non-empty-string  $hmac                HMAC.
+ * @param non-empty-string  $slug                Slug (hash of normalized query vars).
+ * @param non-empty-string  $current_etag        Current ETag.
+ * @param string            $url                 URL.
+ * @param positive-int|null $cache_purge_post_id Cache purge post ID.
  * @return bool Whether the HMAC is valid.
  */
 function od_verify_url_metrics_storage_hmac( string $hmac, string $slug, string $current_etag, string $url, ?int $cache_purge_post_id = null ): bool {
@@ -360,7 +369,7 @@ function od_get_maximum_viewport_aspect_ratio(): float {
  * @access private
  * @link https://github.com/WordPress/gutenberg/blob/093d52cbfd3e2c140843d3fb91ad3d03330320a5/packages/base-styles/_breakpoints.scss#L11-L13
  *
- * @return int[] Breakpoint max widths, sorted in ascending order.
+ * @return positive-int[] Breakpoint max widths, sorted in ascending order.
  */
 function od_get_breakpoint_max_widths(): array {
 	$function_name = __FUNCTION__;
@@ -425,7 +434,7 @@ function od_get_breakpoint_max_widths(): array {
  * @since 0.1.0
  * @access private
  *
- * @return int Sample size.
+ * @return int<1, max> Sample size.
  */
 function od_get_url_metrics_breakpoint_sample_size(): int {
 	/**

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -72,7 +72,7 @@ function od_register_endpoint(): void {
 			'required'          => true,
 			'pattern'           => '^[0-9a-f]+\z',
 			'validate_callback' => static function ( string $hmac, WP_REST_Request $request ) {
-				if ( ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $request['cache_purge_post_id'] ?? null ) ) {
+				if ( '' === $hmac || ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $request['cache_purge_post_id'] ?? null ) ) {
 					return new WP_Error( 'invalid_hmac', __( 'URL Metrics HMAC verification failure.', 'optimization-detective' ) );
 				}
 				return true;

--- a/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-url-metrics-post-type.php
@@ -190,7 +190,8 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 	public function test_store_url_metric(): void {
 		$slug = od_get_url_metrics_slug( array( 'p' => 1 ) );
 
-		$validated_url_metric = $this->get_sample_url_metric( array( 'url' => home_url( '/' ) ) );
+		$validated_url_metric         = $this->get_sample_url_metric( array( 'url' => home_url( '/' ) ) );
+		$another_validated_url_metric = $this->get_sample_url_metric( array( 'url' => home_url( '/sample-page/' ) ) );
 
 		$post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $validated_url_metric );
 		$this->assertIsInt( $post_id );
@@ -198,15 +199,22 @@ class Test_OD_Storage_Post_Type extends WP_UnitTestCase {
 		$post = OD_URL_Metrics_Post_Type::get_post( $slug );
 		$this->assertInstanceOf( WP_Post::class, $post );
 		$this->assertSame( $post_id, $post->ID );
+		$parsed_json = json_decode( $post->post_content, true );
+		$this->assertIsArray( $parsed_json );
+		$this->assertSame( array( $validated_url_metric->jsonSerialize() ), $parsed_json );
 
 		$url_metrics = OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post );
 		$this->assertCount( 1, $url_metrics );
 
-		$again_post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $validated_url_metric );
-		$post          = get_post( $again_post_id );
+		$again_post_id = OD_URL_Metrics_Post_Type::store_url_metric( $slug, $another_validated_url_metric );
+		$again_post    = get_post( $again_post_id );
+		$this->assertInstanceOf( WP_Post::class, $again_post );
 		$this->assertSame( $post_id, $again_post_id );
-		$url_metrics = OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $post );
+		$url_metrics = OD_URL_Metrics_Post_Type::get_url_metrics_from_post( $again_post );
 		$this->assertCount( 2, $url_metrics );
+		$parsed_json = json_decode( $again_post->post_content, true );
+		$this->assertIsArray( $parsed_json );
+		$this->assertSame( array( $validated_url_metric->jsonSerialize(), $another_validated_url_metric->jsonSerialize() ), $parsed_json );
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -674,13 +674,9 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 				'breakpoints' => array( 0 ),
 				'expected'    => array( 1 ),
 			),
-			'max'      => array(
-				'breakpoints' => array( PHP_INT_MAX ),
-				'expected'    => array( PHP_INT_MAX - 1 ),
-			),
 			'multiple' => array(
 				'breakpoints' => array( -1, 0, 10, PHP_INT_MAX ),
-				'expected'    => array( 1, 10, PHP_INT_MAX - 1 ),
+				'expected'    => array( 1, 10, PHP_INT_MAX ),
 			),
 		);
 	}

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -573,7 +573,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		);
 		$url_metric_groups = iterator_to_array( $group_collection );
 		$this->assertSame(
-			array( 0, $breakpoint_width + 1 ),
+			array( 0, $breakpoint_width ),
 			array_map(
 				static function ( OD_URL_Metric_Group $group ) {
 					return $group->get_minimum_viewport_width();

--- a/plugins/optimization-detective/tests/test-class-od-link-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-link-collection.php
@@ -79,9 +79,9 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 					),
 				),
 				'expected_html'   => '
-					<link data-od-added-tag rel="preload" href="https://example.com/foo.jpg" crossorigin="anonymous" fetchpriority="high" as="image" media="screen and (min-width: 100px) and (max-width: 200px)">
+					<link data-od-added-tag rel="preload" href="https://example.com/foo.jpg" crossorigin="anonymous" fetchpriority="high" as="image" media="screen and (min-width: 101px) and (max-width: 200px)">
 				',
-				'expected_header' => 'Link: <https://example.com/foo.jpg>; rel="preload"; crossorigin="anonymous"; fetchpriority="high"; as="image"; media="screen and (min-width: 100px) and (max-width: 200px)"',
+				'expected_header' => 'Link: <https://example.com/foo.jpg>; rel="preload"; crossorigin="anonymous"; fetchpriority="high"; as="image"; media="screen and (min-width: 101px) and (max-width: 200px)"',
 				'expected_count'  => 1,
 				'error'           => '',
 			),
@@ -116,15 +116,15 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 							'as'            => 'image',
 							'media'         => 'screen',
 						),
-						201,
+						200,
 						300,
 					),
 				),
 				'expected_html'   => '
 					<link data-od-added-tag rel="preload" href="https://example.com/bar.jpg" as="image" media="screen">
-					<link data-od-added-tag rel="preload" href="https://example.com/foo.jpg" crossorigin="anonymous" fetchpriority="high" as="image" media="screen and (min-width: 100px) and (max-width: 300px)">
+					<link data-od-added-tag rel="preload" href="https://example.com/foo.jpg" crossorigin="anonymous" fetchpriority="high" as="image" media="screen and (min-width: 101px) and (max-width: 300px)">
 				',
-				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"; media="screen", <https://example.com/foo.jpg>; rel="preload"; crossorigin="anonymous"; fetchpriority="high"; as="image"; media="screen and (min-width: 100px) and (max-width: 300px)"',
+				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"; media="screen", <https://example.com/foo.jpg>; rel="preload"; crossorigin="anonymous"; fetchpriority="high"; as="image"; media="screen and (min-width: 101px) and (max-width: 300px)"',
 				'expected_count'  => 3,
 				'error'           => '',
 			),
@@ -135,7 +135,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 							'rel'  => 'preconnect',
 							'href' => 'https://youtube.com/',
 						),
-						201,
+						200,
 						300,
 					),
 				),
@@ -154,7 +154,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 							'href'  => 'https://youtube.com/',
 							'media' => 'tty',
 						),
-						201,
+						200,
 						300,
 					),
 				),

--- a/plugins/optimization-detective/tests/test-class-od-link-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-link-collection.php
@@ -128,6 +128,40 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_count'  => 3,
 				'error'           => '',
 			),
+			'multiple_preloads_merged_full_range'        => array(
+				'links_args'      => array(
+					array(
+						array(
+							'rel'           => 'preload',
+							'href'          => 'https://example.com/foo.jpg',
+							'crossorigin'   => 'anonymous',
+							'fetchpriority' => 'high',
+							'as'            => 'image',
+							'media'         => 'screen',
+						),
+						0,
+						800,
+					),
+					array(
+						array(
+							'rel'           => 'preload',
+							'href'          => 'https://example.com/foo.jpg',
+							'crossorigin'   => 'anonymous',
+							'fetchpriority' => 'high',
+							'as'            => 'image',
+							'media'         => 'screen',
+						),
+						800,
+						null,
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag rel="preload" href="https://example.com/foo.jpg" crossorigin="anonymous" fetchpriority="high" as="image" media="screen">
+				',
+				'expected_header' => 'Link: <https://example.com/foo.jpg>; rel="preload"; crossorigin="anonymous"; fetchpriority="high"; as="image"; media="screen"',
+				'expected_count'  => 2,
+				'error'           => '',
+			),
 			'preconnect_with_min_max_viewport_widths'    => array(
 				'links_args'      => array(
 					array(

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -156,7 +156,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					800 => 1,
 				),
 				'expected_counts' => array(
-					0   => 3,
+					1   => 3,
 					481 => 3,
 					783 => 1,
 				),
@@ -171,7 +171,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					783 => 6,
 				),
 				'expected_counts' => array(
-					0   => 2,
+					1   => 2,
 					481 => 2,
 					601 => 2,
 					783 => 2,
@@ -185,7 +185,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					800 => 1,
 				),
 				'expected_counts' => array(
-					0   => 1,
+					1   => 1,
 					481 => 1,
 				),
 			),
@@ -197,7 +197,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					600 => 1,
 				),
 				'expected_counts' => array(
-					0 => 2,
+					1 => 2,
 				),
 			),
 		);
@@ -346,12 +346,12 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 						'url_metric_viewport_widths' => array( 400, 480 ),
 					),
 					array(
-						'minimum_viewport_width'     => 481,
+						'minimum_viewport_width'     => 480,
 						'maximum_viewport_width'     => 640,
 						'url_metric_viewport_widths' => array(),
 					),
 					array(
-						'minimum_viewport_width'     => 641,
+						'minimum_viewport_width'     => 640,
 						'maximum_viewport_width'     => PHP_INT_MAX,
 						'url_metric_viewport_widths' => array( 800 ),
 					),
@@ -367,7 +367,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 						'url_metric_viewport_widths' => array( 400 ),
 					),
 					array(
-						'minimum_viewport_width'     => 481,
+						'minimum_viewport_width'     => 480,
 						'maximum_viewport_width'     => PHP_INT_MAX,
 						'url_metric_viewport_widths' => array( 600, 800, 1000 ),
 					),
@@ -499,7 +499,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 							'complete'             => true,
 						),
 						array(
-							'minimumViewportWidth' => 481,
+							'minimumViewportWidth' => 480,
 							'complete'             => true,
 						),
 					),
@@ -523,7 +523,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 							'complete'             => false,
 						),
 						array(
-							'minimumViewportWidth' => 481,
+							'minimumViewportWidth' => 480,
 							'complete'             => false,
 						),
 					),
@@ -550,7 +550,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 							'complete'             => false,
 						),
 						array(
-							'minimumViewportWidth' => 481,
+							'minimumViewportWidth' => 480,
 							'complete'             => true,
 						),
 					),
@@ -578,7 +578,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 							'complete'             => true,
 						),
 						array(
-							'minimumViewportWidth' => 481,
+							'minimumViewportWidth' => 480,
 							'complete'             => false,
 						),
 					),
@@ -740,13 +740,13 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 		$current_etag     = md5( '' );
 		$group_collection = new OD_URL_Metric_Group_Collection(
 			array(
-				// Group 1: 0-480 viewport widths.
+				// Group 1: >0-480 viewport widths.
 				$get_url_metric_with_one_lcp_element( 400, $first_child_image_xpath ),
 				$get_url_metric_with_one_lcp_element( 420, $first_child_image_xpath ),
 				$get_url_metric_with_one_lcp_element( 440, $second_child_image_xpath ),
-				// Group 2: 481-800 viewport widths.
+				// Group 2: >480-800 viewport widths.
 				$get_url_metric_with_one_lcp_element( 500, $first_child_h1_xpath ),
-				// Group 3: 801-Infinity viewport widths.
+				// Group 3: >800-Infinity viewport widths.
 				$get_url_metric_with_one_lcp_element( 820, $first_child_image_xpath ),
 				$get_url_metric_with_one_lcp_element( 900, $first_child_image_xpath ),
 			),

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group-collection.php
@@ -46,14 +46,6 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 				'freshness_ttl' => HOUR_IN_SECONDS,
 				'exception'     => InvalidArgumentException::class,
 			),
-			'max_breakpoint_bad'         => array(
-				'url_metrics'   => array(),
-				'current_etag'  => $current_etag,
-				'breakpoints'   => array( PHP_INT_MAX ),
-				'sample_size'   => 3,
-				'freshness_ttl' => HOUR_IN_SECONDS,
-				'exception'     => InvalidArgumentException::class,
-			),
 			'string_breakpoint_bad'      => array(
 				'url_metrics'   => array(),
 				'current_etag'  => $current_etag,
@@ -352,7 +344,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					),
 					array(
 						'minimum_viewport_width'     => 640,
-						'maximum_viewport_width'     => PHP_INT_MAX,
+						'maximum_viewport_width'     => null,
 						'url_metric_viewport_widths' => array( 800 ),
 					),
 				),
@@ -368,7 +360,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 					),
 					array(
 						'minimum_viewport_width'     => 480,
-						'maximum_viewport_width'     => PHP_INT_MAX,
+						'maximum_viewport_width'     => null,
 						'url_metric_viewport_widths' => array( 600, 800, 1000 ),
 					),
 				),
@@ -379,7 +371,7 @@ class Test_OD_URL_Metric_Group_Collection extends WP_UnitTestCase {
 				'expected_groups' => array(
 					array(
 						'minimum_viewport_width'     => 0,
-						'maximum_viewport_width'     => PHP_INT_MAX,
+						'maximum_viewport_width'     => null,
 						'url_metric_viewport_widths' => array( 250, 500, 1000 ),
 					),
 				),

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -141,7 +141,8 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 				'breakpoints'              => array( 10 ),
 				'group_index'              => 0,
 				'viewport_widths_expected' => array(
-					0  => true,
+					-1 => false,
+					0  => false,
 					1  => true,
 					9  => true,
 					10 => true,
@@ -152,7 +153,9 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 				'breakpoints'              => array( 99, 200 ),
 				'group_index'              => 1,
 				'viewport_widths_expected' => array(
+					-1  => false,
 					0   => false,
+					1   => false,
 					99  => false,
 					100 => true,
 					101 => true,
@@ -326,8 +329,8 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 				'expected_lcp_element_xpaths' => array_fill_keys(
 					array(
 						'0:600',
-						'601:800',
-						'801:',
+						'600:800',
+						'800:',
 					),
 					$this->get_xpath( 'HTML', 'BODY', 'FIGURE', 'IMG' )
 				),
@@ -345,7 +348,7 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 				),
 				'expected_lcp_element_xpaths' => array(
 					'0:600' => $this->get_xpath( 'HTML', 'BODY', 'FIGURE', 'IMG' ),
-					'601:'  => $this->get_xpath( 'HTML', 'BODY', 'MAIN', 'IMG' ),
+					'600:'  => $this->get_xpath( 'HTML', 'BODY', 'MAIN', 'IMG' ),
 				),
 			),
 			'same_lcp_element_across_non_consecutive_breakpoints' => array(
@@ -361,8 +364,8 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 				),
 				'expected_lcp_element_xpaths' => array(
 					'0:400'   => $this->get_xpath( 'HTML', 'BODY', 'MAIN', 'IMG' ),
-					'401:600' => null, // The (image) element is either not visible at this breakpoint or it is not LCP element.
-					'601:'    => $this->get_xpath( 'HTML', 'BODY', 'MAIN', 'IMG' ),
+					'400:600' => null, // The (image) element is either not visible at this breakpoint or it is not LCP element.
+					'600:'    => $this->get_xpath( 'HTML', 'BODY', 'MAIN', 'IMG' ),
 				),
 			),
 			'no_lcp_image_elements'                    => array(
@@ -376,7 +379,7 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 				'expected_lcp_element_xpaths' => array_fill_keys(
 					array(
 						'0:600',
-						'601:',
+						'600:',
 					),
 					null
 				),

--- a/plugins/optimization-detective/tests/test-detection.php
+++ b/plugins/optimization-detective/tests/test-detection.php
@@ -152,9 +152,9 @@ class Test_OD_Detection extends WP_UnitTestCase {
 			$web_vitals_library_src
 		);
 		$this->assertStringContainsString( '"minimumViewportWidth":0', $script );
-		$this->assertStringContainsString( '"minimumViewportWidth":481', $script );
-		$this->assertStringContainsString( '"minimumViewportWidth":601', $script );
-		$this->assertStringContainsString( '"minimumViewportWidth":783', $script );
+		$this->assertStringContainsString( '"minimumViewportWidth":480', $script );
+		$this->assertStringContainsString( '"minimumViewportWidth":600', $script );
+		$this->assertStringContainsString( '"minimumViewportWidth":782', $script );
 		$this->assertStringContainsString( '"complete":false', $script );
 	}
 }

--- a/plugins/optimization-detective/tests/test-helper.php
+++ b/plugins/optimization-detective/tests/test-helper.php
@@ -42,17 +42,17 @@ class Test_OD_Helper extends WP_UnitTestCase {
 				'expected'  => '(max-width: 320px)',
 			),
 			'tablet'      => array(
-				'min_width' => 321,
+				'min_width' => 320,
 				'max_width' => 600,
 				'expected'  => '(min-width: 321px) and (max-width: 600px)',
 			),
 			'desktop'     => array(
-				'min_width' => 601,
+				'min_width' => 600,
 				'max_width' => PHP_INT_MAX,
 				'expected'  => '(min-width: 601px)',
 			),
 			'desktop_alt' => array(
-				'min_width' => 601,
+				'min_width' => 600,
 				'max_width' => null,
 				'expected'  => '(min-width: 601px)',
 			),

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -34,6 +34,7 @@ export type ExtendedRootData = ExcludeProps< URLMetric >;
 
 export interface URLMetricGroupStatus {
 	minimumViewportWidth: number;
+	maximumViewportWidth: number;
 	complete: boolean;
 }
 

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -34,7 +34,7 @@ export type ExtendedRootData = ExcludeProps< URLMetric >;
 
 export interface URLMetricGroupStatus {
 	minimumViewportWidth: number;
-	maximumViewportWidth: number;
+	maximumViewportWidth: number | null; // Note that null is output to the frontend as opposed to PHP_INT_MAX.
 	complete: boolean;
 }
 

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -34,7 +34,7 @@ export type ExtendedRootData = ExcludeProps< URLMetric >;
 
 export interface URLMetricGroupStatus {
 	minimumViewportWidth: number;
-	maximumViewportWidth: number | null; // Note that null is output to the frontend as opposed to PHP_INT_MAX.
+	maximumViewportWidth: number | null;
 	complete: boolean;
 }
 


### PR DESCRIPTION
## Summary

This is a dependency to fix https://github.com/WordPress/performance/issues/1696 and blocks #1833 from being merged. This change allows for creating media queries that avoid any 1px gaps. The key code change is in `OD_URL_Metric_Group::is_viewport_width_in_range()` (and `isViewportNeeded` in `detect.js`). This also avoid the need to add the number 1 to the minimum viewport width which can be confusing given the known breakpoints. This instead moves the addition of 1 at the moment to `od_generate_media_query()` but this will be removed with resolution of #1696.

As part of this, the viewport width and height for a URL Metric are now required to be at least 1px, whereas before they could theoretically be 0px (which doesn't make sense).

While auditing the types after the above change, I also improved the type specificity with PHPStan's richer types.

Note that all of the snapshot tests for Optimization Detective, Image Prioritizer, and Embed Optimizer are all passing without any modification in this PR. This shows that the code change does not impact the output.