### PR TITLE
Update `OD_HTML_Tag_Processor::next_tag()` to allow `$query` arg and prepare to skip visiting tag closers by default

### DIFF
--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -191,8 +191,7 @@ function embed_optimizer_update_markup( WP_HTML_Tag_Processor $html_processor, b
 	// As of 1.0.0-beta3, next_tag() allows $query and is beginning to migrate to skip tag closers by default.
 	// In versions prior to this, the method always visited closers and passing a $query actually threw an exception.
 	$tag_query = version_compare( OPTIMIZATION_DETECTIVE_VERSION, '1.0.0-beta3', '>=' )
-		? array( 'tag_closers' => 'visit' )
-		: null;
+		? array( 'tag_closers' => 'visit' ) : null;
 	try {
 		/*
 		 * Determine how to lazy load the embed.

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -44,8 +44,13 @@ function embed_optimizer_add_non_optimization_detective_hooks(): void {
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */
 function embed_optimizer_init_optimization_detective( string $optimization_detective_version ): void {
-	$required_od_version = '0.9.0';
-	if ( version_compare( (string) strtok( $optimization_detective_version, '-' ), $required_od_version, '<' ) ) {
+	if (
+		version_compare( (string) strtok( $optimization_detective_version, '-' ), '1.0.0', '<' )
+		||
+		'1.0.0-beta1' === $optimization_detective_version
+		||
+		'1.0.0-beta2' === $optimization_detective_version
+	) {
 		add_action(
 			'admin_notices',
 			static function (): void {
@@ -253,7 +258,7 @@ function embed_optimizer_update_markup( WP_HTML_Tag_Processor $html_processor, b
 					}
 				}
 			}
-		} while ( $html_processor->next_tag() );
+		} while ( $html_processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		// If there was only one non-inline script, make it lazy.
 		if ( 1 === $script_count && ! $has_inline_script && $html_processor->has_bookmark( $bookmark_names['script'] ) ) {
 			$needs_lazy_script = true;

--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -44,13 +44,8 @@ function embed_optimizer_add_non_optimization_detective_hooks(): void {
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */
 function embed_optimizer_init_optimization_detective( string $optimization_detective_version ): void {
-	if (
-		version_compare( (string) strtok( $optimization_detective_version, '-' ), '1.0.0', '<' )
-		||
-		'1.0.0-beta1' === $optimization_detective_version
-		||
-		'1.0.0-beta2' === $optimization_detective_version
-	) {
+	$required_od_version = '0.9.0';
+	if ( version_compare( (string) strtok( $optimization_detective_version, '-' ), $required_od_version, '<' ) ) {
 		add_action(
 			'admin_notices',
 			static function (): void {
@@ -192,6 +187,12 @@ function embed_optimizer_update_markup( WP_HTML_Tag_Processor $html_processor, b
 	$trigger_error  = static function ( string $message ) use ( $function_name ): void {
 		wp_trigger_error( $function_name, esc_html( $message ) );
 	};
+
+	// As of 1.0.0-beta3, next_tag() allows $query and is beginning to migrate to skip tag closers by default.
+	// In versions prior to this, the method always visited closers and passing a $query actually threw an exception.
+	$tag_query = version_compare( OPTIMIZATION_DETECTIVE_VERSION, '1.0.0-beta3', '>=' )
+		? array( 'tag_closers' => 'visit' )
+		: null;
 	try {
 		/*
 		 * Determine how to lazy load the embed.
@@ -258,7 +259,7 @@ function embed_optimizer_update_markup( WP_HTML_Tag_Processor $html_processor, b
 					}
 				}
 			}
-		} while ( $html_processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
+		} while ( $html_processor->next_tag( $tag_query ) );
 		// If there was only one non-inline script, make it lazy.
 		if ( 1 === $script_count && ! $has_inline_script && $html_processor->has_bookmark( $bookmark_names['script'] ) ) {
 			$needs_lazy_script = true;

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -226,7 +226,7 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 		$crossorigin    = null;
 
 		// Loop through child tags until we reach the closing PICTURE tag.
-		while ( $processor->next_tag() ) {
+		while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 			$tag = $processor->get_tag();
 
 			// If we reached the closing PICTURE tag, break.

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -229,8 +229,7 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 		// As of 1.0.0-beta3, next_tag() allows $query and is beginning to migrate to skip tag closers by default.
 		// In versions prior to this, the method always visited closers and passing a $query actually threw an exception.
 		$tag_query = version_compare( OPTIMIZATION_DETECTIVE_VERSION, '1.0.0-beta3', '>=' )
-			? array( 'tag_closers' => 'visit' )
-			: null;
+			? array( 'tag_closers' => 'visit' ) : null;
 		while ( $processor->next_tag( $tag_query ) ) {
 			$tag = $processor->get_tag();
 

--- a/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
+++ b/plugins/image-prioritizer/class-image-prioritizer-img-tag-visitor.php
@@ -226,7 +226,12 @@ final class Image_Prioritizer_Img_Tag_Visitor extends Image_Prioritizer_Tag_Visi
 		$crossorigin    = null;
 
 		// Loop through child tags until we reach the closing PICTURE tag.
-		while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
+		// As of 1.0.0-beta3, next_tag() allows $query and is beginning to migrate to skip tag closers by default.
+		// In versions prior to this, the method always visited closers and passing a $query actually threw an exception.
+		$tag_query = version_compare( OPTIMIZATION_DETECTIVE_VERSION, '1.0.0-beta3', '>=' )
+			? array( 'tag_closers' => 'visit' )
+			: null;
+		while ( $processor->next_tag( $tag_query ) ) {
 			$tag = $processor->get_tag();
 
 			// If we reached the closing PICTURE tag, break.

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -21,8 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */
 function image_prioritizer_init( string $optimization_detective_version ): void {
-	$required_od_version = '0.9.0';
-	if ( ! version_compare( (string) strtok( $optimization_detective_version, '-' ), $required_od_version, '>=' ) ) {
+	if (
+		version_compare( (string) strtok( $optimization_detective_version, '-' ), '1.0.0', '<' )
+		||
+		'1.0.0-beta1' === $optimization_detective_version
+		||
+		'1.0.0-beta2' === $optimization_detective_version
+	) {
 		add_action(
 			'admin_notices',
 			static function (): void {

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -21,13 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */
 function image_prioritizer_init( string $optimization_detective_version ): void {
-	if (
-		version_compare( (string) strtok( $optimization_detective_version, '-' ), '1.0.0', '<' )
-		||
-		'1.0.0-beta1' === $optimization_detective_version
-		||
-		'1.0.0-beta2' === $optimization_detective_version
-	) {
+	$required_od_version = '0.9.0';
+	if ( ! version_compare( (string) strtok( $optimization_detective_version, '-' ), $required_od_version, '>=' ) ) {
 		add_action(
 			'admin_notices',
 			static function (): void {

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -246,38 +246,35 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Finds the next tag.
 	 *
-	 * Unlike the base class, this subclass disallows querying. This is to ensure the breadcrumbs can be tracked.
-	 * It will _always_ visit tag closers.
+	 * Unlike the base class, this subclass visits tag closers by default.
 	 *
 	 * @inheritDoc
 	 * @since 0.4.0
+	 * @since n.e.x.t Passing a $query is now allowed.
 	 *
-	 * @param array{tag_name?: string|null, match_offset?: int|null, class_name?: string|null, tag_closers?: string|null}|null $query Query, but only null is accepted for this subclass.
+	 * @param array{tag_name?: string|null, match_offset?: int|null, class_name?: string|null, tag_closers?: string|null}|null $query Query.
 	 * @return bool Whether a tag was matched.
 	 *
 	 * @throws InvalidArgumentException If attempting to pass a query.
 	 */
 	public function next_tag( $query = null ): bool {
-		if ( null !== $query ) {
-			throw new InvalidArgumentException( esc_html__( 'Processor subclass does not support queries.', 'optimization-detective' ) );
+		if ( null === $query ) {
+			// For back-compat with tag visitor which previously relied next_tag() always visiting tag closers.
+			$query = array( array( 'tag_closers' => 'visit' ) );
 		}
-
-		// Elements in the Admin Bar are not relevant for optimization, so this loop ensures that no tags in the Admin Bar are visited.
-		do {
-			$matched = parent::next_tag( array( 'tag_closers' => 'visit' ) );
-		} while ( $matched && $this->is_admin_bar() );
-		return $matched;
+		return parent::next_tag( $query );
 	}
 
 	/**
 	 * Finds the next open tag.
 	 *
 	 * @since 0.4.0
+	 * @deprecated
 	 *
 	 * @return bool Whether a tag was matched.
 	 */
 	public function next_open_tag(): bool {
-		while ( $this->next_tag() ) {
+		while ( $this->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 			if ( ! $this->is_tag_closer() ) {
 				return true;
 			}

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -715,7 +715,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @return bool Whether at or inside the admin bar.
 	 */
-	private function is_admin_bar(): bool {
+	public function is_admin_bar(): bool {
 		return (
 			isset( $this->open_stack_tags[2], $this->open_stack_attributes[2]['id'] )
 			&&

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -250,17 +250,18 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 *
 	 * @inheritDoc
 	 * @since 0.4.0
-	 * @since n.e.x.t Passing a $query is now allowed.
+	 * @since n.e.x.t Passing a $query is now allowed. In a future release, this will default to skipping tag closers.
 	 *
 	 * @param array{tag_name?: string|null, match_offset?: int|null, class_name?: string|null, tag_closers?: string|null}|null $query Query.
 	 * @return bool Whether a tag was matched.
-	 *
-	 * @throws InvalidArgumentException If attempting to pass a query.
 	 */
 	public function next_tag( $query = null ): bool {
 		if ( null === $query ) {
-			// For back-compat with tag visitor which previously relied next_tag() always visiting tag closers.
-			$query = array( array( 'tag_closers' => 'visit' ) );
+			$query = array( 'tag_closers' => 'visit' );
+			$this->warn(
+				__METHOD__,
+				esc_html__( 'Previously this method always visited tag closers and did not allow a query to be supplied. Now, however, a query can be supplied. To align this method with the behavior of the base class, a future version of this method will default to skipping tag closers.', 'optimization-detective' )
+			);
 		}
 		return parent::next_tag( $query );
 	}
@@ -269,17 +270,11 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * Finds the next open tag.
 	 *
 	 * @since 0.4.0
-	 * @deprecated
 	 *
 	 * @return bool Whether a tag was matched.
 	 */
 	public function next_open_tag(): bool {
-		while ( $this->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
-			if ( ! $this->is_tag_closer() ) {
-				return true;
-			}
-		}
-		return false;
+		return $this->next_tag( array( 'tag_closers' => 'skip' ) );
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -246,11 +246,13 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Finds the next tag.
 	 *
-	 * Unlike the base class, this subclass visits tag closers by default.
+	 * Unlike the base class, this subclass currently visits tag closers by default.
+	 * However, for the 1.0.0 release this method will behave the same as the method in
+	 * the base class, where it skips tag closers by default.
 	 *
 	 * @inheritDoc
 	 * @since 0.4.0
-	 * @since n.e.x.t Passing a $query is now allowed. In a future release, this will default to skipping tag closers.
+	 * @since n.e.x.t Passing a $query is now allowed. In the 1.0.0 release, this will default to skipping tag closers.
 	 *
 	 * @param array{tag_name?: string|null, match_offset?: int|null, class_name?: string|null, tag_closers?: string|null}|null $query Query.
 	 * @return bool Whether a tag was matched.
@@ -269,7 +271,10 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Finds the next open tag.
 	 *
+	 * This method will soon be equivalent to calling {@see self::next_tag()} without passing any `$query`.
+	 *
 	 * @since 0.4.0
+	 * @deprecated n.e.x.t Use {@see self::next_tag()} instead.
 	 *
 	 * @return bool Whether a tag was matched.
 	 */

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -716,7 +716,12 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	/**
 	 * Returns whether the processor is currently at or inside the admin bar.
 	 *
+	 * This is only intended to be used internally by Optimization Detective as part of the "optimization loop". Tag
+	 * visitors should not rely on this method as it may be deprecated in the future, especially with a migration to
+	 * WP_HTML_Processor after {@link https://core.trac.wordpress.org/ticket/63020} is implemented.
+	 *
 	 * @since 1.0.0
+	 * @access private
 	 *
 	 * @return bool Whether at or inside the admin bar.
 	 */

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides a framework for leveraging real user metrics to detect optimizations for improving page performance.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.0.0-beta2
+ * Version: 1.0.0-beta3
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'1.0.0-beta2',
+	'1.0.0-beta3',
 	static function ( string $version ): void {
 		if ( defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			return;

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -359,7 +359,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 		if (
 			in_array( 'NOSCRIPT', $processor->get_breadcrumbs(), true )
 			||
-			str_starts_with( $processor->get_stored_xpath(), "/HTML/BODY/DIV[@id='wpadminbar']" )
+			$processor->is_admin_bar()
 		) {
 			continue;
 		}

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -238,7 +238,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	// If the initial tag is not an open HTML tag, then abort since the buffer is not a complete HTML document.
 	$processor = new OD_HTML_Tag_Processor( $buffer );
 	if ( ! (
-		$processor->next_tag() &&
+		$processor->next_tag( array( 'tag_closers' => 'visit' ) ) &&
 		! $processor->is_tag_closer() &&
 		'HTML' === $processor->get_tag()
 	) ) {
@@ -359,7 +359,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 		if (
 			in_array( 'NOSCRIPT', $processor->get_breadcrumbs(), true )
 			||
-			str_starts_with( $processor->get_xpath(), "/HTML/BODY/DIV[@id='wpadminbar']" )
+			str_starts_with( $processor->get_stored_xpath(), "/HTML/BODY/DIV[@id='wpadminbar']" )
 		) {
 			continue;
 		}

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -355,7 +355,12 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 
 	do {
 		// Never process anything inside NOSCRIPT since it will never show up in the DOM when scripting is enabled, and thus it can never be detected nor measured.
-		if ( in_array( 'NOSCRIPT', $processor->get_breadcrumbs(), true ) ) {
+		// Similarly, elements in the Admin Bar are not relevant for optimization, so this loop ensures that no tags in the Admin Bar are visited.
+		if (
+			in_array( 'NOSCRIPT', $processor->get_breadcrumbs(), true )
+			||
+			str_starts_with( $processor->get_xpath(), "/HTML/BODY/DIV[@id='wpadminbar']" )
+		) {
 			continue;
 		}
 
@@ -388,7 +393,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 		}
 
 		$visited_tag_state->reset();
-	} while ( $processor->next_open_tag() );
+	} while ( $processor->next_tag( array( 'tag_closers' => 'skip' ) ) );
 
 	// Send any preload links in a Link response header and in a LINK tag injected at the end of the HEAD.
 	if ( count( $link_collection ) > 0 ) {

--- a/plugins/optimization-detective/tests/test-cases/admin-bar/set-up.php
+++ b/plugins/optimization-detective/tests/test-cases/admin-bar/set-up.php
@@ -6,7 +6,8 @@ return static function ( Test_OD_Optimization $test_case ): void {
 			$registry->register(
 				'everything',
 				static function ( OD_Tag_Visitor_Context $context ) use ( $test_case ): void {
-					$test_case->assertNotEquals( 'wpadminbar', $context->processor->get_attribute( 'id' ) );
+					$test_case->assertStringNotContainsString( 'wpadminbar', $context->processor->get_xpath() );
+					$test_case->assertNotEquals( 'wpadminbar', $context->processor->get_attribute( 'id' ), $context->processor->get_xpath() );
 					$test_case->assertNull( $context->url_metrics_id, 'Expected url_metrics_id to be null since no od_url_metrics_post exists for this URL.' );
 				}
 			);

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -527,6 +527,57 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test next_tag() without passing query.
+	 *
+	 * @todo This test will need to be updated once next_tag() defaults to not visiting closers by default.
+	 *
+	 * @covers ::next_tag
+	 */
+	public function test_next_tag_without_query(): void {
+		$html = '
+			<!DOCTYPE html>
+			<html>
+				<head>
+					<title></title>
+				</head>
+				<body></body>
+			</html>
+		';
+
+		$p = new OD_HTML_Tag_Processor( $html );
+		$this->assertTrue( $p->next_tag() );
+		$this->assertSame( 'HTML', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_tag() );
+		$this->assertSame( 'HEAD', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_tag() );
+		$this->assertSame( 'TITLE', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		// Note: This is not a closing TITLE tag as would be expected since it is special.
+		$this->assertTrue( $p->next_tag() );
+		$this->assertSame( 'HEAD', $p->get_tag() );
+		$this->assertTrue( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_tag() );
+		$this->assertSame( 'BODY', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_tag() );
+		$this->assertSame( 'BODY', $p->get_tag() );
+		$this->assertTrue( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_tag() );
+		$this->assertSame( 'HTML', $p->get_tag() );
+		$this->assertTrue( $p->is_tag_closer() );
+
+		$this->assertFalse( $p->next_tag() );
+	}
+
+	/**
 	 * Test expects_closer().
 	 *
 	 * @covers ::expects_closer

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -341,18 +341,20 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 						</body>
 					</html>
 				',
-				'open_tags'         => array( 'HTML', 'HEAD', 'BODY', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG' ),
+				'open_tags'         => array( 'HTML', 'HEAD', 'BODY', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG' ),
 				'xpath_breadcrumbs' => array(
-					'/HTML'                             => array( 'HTML' ),
-					'/HTML/HEAD'                        => array( 'HTML', 'HEAD' ),
-					'/HTML/BODY'                        => array( 'HTML', 'BODY' ),
-					'/HTML/BODY/DIV[@id=\'header\']'    => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML'                              => array( 'HTML' ),
+					'/HTML/HEAD'                         => array( 'HTML', 'HEAD' ),
+					'/HTML/BODY'                         => array( 'HTML', 'BODY' ),
+					'/HTML/BODY/DIV[@id=\'wpadminbar\']' => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'wpadminbar\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
+					'/HTML/BODY/DIV[@id=\'header\']'     => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@id=\'header\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
-					'/HTML/BODY/DIV[@id=\'primary\']'   => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'primary\']'    => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@id=\'primary\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
-					'/HTML/BODY/DIV[@id=\'secondary\']' => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'secondary\']'  => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@id=\'secondary\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
-					'/HTML/BODY/DIV[@id=\'colophon\']'  => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'colophon\']'   => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@id=\'colophon\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
 				),
 			),
@@ -392,12 +394,14 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 						</body>
 					</html>
 				',
-				'open_tags'         => array( 'HTML', 'HEAD', 'BODY', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG' ),
+				'open_tags'         => array( 'HTML', 'HEAD', 'BODY', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG', 'DIV', 'IMG' ),
 				'xpath_breadcrumbs' => array(
-					'/HTML'                            => array( 'HTML' ),
-					'/HTML/HEAD'                       => array( 'HTML', 'HEAD' ),
-					'/HTML/BODY'                       => array( 'HTML', 'BODY' ),
-					'/HTML/BODY/DIV[@role=\'banner\']' => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML'                              => array( 'HTML' ),
+					'/HTML/HEAD'                         => array( 'HTML', 'HEAD' ),
+					'/HTML/BODY'                         => array( 'HTML', 'BODY' ),
+					'/HTML/BODY/DIV[@id=\'wpadminbar\']' => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'wpadminbar\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
+					'/HTML/BODY/DIV[@role=\'banner\']'   => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@role=\'banner\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
 					'/HTML/BODY/DIV[@class=\'content-area main\']' => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@class=\'content-area main\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
@@ -405,12 +409,12 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 					'/HTML/BODY/DIV[@class=\'widget-area\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
 					'/HTML/BODY/DIV[@class=\'site-footer\']' => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@class=\'site-footer\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
-					'/HTML/BODY/DIV[@class=\'\']'      => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@class=\'\']'        => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@class=\'\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
-					'/HTML/BODY/DIV[@role=\'\']'       => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@role=\'\']'         => array( 'HTML', 'BODY', 'DIV' ),
 					'/HTML/BODY/DIV[@role=\'\']/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
-					'/HTML/BODY/DIV'                   => array( 'HTML', 'BODY', 'DIV' ),
-					'/HTML/BODY/DIV/*[1][self::IMG]'   => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
+					'/HTML/BODY/DIV'                     => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV/*[1][self::IMG]'     => array( 'HTML', 'BODY', 'DIV', 'IMG' ),
 				),
 			),
 		);
@@ -442,7 +446,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 		$this->assertSame( '', $p->get_stored_xpath(), 'Expected empty XPath since iteration has not started.' );
 		$actual_open_tags                 = array();
 		$actual_xpath_breadcrumbs_mapping = array();
-		while ( $p->next_open_tag() ) {
+		while ( $p->next_tag( array( 'tag_closers' => 'skip' ) ) ) {
 			$actual_open_tags[] = $p->get_tag();
 
 			$xpath = $p->get_stored_xpath();
@@ -466,14 +470,60 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test next_tag() passing query which is invalid.
+	 * Test next_tag() passing query.
 	 *
 	 * @covers ::next_tag
+	 * @covers ::get_xpath
+	 * @covers ::get_current_depth
 	 */
 	public function test_next_tag_with_query(): void {
-		$this->expectException( InvalidArgumentException::class );
-		$p = new OD_HTML_Tag_Processor( '<html></html>' );
-		$p->next_tag( array( 'tag_name' => 'HTML' ) );
+		$html = '
+			<!DOCTYPE html>
+			<html>
+				<head>
+					<title></title>
+				</head>
+				<body>
+					<main>
+						<p>Hello world</p>
+						<figure>
+							<img src="https://example.com/img1.jpg">
+						</figure>
+						<figure>
+							<img src="https://example.com/img2.jpg">
+						</figure>
+						<div class="foo">
+							Foo!
+						</div>
+					</main>
+				</body>
+			</html>
+		';
+
+		$p = new OD_HTML_Tag_Processor( $html );
+		$this->assertTrue( $p->next_tag( array( 'tag_name' => 'HTML' ) ) );
+		$this->assertTrue( $p->set_bookmark( 'document_root' ) );
+		$this->assertSame( 1, $p->get_current_depth() );
+
+		$this->assertTrue( $p->next_tag( array( 'tag_name' => 'IMG' ) ) );
+		$this->assertEquals( '/HTML/BODY/MAIN/*[2][self::FIGURE]/*[1][self::IMG]', $p->get_xpath() );
+		$this->assertSame( 5, $p->get_current_depth() );
+
+		$this->assertTrue( $p->next_tag( array( 'class_name' => 'foo' ) ) );
+		$this->assertEquals( '/HTML/BODY/MAIN/*[4][self::DIV]', $p->get_xpath() );
+		$this->assertSame( 4, $p->get_current_depth() );
+
+		$this->assertTrue( $p->seek( 'document_root' ) );
+		$this->assertTrue(
+			$p->next_tag(
+				array(
+					'tag_name'     => 'IMG',
+					'match_offset' => 2,
+				)
+			)
+		);
+		$this->assertEquals( '/HTML/BODY/MAIN/*[3][self::FIGURE]/*[1][self::IMG]', $p->get_xpath() );
+		$this->assertSame( 5, $p->get_current_depth() );
 	}
 
 	/**
@@ -484,7 +534,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	public function test_expects_closer(): void {
 		$p = new OD_HTML_Tag_Processor( '<html><body><hr></body></html>' );
 		$this->assertFalse( $p->expects_closer() );
-		while ( $p->next_tag() ) {
+		while ( $p->next_tag( array( 'tag_closers' => 'visit' ) ) ) {
 			if ( 'BODY' === $p->get_tag() ) {
 				break;
 			}
@@ -492,7 +542,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 		$this->assertSame( 'BODY', $p->get_tag() );
 		$this->assertFalse( $p->expects_closer( 'IMG' ) );
 		$this->assertTrue( $p->expects_closer() );
-		$p->next_tag();
+		$p->next_tag( array( 'tag_closers' => 'visit' ) );
 		$this->assertSame( 'HR', $p->get_tag() );
 		$this->assertFalse( $p->expects_closer() );
 		$this->assertTrue( $p->expects_closer( 'DIV' ) );
@@ -594,7 +644,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 			</html>
 		';
 		$processor = new OD_HTML_Tag_Processor( $html );
-		$this->assertTrue( $processor->next_tag() );
+		$this->assertTrue( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertEquals( 'HTML', $processor->get_tag() );
 		$max_bookmarks = max( WP_HTML_Processor::MAX_BOOKMARKS, WP_HTML_Tag_Processor::MAX_BOOKMARKS );
 		for ( $i = 0; $i < $max_bookmarks + 1; $i++ ) {
@@ -710,7 +760,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 					if ( $processor->get_current_depth() < $embed_block_depth ) {
 						break;
 					}
-				} while ( $processor->next_tag() );
+				} while ( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 			}
 		}
 
@@ -790,31 +840,31 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 			)
 		);
 		$this->assertSame( 0, $processor->get_cursor_move_count() );
-		$this->assertTrue( $processor->next_tag() );
+		$this->assertTrue( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 'HTML', $processor->get_tag() );
 		$this->assertTrue( $processor->set_bookmark( 'document_root' ) );
 		$this->assertSame( 1, $processor->get_cursor_move_count() );
-		$this->assertTrue( $processor->next_tag() );
+		$this->assertTrue( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 'HEAD', $processor->get_tag() );
 		$this->assertSame( 3, $processor->get_cursor_move_count() ); // Note that next_token() call #2 was for the whitespace between <html> and <head>.
-		$this->assertTrue( $processor->next_tag() );
+		$this->assertTrue( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 'HEAD', $processor->get_tag() );
 		$this->assertTrue( $processor->is_tag_closer() );
 		$this->assertSame( 4, $processor->get_cursor_move_count() );
-		$this->assertTrue( $processor->next_tag() );
+		$this->assertTrue( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 'BODY', $processor->get_tag() );
 		$this->assertSame( 6, $processor->get_cursor_move_count() ); // Note that next_token() call #5 was for the whitespace between </head> and <body>.
-		$this->assertTrue( $processor->next_tag() );
+		$this->assertTrue( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 'BODY', $processor->get_tag() );
 		$this->assertTrue( $processor->is_tag_closer() );
 		$this->assertSame( 7, $processor->get_cursor_move_count() );
-		$this->assertTrue( $processor->next_tag() );
+		$this->assertTrue( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 'HTML', $processor->get_tag() );
 		$this->assertTrue( $processor->is_tag_closer() );
 		$this->assertSame( 9, $processor->get_cursor_move_count() ); // Note that next_token() call #8 was for the whitespace between </body> and <html>.
-		$this->assertFalse( $processor->next_tag() );
+		$this->assertFalse( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 10, $processor->get_cursor_move_count() );
-		$this->assertFalse( $processor->next_tag() );
+		$this->assertFalse( $processor->next_tag( array( 'tag_closers' => 'visit' ) ) );
 		$this->assertSame( 11, $processor->get_cursor_move_count() );
 		$this->assertTrue( $processor->seek( 'document_root' ) );
 		$this->assertSame( 12, $processor->get_cursor_move_count() );

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -578,6 +578,42 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test next_open_tag().
+	 *
+	 * @covers ::next_open_tag
+	 */
+	public function test_next_open_tag(): void {
+		$html = '
+			<!DOCTYPE html>
+			<html>
+				<head>
+					<title></title>
+				</head>
+				<body></body>
+			</html>
+		';
+
+		$p = new OD_HTML_Tag_Processor( $html );
+		$this->assertTrue( $p->next_open_tag() ); // @phpstan-ignore method.deprecated
+		$this->assertSame( 'HTML', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_open_tag() ); // @phpstan-ignore method.deprecated
+		$this->assertSame( 'HEAD', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_open_tag() ); // @phpstan-ignore method.deprecated
+		$this->assertSame( 'TITLE', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		$this->assertTrue( $p->next_open_tag() ); // @phpstan-ignore method.deprecated
+		$this->assertSame( 'BODY', $p->get_tag() );
+		$this->assertFalse( $p->is_tag_closer() );
+
+		$this->assertFalse( $p->next_open_tag() ); // @phpstan-ignore method.deprecated
+	}
+
+	/**
 	 * Test expects_closer().
 	 *
 	 * @covers ::expects_closer
@@ -632,7 +668,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 		$saw_head = false;
 		$saw_body = false;
 		$did_seek = false;
-		while ( $processor->next_open_tag() ) {
+		while ( $processor->next_tag( array( 'tag_closers' => 'skip' ) ) ) {
 			$this->assertStringNotContainsString( $head_injected, $processor->get_updated_html(), 'Only expecting end-of-head injection once document was finalized.' );
 			$this->assertStringNotContainsString( $body_injected, $processor->get_updated_html(), 'Only expecting end-of-body injection once document was finalized.' );
 			$tag = $processor->get_tag();
@@ -708,7 +744,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 
 		$saw_head = false;
 		$saw_body = false;
-		while ( $processor->next_open_tag() ) {
+		while ( $processor->next_tag( array( 'tag_closers' => 'skip' ) ) ) {
 			$tag = $processor->get_tag();
 			if ( 'HEAD' === $tag ) {
 				$saw_head = true;
@@ -732,7 +768,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 	 */
 	public function test_html_tag_processor_wrapper_methods(): void {
 		$processor = new OD_HTML_Tag_Processor( '<html lang="en" class="foo" dir="ltr" data-novalue></html>' );
-		while ( $processor->next_open_tag() ) {
+		while ( $processor->next_tag( array( 'tag_closers' => 'skip' ) ) ) {
 			$open_tag = $processor->get_tag();
 			if ( 'HTML' === $open_tag ) {
 				$processor->set_attribute( 'lang', 'es' );
@@ -787,7 +823,7 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 		$this->assertSame( 0, $last_cursor_move_count );
 
 		$bookmarks = array();
-		while ( $processor->next_open_tag() ) {
+		while ( $processor->next_tag( array( 'tag_closers' => 'skip' ) ) ) {
 			$this_cursor_move_count = $processor->get_cursor_move_count();
 			$this->assertGreaterThan( $last_cursor_move_count, $this_cursor_move_count );
 			$last_cursor_move_count = $this_cursor_move_count;

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -376,6 +376,7 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 	 * @covers OD_Visited_Tag_State::track_tag
 	 * @covers OD_Visited_Tag_State::is_tag_tracked
 	 * @covers OD_Visited_Tag_State::reset
+	 * @covers OD_HTML_Tag_Processor::is_admin_bar
 	 *
 	 * @dataProvider data_provider_test_od_optimize_template_output_buffer
 	 *


### PR DESCRIPTION
I realized that the restriction to disallow passing the `$query` arg to `next_tag()` is obsolete since the breadcrumbs are tracked by calls to `next_token()`. The disallowing of the `$query` arg was a mistake ever since the subclass was introduced in https://github.com/WordPress/performance/pull/1302. 

The `test_next_tag_with_query` test case confirms that the breadcrumbs (XPaths) are still computed correctly even when passing queries to `next_token()`.

Before `OD_HTML_Tag_Processor` was introduced there was the `OD_HTML_Tag_Walker` class which wrapped an instance of `WP_HTML_Tag_Processor`. This wrapper walker class at that time was responsible for keeping track of the breadcrumbs and computing the XPaths. It only ever called `$processor->next_tag( array( 'tag_closers' => 'visit' ) )` as it didn't integrate with the lower-level `next_token()` method to be able to observe the consumption of all tokens. This logic was ported over to the `OD_HTML_Tag_Processor` subclass of `WP_HTML_Tag_Processor` unnecessarily. 

Also, since the `OD_HTML_Tag_Walker` had to visit all tags including tag closers in order to keep track of the breadcrumbs, this meant that the ported logic into the `OD_HTML_Tag_Processor::next_tag()` method visited tag closers by default even though `WP_HTML_Tag_Processor::next_tag()` does _not_ visit tag closers by default. In fact, there was a `OD_HTML_Tag_Processor::next_open_tag()` method introduced which had the behavior for skipping tag closer visiting. All of this seems like it would be confusing for people expecting that the `$context->processor` supplied to tag visitors would have a `next_tag()` method that behaves like they expect, to skip visiting tag closers by default. But currently it doesn't: again, it _does_ visit tag closers by default. This PR intends to move toward restoring the base method's logic. (This PR also soft-deprecates the redundant `next_open_tag()` method.)

The first step is to add a warning when _no_ `$query` arg is supplied to the `next_tag()` method. Previously if a plugin tried to supply a `$query` it would actually throw an exception. Now, however, they'll get a migration warning when they _don't_ supply the `$query` argument. The migration warning is to inform developers that the default behavior of `next_tag()` is changing from visiting tag closers by default to skipping tag visitors by default. 

See https://github.com/westonruter/od-intrinsic-dimensions/pull/2 for how another plugin can avoid the migration warning while also avoiding a fatal error when attempting to run with an older version of Optimization Detective which doesn't allow passing `$query` to `next_tag()`. 

I think this necessitates adding an `optimization-detective 1.0.0-beta3` milestone. This bumps the version to 1.0.0-beta3 to anticipate this.

Lastly, the handling of the admin bar is now consistent with the handling of `NOSCRIPT`. While no tag visitor will be explicitly be invoked with either the `NOSCRIPT` tag or any tag in the admin bar, it is possible for tag visitors to manually walk over those tags if they want to. This was done so that the `next_tag()` method can be (eventually) unmodified in its behavior from the method in the base class.