### PR TITLE
Account for 64 KiB limit for sending beacon data

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -688,6 +688,7 @@ export default async function detect( {
 		return;
 	}
 
+	// Finalize extensions.
 	if ( extensions.size > 0 ) {
 		/** @type {Promise[]} */
 		const extensionFinalizePromises = [];
@@ -740,6 +741,36 @@ export default async function detect( {
 		}
 	}
 
+	/*
+	 * Now prepare the URL Metric to be sent as JSON request body.
+	 */
+
+	const maxBodyLengthKiB = 64;
+	const maxBodyLengthBytes = maxBodyLengthKiB * 1024;
+
+	// TODO: Consider adding replacer to reduce precision on numbers in DOMRect to reduce payload size.
+	const jsonBody = JSON.stringify( urlMetric );
+	const percentOfBudget =
+		( jsonBody.length / ( maxBodyLengthKiB * 1000 ) ) * 100;
+
+	/*
+	 * According to the fetch() spec:
+	 * "If the sum of contentLength and inflightKeepaliveBytes is greater than 64 kibibytes, then return a network error."
+	 * This is what browsers also implement for navigator.sendBeacon(). Therefore, if the size of the JSON is greater
+	 * than the maximum, we should avoid even trying to send it.
+	 */
+	if ( jsonBody.length > maxBodyLengthBytes ) {
+		if ( isDebug ) {
+			error(
+				`Unable to send URL Metric because it is ${ jsonBody.length.toLocaleString() } bytes, ${ Math.round(
+					percentOfBudget
+				) }% of ${ maxBodyLengthKiB } KiB limit:`,
+				urlMetric
+			);
+		}
+		return;
+	}
+
 	// Even though the server may reject the REST API request, we still have to set the storage lock
 	// because we can't look at the response when sending a beacon.
 	setStorageLock( getCurrentTime() );
@@ -751,7 +782,16 @@ export default async function detect( {
 	);
 
 	if ( isDebug ) {
-		log( 'Sending URL Metric:', urlMetric );
+		const message = `Sending URL Metric (${ jsonBody.length.toLocaleString() } bytes, ${ Math.round(
+			percentOfBudget
+		) }% of ${ maxBodyLengthKiB } KiB limit):`;
+
+		// The threshold of 50% is used because the limit for all beacons combined is 64 KiB, not just the data for one beacon.
+		if ( percentOfBudget < 50 ) {
+			log( message, urlMetric );
+		} else {
+			warn( message, urlMetric );
+		}
 	}
 
 	const url = new URL( restApiEndpoint );
@@ -769,7 +809,7 @@ export default async function detect( {
 	url.searchParams.set( 'hmac', urlMetricHMAC );
 	navigator.sendBeacon(
 		url,
-		new Blob( [ JSON.stringify( urlMetric ) ], {
+		new Blob( [ jsonBody ], {
 			type: 'application/json',
 		} )
 	);

--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -214,6 +214,27 @@ function od_handle_rest_request( WP_REST_Request $request ) {
 		);
 	}
 
+	/*
+	 * The limit for data sent via navigator.sendBeacon() is 64 KiB. This limit is checked in detect.js so that the
+	 * request will not even be attempted if the payload is too large. This server-side restriction is added as a
+	 * safeguard against clients sending possibly malicious payloads much larger than 64 KiB which should never be
+	 * getting sent.
+	 */
+	$max_size       = 64 * 1024;
+	$content_length = strlen( (string) wp_json_encode( $url_metric ) );
+	if ( $content_length > $max_size ) {
+		return new WP_Error(
+			'rest_content_too_large',
+			sprintf(
+				/* translators: 1: the size of the payload, 2: the maximum allowed payload size */
+				__( 'JSON payload size is %1$s bytes which is larger than the maximum allowed size of %2$s bytes.', 'optimization-detective' ),
+				number_format_i18n( $content_length ),
+				number_format_i18n( $max_size )
+			),
+			array( 'status' => 413 )
+		);
+	}
+
 	// TODO: This should be changed from store_url_metric($slug, $url_metric) instead be update_post( $slug, $group_collection ). As it stands, store_url_metric() is duplicating logic here.
 	$result = OD_URL_Metrics_Post_Type::store_url_metric(
 		$request->get_param( 'slug' ),

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -173,123 +173,269 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		$valid_params  = $this->get_valid_params();
 		$valid_element = $valid_params['elements'][0];
 
-		return array_map(
-			static function ( $params ) use ( $valid_params ) {
-				return array(
-					'params' => array_merge( $valid_params, $params ),
-				);
-			},
-			array(
-				'bad_url'                                  => array(
-					'url' => 'bad://url',
+		return array(
+			'missing_callback_params'                  => array(
+				'params'          => array(
+					'slug' => $valid_params['slug'],
 				),
-				'bad_current_etag1'                        => array(
-					'current_etag' => 'foo',
+				'expected_status' => 400,
+				'expected_code'   => 'rest_missing_callback_param',
+			),
+			'bad_url'                                  => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'url' => 'bad://url',
+					)
 				),
-				'bad_current_etag2'                        => array(
-					'current_etag' => $valid_params['current_etag'] . "\n",
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'bad_current_etag1'                        => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'current_etag' => 'foo',
+					)
 				),
-				'bad_slug'                                 => array(
-					'slug' => '<script>document.write("evil")</script>',
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'bad_current_etag2'                        => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'current_etag' => $valid_params['current_etag'] . "\n",
+					)
 				),
-				'bad_hmac'                                 => array(
-					'hmac' => 'not even a hash',
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'bad_slug'                                 => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'slug' => '<script>document.write("evil")</script>',
+					)
 				),
-				'invalid_hmac'                             => array(
-					'hmac' => od_get_url_metrics_storage_hmac( od_get_url_metrics_slug( array( 'different' => 'query vars' ) ), $valid_params['current_etag'], home_url( '/' ) ),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'bad_hmac'                                 => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'hmac' => 'not even a hash',
+					)
 				),
-				'invalid_hmac_with_queried_object'         => array(
-					'hmac' => od_get_url_metrics_storage_hmac( od_get_url_metrics_slug( array() ), $valid_params['current_etag'], home_url( '/' ), 1 ),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_hmac'                             => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'hmac' => od_get_url_metrics_storage_hmac( od_get_url_metrics_slug( array( 'different' => 'query vars' ) ), $valid_params['current_etag'], home_url( '/' ) ),
+					)
 				),
-				'invalid_viewport_type'                    => array(
-					'viewport' => '640x480',
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_hmac_with_queried_object'         => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'hmac' => od_get_url_metrics_storage_hmac( od_get_url_metrics_slug( array() ), $valid_params['current_etag'], home_url( '/' ), 1 ),
+					)
 				),
-				'invalid_viewport_values'                  => array(
-					'viewport' => array(
-						'breadth' => 100,
-						'depth'   => 200,
-					),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_viewport_type'                    => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'viewport' => '640x480',
+					)
 				),
-				'invalid_viewport_aspect_ratio'            => array(
-					'viewport' => array(
-						'width'  => 1024,
-						'height' => 12000,
-					),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_viewport_values'                  => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'viewport' => array(
+							'breadth' => 100,
+							'depth'   => 200,
+						),
+					)
 				),
-				'invalid_elements_type'                    => array(
-					'elements' => 'bad',
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_viewport_aspect_ratio'            => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'viewport' => array(
+							'width'  => 1024,
+							'height' => 12000,
+						),
+					)
 				),
