### PR TITLE
Post 3.9.0 release merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][9],  [Issues][17], [PRs][25]
 [Image Prioritizer][7]          | `image-prioritizer`       | No           | [Source][15], [Issues][23], [PRs][31]
 [Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
+[Optimization Detective][33]    | `optimization-detective`  | No           | [Source][34], [Issues][35], [PRs][36]
 [Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
 [Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
 [Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][14], [Issues][22], [PRs][30]
@@ -28,6 +29,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [6]: https://wordpress.org/plugins/auto-sizes/
 [7]: https://wordpress.org/plugins/image-prioritizer/
 [8]: https://wordpress.org/plugins/web-worker-offloading/
+[33]: https://wordpress.org/plugins/optimization-detective/
 
 [9]: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
 [10]: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
@@ -37,6 +39,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [14]: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
 [15]: https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer
 [16]: https://github.com/WordPress/performance/tree/trunk/plugins/web-worker-offloading
+[34]: https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective
 
 [17]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
 [18]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
@@ -46,6 +49,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [22]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
 [23]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
 [24]: https://github.com/WordPress/performance/issues?q=is%3Aopen%20label%3A%22%5BPlugin%5D%20Web%20Worker%20Offloading%22
+[35]: https://github.com/WordPress/performance/issues?q=is%3Aopen%20label%3A%22%5BPlugin%5D%20Optimization%20Detective%22
 
 [25]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
 [26]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
@@ -55,5 +59,6 @@ Plugin                          | Slug                      | Experimental | Lin
 [30]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Enhanced+Responsive+Images%22
 [31]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Image+Prioritizer%22
 [32]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Web%20Worker%20Offloading%22
+[36]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Optimization%20Detective%22
 
 Note that the plugin names sometimes diverge from the plugin slugs due to scope changes. For example, a plugin's purpose may change as some of its features are merged into WordPress core.

--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -5,7 +5,7 @@
  * Description: Optimizes the performance of embeds through lazy-loading, preconnecting, and reserving space to reduce layout shifts.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 0.4.1
+ * Version: 1.0.0-beta1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'embed_optimizer_pending_plugin',
-	'0.4.1',
+	'1.0.0-beta1',
 	static function ( string $version ): void {
 		if ( defined( 'EMBED_OPTIMIZER_VERSION' ) ) {
 			return;

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   0.4.1
+Stable tag:   1.0.0-beta1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, embeds
@@ -66,6 +66,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 1.0.0-beta1 =
 
 = 0.4.1 =
 

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -69,6 +69,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 1.0.0-beta1 =
 
+**Enhancements**
+
+* Bump version to 1.0.0-beta1 to indicate graduation from being experimental. See [1846](https://github.com/WordPress/performance/pull/1846).
+* Use CSS range syntax in media queries. ([1833](https://github.com/WordPress/performance/pull/1833))
+
 = 0.4.1 =
 
 **Bug Fixes**

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -412,7 +412,7 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 	/**
 	 * Computes responsive sizes for the current element based on its boundingClientRect width captured in URL Metrics.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @param OD_Tag_Visitor_Context $context Context.
 	 * @return non-empty-string[] Computed sizes.

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.6
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 0.3.1
+ * Version: 1.0.0-beta1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -72,7 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'0.3.1',
+	'1.0.0-beta1',
 	static function ( string $version ): void {
 		if ( defined( 'IMAGE_PRIORITIZER_VERSION' ) ) {
 			return;

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   0.3.1
+Stable tag:   1.0.0-beta1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, lcp, lazy-load
@@ -71,6 +71,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 1.0.0-beta1 =
 
 = 0.3.1 =
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -74,6 +74,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 1.0.0-beta1 =
 
+**Enhancements**
+
+* Bump version to 1.0.0-beta1 to indicate graduation from being experimental. See [1846](https://github.com/WordPress/performance/pull/1846).
+* Compute responsive `sizes` attribute based on the `width` from the `boundingClientRect` in captured URL Metrics. ([1840](https://github.com/WordPress/performance/pull/1840))
+
 = 0.3.1 =
 
 **Bug Fixes**

--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -267,20 +267,30 @@ final class OD_Link_Collection implements Countable {
 
 		foreach ( $this->get_prepared_links() as $link ) {
 			if ( isset( $link['href'] ) ) {
-				$decoded_url = urldecode( $link['href'] );
-
-				// Encode characters not allowed in a URL per RFC 3986 (anything that is not among the reserved and unreserved characters).
-				$encoded_url  = preg_replace_callback(
-					'/[^A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=]/',
-					static function ( $matches ) {
-						return rawurlencode( $matches[0] );
-					},
-					$decoded_url
-				);
-				$link['href'] = esc_url_raw( $encoded_url ?? '' );
+				$link['href'] = $this->encode_url_for_response_header( $link['href'] );
 			} else {
 				// The about:blank is present since a Link without a reference-uri is invalid so any imagesrcset would otherwise not get downloaded.
 				$link['href'] = 'about:blank';
+			}
+
+			// Encode the URLs in the srcset.
+			if ( isset( $link['imagesrcset'] ) ) {
+				$link['imagesrcset'] = join(
+					', ',
+					array_map(
+						function ( $image_candidate ) {
+							// Parse out the URL to separate it from the descriptor.
+							$image_candidate_parts = (array) preg_split( '/\s+/', (string) $image_candidate, 2 );
+
+							// Encode the URL.
+							$image_candidate_parts[0] = $this->encode_url_for_response_header( (string) $image_candidate_parts[0] );
+
+							// Re-join the URL with the descriptor.
+							return implode( ' ', $image_candidate_parts );
+						},
+						(array) preg_split( '/\s*,\s*/', $link['imagesrcset'] )
+					)
+				);
 			}
 
 			$link_header = '<' . $link['href'] . '>';
@@ -308,6 +318,28 @@ final class OD_Link_Collection implements Countable {
 		}
 
 		return 'Link: ' . implode( ', ', $link_headers );
+	}
+
+	/**
+	 * Encodes a URL for serving in an HTTP response header.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param string $url URL to percent encode. Any existing percent encodings will first be decoded.
+	 * @return string Percent-encoded URL.
+	 */
+	private function encode_url_for_response_header( string $url ): string {
+		$decoded_url = urldecode( $url );
+
+		// Encode characters not allowed in a URL per RFC 3986 (anything that is not among the reserved and unreserved characters).
+		$encoded_url = (string) preg_replace_callback(
+			'/[^A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=]/',
+			static function ( $matches ) {
+				return rawurlencode( $matches[0] );
+			},
+			$decoded_url
+		);
+		return esc_url_raw( $encoded_url );
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-tag-visitor-context.php
+++ b/plugins/optimization-detective/class-od-tag-visitor-context.php
@@ -54,7 +54,7 @@ final class OD_Tag_Visitor_Context {
 	 *
 	 * May be null if no post has been created yet.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 * @var positive-int|null
 	 */
 	private $url_metrics_id;

--- a/plugins/optimization-detective/class-od-url-metric-group-collection.php
+++ b/plugins/optimization-detective/class-od-url-metric-group-collection.php
@@ -202,7 +202,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	/**
 	 * Gets the breakpoints in max widths.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @return positive-int[] Breakpoints in max widths.
 	 */
@@ -213,7 +213,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	/**
 	 * Gets the sample size for URL Metrics for a given breakpoint.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @return int<1, max> Sample size for URL Metrics for a given breakpoint.
 	 */
@@ -224,7 +224,7 @@ final class OD_URL_Metric_Group_Collection implements Countable, IteratorAggrega
 	/**
 	 * Gets the freshness age (TTL) for a given URL Metric..
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @return int<0, max> Freshness age (TTL) for a given URL Metric.
 	 */

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -212,7 +212,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	/**
 	 * Gets the collection that this group is a part of.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @todo Eliminate in favor of readonly public property.
 	 * @return OD_URL_Metric_Group_Collection Collection.

--- a/plugins/optimization-detective/class-od-url-metric.php
+++ b/plugins/optimization-detective/class-od-url-metric.php
@@ -176,7 +176,7 @@ class OD_URL_Metric implements JsonSerializable {
 	 *
 	 * @since 0.1.0
 	 * @since 0.9.0 Added the 'etag' property to the schema.
-	 * @since n.e.x.t The 'etag' property is now required.
+	 * @since 1.0.0 The 'etag' property is now required.
 	 *
 	 * @todo Cache the return value?
 	 *
@@ -451,7 +451,7 @@ class OD_URL_Metric implements JsonSerializable {
 	 * Gets ETag.
 	 *
 	 * @since 0.9.0
-	 * @since n.e.x.t No longer returns null as 'etag' is now required.
+	 * @since 1.0.0 No longer returns null as 'etag' is now required.
 	 *
 	 * @return non-empty-string ETag.
 	 */

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -57,6 +57,26 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 1.0.0-beta2 =
 
+**Enhancements**
+
+* Account for 64 KiB limit for sending beacon data. ([1851](https://github.com/WordPress/performance/pull/1851))
+* Add post ID for the `od_url_metrics` post to the tag visitor context. ([1847](https://github.com/WordPress/performance/pull/1847))
+* Change minimum viewport width to be exclusive whereas the maximum width remains inclusive. ([1839](https://github.com/WordPress/performance/pull/1839))
+* Disable URL Metric storage locking by default for administrators. ([1835](https://github.com/WordPress/performance/pull/1835))
+* Include active plugins in ETag data and increase default freshness TTL from 1 day to 1 week. ([1854](https://github.com/WordPress/performance/pull/1854))
+* Make ETag a required property of the URL Metric. ([1824](https://github.com/WordPress/performance/pull/1824))
+* Use CSS range syntax in media queries. ([1833](https://github.com/WordPress/performance/pull/1833))
+* Use `IFRAME` to display HTML responses for REST API storage request failures in Site Health test. ([1849](https://github.com/WordPress/performance/pull/1849))
+
+**Bug Fixes**
+
+* Prevent URL in `Link` header from including invalid characters. ([1802](https://github.com/WordPress/performance/pull/1802))
+* Prevent optimizing post previews by default. ([1848](https://github.com/WordPress/performance/pull/1848))
+
+**Documentation**
+
+* Improve Optimization Detective documentation. ([1782](https://github.com/WordPress/performance/pull/1782))
+
 = 1.0.0-beta1 =
 
 **Enhancements**

--- a/plugins/optimization-detective/storage/class-od-storage-lock.php
+++ b/plugins/optimization-detective/storage/class-od-storage-lock.php
@@ -23,7 +23,7 @@ final class OD_Storage_Lock {
 	/**
 	 * Capability for being able to store a URL Metric now.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 * @var string
 	 */
 	const STORE_URL_METRIC_NOW_CAPABILITY = 'od_store_url_metric_now';
@@ -31,7 +31,7 @@ final class OD_Storage_Lock {
 	/**
 	 * Adds hooks.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 */
 	public static function add_hooks(): void {
 		add_filter( 'user_has_cap', array( __CLASS__, 'filter_user_has_cap' ) );
@@ -40,7 +40,7 @@ final class OD_Storage_Lock {
 	/**
 	 * Filters `user_has_cap` to grant the `od_store_url_metric_now` capability to users who can `manage_options` by default.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @param array<string, bool>|mixed $allcaps Capability names mapped to boolean values for whether the user has that capability.
 	 * @return array<string, bool> Capability names mapped to boolean values for whether the user has that capability.

--- a/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
+++ b/plugins/optimization-detective/storage/class-od-url-metric-store-request-context.php
@@ -39,7 +39,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	 *
 	 * This was originally $post_id which was introduced in 0.7.0.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 * @var positive-int
 	 */
 	private $url_metrics_id;
@@ -92,7 +92,7 @@ final class OD_URL_Metric_Store_Request_Context {
 	/**
 	 * Gets a property.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 *
 	 * @param string $name Property name.
 	 * @return mixed Property value.
@@ -121,7 +121,7 @@ final class OD_URL_Metric_Store_Request_Context {
 							__CLASS__ . '::$url_metrics_id'
 						)
 					),
-					'optimization-detective n.e.x.t'
+					'optimization-detective 1.0.0'
 				);
 				return $this->url_metrics_id;
 			default:

--- a/plugins/optimization-detective/tests/test-class-od-link-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-link-collection.php
@@ -268,7 +268,25 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_html'   => '
 					<link data-od-added-tag rel="preload" href="https://example.com/bar.jpg" as="image" fetchpriority="high" imagesrcset="https://example.com/&quot;bar&quot;-480w.jpg 480w, https://example.com/&quot;bar&quot;-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous">
 				',
-				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"; fetchpriority="high"; imagesrcset="https://example.com/\"bar\"-480w.jpg 480w, https://example.com/\"bar\"-800w.jpg 800w"; imagesizes="(max-width: 600px) 480px, 800px"; crossorigin="anonymous"',
+				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"; fetchpriority="high"; imagesrcset="https://example.com/%22bar%22-480w.jpg 480w, https://example.com/%22bar%22-800w.jpg 800w"; imagesizes="(max-width: 600px) 480px, 800px"; crossorigin="anonymous"',
+				'expected_count'  => 1,
+				'error'           => '',
+			),
+			'preload_mime_with_quotes'                   => array(
+				'links_args'      => array(
+					array(
+						array(
+							'rel'  => 'preload',
+							'href' => 'https://example.com/bar.webm',
+							'as'   => 'video',
+							'type' => 'video/webm; codecs="vp8, vorbis"',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag rel="preload" href="https://example.com/bar.webm" as="video" type="video/webm; codecs=&quot;vp8, vorbis&quot;">
+				',
+				'expected_header' => 'Link: <https://example.com/bar.webm>; rel="preload"; as="video"; type="video/webm; codecs=\"vp8, vorbis\""',
 				'expected_count'  => 1,
 				'error'           => '',
 			),
@@ -422,6 +440,25 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_count'  => 1,
 				'error'           => '',
 			),
+			'non_ascii_srcset'                           => array(
+				'links_args'      => array(
+					array(
+						array(
+							'href'        => 'https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp',
+							'rel'         => 'preload',
+							'as'          => 'image',
+							'imagesizes'  => '(width <= 480px) 316px, (480px < width <= 600px) 489px, (600px < width <= 782px) 644px, (782px < width) 644px',
+							'imagesrcset' => 'https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/البيسون-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/البيسون-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/البيسون-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/البيسون-2048x1336-jpg.webp 2048w',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag href="https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp" rel="preload" as="image" imagesizes="(width &lt;= 480px) 316px, (480px &lt; width &lt;= 600px) 489px, (600px &lt; width &lt;= 782px) 644px, (782px &lt; width) 644px" imagesrcset="https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/البيسون-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/البيسون-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/البيسون-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/البيسون-2048x1336-jpg.webp 2048w">
+				',
+				'expected_header' => 'Link: <https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668-jpg.webp>; rel="preload"; as="image"; imagesizes="(width <= 480px) 316px, (480px < width <= 600px) 489px, (600px < width <= 782px) 644px, (782px < width) 644px"; imagesrcset="https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-2048x1336-jpg.webp 2048w"',
+				'expected_count'  => 1,
+				'error'           => '',
+			),
 			'percent-in-path'                            => array(
 				'links_args'      => array(
 					array(
@@ -467,6 +504,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 	 * @covers ::get_prepared_links
 	 * @covers ::merge_consecutive_links
 	 * @covers ::get_response_header
+	 * @covers ::encode_url_for_response_header
 	 * @covers ::count
 	 *
 	 * @dataProvider data_provider_to_test_add_link

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 3.8.0
+ * Version: 3.9.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 // @codeCoverageIgnoreEnd
 
-define( 'PERFLAB_VERSION', '3.8.0' );
+define( 'PERFLAB_VERSION', '3.9.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -19,6 +19,7 @@ The feature plugins which are currently featured by this plugin are:
 * [Image Placeholders](https://wordpress.org/plugins/dominant-color-images/)
 * [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/)
 * [Modern Image Formats](https://wordpress.org/plugins/webp-uploads/)
+* [Optimization Detective](https://wordpress.org/plugins/optimization-detective/) (dependency for Embed Optimizer and Image Prioritizer)
 * [Performant Translations](https://wordpress.org/plugins/performant-translations/)
 * [Speculative Loading](https://wordpress.org/plugins/speculation-rules/)
 * [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/) _(experimental)_

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -73,6 +73,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 3.9.0 =
 
+**Enhancements**
+
+* Remove experimental flags from Embed Optimizer and Image Prioritizer. ([1846](https://github.com/WordPress/performance/pull/1846))
+
 = 3.8.0 =
 
 **Enhancements**

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -15,13 +15,13 @@ The Performance Lab plugin is a collection of features focused on enhancing perf
 
 The feature plugins which are currently featured by this plugin are:
 
+* [Embed Optimizer](https://wordpress.org/plugins/embed-optimizer/)
 * [Image Placeholders](https://wordpress.org/plugins/dominant-color-images/)
+* [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/)
 * [Modern Image Formats](https://wordpress.org/plugins/webp-uploads/)
 * [Performant Translations](https://wordpress.org/plugins/performant-translations/)
 * [Speculative Loading](https://wordpress.org/plugins/speculation-rules/)
-* [Embed Optimizer](https://wordpress.org/plugins/embed-optimizer/) _(experimental)_
 * [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/) _(experimental)_
-* [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/) _(experimental)_
 * [Web Worker Offloading](https://wordpress.org/plugins/web-worker-offloading/) _(experimental)_
 
 These plugins can also be installed separately from installing Performance Lab, but having the Performance Lab plugin also active will ensure you find out about new performance features as they are developed.

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.7
-Stable tag:   3.8.0
+Stable tag:   3.9.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -70,6 +70,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 3.9.0 =
 
 = 3.8.0 =
 


### PR DESCRIPTION
Fixes #1852

- **Bump versions**
- **Run npm run since and strip beta suffixes**
- **Update changelogs**
- **Remove experimental flag from Image Prioritizer and Embed Optimizer**
- **Include Optimization Detective in list of plugins featured in readmes**
- **Add percent encoding of URLs in imagesrcset param of Link response header**
