### PR TITLE
Prevent optimizing post previews by default

### DIFF
--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -167,6 +167,8 @@ function od_can_optimize_response(): bool {
 		// > Access to script at '.../detect.js?ver=0.4.1' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
 		// So it's better to just avoid attempting to optimize Post Embed responses (which don't need optimization anyway).
 		is_embed() ||
+		// Do not gather url metric for post that is not published yet, see - https://github.com/WordPress/performance/issues/1841.
+		is_preview() ||
 		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
 		is_customize_preview() ||
 		// Since the images detected in the response body of a POST request cannot, by definition, be cached.

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -167,7 +167,7 @@ function od_can_optimize_response(): bool {
 		// > Access to script at '.../detect.js?ver=0.4.1' from origin 'null' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.
 		// So it's better to just avoid attempting to optimize Post Embed responses (which don't need optimization anyway).
 		is_embed() ||
-		// Do not gather url metric for post that is not published yet, see - https://github.com/WordPress/performance/issues/1841.
+		// Skip posts that aren't published yet.
 		is_preview() ||
 		// Since injection of inline-editing controls interfere with breadcrumbs, while also just not necessary in this context.
 		is_customize_preview() ||

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -291,6 +291,13 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 				},
 				'expected' => false,
 			),
+			'singular_as_post_preview'             => array(
+				'set_up'   => static function (): string {
+					$post_id = self::factory()->post->create( array( 'post_title' => 'Hello', 'post_status' => 'draft' ) );
+					return get_preview_post_link( $post_id );
+				},
+				'expected' => false,
+			),
 			'home_post_request_as_anonymous'       => array(
 				'set_up'   => static function (): string {
 					$_SERVER['REQUEST_METHOD'] = 'POST';

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -293,10 +293,13 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 			),
 			'singular_as_post_preview'             => array(
 				'set_up'   => static function (): string {
+					$user_id = self::factory()->user->create( array( 'role' => 'author' ) );
+					wp_set_current_user( $user_id );
 					$post_id = self::factory()->post->create(
 						array(
 							'post_title'  => 'Hello',
 							'post_status' => 'draft',
+							'post_author' => $user_id,
 						)
 					);
 					return (string) get_preview_post_link( $post_id );

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -293,7 +293,12 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 			),
 			'singular_as_post_preview'             => array(
 				'set_up'   => static function (): string {
-					$post_id = self::factory()->post->create( array( 'post_title' => 'Hello', 'post_status' => 'draft' ) );
+					$post_id = self::factory()->post->create(
+						array(
+							'post_title' => 'Hello',
+							'post_status' => 'draft'
+						)
+					);
 					return get_preview_post_link( $post_id );
 				},
 				'expected' => false,

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -295,8 +295,8 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 				'set_up'   => static function (): string {
 					$post_id = self::factory()->post->create(
 						array(
-							'post_title' => 'Hello',
-							'post_status' => 'draft'
+							'post_title'  => 'Hello',
+							'post_status' => 'draft',
 						)
 					);
 					return get_preview_post_link( $post_id );

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -299,7 +299,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 							'post_status' => 'draft',
 						)
 					);
-					return get_preview_post_link( $post_id );
+					return (string) get_preview_post_link( $post_id );
 				},
 				'expected' => false,
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1841 

## Relevant technical choices

<!-- Please describe your changes. -->
- This PR adds the condition `is_preview()` in `od_can_optimize_response` function to exclude the post/page preview, because it won't make sense to gather the URL metric data for the post that is not yet published.
- See - #1841 


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