-				'invalid_elements_prop_is_lcp'             => array(
-					'elements' => array(
-						array_merge(
-							$valid_element,
-							array(
-								'isLCP' => 'totally!',
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_elements_type'                    => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'elements' => 'bad',
+					)
+				),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_elements_prop_is_lcp'             => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'elements' => array(
+							array_merge(
+								$valid_element,
+								array(
+									'isLCP' => 'totally!',
+								)
+							),
+						),
+					)
+				),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_elements_prop_xpath'              => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'elements' => array(
+							array_merge(
+								$valid_element,
+								array(
+									'xpath' => 'html > body img',
+								)
+							),
+						),
+					)
+				),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_content_length'                   => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						// Repeat the elements until the JSON will surpass 64 KiB.
+						'elements' => array_fill(
+							0,
+							200,
+							array_merge(
+								$valid_element,
+								array(
+									'xpath' => '/HTML/BODY/DIV[@id=\'page\']/*[1][self::DIV]',
+								)
 							)
 						),
-					),
+					)
 				),
-				'invalid_elements_prop_xpath'              => array(
-					'elements' => array(
-						array_merge(
-							$valid_element,
-							array(
-								'xpath' => 'html > body img',
-							)
+				'expected_status' => 413,
+				'expected_code'   => 'rest_content_too_large',
+			),
+			'invalid_elements_prop_intersection_ratio' => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'elements' => array(
+							array_merge(
+								$valid_element,
+								array(
+									'intersectionRatio' => - 1,
+								)
+							),
 						),
-					),
+					)
 				),
-				'invalid_elements_prop_intersection_ratio' => array(
-					'elements' => array(
-						array_merge(
-							$valid_element,
-							array(
-								'intersectionRatio' => - 1,
-							)
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_elements_additional_intersect_rect_property' => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'elements' => array(
+							array_merge(
+								$valid_element,
+								array(
+									'intersectionRect' => array(
+										'width'  => 640,
+										'height' => 480,
+										'wooHoo' => 'bad',
+									),
+								)
+							),
 						),
-					),
+					)
 				),
-				'invalid_elements_additional_intersect_rect_property' => array(
-					'elements' => array(
-						array_merge(
-							$valid_element,
-							array(
-								'intersectionRect' => array(
-									'width'  => 640,
-									'height' => 480,
-									'wooHoo' => 'bad',
-								),
-							)
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_elements_negative_width_intersect_rect_property' => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'elements' => array(
+							array_merge(
+								$valid_element,
+								array(
+									'intersectionRect' => array(
+										'width'  => -640,
+										'height' => 480,
+									),
+								)
+							),
 						),
-					),
+					)
 				),
