### PR TITLE
Use `IFRAME` to display HTML responses for REST API storage request failures in Site Health test

### DIFF
--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -127,6 +127,7 @@ function od_compose_site_health_result( $response ): array {
 		$message = wp_remote_retrieve_response_message( $response );
 		$body    = wp_remote_retrieve_body( $response );
 		$data    = json_decode( $body, true );
+		$header  = wp_remote_retrieve_header( $response, 'content-type' );
 
 		$is_expected = (
 			400 === $code &&
@@ -156,7 +157,14 @@ function od_compose_site_health_result( $response ): array {
 				$result['description'] .= '<blockquote>' . esc_html( $data['message'] ) . '</blockquote>';
 			}
 
-			$result['description'] .= '<details><summary>' . esc_html__( 'Raw response:', 'optimization-detective' ) . '</summary><pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre></details>';
+			$result['description'] .= '<details><summary>' . esc_html__( 'Raw response:', 'optimization-detective' ) . '</summary>';
+
+			if ( isset( $header ) && 'text/html' === $header ) {
+				$escaped_content        = htmlspecialchars( $body, ENT_QUOTES, 'UTF-8' );
+				$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox seamless></iframe></details>';
+			} else {
+				$result['description'] .= '<pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre></details>';
+			}
 		}
 	}
 	return $result;
@@ -238,7 +246,7 @@ function od_maybe_render_rest_api_health_check_admin_notice( bool $in_plugin_row
 		$message = "<details>$message</details>";
 	}
 
