### PR TITLE
Update URL Metric storage REST API endpoint to return status code `423 Locked` instead of `403 Forbidden`

### DIFF
--- a/plugins/optimization-detective/storage/rest-api.php
+++ b/plugins/optimization-detective/storage/rest-api.php
@@ -102,7 +102,7 @@ function od_register_endpoint(): void {
 					return new WP_Error(
 						'url_metric_storage_locked',
 						__( 'URL Metric storage is presently locked for the current IP.', 'optimization-detective' ),
-						array( 'status' => 403 ) // TODO: Consider 423 Locked status code.
+						array( 'status' => 423 )
 					);
 				}
 				return true;

--- a/plugins/optimization-detective/tests/storage/test-rest-api.php
+++ b/plugins/optimization-detective/tests/storage/test-rest-api.php
@@ -635,7 +635,7 @@ class Test_OD_Storage_REST_API extends WP_UnitTestCase {
 		$request = $this->create_request( $this->get_valid_params() );
 
 		$response = rest_get_server()->dispatch( $request );
-		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 423, $response->get_status() );
 		$this->assertSame( 'url_metric_storage_locked', $response->get_data()['code'] );
 	}
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1860 

## Relevant technical choices

<!-- Please describe your changes. -->
- Updated the `permission_callback` for `url-metrics:store` route to use `423` as status code instead of 403. 

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