-				'invalid_elements_negative_width_intersect_rect_property' => array(
-					'elements' => array(
-						array_merge(
-							$valid_element,
-							array(
-								'intersectionRect' => array(
-									'width'  => -640,
-									'height' => 480,
-								),
-							)
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_root_property'                    => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'is_touch' => false,
+					)
+				),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'invalid_element_property'                 => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'elements' => array(
+							array_merge(
+								$valid_element,
+								array(
+									'is_big' => true,
+								)
+							),
 						),
-					),
+					)
 				),
-				'invalid_root_property'                    => array(
-					'is_touch' => false,
-				),
-				'invalid_element_property'                 => array(
-					'elements' => array(
-						array_merge(
-							$valid_element,
-							array(
-								'is_big' => true,
-							)
-						),
-					),
-				),
-			)
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
 		);
 	}
 
@@ -304,11 +450,11 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 	 *
 	 * @param array<string, mixed> $params Params.
 	 */
-	public function test_rest_request_bad_params( array $params ): void {
+	public function test_rest_request_bad_params( array $params, int $expected_status, string $expected_code ): void {
 		$request  = $this->create_request( $params );
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 400, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
-		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'], 'Response: ' . wp_json_encode( $response ) );
+		$this->assertSame( $expected_status, $response->get_status(), 'Response: ' . wp_json_encode( $response ) );
+		$this->assertSame( $expected_code, $response->get_data()['code'], 'Response: ' . wp_json_encode( $response ) );
 
 		$this->assertNull( OD_URL_Metrics_Post_Type::get_post( $params['slug'] ) );
 		$this->assertSame( 0, did_action( 'od_url_metric_stored' ) );


### PR DESCRIPTION
This comes out of a discovery from https://github.com/WordPress/performance/issues/1311#issuecomment-2638242854:

> Well, it turns out that `fetch()` _can_ now be used as a replacement for `navigator.sendBeacon()` when the the [`keepalive`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#keepalive) property is set ([supported](https://caniuse.com/mdn-api_fetch_init_keepalive_parameter) by all browsers). It seems that uBlock [may block `navigator.sendBeacon()`](https://www.reddit.com/r/uBlockOrigin/comments/vo64tk/sendbeacon_blocked/) for the sake of privacy, so using `fetch()` may be more reliable.
> 
> [According to the spec](https://fetch.spec.whatwg.org/#requestinit:~:text=If%20the%20sum%20of%20contentLength%20and%20inflightKeepaliveBytes%20is%20greater%20than%2064%20kibibytes%2C%20then%20return%20a%20network%20error.), I'm just seeing that such `keepalive` requests have a `POST` body have a size limit of 64 KiB (65,536 bytes):
> 
> > If the sum of contentLength and inflightKeepaliveBytes is greater than 64 kibibytes, then return a [network error](https://fetch.spec.whatwg.org/#concept-network-error).
> 
> This is an _aggregated_ limit, so if multiple keepalive `fetch()` requests are being made, then as soon as one is added which goes over the limit, then a network error will occur. Apparently for `navigator.sendBeacon()` there is also a [limit of 64 KiB for all pending beacons on the page](https://stackoverflow.com/a/50381832/93579), just for one beacon.

I was not aware of this restriction on sending beacon data, but it makes sense. The browser shouldn't be sending huge payloads on pages that the user has closed. Nevertheless, this is a complication for Optimization Detective because a URL Metric can contain a lot of data. When there are 100 images on a page, this results in a URL Metric JSON body of that is ~53,371 bytes or **83% of 64 KiB limit**. When there are 200 images, then the URL Metric is ~106,024 bytes, or **166% of 64 KiB limit**. However, this 64 KiB limit is not for a single beacon but for _all beacons combined_. Therefore, if there are various analytics providers attempting to also send a lot of data, then this 64 KiB limit could be breached even when only 50% (32 KiB) of the limit is being used.

So this PR starts to address this issue by:

* Measure the length of the JSON that is pending being sent and include the length and the budget percentage in the console logs when debugging is enabled. 
* If the size is larger than 64 KiB then the request is aborted entirely and, when debugging is enabled, an error is shown in the console.
* If the size is 50% or greater of the 64 KiB limit, then a warning is used in the console when the debug message is logged for sending the URL Metric.
* Add a TODO for how we might start to reduce the size of the JSON. 

We can reduce the precision in the numbers to reduce the size somewhat. When there are 100 images, rounding the numbers to the nearest whole number reduces the size from 83% down to 68% of the budget. Other strategies could be employed, like coming up with a compression algorithm to replace common JSON strings. But we can explore that later as we start monitoring how close we are getting to the maximum. I need to look at my own site to see how close the captured URL metrics are to the 64 KiB limit for some real world data. **Update:** See https://github.com/WordPress/performance/pull/1851#issuecomment-2638375131.

# Screenshots

When there are 3 images:

![image](https://github.com/user-attachments/assets/90cca551-7d27-42b3-b7c2-1fe0d484521c)

When there are 100 images:

![image](https://github.com/user-attachments/assets/15c0bb15-78f7-4beb-964a-5ada79661589)

When there are 200 images:

![image](https://github.com/user-attachments/assets/1f6481f8-6152-4591-9332-a36398f10599)
