### PR TITLE
Add post ID for the `od_url_metrics` post to the tag visitor context

### DIFF
--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -17,7 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 0.4.0
  *
- * @property-read OD_URL_Metric_Group_Collection $url_metrics_group_collection Deprecated property accessed via magic getter. Use the url_metric_group_collection property instead.
+ * @property-read OD_HTML_Tag_Processor          $processor                    HTML tag processor.
+ * @property-read OD_URL_Metric_Group_Collection $url_metric_group_collection  URL Metric group collection.
+ * @property-read OD_Link_Collection             $link_collection              Link collection.
+ * @property-read positive-int|null              $url_metrics_id               ID for the od_url_metrics post which provided the URL Metrics in the collection.
+ * @property-read OD_URL_Metric_Group_Collection $url_metrics_group_collection Deprecated alias for the url_metric_group_collection property.
  */
 final class OD_Tag_Visitor_Context {
 
@@ -26,27 +30,24 @@ final class OD_Tag_Visitor_Context {
 	 *
 	 * @since 0.4.0
 	 * @var OD_HTML_Tag_Processor
-	 * @readonly
 	 */
-	public $processor;
+	private $processor;
 
 	/**
 	 * URL Metric group collection.
 	 *
 	 * @since 0.4.0
 	 * @var OD_URL_Metric_Group_Collection
-	 * @readonly
 	 */
-	public $url_metric_group_collection;
+	private $url_metric_group_collection;
 
 	/**
 	 * Link collection.
 	 *
 	 * @since 0.4.0
 	 * @var OD_Link_Collection
-	 * @readonly
 	 */
-	public $link_collection;
+	private $link_collection;
 
 	/**
 	 * ID for the od_url_metrics post which provided the URL Metrics in the collection.
@@ -55,12 +56,13 @@ final class OD_Tag_Visitor_Context {
 	 *
 	 * @since n.e.x.t
 	 * @var positive-int|null
-	 * @readonly
 	 */
-	public $url_metrics_id;
+	private $url_metrics_id;
 
 	/**
 	 * Visited tag state.
+	 *
+	 * Important: This object is not exposed directly by the getter. It is only exposed via {@see self::track_tag()}.
 	 *
 	 * @since 1.0.0
 	 * @var OD_Visited_Tag_State
@@ -98,39 +100,50 @@ final class OD_Tag_Visitor_Context {
 	}
 
 	/**
-	 * Gets deprecated property.
+	 * Gets a property.
 	 *
 	 * @since 0.7.0
-	 * @todo Remove this when no plugins are possibly referring to the url_metrics_group_collection property anymore.
 	 *
 	 * @param string $name Property name.
-	 * @return OD_URL_Metric_Group_Collection URL Metric group collection.
+	 * @return mixed Property value.
 	 *
 	 * @throws Error When property is unknown.
 	 */
-	public function __get( string $name ): OD_URL_Metric_Group_Collection {
-		if ( 'url_metrics_group_collection' === $name ) {
-			_doing_it_wrong(
-				__CLASS__ . '::$url_metrics_group_collection',
-				esc_html(
-					sprintf(
+	public function __get( string $name ) {
+		// Note that there is intentionally not a case for 'visited_tag_state'.
+		switch ( $name ) {
+			case 'processor':
+				return $this->processor;
+			case 'link_collection':
+				return $this->link_collection;
+			case 'url_metrics_id':
+				return $this->url_metrics_id;
+			case 'url_metric_group_collection':
+				return $this->url_metric_group_collection;
+			case 'url_metrics_group_collection':
+				// TODO: Remove this when no plugins are possibly referring to the url_metrics_group_collection property anymore.
+				_doing_it_wrong(
+					__CLASS__ . '::$url_metrics_group_collection',
+					esc_html(
+						sprintf(
 						/* translators: %s is class member variable name */
-						__( 'Use %s instead.', 'optimization-detective' ),
-						__CLASS__ . '::$url_metric_group_collection'
+							__( 'Use %s instead.', 'optimization-detective' ),
+							__CLASS__ . '::$url_metric_group_collection'
+						)
+					),
+					'optimization-detective 0.7.0'
+				);
+				return $this->url_metric_group_collection;
+			default:
+				throw new Error(
+					esc_html(
+						sprintf(
+							/* translators: %s is class member variable name */
+							__( 'Unknown property %s.', 'optimization-detective' ),
+							__CLASS__ . '::$' . $name
+						)
 					)
-				),
-				'optimization-detective 0.7.0'
-			);
-			return $this->url_metric_group_collection;
+				);
 		}
-		throw new Error(
-			esc_html(
-				sprintf(
-					/* translators: %s is class member variable name */
-					__( 'Unknown property %s.', 'optimization-detective' ),
-					__CLASS__ . '::$' . $name
-				)
-			)
-		);
 	}
 }

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -49,7 +49,7 @@ final class OD_Tag_Visitor_Context {
 	public $link_collection;
 
 	/**
-	 * Post ID for the od_url_metrics post which provided the URL Metrics in the collection.
+	 * ID for the od_url_metrics post which provided the URL Metrics in the collection.
 	 *
 	 * May be null if no post has been created yet.
 	 *
@@ -57,7 +57,7 @@ final class OD_Tag_Visitor_Context {
 	 * @var positive-int|null
 	 * @readonly
 	 */
-	public $url_metrics_post_id;
+	public $url_metrics_id;
 
 	/**
 	 * Visited tag state.
@@ -76,14 +76,14 @@ final class OD_Tag_Visitor_Context {
 	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL Metric group collection.
 	 * @param OD_Link_Collection             $link_collection             Link collection.
 	 * @param OD_Visited_Tag_State           $visited_tag_state           Visited tag state.
-	 * @param positive-int|null              $url_metrics_post_id         Post ID for the od_url_metrics post which provided the URL Metrics in the collection. May be null if no post has been created yet.
+	 * @param positive-int|null              $url_metrics_id              ID for the od_url_metrics post which provided the URL Metrics in the collection. May be null if no post has been created yet.
 	 */
-	public function __construct( OD_HTML_Tag_Processor $processor, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_Link_Collection $link_collection, OD_Visited_Tag_State $visited_tag_state, ?int $url_metrics_post_id ) {
+	public function __construct( OD_HTML_Tag_Processor $processor, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_Link_Collection $link_collection, OD_Visited_Tag_State $visited_tag_state, ?int $url_metrics_id ) {
 		$this->processor                   = $processor;
 		$this->url_metric_group_collection = $url_metric_group_collection;
 		$this->link_collection             = $link_collection;
 		$this->visited_tag_state           = $visited_tag_state;
-		$this->url_metrics_post_id         = $url_metrics_post_id;
+		$this->url_metrics_id              = $url_metrics_id;
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -49,6 +49,17 @@ final class OD_Tag_Visitor_Context {
 	public $link_collection;
 
 	/**
+	 * Post ID for the od_url_metrics post which provided the URL Metrics in the collection.
+	 *
+	 * May be null if no post has been created yet.
+	 *
+	 * @since n.e.x.t
+	 * @var positive-int|null
+	 * @readonly
+	 */
+	public $url_metrics_post_id;
+
+	/**
 	 * Visited tag state.
 	 *
 	 * @since 1.0.0
@@ -65,12 +76,14 @@ final class OD_Tag_Visitor_Context {
 	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL Metric group collection.
 	 * @param OD_Link_Collection             $link_collection             Link collection.
 	 * @param OD_Visited_Tag_State           $visited_tag_state           Visited tag state.
+	 * @param positive-int|null              $url_metrics_post_id         Post ID for the od_url_metrics post which provided the URL Metrics in the collection. May be null if no post has been created yet.
 	 */
-	public function __construct( OD_HTML_Tag_Processor $processor, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_Link_Collection $link_collection, OD_Visited_Tag_State $visited_tag_state ) {
+	public function __construct( OD_HTML_Tag_Processor $processor, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_Link_Collection $link_collection, OD_Visited_Tag_State $visited_tag_state, ?int $url_metrics_post_id ) {
 		$this->processor                   = $processor;
 		$this->url_metric_group_collection = $url_metric_group_collection;
 		$this->link_collection             = $link_collection;
 		$this->visited_tag_state           = $visited_tag_state;
+		$this->url_metrics_post_id         = $url_metrics_post_id;
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @property-read OD_URL_Metric_Group_Collection $url_metric_group_collection  URL Metric group collection.
  * @property-read OD_Link_Collection             $link_collection              Link collection.
  * @property-read positive-int|null              $url_metrics_id               ID for the od_url_metrics post which provided the URL Metrics in the collection.
- * @property-read OD_URL_Metric_Group_Collection $url_metrics_group_collection Deprecated alias for the url_metric_group_collection property.
+ * @property-read OD_URL_Metric_Group_Collection $url_metrics_group_collection Deprecated alias for the $url_metric_group_collection property.
  */
 final class OD_Tag_Visitor_Context {
 
@@ -123,10 +123,10 @@ final class OD_Tag_Visitor_Context {
 			case 'url_metrics_group_collection':
 				// TODO: Remove this when no plugins are possibly referring to the url_metrics_group_collection property anymore.
 				_doing_it_wrong(
-					__CLASS__ . '::$url_metrics_group_collection',
+					esc_html( __CLASS__ . '::$' . $name ),
 					esc_html(
 						sprintf(
-						/* translators: %s is class member variable name */
+							/* translators: %s is class member variable name */
 							__( 'Use %s instead.', 'optimization-detective' ),
 							__CLASS__ . '::$url_metric_group_collection'
 						)

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -209,6 +209,18 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	}
 
 	/**
+	 * Gets the collection that this group is a part of.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @todo Eliminate in favor of readonly public property.
+	 * @return OD_URL_Metric_Group_Collection Collection.
+	 */
+	public function get_collection(): OD_URL_Metric_Group_Collection {
+		return $this->collection;
+	}
+
+	/**
 	 * Checks whether the provided viewport width is between the minimum (exclusive) and maximum (inclusive).
 	 *
 	 * @since 0.1.0

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides an API for leveraging real user metrics to detect optimizations to apply on the frontend to improve page performance.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.0.0-beta1
+ * Version: 1.0.0-beta2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'1.0.0-beta1',
+	'1.0.0-beta2',
 	static function ( string $version ): void {
 		if ( defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			return;

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -267,7 +267,13 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	);
 	$link_collection      = new OD_Link_Collection();
 	$visited_tag_state    = new OD_Visited_Tag_State();
-	$tag_visitor_context  = new OD_Tag_Visitor_Context( $processor, $group_collection, $link_collection, $visited_tag_state );
+	$tag_visitor_context  = new OD_Tag_Visitor_Context(
+		$processor,
+		$group_collection,
+		$link_collection,
+		$visited_tag_state,
+		$post instanceof WP_Post && $post->ID > 0 ? $post->ID : null
+	);
 	$current_tag_bookmark = 'optimization_detective_current_tag';
 	$visitors             = iterator_to_array( $tag_visitor_registry );
 

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   1.0.0-beta1
+Stable tag:   1.0.0-beta2
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, rum
@@ -54,6 +54,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 1.0.0-beta2 =
 
 = 1.0.0-beta1 =
 

--- a/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
+++ b/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
@@ -18,10 +18,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 0.7.0
  *
  * @property-read WP_REST_Request<array<string, mixed>> $request                     Request.
- * @property-read positive-int                          $post_id                     ID for the od_url_metrics post.
+ * @property-read positive-int                          $url_metrics_id              ID for the od_url_metrics post.
  * @property-read OD_URL_Metric_Group_Collection        $url_metric_group_collection URL Metric group collection.
  * @property-read OD_URL_Metric_Group                   $url_metric_group            URL Metric group.
  * @property-read OD_URL_Metric                         $url_metric                  URL Metric.
+ * @property-read positive-int                          $post_id                     Deprecated alias for the $url_metrics_id property.
  */
 final class OD_URL_Metric_Store_Request_Context {
 
@@ -36,10 +37,12 @@ final class OD_URL_Metric_Store_Request_Context {
 	/**
 	 * ID for the od_url_metrics post.
 	 *
-	 * @since 0.7.0
+	 * This was originally $post_id which was introduced in 0.7.0.
+	 *
+	 * @since n.e.x.t
 	 * @var positive-int
 	 */
-	private $post_id;
+	private $url_metrics_id;
 
 	/**
 	 * URL Metric group collection.
@@ -73,14 +76,14 @@ final class OD_URL_Metric_Store_Request_Context {
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
 	 * @param WP_REST_Request                $request                     REST API request.
-	 * @param positive-int                   $post_id                     ID for the URL Metric post.
+	 * @param positive-int                   $url_metrics_id              ID for the URL Metric post.
 	 * @param OD_URL_Metric_Group_Collection $url_metric_group_collection URL Metric group collection.
 	 * @param OD_URL_Metric_Group            $url_metric_group            URL Metric group.
 	 * @param OD_URL_Metric                  $url_metric                  URL Metric.
 	 */
-	public function __construct( WP_REST_Request $request, int $post_id, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_URL_Metric_Group $url_metric_group, OD_URL_Metric $url_metric ) {
+	public function __construct( WP_REST_Request $request, int $url_metrics_id, OD_URL_Metric_Group_Collection $url_metric_group_collection, OD_URL_Metric_Group $url_metric_group, OD_URL_Metric $url_metric ) {
 		$this->request                     = $request;
-		$this->post_id                     = $post_id;
+		$this->url_metrics_id              = $url_metrics_id;
 		$this->url_metric_group_collection = $url_metric_group_collection;
 		$this->url_metric_group            = $url_metric_group;
 		$this->url_metric                  = $url_metric;
@@ -100,14 +103,27 @@ final class OD_URL_Metric_Store_Request_Context {
 		switch ( $name ) {
 			case 'request':
 				return $this->request;
-			case 'post_id':
-				return $this->post_id;
+			case 'url_metrics_id':
+				return $this->url_metrics_id;
 			case 'url_metric_group_collection':
 				return $this->url_metric_group_collection;
 			case 'url_metric_group':
 				return $this->url_metric_group;
 			case 'url_metric':
 				return $this->url_metric;
+			case 'post_id':
+				_doing_it_wrong(
+					esc_html( __CLASS__ . '::$' . $name ),
+					esc_html(
+						sprintf(
+							/* translators: %s is class member variable name */
+							__( 'Use %s instead.', 'optimization-detective' ),
+							__CLASS__ . '::$url_metrics_id'
+						)
+					),
+					'optimization-detective n.e.x.t'
+				);
+				return $this->url_metrics_id;
 			default:
 				throw new Error(
 					esc_html(

--- a/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
+++ b/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
@@ -16,52 +16,59 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Context for when a URL Metric is successfully stored via the REST API.
  *
  * @since 0.7.0
- * @access private
+ *
+ * @property-read WP_REST_Request<array<string, mixed>> $request                     Request.
+ * @property-read positive-int                          $post_id                     ID for the od_url_metrics post.
+ * @property-read OD_URL_Metric_Group_Collection        $url_metric_group_collection URL Metric group collection.
+ * @property-read OD_URL_Metric_Group                   $url_metric_group            URL Metric group.
+ * @property-read OD_URL_Metric                         $url_metric                  URL Metric.
  */
 final class OD_URL_Metric_Store_Request_Context {
 
 	/**
 	 * Request.
 	 *
+	 * @since 0.7.0
 	 * @var WP_REST_Request<array<string, mixed>>
-	 * @readonly
 	 */
-	public $request;
+	private $request;
 
 	/**
-	 * ID for the URL Metric post.
+	 * ID for the od_url_metrics post.
 	 *
+	 * @since 0.7.0
 	 * @var positive-int
-	 * @readonly
 	 */
-	public $post_id;
+	private $post_id;
 
 	/**
 	 * URL Metric group collection.
 	 *
+	 * @since 0.7.0
 	 * @var OD_URL_Metric_Group_Collection
-	 * @readonly
 	 */
-	public $url_metric_group_collection;
+	private $url_metric_group_collection;
 
 	/**
 	 * URL Metric group.
 	 *
+	 * @since 0.7.0
 	 * @var OD_URL_Metric_Group
-	 * @readonly
 	 */
-	public $url_metric_group;
+	private $url_metric_group;
 
 	/**
 	 * URL Metric.
 	 *
+	 * @since 0.7.0
 	 * @var OD_URL_Metric
-	 * @readonly
 	 */
-	public $url_metric;
+	private $url_metric;
 
 	/**
 	 * Constructor.
+	 *
+	 * @since 0.7.0
 	 *
 	 * @phpstan-param WP_REST_Request<array<string, mixed>> $request
 	 *
@@ -77,5 +84,40 @@ final class OD_URL_Metric_Store_Request_Context {
 		$this->url_metric_group_collection = $url_metric_group_collection;
 		$this->url_metric_group            = $url_metric_group;
 		$this->url_metric                  = $url_metric;
+	}
+
+	/**
+	 * Gets a property.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $name Property name.
+	 * @return mixed Property value.
+	 *
+	 * @throws Error When property is unknown.
+	 */
+	public function __get( string $name ) {
+		switch ( $name ) {
+			case 'request':
+				return $this->request;
+			case 'post_id':
+				return $this->post_id;
+			case 'url_metric_group_collection':
+				return $this->url_metric_group_collection;
+			case 'url_metric_group':
+				return $this->url_metric_group;
+			case 'url_metric':
+				return $this->url_metric;
+			default:
+				throw new Error(
+					esc_html(
+						sprintf(
+							/* translators: %s is class member variable name */
+							__( 'Unknown property %s.', 'optimization-detective' ),
+							__CLASS__ . '::$' . $name
+						)
+					)
+				);
+		}
 	}
 }

--- a/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
+++ b/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
@@ -23,7 +23,7 @@ trait Optimization_Detective_Test_Helpers {
 	 * @phpstan-param ElementDataSubset[] $elements
 	 * @param array[] $elements Element data.
 	 * @param bool    $complete Whether to fully populate the groups.
-	 * @return positive-int Post ID.
+	 * @return positive-int ID for od_url_metrics post.
 	 * @throws Exception If something terrible happens.
 	 */
 	public function populate_url_metrics( array $elements, bool $complete = true ): int {

--- a/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
+++ b/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
@@ -23,15 +23,17 @@ trait Optimization_Detective_Test_Helpers {
 	 * @phpstan-param ElementDataSubset[] $elements
 	 * @param array[] $elements Element data.
 	 * @param bool    $complete Whether to fully populate the groups.
-	 * @throws Exception But it won't.
+	 * @return positive-int Post ID.
+	 * @throws Exception If something terrible happens.
 	 */
-	public function populate_url_metrics( array $elements, bool $complete = true ): void {
+	public function populate_url_metrics( array $elements, bool $complete = true ): int {
 		$slug        = od_get_url_metrics_slug( od_get_normalized_query_vars() );
 		$etag        = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), null, null ); // Note: Tests rely on the od_current_url_metrics_etag_data filter to set the desired value.
 		$sample_size = $complete ? od_get_url_metrics_breakpoint_sample_size() : 1;
+		$last_result = null;
 		foreach ( array_merge( od_get_breakpoint_max_widths(), array( 1000 ) ) as $viewport_width ) {
 			for ( $i = 0; $i < $sample_size; $i++ ) {
-				OD_URL_Metrics_Post_Type::store_url_metric(
+				$result = OD_URL_Metrics_Post_Type::store_url_metric(
 					$slug,
 					$this->get_sample_url_metric(
 						array(
@@ -41,8 +43,19 @@ trait Optimization_Detective_Test_Helpers {
 						)
 					)
 				);
+				if ( $result instanceof WP_Error ) {
+					throw new Exception( 'Failed to store URL Metric: ' . $result->get_error_message() );
+				}
+				if ( null !== $last_result && $result !== $last_result ) {
+					throw new Exception( 'Expected same post ID to always be returned.' );
+				}
+				$last_result = $result;
 			}
 		}
+		if ( null === $last_result ) {
+			throw new Exception( 'Unexpectedly did not create any URL Metrics.' );
+		}
+		return $last_result;
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -77,6 +77,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 	 * @covers ::od_trigger_page_cache_invalidation
 	 * @covers OD_Strict_URL_Metric::set_additional_properties_to_false
 	 * @covers OD_URL_Metric_Store_Request_Context::__construct
+	 * @covers OD_URL_Metric_Store_Request_Context::__get
 	 */
 	public function test_rest_request_good_params( Closure $set_up ): void {
 		$stored_context = null;
@@ -88,6 +89,15 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 				$this->assertInstanceOf( OD_URL_Metric::class, $context->url_metric );
 				$this->assertInstanceOf( WP_REST_Request::class, $context->request );
 				$this->assertIsInt( $context->post_id );
+				$error = null;
+				$value = '';
+				try {
+					$value = $context->__get( 'unknown' );
+				} catch ( Error $e ) {
+					$error = $e;
+				}
+				$this->assertSame( '', $value );
+				$this->assertInstanceOf( Error::class, $error );
 				$stored_context = $context;
 			}
 		);

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -88,7 +88,11 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 				$this->assertInstanceOf( OD_URL_Metric_Group::class, $context->url_metric_group );
 				$this->assertInstanceOf( OD_URL_Metric::class, $context->url_metric );
 				$this->assertInstanceOf( WP_REST_Request::class, $context->request );
+				$this->assertIsInt( $context->url_metrics_id );
+				$this->setExpectedIncorrectUsage( 'OD_URL_Metric_Store_Request_Context::$post_id' );
 				$this->assertIsInt( $context->post_id );
+				$this->assertSame( $context->url_metrics_id, $context->post_id );
+
 				$error = null;
 				$value = '';
 				try {

--- a/plugins/optimization-detective/tests/test-cases/admin-bar/set-up.php
+++ b/plugins/optimization-detective/tests/test-cases/admin-bar/set-up.php
@@ -7,7 +7,7 @@ return static function ( Test_OD_Optimization $test_case ): void {
 				'everything',
 				static function ( OD_Tag_Visitor_Context $context ) use ( $test_case ): void {
 					$test_case->assertNotEquals( 'wpadminbar', $context->processor->get_attribute( 'id' ) );
-					$test_case->assertNull( $context->url_metrics_post_id, 'Expected url_metrics_post_id to be null since no od_url_metrics_post exists for this URL.' );
+					$test_case->assertNull( $context->url_metrics_id, 'Expected url_metrics_id to be null since no od_url_metrics_post exists for this URL.' );
 				}
 			);
 		}

--- a/plugins/optimization-detective/tests/test-cases/admin-bar/set-up.php
+++ b/plugins/optimization-detective/tests/test-cases/admin-bar/set-up.php
@@ -1,2 +1,15 @@
 <?php
-return static function (): void {};
+return static function ( Test_OD_Optimization $test_case ): void {
+	add_action(
+		'od_register_tag_visitors',
+		static function ( OD_Tag_Visitor_Registry $registry ) use ( $test_case ): void {
+			$registry->register(
+				'everything',
+				static function ( OD_Tag_Visitor_Context $context ) use ( $test_case ): void {
+					$test_case->assertNotEquals( 'wpadminbar', $context->processor->get_attribute( 'id' ) );
+					$test_case->assertNull( $context->url_metrics_post_id, 'Expected url_metrics_post_id to be null since no od_url_metrics_post exists for this URL.' );
+				}
+			);
+		}
+	);
+};

--- a/plugins/optimization-detective/tests/test-cases/complete-url-metrics/set-up.php
+++ b/plugins/optimization-detective/tests/test-cases/complete-url-metrics/set-up.php
@@ -23,7 +23,7 @@ return static function ( Test_OD_Optimization $test_case ): void {
 			$registry->register(
 				'everything',
 				static function ( OD_Tag_Visitor_Context $context ) use ( $test_case, $post_id ): void {
-					$test_case->assertSame( $post_id, $context->url_metrics_post_id, 'Expected url_metrics_post_id in context too match the ID from when URL Metrics were populated.' );
+					$test_case->assertSame( $post_id, $context->url_metrics_id, 'Expected url_metrics_id in context too match the ID from when URL Metrics were populated.' );
 				}
 			);
 		}

--- a/plugins/optimization-detective/tests/test-cases/complete-url-metrics/set-up.php
+++ b/plugins/optimization-detective/tests/test-cases/complete-url-metrics/set-up.php
@@ -8,12 +8,24 @@ return static function ( Test_OD_Optimization $test_case ): void {
 	// the output begins to be processed by od_optimize_template_output_buffer().
 	add_filter( 'od_current_url_metrics_etag_data', '__return_empty_array' );
 
-	$test_case->populate_url_metrics(
+	$post_id = $test_case->populate_url_metrics(
 		array(
 			array(
 				'xpath' => '/HTML/BODY/DIV/*[1][self::IMG]',
 				'isLCP' => true,
 			),
 		)
+	);
+
+	add_action(
+		'od_register_tag_visitors',
+		static function ( OD_Tag_Visitor_Registry $registry ) use ( $test_case, $post_id ): void {
+			$registry->register(
+				'everything',
+				static function ( OD_Tag_Visitor_Context $context ) use ( $test_case, $post_id ): void {
+					$test_case->assertSame( $post_id, $context->url_metrics_post_id, 'Expected url_metrics_post_id in context too match the ID from when URL Metrics were populated.' );
+				}
+			);
+		}
 	);
 };

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -98,6 +98,7 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 	 * @covers ::get_maximum_viewport_width
 	 * @covers ::get_sample_size
 	 * @covers ::get_freshness_ttl
+	 * @covers ::get_collection
 	 * @covers ::getIterator
 	 * @covers ::count
 	 *
@@ -126,6 +127,7 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 		$this->assertSame( $maximum_viewport_width, $group->get_maximum_viewport_width() );
 		$this->assertSame( $sample_size, $group->get_sample_size() );
 		$this->assertSame( $freshness_ttl, $group->get_freshness_ttl() );
+		$this->assertSame( $dummy_collection, $group->get_collection() );
 		$this->assertCount( count( $url_metrics ), $group );
 		$this->assertSame( $url_metrics, iterator_to_array( $group ) );
 	}

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -380,6 +380,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 						$this->assertInstanceOf( OD_URL_Metric_Group_Collection::class, $context->url_metrics_group_collection );
 						$this->assertInstanceOf( OD_HTML_Tag_Processor::class, $context->processor );
 						$this->assertInstanceOf( OD_Link_Collection::class, $context->link_collection );
+						$this->assertTrue( null === $context->url_metrics_post_id || $context->url_metrics_post_id > 0 );
 
 						$error = null;
 						$value = '';

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -378,6 +378,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 						$this->assertInstanceOf( OD_URL_Metric_Group_Collection::class, $context->url_metric_group_collection );
 						$this->setExpectedIncorrectUsage( 'OD_Tag_Visitor_Context::$url_metrics_group_collection' );
 						$this->assertInstanceOf( OD_URL_Metric_Group_Collection::class, $context->url_metrics_group_collection );
+						$this->assertSame( $context->url_metric_group_collection, $context->url_metrics_group_collection );
 						$this->assertInstanceOf( OD_HTML_Tag_Processor::class, $context->processor );
 						$this->assertInstanceOf( OD_Link_Collection::class, $context->link_collection );
 						$this->assertTrue( null === $context->url_metrics_id || $context->url_metrics_id > 0 );

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -380,7 +380,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 						$this->assertInstanceOf( OD_URL_Metric_Group_Collection::class, $context->url_metrics_group_collection );
 						$this->assertInstanceOf( OD_HTML_Tag_Processor::class, $context->processor );
 						$this->assertInstanceOf( OD_Link_Collection::class, $context->link_collection );
-						$this->assertTrue( null === $context->url_metrics_post_id || $context->url_metrics_post_id > 0 );
+						$this->assertTrue( null === $context->url_metrics_id || $context->url_metrics_id > 0 );
 
 						$error = null;
 						$value = '';


### PR DESCRIPTION
This adds a `$url_metrics_post_id` property to the `OD_Tag_Visitor_Context` class for the sake of extensions which may be attaching postmeta to the `od_url_metrics` post during the `od_url_metric_stored` action. For example, the [Optimization Detective Content Visibility](https://github.com/westonruter/od-content-visibility) plugin [does this](https://github.com/westonruter/od-content-visibility/blob/9de0e54787221681db73b26bc34556afbd959366/helper.php#L80-L130). The `OD_URL_Metric_Store_Request_Context` instance passed to the `od_url_metric_stored` action includes such a `post_id`, but the context passed to the tag visitors did not. This necessitated [manually calculating the slug to obtain the post ID](https://github.com/westonruter/od-content-visibility/blob/9de0e54787221681db73b26bc34556afbd959366/class-odcv-content-visibility-visitor.php#L44-L52). By making the post ID available on the `OD_Tag_Visitor_Context` then this is greatly simplified, as seen in https://github.com/westonruter/od-content-visibility/pull/1.

This PR also introduces a `OD_URL_Metric_Group::get_collection()` method to provide a way to access the private `$collection` variable. This parallels how `OD_URL_Metric::get_group()` provides access to the private `$group` variable a level lower.

This PR facilitates the ability for extensions to persist data outside of the URL Metric itself and in the postmeta of the `od_url_metrics` post type. This is required when data being collected in URL Metrics is not always available. For example, with Embed Optimizer, not every collected URL Metric will include the resized height for an embed since a user may not scroll down to see it in the viewport to cause it to be lazily-loaded. And in the case of Content Visibility, once an element has `content-visibility` applied, it is not longer able to be measured during detection unless, again, the user happens to scroll down to view the element that has CV applied. So we need to capture the initial height of the element in addition to the height of the element when users happen to scroll to it. Persisting this information in postmeta outside of URL Metrics is a way to do this. We should explore further if the core URL Metric construct should have a way to persist some data as new URL Metrics push out old ones, but in the meantime using postmeta as an _ad hoc_ storage area is a way for us to experiment.