-	wp_admin_notice(
+	$notice = wp_get_admin_notice(
 		$message,
 		array(
 			'type'               => 'warning',
@@ -246,6 +254,15 @@ function od_maybe_render_rest_api_health_check_admin_notice( bool $in_plugin_row
 			'paragraph_wrap'     => false,
 		)
 	);
+
+	$allowed_tags           = wp_kses_allowed_html( 'post' );
+	$allowed_tags['iframe'] = array(
+		'srcdoc'   => true,
+		'seamless' => true,
+		'sandbox'  => true,
+	);
+
+	echo wp_kses( $notice, $allowed_tags );
 }
 
 /**

--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -165,7 +165,7 @@ function od_compose_site_health_result( $response ): array {
 
 				if ( is_string( $header ) && str_contains( $header, 'html' ) ) {
 					$escaped_content        = htmlspecialchars( $body, ENT_QUOTES, 'UTF-8' );
-					$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox seamless width="100%" height="300"></iframe></details>';
+					$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox width="100%" height="300"></iframe></details>';
 				} else {
 					$result['description'] .= '<pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre></details>';
 				}
@@ -265,7 +265,7 @@ function od_maybe_render_rest_api_health_check_admin_notice( bool $in_plugin_row
 		array_merge(
 			wp_kses_allowed_html( 'post' ),
 			array(
-				'iframe' => array_fill_keys( array( 'srcdoc', 'seamless', 'sandbox', 'width', 'height' ), true ),
+				'iframe' => array_fill_keys( array( 'srcdoc', 'sandbox', 'width', 'height' ), true ),
 			)
 		)
 	);

--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -161,14 +161,16 @@ function od_compose_site_health_result( $response ): array {
 			}
 
 			if ( '' !== $body ) {
-				$result['description'] .= '<details><summary>' . esc_html__( 'Raw response:', 'optimization-detective' ) . '</summary>';
+				$result['description'] .= '<details>';
+				$result['description'] .= '<summary>' . esc_html__( 'Raw response:', 'optimization-detective' ) . '</summary>';
 
 				if ( is_string( $header ) && str_contains( $header, 'html' ) ) {
 					$escaped_content        = htmlspecialchars( $body, ENT_QUOTES, 'UTF-8' );
-					$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox width="100%" height="300"></iframe></details>';
+					$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox width="100%" height="300"></iframe>';
 				} else {
-					$result['description'] .= '<pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre></details>';
+					$result['description'] .= '<pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre>';
 				}
+				$result['description'] .= '</details>';
 			}
 		}
 	}

--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -128,6 +128,9 @@ function od_compose_site_health_result( $response ): array {
 		$body    = wp_remote_retrieve_body( $response );
 		$data    = json_decode( $body, true );
 		$header  = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( is_array( $header ) ) {
+			$header = array_pop( $header );
+		}
 
 		$is_expected = (
 			400 === $code &&
@@ -157,13 +160,15 @@ function od_compose_site_health_result( $response ): array {
 				$result['description'] .= '<blockquote>' . esc_html( $data['message'] ) . '</blockquote>';
 			}
 
-			$result['description'] .= '<details><summary>' . esc_html__( 'Raw response:', 'optimization-detective' ) . '</summary>';
+			if ( '' !== $body ) {
+				$result['description'] .= '<details><summary>' . esc_html__( 'Raw response:', 'optimization-detective' ) . '</summary>';
 
-			if ( isset( $header ) && 'text/html' === $header ) {
-				$escaped_content        = htmlspecialchars( $body, ENT_QUOTES, 'UTF-8' );
-				$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox seamless></iframe></details>';
-			} else {
-				$result['description'] .= '<pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre></details>';
+				if ( is_string( $header ) && str_contains( $header, 'html' ) ) {
+					$escaped_content        = htmlspecialchars( $body, ENT_QUOTES, 'UTF-8' );
+					$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox seamless></iframe></details>';
+				} else {
+					$result['description'] .= '<pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre></details>';
+				}
 			}
 		}
 	}

--- a/plugins/optimization-detective/site-health.php
+++ b/plugins/optimization-detective/site-health.php
@@ -165,7 +165,7 @@ function od_compose_site_health_result( $response ): array {
 
 				if ( is_string( $header ) && str_contains( $header, 'html' ) ) {
 					$escaped_content        = htmlspecialchars( $body, ENT_QUOTES, 'UTF-8' );
-					$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox seamless></iframe></details>';
+					$result['description'] .= '<iframe srcdoc="' . $escaped_content . '" sandbox seamless width="100%" height="300"></iframe></details>';
 				} else {
 					$result['description'] .= '<pre style="white-space: pre-wrap">' . esc_html( $body ) . '</pre></details>';
 				}
@@ -260,14 +260,15 @@ function od_maybe_render_rest_api_health_check_admin_notice( bool $in_plugin_row
 		)
 	);
 
-	$allowed_tags           = wp_kses_allowed_html( 'post' );
-	$allowed_tags['iframe'] = array(
-		'srcdoc'   => true,
-		'seamless' => true,
-		'sandbox'  => true,
+	echo wp_kses(
+		$notice,
+		array_merge(
+			wp_kses_allowed_html( 'post' ),
+			array(
+				'iframe' => array_fill_keys( array( 'srcdoc', 'seamless', 'sandbox', 'width', 'height' ), true ),
+			)
+		)
 	);
-
-	echo wp_kses( $notice, $allowed_tags );
 }
 
 /**

--- a/plugins/optimization-detective/tests/test-site-health.php
+++ b/plugins/optimization-detective/tests/test-site-health.php
@@ -120,6 +120,9 @@ class Test_OD_Site_Health extends WP_UnitTestCase {
 						'code'    => 403,
 						'message' => 'Forbidden',
 					),
+					'headers'  => array(
+						'content-type' => 'text/html',
+					),
 					'body'     => "<html>\n<head><title>403 Forbidden</title></head>\n<body>\n<center><h1>403 Forbidden</h1></center>\n<hr><center>nginx</center>\n</body>\n</html>",
 				),
 				'expected_option'      => '1',
@@ -151,6 +154,10 @@ class Test_OD_Site_Health extends WP_UnitTestCase {
 		$this->filter_rest_api_response( $mocked_response );
 
 		$result = od_test_rest_api_availability();
+		if ( 'nginx_forbidden' === $this->dataName() ) {
+			$notice = get_echo( 'od_render_rest_api_health_check_admin_notice_in_plugin_row', array( 'optimization-detective/load.php' ) );
+			$this->assertStringContainsString( '</iframe>', $notice );
+		}
 		$this->assertArrayHasKey( 'label', $result );
 		$this->assertArrayHasKey( 'status', $result );
 		$this->assertArrayHasKey( 'badge', $result );

--- a/plugins/optimization-detective/tests/test-site-health.php
+++ b/plugins/optimization-detective/tests/test-site-health.php
@@ -129,6 +129,24 @@ class Test_OD_Site_Health extends WP_UnitTestCase {
 				'expected_status'      => 'recommended',
 				'expected_unavailable' => true,
 			),
+			'other_forbidden' => array(
+				'mocked_response'      => array(
+					'response' => array(
+						'code'    => 403,
+						'message' => 'Forbidden',
+					),
+					'headers'  => array(
+						'content-type' => array(
+							'text/html; charset=utf-8',
+							'application/xhtml+xml',
+						),
+					),
+					'body'     => '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN"><html><head><title>403 Forbidden</title></head><body><h1>Forbidden</h1><p>You don\'t have permission to access this resource.</p></body></html>',
+				),
+				'expected_option'      => '1',
+				'expected_status'      => 'recommended',
+				'expected_unavailable' => true,
+			),
 			'error'           => array(
 				'mocked_response'      => new WP_Error( 'bad', 'Something terrible has happened' ),
 				'expected_option'      => '1',

--- a/plugins/optimization-detective/tests/test-site-health.php
+++ b/plugins/optimization-detective/tests/test-site-health.php
@@ -163,6 +163,8 @@ class Test_OD_Site_Health extends WP_UnitTestCase {
 	 * @covers ::od_compose_site_health_result
 	 * @covers ::od_get_rest_api_health_check_response
 	 * @covers ::od_is_rest_api_unavailable
+	 * @covers ::od_render_rest_api_health_check_admin_notice_in_plugin_row
+	 * @covers ::od_maybe_render_rest_api_health_check_admin_notice
 	 *
 	 * @dataProvider data_provider_test_rest_api_availability
 	 *
@@ -172,9 +174,23 @@ class Test_OD_Site_Health extends WP_UnitTestCase {
 		$this->filter_rest_api_response( $mocked_response );
 
 		$result = od_test_rest_api_availability();
-		if ( 'nginx_forbidden' === $this->dataName() ) {
-			$notice = get_echo( 'od_render_rest_api_health_check_admin_notice_in_plugin_row', array( 'optimization-detective/load.php' ) );
-			$this->assertStringContainsString( '</iframe>', $notice );
+		$notice = get_echo( 'od_render_rest_api_health_check_admin_notice_in_plugin_row', array( 'optimization-detective/load.php' ) );
+		if ( $expected_unavailable ) {
+			$this->assertStringContainsString( '<code>', $notice );
+			if ( is_array( $mocked_response ) ) {
+				if ( isset( $mocked_response['headers']['content-type'] ) && str_contains( join( '', (array) $mocked_response['headers']['content-type'] ), 'html' ) ) {
+					$this->assertStringContainsString( '</iframe>', $notice );
+					$this->assertStringNotContainsString( '</pre>', $notice );
+				} else {
+					$this->assertStringContainsString( '</pre>', $notice );
+					$this->assertStringNotContainsString( '</iframe>', $notice );
+				}
+			} else {
+				$this->assertStringNotContainsString( '</iframe>', $notice );
+				$this->assertStringNotContainsString( '</pre>', $notice );
+			}
+		} else {
+			$this->assertSame( '', $notice );
 		}
 		$this->assertArrayHasKey( 'label', $result );
 		$this->assertArrayHasKey( 'status', $result );
@@ -417,7 +433,7 @@ class Test_OD_Site_Health extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Build a mock response.
+	 * Build a mock JSON response.
 	 *
 	 * @param int                  $status_code HTTP status code.
 	 * @param string               $message     HTTP status message.
@@ -431,6 +447,9 @@ class Test_OD_Site_Health extends WP_UnitTestCase {
 				'message' => $message,
 			),
 			'body'     => wp_json_encode( $body ),
+			'headers'  => array(
+				'content-type' => 'application/json',
+			),
 		);
 	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1828

## Relevant technical choices

<!-- Please describe your changes. -->
- If the raw response for Optimization Detective storage request failure has a `text/html` type, use an IFRAME combined with `sandbox` ~and `seamless`~ attributes.
- Replace  the wrapper function`wp_admin_notice` with `wp_get_admin_notice` to whitelist the used IFRAME and posts parameters using wp_kses function.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
## Screenshots or screencast

<img width="763" alt="Screenshot 2025-02-05 at 2 52 51 PM" src="https://github.com/user-attachments/assets/0b3499e7-3692-46f8-8d57-f85ee2b67b82" />
