### PR TITLE
Add percent encoding of URLs in `imagesrcset` param of `Link` response header

### DIFF
--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -267,20 +267,30 @@ final class OD_Link_Collection implements Countable {
 
 		foreach ( $this->get_prepared_links() as $link ) {
 			if ( isset( $link['href'] ) ) {
-				$decoded_url = urldecode( $link['href'] );
-
-				// Encode characters not allowed in a URL per RFC 3986 (anything that is not among the reserved and unreserved characters).
-				$encoded_url  = preg_replace_callback(
-					'/[^A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=]/',
-					static function ( $matches ) {
-						return rawurlencode( $matches[0] );
-					},
-					$decoded_url
-				);
-				$link['href'] = esc_url_raw( $encoded_url ?? '' );
+				$link['href'] = $this->encode_url_for_response_header( $link['href'] );
 			} else {
 				// The about:blank is present since a Link without a reference-uri is invalid so any imagesrcset would otherwise not get downloaded.
 				$link['href'] = 'about:blank';
+			}
+
+			// Encode the URLs in the srcset.
+			if ( isset( $link['imagesrcset'] ) ) {
+				$link['imagesrcset'] = join(
+					', ',
+					array_map(
+						function ( $image_candidate ) {
+							// Parse out the URL to separate it from the descriptor.
+							$image_candidate_parts = (array) preg_split( '/\s+/', (string) $image_candidate, 2 );
+
+							// Encode the URL.
+							$image_candidate_parts[0] = $this->encode_url_for_response_header( (string) $image_candidate_parts[0] );
+
+							// Re-join the URL with the descriptor.
+							return implode( ' ', $image_candidate_parts );
+						},
+						(array) preg_split( '/\s*,\s*/', $link['imagesrcset'] )
+					)
+				);
 			}
 
 			$link_header = '<' . $link['href'] . '>';
@@ -308,6 +318,28 @@ final class OD_Link_Collection implements Countable {
 		}
 
 		return 'Link: ' . implode( ', ', $link_headers );
+	}
+
+	/**
+	 * Encodes a URL for serving in an HTTP response header.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $url URL to percent encode. Any existing percent encodings will first be decoded.
+	 * @return string Percent-encoded URL.
+	 */
+	private function encode_url_for_response_header( string $url ): string {
+		$decoded_url = urldecode( $url );
+
+		// Encode characters not allowed in a URL per RFC 3986 (anything that is not among the reserved and unreserved characters).
+		$encoded_url = (string) preg_replace_callback(
+			'/[^A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=]/',
+			static function ( $matches ) {
+				return rawurlencode( $matches[0] );
+			},
+			$decoded_url
+		);
+		return esc_url_raw( $encoded_url );
 	}
 
 	/**

--- a/plugins/optimization-detective/tests/test-class-od-link-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-link-collection.php
@@ -268,7 +268,25 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_html'   => '
 					<link data-od-added-tag rel="preload" href="https://example.com/bar.jpg" as="image" fetchpriority="high" imagesrcset="https://example.com/&quot;bar&quot;-480w.jpg 480w, https://example.com/&quot;bar&quot;-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous">
 				',
-				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"; fetchpriority="high"; imagesrcset="https://example.com/\"bar\"-480w.jpg 480w, https://example.com/\"bar\"-800w.jpg 800w"; imagesizes="(max-width: 600px) 480px, 800px"; crossorigin="anonymous"',
+				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"; fetchpriority="high"; imagesrcset="https://example.com/%22bar%22-480w.jpg 480w, https://example.com/%22bar%22-800w.jpg 800w"; imagesizes="(max-width: 600px) 480px, 800px"; crossorigin="anonymous"',
+				'expected_count'  => 1,
+				'error'           => '',
+			),
+			'preload_mime_with_quotes'                   => array(
+				'links_args'      => array(
+					array(
+						array(
+							'rel'  => 'preload',
+							'href' => 'https://example.com/bar.webm',
+							'as'   => 'video',
+							'type' => 'video/webm; codecs="vp8, vorbis"',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag rel="preload" href="https://example.com/bar.webm" as="video" type="video/webm; codecs=&quot;vp8, vorbis&quot;">
+				',
+				'expected_header' => 'Link: <https://example.com/bar.webm>; rel="preload"; as="video"; type="video/webm; codecs=\"vp8, vorbis\""',
 				'expected_count'  => 1,
 				'error'           => '',
 			),
@@ -422,6 +440,25 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_count'  => 1,
 				'error'           => '',
 			),
+			'non_ascii_srcset'                           => array(
+				'links_args'      => array(
+					array(
+						array(
+							'href'        => 'https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp',
+							'rel'         => 'preload',
+							'as'          => 'image',
+							'imagesizes'  => '(width <= 480px) 316px, (480px < width <= 600px) 489px, (600px < width <= 782px) 644px, (782px < width) 644px',
+							'imagesrcset' => 'https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/البيسون-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/البيسون-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/البيسون-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/البيسون-2048x1336-jpg.webp 2048w',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag href="https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp" rel="preload" as="image" imagesizes="(width &lt;= 480px) 316px, (480px &lt; width &lt;= 600px) 489px, (600px &lt; width &lt;= 782px) 644px, (782px &lt; width) 644px" imagesrcset="https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/البيسون-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/البيسون-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/البيسون-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/البيسون-2048x1336-jpg.webp 2048w">
+				',
+				'expected_header' => 'Link: <https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668-jpg.webp>; rel="preload"; as="image"; imagesizes="(width <= 480px) 316px, (480px < width <= 600px) 489px, (600px < width <= 782px) 644px, (782px < width) 644px"; imagesrcset="https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-2048x1336-jpg.webp 2048w"',
+				'expected_count'  => 1,
+				'error'           => '',
+			),
 			'percent-in-path'                            => array(
 				'links_args'      => array(
 					array(
@@ -467,6 +504,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 	 * @covers ::get_prepared_links
 	 * @covers ::merge_consecutive_links
 	 * @covers ::get_response_header
+	 * @covers ::encode_url_for_response_header
 	 * @covers ::count
 	 *
 	 * @dataProvider data_provider_to_test_add_link


### PR DESCRIPTION
In testing Optimization Detective for the release in 2 days, I discovered a problem when I upload an image file with non-ASCII filename (`البيسون.jpg`):

![Image](https://github.com/user-attachments/assets/d4c79056-85ed-4bb4-a23e-29ae38547549)

It's returning a 404 because the image URLs in the `imagesrcset` aren't getting the same encoding as is the original URL in the `href`.

```http
Link: <https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668.jpg>; rel="preload"; fetchpriority="high"; as="image"; imagesrcset="https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/Ø§Ù„Ø¨ÙŠØ³ÙˆÙ†-1024x668.jpg 1024w, https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/Ø§Ù„Ø¨ÙŠØ³ÙˆÙ†-300x196.jpg 300w, https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/Ø§Ù„Ø¨ÙŠØ³ÙˆÙ†-768x501.jpg 768w, https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/Ø§Ù„Ø¨ÙŠØ³ÙˆÙ†-1536x1002.jpg 1536w, https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/Ø§Ù„Ø¨ÙŠØ³ÙˆÙ†-2048x1336.jpg 2048w"; imagesizes="(782px < width) 644px, (max-width: 1024px) 100vw, 1024px"; media="screen and (782px < width)"
```

Expected versus actual:

```diff
- https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668.jpg
+ https://complicated-lyrebird-c797ca.instawp.xyz/wp-content/uploads/2025/02/Ø§Ù„Ø¨ÙŠØ³ÙˆÙ†-1024x668.jpg
```

This is something we missed in #1802 while fixing #1775.

So this PR adds URL encoding of the `imagesrcset`:

![image](https://github.com/user-attachments/assets/77120cf3-fc5a-401c-b271-d37e64ab4f54)
