### PR TITLE
Fix Modern Image Format not cropping image if crop is an array

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -82,11 +82,11 @@ function webp_uploads_get_upload_image_mime_transforms(): array {
  * @since 1.0.0
  * @access private
  *
- * @param int                                                                     $attachment_id         The ID of the attachment from where this image would be created.
- * @param string                                                                  $image_size            The size name that would be used to create the image source, out of the registered subsizes.
- * @param array{ width: int, height: int, crop: bool|array{0: string, 1: string}} $size_data             An array with the dimensions of the image: height, width and crop.
- * @param string                                                                  $mime                  The target mime in which the image should be created.
- * @param string|null                                                             $destination_file_name The path where the file would be stored, including the extension. If null, `generate_filename` is used to create the destination file name.
+ * @param int                                                               $attachment_id         The ID of the attachment from where this image would be created.
+ * @param string                                                            $image_size            The size name that would be used to create the image source, out of the registered subsizes.
+ * @param array{ width: int, height: int, crop: bool|array{string, string}} $size_data             An array with the dimensions of the image: height, width and crop.
+ * @param string                                                            $mime                  The target mime in which the image should be created.
+ * @param string|null                                                       $destination_file_name The path where the file would be stored, including the extension. If null, `generate_filename` is used to create the destination file name.
  *
  * @return array{ file: string, filesize: int }|WP_Error An array with the file and filesize if the image was created correctly, otherwise a WP_Error.
  */
@@ -109,7 +109,7 @@ function webp_uploads_generate_additional_image_source( int $attachment_id, stri
 	 * @param array{
 	 *            width: int,
 	 *            height: int,
-	 *            crop: bool|array{0: string, 1: string}
+	 *            crop: bool|array{string, string}
 	 *        }               $size_data     An array with the dimensions of the image.
 	 * @param string          $mime          The target mime in which the image should be created.
 	 */
@@ -240,20 +240,7 @@ function webp_uploads_generate_image_size( int $attachment_id, string $size, str
 		$size_data['height'] = $metadata['sizes'][ $size ]['height'];
 	}
 
-	if (
-		isset( $sizes[ $size ]['crop'] ) &&
-		(
-			(
-				is_array( $sizes[ $size ]['crop'] ) &&
-				count( $sizes[ $size ]['crop'] ) === 2 &&
-				isset( $sizes[ $size ]['crop'][0] ) &&
-				isset( $sizes[ $size ]['crop'][1] ) &&
-				is_string( $sizes[ $size ]['crop'][0] ) &&
-				is_string( $sizes[ $size ]['crop'][1] )
-			) ||
-			is_bool( $sizes[ $size ]['crop'] )
-		)
-	) {
+	if ( isset( $sizes[ $size ]['crop'] ) ) {
 		$size_data['crop'] = $sizes[ $size ]['crop'];
 	}
 

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -82,11 +82,11 @@ function webp_uploads_get_upload_image_mime_transforms(): array {
  * @since 1.0.0
  * @access private
  *
- * @param int                                          $attachment_id         The ID of the attachment from where this image would be created.
- * @param string                                       $image_size            The size name that would be used to create the image source, out of the registered subsizes.
- * @param array{ width: int, height: int, crop: bool } $size_data             An array with the dimensions of the image: height, width and crop.
- * @param string                                       $mime                  The target mime in which the image should be created.
- * @param string|null                                  $destination_file_name The path where the file would be stored, including the extension. If null, `generate_filename` is used to create the destination file name.
+ * @param int                                                                     $attachment_id         The ID of the attachment from where this image would be created.
+ * @param string                                                                  $image_size            The size name that would be used to create the image source, out of the registered subsizes.
+ * @param array{ width: int, height: int, crop: bool|array{0: string, 1: string}} $size_data             An array with the dimensions of the image: height, width and crop.
+ * @param string                                                                  $mime                  The target mime in which the image should be created.
+ * @param string|null                                                             $destination_file_name The path where the file would be stored, including the extension. If null, `generate_filename` is used to create the destination file name.
  *
  * @return array{ file: string, filesize: int }|WP_Error An array with the file and filesize if the image was created correctly, otherwise a WP_Error.
  */
@@ -109,7 +109,7 @@ function webp_uploads_generate_additional_image_source( int $attachment_id, stri
 	 * @param array{
 	 *            width: int,
 	 *            height: int,
-	 *            crop: bool
+	 *            crop: bool|array{0: string, 1: string}
 	 *        }               $size_data     An array with the dimensions of the image.
 	 * @param string          $mime          The target mime in which the image should be created.
 	 */
@@ -156,7 +156,7 @@ function webp_uploads_generate_additional_image_source( int $attachment_id, stri
 
 	$height = isset( $size_data['height'] ) ? (int) $size_data['height'] : 0;
 	$width  = isset( $size_data['width'] ) ? (int) $size_data['width'] : 0;
-	$crop   = isset( $size_data['crop'] ) && $size_data['crop'];
+	$crop   = isset( $size_data['crop'] ) ? $size_data['crop'] : false;
 	if ( $width <= 0 && $height <= 0 ) {
 		return new WP_Error( 'image_wrong_dimensions', __( 'At least one of the dimensions must be a positive number.', 'webp-uploads' ) );
 	}
@@ -240,8 +240,21 @@ function webp_uploads_generate_image_size( int $attachment_id, string $size, str
 		$size_data['height'] = $metadata['sizes'][ $size ]['height'];
 	}
 
-	if ( isset( $sizes[ $size ]['crop'] ) ) {
-		$size_data['crop'] = (bool) $sizes[ $size ]['crop'];
+	if (
+		isset( $sizes[ $size ]['crop'] ) &&
+		(
+			(
+				is_array( $sizes[ $size ]['crop'] ) &&
+				count( $sizes[ $size ]['crop'] ) === 2 &&
+				isset( $sizes[ $size ]['crop'][0] ) &&
+				isset( $sizes[ $size ]['crop'][1] ) &&
+				is_string( $sizes[ $size ]['crop'][0] ) &&
+				is_string( $sizes[ $size ]['crop'][1] )
+			) ||
+			is_bool( $sizes[ $size ]['crop'] )
+		)
+	) {
+		$size_data['crop'] = $sizes[ $size ]['crop'];
 	}
 
 	return webp_uploads_generate_additional_image_source( $attachment_id, $size, $size_data, $mime );

--- a/plugins/webp-uploads/tests/test-helper.php
+++ b/plugins/webp-uploads/tests/test-helper.php
@@ -345,6 +345,56 @@ class Test_WebP_Uploads_Helper extends TestCase {
 	}
 
 	/**
+	 * Test that image is cropped correctly when crop is an array.
+	 *
+	 * @covers ::webp_uploads_generate_additional_image_source
+	 */
+	public function test_it_should_crop_image_with_array_crop_value(): void {
+		if ( ! wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {
+			$this->markTestSkipped( 'Mime type image/webp is not supported.' );
+		}
+
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/car.jpeg' );
+		$size_data     = array(
+			'width'  => 300,
+			'height' => 300,
+			'crop'   => array( 'left', 'top' ),
+		);
+
+		$captured_crop = null;
+		// Add filter to intercept the crop value.
+		remove_all_filters( 'image_resize_dimensions' );
+		add_filter(
+			'image_resize_dimensions',
+			static function ( $passthrough, $orig_w, $orig_h, $dest_w, $dest_h, $crop ) use ( &$captured_crop ) {
+				$captured_crop = $crop;
+				return $passthrough;
+			},
+			10,
+			6
+		);
+
+		$result = webp_uploads_generate_additional_image_source( $attachment_id, 'medium', $size_data, 'image/webp', '/tmp/image.jpg' );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'filesize', $result );
+		$this->assertArrayHasKey( 'file', $result );
+		$this->assertStringEndsWith( 'image.webp', $result['file'] );
+		$this->assertFileExists( '/tmp/image.webp' );
+
+		// Get image dimensions to verify crop worked.
+		$image_editor = wp_get_image_editor( '/tmp/image.webp' );
+		$size         = $image_editor->get_size();
+
+		// Verify dimensions are as expected.
+		$this->assertEquals( 300, $size['width'] );
+		$this->assertEquals( 300, $size['height'] );
+
+		// Verify crop value is as expected.
+		$this->assertEquals( array( 'left', 'top' ), $captured_crop );
+	}
+
+	/**
 	 * Returns an empty array when the overwritten with empty array by webp_uploads_upload_image_mime_transforms filter.
 	 */
 	public function test_it_should_return_empty_array_when_filter_returns_empty_array(): void {


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1881 

## Relevant technical choices

<!-- Please describe your changes. -->

This PR fixes the issue of Modern Image Format not cropping image if crop is an array.

Below is the code snippet to reproduce the bug:
```php
add_filter( 'pre_option_medium_crop', function() { return array( 'right', 'right' ); } );
```


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
