### PR TITLE
Remove experimental flags from Embed Optimizer and Image Prioritizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Plugin                          | Slug                      | Experimental | Lin
 [Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
 [Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
 [Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
-[Embed Optimizer][5]            | `embed-optimizer`         | Yes          | [Source][13], [Issues][21], [PRs][29]
+[Embed Optimizer][5]            | `embed-optimizer`         | No           | [Source][13], [Issues][21], [PRs][29]
+[Image Prioritizer][7]          | `image-prioritizer`       | No           | [Source][15], [Issues][23], [PRs][31]
 [Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][14], [Issues][22], [PRs][30]
-[Image Prioritizer][7]          | `image-prioritizer`       | Yes          | [Source][15], [Issues][23], [PRs][31]
 [Web Worker Offloading][8]      | `web-worker-offloading`   | Yes          | [Source][16], [Issues][24], [PRs][32]
 
 [1]: https://wordpress.org/plugins/dominant-color-images/

--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The feature plugins which are currently featured by this plugin are:
 
 Plugin                          | Slug                      | Experimental | Links
 --------------------------------|---------------------------|--------------|-------------
+[Embed Optimizer][5]            | `embed-optimizer`         | No           | [Source][13], [Issues][21], [PRs][29]
 [Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][9],  [Issues][17], [PRs][25]
+[Image Prioritizer][7]          | `image-prioritizer`       | No           | [Source][15], [Issues][23], [PRs][31]
 [Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
 [Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
 [Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
-[Embed Optimizer][5]            | `embed-optimizer`         | No           | [Source][13], [Issues][21], [PRs][29]
-[Image Prioritizer][7]          | `image-prioritizer`       | No           | [Source][15], [Issues][23], [PRs][31]
 [Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][14], [Issues][22], [PRs][30]
 [Web Worker Offloading][8]      | `web-worker-offloading`   | Yes          | [Source][16], [Issues][24], [PRs][32]
 

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -104,11 +104,11 @@ function perflab_get_standalone_plugin_data(): array {
 		),
 		'embed-optimizer'         => array(
 			'constant'     => 'EMBED_OPTIMIZER_VERSION',
-			'experimental' => true,
+			'experimental' => false,
 		),
 		'image-prioritizer'       => array(
 			'constant'     => 'IMAGE_PRIORITIZER_VERSION',
-			'experimental' => true,
+			'experimental' => false,
 		),
 		'performant-translations' => array(
 			'constant' => 'PERFORMANT_TRANSLATIONS_VERSION',


### PR DESCRIPTION
The currently-released version of Optimization Detective plugin is 1.0.0-beta1. Optimization Detective, Embed Optimizer, and Image Prioritizer all 20,000+ active installs respectively. Analysis of these plugins on sites in HTTP Archive has shown them to be effective at improving performance. The plugins running in the wild has not resulted in major issues that would put their stability into question. Therefore, it's time to remove the experimental labels from these plugins.

In a subsequent PR for the next Performance Lab release we may bump Image Optimizer and Embed Optimizer to 1.0.0-beta1 as another indication of the maturity for these plugins.

![image](https://github.com/user-attachments/assets/6414d7f3-4612-411a-8b34-1dff6fd2af57)
