### PR TITLE
Expose the logging functions to client-side extensions and automatically account for the value of `isDebug`

### DIFF
--- a/plugins/embed-optimizer/detect.js
+++ b/plugins/embed-optimizer/detect.js
@@ -6,7 +6,7 @@
  * when it is submitted for storage.
  */
 
-const consoleLogPrefix = '[Embed Optimizer]';
+export const consoleLogPrefix = '[Embed Optimizer]';
 
 /**
  * @typedef {import("../optimization-detective/types.ts").URLMetric} URLMetric
@@ -16,27 +16,8 @@ const consoleLogPrefix = '[Embed Optimizer]';
  * @typedef {import("../optimization-detective/types.ts").FinalizeArgs} FinalizeArgs
  * @typedef {import("../optimization-detective/types.ts").FinalizeCallback} FinalizeCallback
  * @typedef {import("../optimization-detective/types.ts").ExtendedElementData} ExtendedElementData
+ * @typedef {import("../optimization-detective/types.ts").Logger} Logger
  */
-
-/**
- * Logs a message.
- *
- * @param {...*} message
- */
-function log( ...message ) {
-	// eslint-disable-next-line no-console
-	console.log( consoleLogPrefix, ...message );
-}
-
-/**
- * Logs an error.
- *
- * @param {...*} message
- */
-function error( ...message ) {
-	// eslint-disable-next-line no-console
-	console.error( consoleLogPrefix, ...message );
-}
 
 /**
  * Embed element heights.
@@ -51,19 +32,17 @@ const loadedElementContentRects = new Map();
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { isDebug } ) {
+export async function initialize( { logger } ) {
 	/** @type NodeListOf<HTMLDivElement> */
 	const embedWrappers = document.querySelectorAll(
 		'.wp-block-embed > .wp-block-embed__wrapper[data-od-xpath]'
 	);
 
 	for ( /** @type {HTMLElement} */ const embedWrapper of embedWrappers ) {
-		monitorEmbedWrapperForResizes( embedWrapper, isDebug );
+		monitorEmbedWrapperForResizes( embedWrapper, logger );
 	}
 
-	if ( isDebug ) {
-		log( 'Loaded embed content rects:', loadedElementContentRects );
-	}
+	logger.log( 'Loaded embed content rects:', loadedElementContentRects );
 }
 
 /**
@@ -73,7 +52,7 @@ export async function initialize( { isDebug } ) {
  * @param {FinalizeArgs} args Args.
  */
 export async function finalize( {
-	isDebug,
+	logger,
 	getElementData,
 	extendElementData,
 } ) {
@@ -82,17 +61,15 @@ export async function finalize( {
 			extendElementData( xpath, {
 				resizedBoundingClientRect: domRect,
 			} );
-			if ( isDebug ) {
-				const elementData = getElementData( xpath );
-				log(
-					`boundingClientRect for ${ xpath } resized:`,
-					elementData.boundingClientRect,
-					'=>',
-					domRect
-				);
-			}
+			const elementData = getElementData( xpath );
+			logger.log(
+				`boundingClientRect for ${ xpath } resized:`,
+				elementData.boundingClientRect,
+				'=>',
+				domRect
+			);
 		} catch ( err ) {
-			error(
+			logger.error(
 				`Failed to extend element data for ${ xpath } with resizedBoundingClientRect:`,
 				domRect,
 				err
@@ -105,9 +82,9 @@ export async function finalize( {
  * Monitors embed wrapper for resizes.
  *
  * @param {HTMLDivElement} embedWrapper Embed wrapper DIV.
- * @param {boolean}        isDebug      Whether debug.
+ * @param {Logger}         logger       Logger.
  */
-function monitorEmbedWrapperForResizes( embedWrapper, isDebug ) {
+function monitorEmbedWrapperForResizes( embedWrapper, logger ) {
 	if ( ! ( 'odXpath' in embedWrapper.dataset ) ) {
 		throw new Error( 'Embed wrapper missing data-od-xpath attribute.' );
 	}
@@ -115,9 +92,7 @@ function monitorEmbedWrapperForResizes( embedWrapper, isDebug ) {
 	const observer = new ResizeObserver( ( entries ) => {
 		const [ entry ] = entries;
 		loadedElementContentRects.set( xpath, entry.contentRect );
-		if ( isDebug ) {
-			log( `Resized element ${ xpath }:`, entry.contentRect );
-		}
+		logger.log( `Resized element ${ xpath }:`, entry.contentRect );
 	} );
 	observer.observe( embedWrapper, { box: 'content-box' } );
 }

--- a/plugins/embed-optimizer/detect.js
+++ b/plugins/embed-optimizer/detect.js
@@ -32,7 +32,10 @@ const loadedElementContentRects = new Map();
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { log } ) {
+export async function initialize( { log: _log } ) {
+	// eslint-disable-next-line no-console
+	const log = _log || console.log; // TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
+
 	/** @type NodeListOf<HTMLDivElement> */
 	const embedWrappers = document.querySelectorAll(
 		'.wp-block-embed > .wp-block-embed__wrapper[data-od-xpath]'
@@ -52,11 +55,17 @@ export async function initialize( { log } ) {
  * @param {FinalizeArgs} args Args.
  */
 export async function finalize( {
-	log,
-	error,
+	log: _log,
+	error: _error,
 	getElementData,
 	extendElementData,
 } ) {
+	/* eslint-disable no-console */
+	// TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
+	const log = _log || console.log;
+	const error = _error || console.error;
+	/* eslint-enable no-console */
+
 	for ( const [ xpath, domRect ] of loadedElementContentRects.entries() ) {
 		try {
 			extendElementData( xpath, {

--- a/plugins/embed-optimizer/detect.js
+++ b/plugins/embed-optimizer/detect.js
@@ -16,7 +16,7 @@ export const name = 'Embed Optimizer';
  * @typedef {import("../optimization-detective/types.ts").FinalizeArgs} FinalizeArgs
  * @typedef {import("../optimization-detective/types.ts").FinalizeCallback} FinalizeCallback
  * @typedef {import("../optimization-detective/types.ts").ExtendedElementData} ExtendedElementData
- * @typedef {import("../optimization-detective/types.ts").Logger} Logger
+ * @typedef {import("../optimization-detective/types.ts").LogFunction} LogFunction
  */
 
 /**
@@ -32,17 +32,17 @@ const loadedElementContentRects = new Map();
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { logger } ) {
+export async function initialize( { log } ) {
 	/** @type NodeListOf<HTMLDivElement> */
 	const embedWrappers = document.querySelectorAll(
 		'.wp-block-embed > .wp-block-embed__wrapper[data-od-xpath]'
 	);
 
 	for ( /** @type {HTMLElement} */ const embedWrapper of embedWrappers ) {
-		monitorEmbedWrapperForResizes( embedWrapper, logger );
+		monitorEmbedWrapperForResizes( embedWrapper, log );
 	}
 
-	logger.log( 'Loaded embed content rects:', loadedElementContentRects );
+	log( 'Loaded embed content rects:', loadedElementContentRects );
 }
 
 /**
@@ -52,7 +52,8 @@ export async function initialize( { logger } ) {
  * @param {FinalizeArgs} args Args.
  */
 export async function finalize( {
-	logger,
+	log,
+	error,
 	getElementData,
 	extendElementData,
 } ) {
@@ -62,14 +63,14 @@ export async function finalize( {
 				resizedBoundingClientRect: domRect,
 			} );
 			const elementData = getElementData( xpath );
-			logger.log(
+			log(
 				`boundingClientRect for ${ xpath } resized:`,
 				elementData.boundingClientRect,
 				'=>',
 				domRect
 			);
 		} catch ( err ) {
-			logger.error(
+			error(
 				`Failed to extend element data for ${ xpath } with resizedBoundingClientRect:`,
 				domRect,
 				err
@@ -82,9 +83,9 @@ export async function finalize( {
  * Monitors embed wrapper for resizes.
  *
  * @param {HTMLDivElement} embedWrapper Embed wrapper DIV.
- * @param {Logger}         logger       Logger.
+ * @param {LogFunction}    log          The function to call with log messages.
  */
-function monitorEmbedWrapperForResizes( embedWrapper, logger ) {
+function monitorEmbedWrapperForResizes( embedWrapper, log ) {
 	if ( ! ( 'odXpath' in embedWrapper.dataset ) ) {
 		throw new Error( 'Embed wrapper missing data-od-xpath attribute.' );
 	}
@@ -92,7 +93,7 @@ function monitorEmbedWrapperForResizes( embedWrapper, logger ) {
 	const observer = new ResizeObserver( ( entries ) => {
 		const [ entry ] = entries;
 		loadedElementContentRects.set( xpath, entry.contentRect );
-		logger.log( `Resized element ${ xpath }:`, entry.contentRect );
+		log( `Resized element ${ xpath }:`, entry.contentRect );
 	} );
 	observer.observe( embedWrapper, { box: 'content-box' } );
 }

--- a/plugins/embed-optimizer/detect.js
+++ b/plugins/embed-optimizer/detect.js
@@ -6,7 +6,7 @@
  * when it is submitted for storage.
  */
 
-export const consoleLogPrefix = '[Embed Optimizer]';
+export const name = 'Embed Optimizer';
 
 /**
  * @typedef {import("../optimization-detective/types.ts").URLMetric} URLMetric

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -40,7 +40,10 @@ const externalBackgroundImages = [];
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { log, onLCP } ) {
+export async function initialize( { log: _log, onLCP } ) {
+	// eslint-disable-next-line no-console
+	const log = _log || console.log; // TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
+
 	onLCP(
 		( metric ) => {
 			handleLCPMetric( metric, log );
@@ -137,7 +140,10 @@ function handleLCPMetric( metric, log ) {
  * @type {FinalizeCallback}
  * @param {FinalizeArgs} args Args.
  */
-export async function finalize( { extendRootData, log } ) {
+export async function finalize( { extendRootData, log: _log } ) {
+	// eslint-disable-next-line no-console
+	const log = _log || console.log; // TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
+
 	if ( externalBackgroundImages.length === 0 ) {
 		return;
 	}

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -9,7 +9,7 @@
  * document has a tag with the same name, ID, and class.
  */
 
-const consoleLogPrefix = '[Image Prioritizer]';
+export const consoleLogPrefix = '[Image Prioritizer]';
 
 /**
  * Detected LCP external background image candidates.
@@ -29,19 +29,8 @@ const externalBackgroundImages = [];
  * @typedef {import("../optimization-detective/types.ts").InitializeArgs} InitializeArgs
  * @typedef {import("../optimization-detective/types.ts").FinalizeArgs} FinalizeArgs
  * @typedef {import("../optimization-detective/types.ts").FinalizeCallback} FinalizeCallback
+ * @typedef {import("../optimization-detective/types.ts").Logger} Logger
  */
-
-/**
- * Logs a message.
- *
- * @since 0.3.0
- *
- * @param {...*} message
- */
-function log( ...message ) {
-	// eslint-disable-next-line no-console
-	console.log( consoleLogPrefix, ...message );
-}
 
 /**
  * Initializes extension.
@@ -51,10 +40,10 @@ function log( ...message ) {
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { isDebug, onLCP } ) {
+export async function initialize( { logger, onLCP } ) {
 	onLCP(
 		( metric ) => {
-			handleLCPMetric( metric, isDebug );
+			handleLCPMetric( metric, logger );
 		},
 		{
 			// This avoids needing to click to finalize LCP candidate. While this is helpful for testing, it also
@@ -70,10 +59,10 @@ export async function initialize( { isDebug, onLCP } ) {
  *
  * @since 0.3.0
  *
- * @param {LCPMetric} metric  - LCP Metric.
- * @param {boolean}   isDebug - Whether in debug mode.
+ * @param {LCPMetric} metric - LCP Metric.
+ * @param {Logger}    logger - Logger.
  */
-function handleLCPMetric( metric, isDebug ) {
+function handleLCPMetric( metric, logger ) {
 	for ( const entry of metric.entries ) {
 		// Look only for LCP entries that have a URL and a corresponding element which is not an IMG or VIDEO.
 		if (
@@ -98,19 +87,15 @@ function handleLCPMetric( metric, isDebug ) {
 
 		// Skip URLs that are excessively long. This is the maxLength defined in image_prioritizer_add_element_item_schema_properties().
 		if ( entry.url.length > 500 ) {
-			if ( isDebug ) {
-				log( `Skipping very long URL: ${ entry.url }` );
-			}
+			logger.log( `Skipping very long URL: ${ entry.url }` );
 			return;
 		}
 
 		// Also skip Custom Elements which have excessively long tag names. This is the maxLength defined in image_prioritizer_add_element_item_schema_properties().
 		if ( entry.element.tagName.length > 100 ) {
-			if ( isDebug ) {
-				log(
-					`Skipping very long tag name: ${ entry.element.tagName }`
-				);
-			}
+			logger.log(
+				`Skipping very long tag name: ${ entry.element.tagName }`
+			);
 			return;
 		}
 
@@ -118,16 +103,12 @@ function handleLCPMetric( metric, isDebug ) {
 		// The maxLengths are defined in image_prioritizer_add_element_item_schema_properties().
 		const id = entry.element.getAttribute( 'id' );
 		if ( typeof id === 'string' && id.length > 100 ) {
-			if ( isDebug ) {
-				log( `Skipping very long ID: ${ id }` );
-			}
+			logger.log( `Skipping very long ID: ${ id }` );
 			return;
 		}
 		const className = entry.element.getAttribute( 'class' );
 		if ( typeof className === 'string' && className.length > 500 ) {
-			if ( isDebug ) {
-				log( `Skipping very long className: ${ className }` );
-			}
+			logger.log( `Skipping very long className: ${ className }` );
 			return;
 		}
 
@@ -141,12 +122,10 @@ function handleLCPMetric( metric, isDebug ) {
 			class: className,
 		};
 
-		if ( isDebug ) {
-			log(
-				'Detected external LCP background image:',
-				externalBackgroundImage
-			);
-		}
+		logger.log(
+			'Detected external LCP background image:',
+			externalBackgroundImage
+		);
 
 		externalBackgroundImages.push( externalBackgroundImage );
 	}
@@ -160,7 +139,7 @@ function handleLCPMetric( metric, isDebug ) {
  * @type {FinalizeCallback}
  * @param {FinalizeArgs} args Args.
  */
-export async function finalize( { extendRootData, isDebug } ) {
+export async function finalize( { extendRootData, logger } ) {
 	if ( externalBackgroundImages.length === 0 ) {
 		return;
 	}
@@ -168,12 +147,10 @@ export async function finalize( { extendRootData, isDebug } ) {
 	// Get the last detected external background image which is going to be for the LCP element (or very likely will be).
 	const lcpElementExternalBackgroundImage = externalBackgroundImages.pop();
 
-	if ( isDebug ) {
-		log(
-			'Sending external background image for LCP element:',
-			lcpElementExternalBackgroundImage
-		);
-	}
+	logger.log(
+		'Sending external background image for LCP element:',
+		lcpElementExternalBackgroundImage
+	);
 
 	extendRootData( { lcpElementExternalBackgroundImage } );
 }

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -9,7 +9,7 @@
  * document has a tag with the same name, ID, and class.
  */
 
-export const consoleLogPrefix = '[Image Prioritizer]';
+export const name = 'Image Prioritizer';
 
 /**
  * Detected LCP external background image candidates.

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -29,7 +29,7 @@ const externalBackgroundImages = [];
  * @typedef {import("../optimization-detective/types.ts").InitializeArgs} InitializeArgs
  * @typedef {import("../optimization-detective/types.ts").FinalizeArgs} FinalizeArgs
  * @typedef {import("../optimization-detective/types.ts").FinalizeCallback} FinalizeCallback
- * @typedef {import("../optimization-detective/types.ts").Logger} Logger
+ * @typedef {import("../optimization-detective/types.ts").LogFunction} LogFunction
  */
 
 /**
@@ -40,10 +40,10 @@ const externalBackgroundImages = [];
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { logger, onLCP } ) {
+export async function initialize( { log, onLCP } ) {
 	onLCP(
 		( metric ) => {
-			handleLCPMetric( metric, logger );
+			handleLCPMetric( metric, log );
 		},
 		{
 			// This avoids needing to click to finalize LCP candidate. While this is helpful for testing, it also
@@ -59,10 +59,10 @@ export async function initialize( { logger, onLCP } ) {
  *
  * @since 0.3.0
  *
- * @param {LCPMetric} metric - LCP Metric.
- * @param {Logger}    logger - Logger.
+ * @param {LCPMetric}   metric - LCP Metric.
+ * @param {LogFunction} log    - The function to call with log messages.
  */
-function handleLCPMetric( metric, logger ) {
+function handleLCPMetric( metric, log ) {
 	for ( const entry of metric.entries ) {
 		// Look only for LCP entries that have a URL and a corresponding element which is not an IMG or VIDEO.
 		if (
@@ -87,15 +87,13 @@ function handleLCPMetric( metric, logger ) {
 
 		// Skip URLs that are excessively long. This is the maxLength defined in image_prioritizer_add_element_item_schema_properties().
 		if ( entry.url.length > 500 ) {
-			logger.log( `Skipping very long URL: ${ entry.url }` );
+			log( `Skipping very long URL: ${ entry.url }` );
 			return;
 		}
 
 		// Also skip Custom Elements which have excessively long tag names. This is the maxLength defined in image_prioritizer_add_element_item_schema_properties().
 		if ( entry.element.tagName.length > 100 ) {
-			logger.log(
-				`Skipping very long tag name: ${ entry.element.tagName }`
-			);
+			log( `Skipping very long tag name: ${ entry.element.tagName }` );
 			return;
 		}
 
@@ -103,12 +101,12 @@ function handleLCPMetric( metric, logger ) {
 		// The maxLengths are defined in image_prioritizer_add_element_item_schema_properties().
 		const id = entry.element.getAttribute( 'id' );
 		if ( typeof id === 'string' && id.length > 100 ) {
-			logger.log( `Skipping very long ID: ${ id }` );
+			log( `Skipping very long ID: ${ id }` );
 			return;
 		}
 		const className = entry.element.getAttribute( 'class' );
 		if ( typeof className === 'string' && className.length > 500 ) {
-			logger.log( `Skipping very long className: ${ className }` );
+			log( `Skipping very long className: ${ className }` );
 			return;
 		}
 
@@ -122,7 +120,7 @@ function handleLCPMetric( metric, logger ) {
 			class: className,
 		};
 
-		logger.log(
+		log(
 			'Detected external LCP background image:',
 			externalBackgroundImage
 		);
@@ -139,7 +137,7 @@ function handleLCPMetric( metric, logger ) {
  * @type {FinalizeCallback}
  * @param {FinalizeArgs} args Args.
  */
-export async function finalize( { extendRootData, logger } ) {
+export async function finalize( { extendRootData, log } ) {
 	if ( externalBackgroundImages.length === 0 ) {
 		return;
 	}
@@ -147,7 +145,7 @@ export async function finalize( { extendRootData, logger } ) {
 	// Get the last detected external background image which is going to be for the LCP element (or very likely will be).
 	const lcpElementExternalBackgroundImage = externalBackgroundImages.pop();
 
-	logger.log(
+	log(
 		'Sending external background image for LCP element:',
 		lcpElementExternalBackgroundImage
 	);

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -503,7 +503,7 @@ export default async function detect( {
 			if ( extension.initialize instanceof Function ) {
 				const initializePromise = extension.initialize( {
 					isDebug,
-					logger: extensionLogger,
+					...extensionLogger,
 					onTTFB,
 					onFCP,
 					onLCP,
@@ -716,7 +716,7 @@ export default async function detect( {
 				try {
 					const finalizePromise = extension.finalize( {
 						isDebug,
-						logger: extensionLogger,
+						...extensionLogger,
 						getRootData,
 						getElementData,
 						extendElementData,

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -70,15 +70,11 @@ function setStorageLock( currentTime ) {
  * Creates a logger object with log, warn, and error methods.
  *
  * @param {boolean} [debugMode=false] - Whether to enable debug mode.
+ * @param {string}  [prefix='']       - Prefix to prepend to the console message.
  * @return {Logger} Logger object with log, warn, and error methods.
  */
-function createLogger( debugMode = false ) {
+function createLogger( debugMode = false, prefix = '' ) {
 	return {
-		/**
-		 * Prefix for log messages.
-		 * @type {string}
-		 */
-		prefix: '',
 
 		/**
 		 * Logs a message if debug mode is enabled.
@@ -88,7 +84,7 @@ function createLogger( debugMode = false ) {
 		log( ...message ) {
 			if ( debugMode ) {
 				// eslint-disable-next-line no-console
-				console.log( this.prefix, ...message );
+				console.log( prefix, ...message );
 			}
 		},
 
@@ -100,7 +96,7 @@ function createLogger( debugMode = false ) {
 		warn( ...message ) {
 			if ( debugMode ) {
 				// eslint-disable-next-line no-console
-				console.warn( this.prefix, ...message );
+				console.warn( prefix, ...message );
 			}
 		},
 
@@ -111,7 +107,7 @@ function createLogger( debugMode = false ) {
 		 */
 		error( ...message ) {
 			// eslint-disable-next-line no-console
-			console.error( this.prefix, ...message );
+			console.error( prefix, ...message );
 		},
 	};
 }
@@ -347,8 +343,7 @@ export default async function detect( {
 	webVitalsLibrarySrc,
 	urlMetricGroupCollection,
 } ) {
-	const logger = createLogger( isDebug );
-	logger.prefix = consoleLogPrefix;
+	const { log, warn, error } = createLogger( isDebug, consoleLogPrefix );
 
 	if ( isDebug ) {
 		const allUrlMetrics = /** @type Array<UrlMetricDebugData> */ [];
@@ -360,19 +355,19 @@ export default async function detect( {
 				allUrlMetrics.push( otherUrlMetric );
 			}
 		}
-		logger.log(
+		log(
 			'Stored URL Metric Group Collection:',
 			urlMetricGroupCollection
 		);
 		allUrlMetrics.sort( ( a, b ) => b.timestamp - a.timestamp );
-		logger.log(
+		log(
 			'Stored URL Metrics in reverse chronological order:',
 			allUrlMetrics
 		);
 	}
 
 	if ( win.innerWidth === 0 || win.innerHeight === 0 ) {
-		logger.log(
+		log(
 			'Window must have non-zero dimensions for URL Metric collection.'
 		);
 		return;
@@ -384,7 +379,7 @@ export default async function detect( {
 		urlMetricGroupStatuses
 	);
 	if ( urlMetricGroupStatus.complete ) {
-		logger.log( 'No need for URL Metrics from the current viewport.' );
+		log( 'No need for URL Metrics from the current viewport.' );
 		return;
 	}
 
@@ -404,7 +399,7 @@ export default async function detect( {
 			! isNaN( previousVisitTime ) &&
 			( getCurrentTime() - previousVisitTime ) / 1000 < freshnessTTL
 		) {
-			logger.log(
+			log(
 				'The current client session already submitted a fresh URL Metric for this URL so a new one will not be collected now.'
 			);
 			return;
@@ -417,7 +412,7 @@ export default async function detect( {
 		aspectRatio < minViewportAspectRatio ||
 		aspectRatio > maxViewportAspectRatio
 	) {
-		logger.warn(
+		warn(
 			`Viewport aspect ratio (${ aspectRatio }) is not in the accepted range of ${ minViewportAspectRatio } to ${ maxViewportAspectRatio }.`
 		);
 		return;
@@ -453,7 +448,7 @@ export default async function detect( {
 	// od_is_url_metric_storage_locked() function returns true. However, the downside with that is page caching could
 	// result in metrics missed from being gathered when a user navigates around a site and primes the page cache.
 	if ( isStorageLocked( getCurrentTime(), storageLockTTL ) ) {
-		logger.warn( 'Aborted detection due to storage being locked.' );
+		warn( 'Aborted detection due to storage being locked.' );
 		return;
 	}
 
@@ -478,13 +473,13 @@ export default async function detect( {
 	// TODO: Does this make sense here?
 	// Prevent detection when page is not scrolled to the initial viewport.
 	if ( doc.documentElement.scrollTop > 0 ) {
-		logger.warn(
+		warn(
 			'Aborted detection since initial scroll position of page is not at the top.'
 		);
 		return;
 	}
 
-	logger.log( 'Proceeding with detection' );
+	log( 'Proceeding with detection' );
 
 	/** @type {Map<string, Extension>} */
 	const extensions = new Map();
@@ -501,9 +496,7 @@ export default async function detect( {
 			const extension = await import( extensionModuleUrl );
 			extensions.set( extensionModuleUrl, extension );
 
-			const extensionLogger = createLogger( isDebug );
-			extensionLogger.prefix =
-				extension.consoleLogPrefix || '[Extension]';
+			const extensionLogger = createLogger( isDebug, extension.name ? `[${extension.name}]` : '[Optimization Detective extension]' );
 
 			// TODO: There should to be a way to pass additional args into the module. Perhaps extensionModuleUrls should be a mapping of URLs to args.
 			if ( extension.initialize instanceof Function ) {
@@ -522,7 +515,7 @@ export default async function detect( {
 				}
 			}
 		} catch ( err ) {
-			logger.error(
+			error(
 				`Failed to start initializing extension '${ extensionModuleUrl }':`,
 				err
 			);
@@ -538,7 +531,7 @@ export default async function detect( {
 		settledInitializePromise,
 	] of settledInitializePromises.entries() ) {
 		if ( settledInitializePromise.status === 'rejected' ) {
-			logger.error(
+			error(
 				`Failed to initialize extension '${ initializingExtensionModuleUrls[ i ] }':`,
 				settledInitializePromise.reason
 			);
@@ -626,7 +619,7 @@ export default async function detect( {
 
 	// Stop observing.
 	disconnectIntersectionObserver();
-	logger.log( 'Detection is stopping.' );
+	log( 'Detection is stopping.' );
 
 	urlMetric = {
 		url: currentUrl,
@@ -643,7 +636,7 @@ export default async function detect( {
 		const xpath = breadcrumbedElementsMap.get( elementIntersection.target );
 		if ( ! xpath ) {
 			if ( isDebug ) {
-				logger.error( 'Unable to look up XPath for element' );
+				error( 'Unable to look up XPath for element' );
 			}
 			continue;
 		}
@@ -674,7 +667,7 @@ export default async function detect( {
 		elementsByXPath.set( elementData.xpath, elementData );
 	}
 
-	logger.log( 'Current URL Metric:', urlMetric );
+	log( 'Current URL Metric:', urlMetric );
 
 	// Wait for the page to be hidden.
 	await new Promise( ( resolve ) => {
@@ -695,7 +688,7 @@ export default async function detect( {
 	// Only proceed with submitting the URL Metric if viewport stayed the same size. Changing the viewport size (e.g. due
 	// to resizing a window or changing the orientation of a device) will result in unexpected metrics being collected.
 	if ( didWindowResize ) {
-		logger.log(
+		log(
 			'Aborting URL Metric collection due to viewport size change.'
 		);
 		return;
@@ -714,9 +707,7 @@ export default async function detect( {
 			extension,
 		] of extensions.entries() ) {
 			if ( extension.finalize instanceof Function ) {
-				const extensionLogger = createLogger( isDebug );
-				extensionLogger.prefix =
-					extension.consoleLogPrefix || '[Extension]';
+				const extensionLogger = createLogger( isDebug, extension.name ? `[${extension.name}]` : '[Optimization Detective extension]' );
 
 				try {
 					const finalizePromise = extension.finalize( {
@@ -734,7 +725,7 @@ export default async function detect( {
 						);
 					}
 				} catch ( err ) {
-					logger.error(
+					error(
 						`Unable to start finalizing extension '${ extensionModuleUrl }':`,
 						err
 					);
@@ -751,7 +742,7 @@ export default async function detect( {
 			settledFinalizePromise,
 		] of settledFinalizePromises.entries() ) {
 			if ( settledFinalizePromise.status === 'rejected' ) {
-				logger.error(
+				error(
 					`Failed to finalize extension '${ finalizingExtensionModuleUrls[ i ] }':`,
 					settledFinalizePromise.reason
 				);
@@ -779,7 +770,7 @@ export default async function detect( {
 	 */
 	if ( jsonBody.length > maxBodyLengthBytes ) {
 		if ( isDebug ) {
-			logger.error(
+			error(
 				`Unable to send URL Metric because it is ${ jsonBody.length.toLocaleString() } bytes, ${ Math.round(
 					percentOfBudget
 				) }% of ${ maxBodyLengthKiB } KiB limit:`,
@@ -805,9 +796,9 @@ export default async function detect( {
 
 	// The threshold of 50% is used because the limit for all beacons combined is 64 KiB, not just the data for one beacon.
 	if ( percentOfBudget < 50 ) {
-		logger.log( message, urlMetric );
+		log( message, urlMetric );
 	} else {
-		logger.warn( message, urlMetric );
+		warn( message, urlMetric );
 	}
 
 	const url = new URL( restApiEndpoint );

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -71,7 +71,7 @@ function setStorageLock( currentTime ) {
  *
  * @param {boolean} [debugMode=false] - Whether to enable debug mode.
  * @param {string}  [prefix='']       - Prefix to prepend to the console message.
- * @return {Logger} Logger object with log, warn, and error methods.
+ * @return {Logger} Logger object with log, info, warn, and error methods.
  */
 function createLogger( debugMode = false, prefix = '' ) {
 	return {
@@ -84,6 +84,18 @@ function createLogger( debugMode = false, prefix = '' ) {
 			if ( debugMode ) {
 				// eslint-disable-next-line no-console
 				console.log( prefix, ...message );
+			}
+		},
+
+		/**
+		 * Logs an informational message if debug mode is enabled.
+		 *
+		 * @param {...*} message - The message(s) to log as info.
+		 */
+		info( ...message ) {
+			if ( debugMode ) {
+				// eslint-disable-next-line no-console
+				console.info( prefix, ...message );
 			}
 		},
 

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -506,9 +506,9 @@ export default async function detect( {
 
 			const extensionLogger = createLogger(
 				isDebug,
-				extension.name
-					? `[${ extension.name }]`
-					: '[Optimization Detective extension]'
+				`[Optimization Detective: ${
+					extension.name || 'Unnamed Extension'
+				}]`
 			);
 
 			// TODO: There should to be a way to pass additional args into the module. Perhaps extensionModuleUrls should be a mapping of URLs to args.
@@ -720,9 +720,9 @@ export default async function detect( {
 			if ( extension.finalize instanceof Function ) {
 				const extensionLogger = createLogger(
 					isDebug,
-					extension.name
-						? `[${ extension.name }]`
-						: '[Optimization Detective extension]'
+					`[Optimization Detective: ${
+						extension.name || 'Unnamed Extension'
+					}]`
 				);
 
 				try {

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -75,7 +75,6 @@ function setStorageLock( currentTime ) {
  */
 function createLogger( debugMode = false, prefix = '' ) {
 	return {
-
 		/**
 		 * Logs a message if debug mode is enabled.
 		 *
@@ -355,10 +354,7 @@ export default async function detect( {
 				allUrlMetrics.push( otherUrlMetric );
 			}
 		}
-		log(
-			'Stored URL Metric Group Collection:',
-			urlMetricGroupCollection
-		);
+		log( 'Stored URL Metric Group Collection:', urlMetricGroupCollection );
 		allUrlMetrics.sort( ( a, b ) => b.timestamp - a.timestamp );
 		log(
 			'Stored URL Metrics in reverse chronological order:',
@@ -496,7 +492,12 @@ export default async function detect( {
 			const extension = await import( extensionModuleUrl );
 			extensions.set( extensionModuleUrl, extension );
 
-			const extensionLogger = createLogger( isDebug, extension.name ? `[${extension.name}]` : '[Optimization Detective extension]' );
+			const extensionLogger = createLogger(
+				isDebug,
+				extension.name
+					? `[${ extension.name }]`
+					: '[Optimization Detective extension]'
+			);
 
 			// TODO: There should to be a way to pass additional args into the module. Perhaps extensionModuleUrls should be a mapping of URLs to args.
 			if ( extension.initialize instanceof Function ) {
@@ -688,9 +689,7 @@ export default async function detect( {
 	// Only proceed with submitting the URL Metric if viewport stayed the same size. Changing the viewport size (e.g. due
 	// to resizing a window or changing the orientation of a device) will result in unexpected metrics being collected.
 	if ( didWindowResize ) {
-		log(
-			'Aborting URL Metric collection due to viewport size change.'
-		);
+		log( 'Aborting URL Metric collection due to viewport size change.' );
 		return;
 	}
 
@@ -707,7 +706,12 @@ export default async function detect( {
 			extension,
 		] of extensions.entries() ) {
 			if ( extension.finalize instanceof Function ) {
-				const extensionLogger = createLogger( isDebug, extension.name ? `[${extension.name}]` : '[Optimization Detective extension]' );
+				const extensionLogger = createLogger(
+					isDebug,
+					extension.name
+						? `[${ extension.name }]`
+						: '[Optimization Detective extension]'
+				);
 
 				try {
 					const finalizePromise = extension.finalize( {

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -17,6 +17,7 @@
  * @typedef {import("./types.ts").Extension} Extension
  * @typedef {import("./types.ts").ExtendedRootData} ExtendedRootData
  * @typedef {import("./types.ts").ExtendedElementData} ExtendedElementData
+ * @typedef {import("./types.ts").Logger} Logger
  */
 
 const win = window;
@@ -66,33 +67,53 @@ function setStorageLock( currentTime ) {
 }
 
 /**
- * Logs a message.
+ * Creates a logger object with log, warn, and error methods.
  *
- * @param {...*} message
+ * @param {boolean} [debugMode=false] - Whether to enable debug mode.
+ * @return {Logger} Logger object with log, warn, and error methods.
  */
-function log( ...message ) {
-	// eslint-disable-next-line no-console
-	console.log( consoleLogPrefix, ...message );
-}
+function createLogger( debugMode = false ) {
+	return {
+		/**
+		 * Prefix for log messages.
+		 * @type {string}
+		 */
+		prefix: '',
 
-/**
- * Logs a warning.
- *
- * @param {...*} message
- */
-function warn( ...message ) {
-	// eslint-disable-next-line no-console
-	console.warn( consoleLogPrefix, ...message );
-}
+		/**
+		 * Logs a message if debug mode is enabled.
+		 *
+		 * @param {...*} message - The message(s) to log.
+		 */
+		log( ...message ) {
+			if ( debugMode ) {
+				// eslint-disable-next-line no-console
+				console.log( this.prefix, ...message );
+			}
+		},
 
-/**
- * Logs an error.
- *
- * @param {...*} message
- */
-function error( ...message ) {
-	// eslint-disable-next-line no-console
-	console.error( consoleLogPrefix, ...message );
+		/**
+		 * Logs a warning if debug mode is enabled.
+		 *
+		 * @param {...*} message - The message(s) to log as a warning.
+		 */
+		warn( ...message ) {
+			if ( debugMode ) {
+				// eslint-disable-next-line no-console
+				console.warn( this.prefix, ...message );
+			}
+		},
+
+		/**
+		 * Logs an error.
+		 *
+		 * @param {...*} message - The message(s) to log as an error.
+		 */
+		error( ...message ) {
+			// eslint-disable-next-line no-console
+			console.error( this.prefix, ...message );
+		},
+	};
 }
 
 /**
@@ -326,6 +347,9 @@ export default async function detect( {
 	webVitalsLibrarySrc,
 	urlMetricGroupCollection,
 } ) {
+	const logger = createLogger( isDebug );
+	logger.prefix = consoleLogPrefix;
+
 	if ( isDebug ) {
 		const allUrlMetrics = /** @type Array<UrlMetricDebugData> */ [];
 		for ( const group of urlMetricGroupCollection.groups ) {
@@ -336,20 +360,21 @@ export default async function detect( {
 				allUrlMetrics.push( otherUrlMetric );
 			}
 		}
-		log( 'Stored URL Metric Group Collection:', urlMetricGroupCollection );
+		logger.log(
+			'Stored URL Metric Group Collection:',
+			urlMetricGroupCollection
+		);
 		allUrlMetrics.sort( ( a, b ) => b.timestamp - a.timestamp );
-		log(
+		logger.log(
 			'Stored URL Metrics in reverse chronological order:',
 			allUrlMetrics
 		);
 	}
 
 	if ( win.innerWidth === 0 || win.innerHeight === 0 ) {
-		if ( isDebug ) {
-			log(
-				'Window must have non-zero dimensions for URL Metric collection.'
-			);
-		}
+		logger.log(
+			'Window must have non-zero dimensions for URL Metric collection.'
+		);
 		return;
 	}
 
@@ -359,9 +384,7 @@ export default async function detect( {
 		urlMetricGroupStatuses
 	);
 	if ( urlMetricGroupStatus.complete ) {
-		if ( isDebug ) {
-			log( 'No need for URL Metrics from the current viewport.' );
-		}
+		logger.log( 'No need for URL Metrics from the current viewport.' );
 		return;
 	}
 
@@ -381,12 +404,10 @@ export default async function detect( {
 			! isNaN( previousVisitTime ) &&
 			( getCurrentTime() - previousVisitTime ) / 1000 < freshnessTTL
 		) {
-			if ( isDebug ) {
-				log(
-					'The current client session already submitted a fresh URL Metric for this URL so a new one will not be collected now.'
-				);
-				return;
-			}
+			logger.log(
+				'The current client session already submitted a fresh URL Metric for this URL so a new one will not be collected now.'
+			);
+			return;
 		}
 	}
 
@@ -396,11 +417,9 @@ export default async function detect( {
 		aspectRatio < minViewportAspectRatio ||
 		aspectRatio > maxViewportAspectRatio
 	) {
-		if ( isDebug ) {
-			warn(
-				`Viewport aspect ratio (${ aspectRatio }) is not in the accepted range of ${ minViewportAspectRatio } to ${ maxViewportAspectRatio }.`
-			);
-		}
+		logger.warn(
+			`Viewport aspect ratio (${ aspectRatio }) is not in the accepted range of ${ minViewportAspectRatio } to ${ maxViewportAspectRatio }.`
+		);
 		return;
 	}
 
@@ -434,9 +453,7 @@ export default async function detect( {
 	// od_is_url_metric_storage_locked() function returns true. However, the downside with that is page caching could
 	// result in metrics missed from being gathered when a user navigates around a site and primes the page cache.
 	if ( isStorageLocked( getCurrentTime(), storageLockTTL ) ) {
-		if ( isDebug ) {
-			warn( 'Aborted detection due to storage being locked.' );
-		}
+		logger.warn( 'Aborted detection due to storage being locked.' );
 		return;
 	}
 
@@ -461,17 +478,13 @@ export default async function detect( {
 	// TODO: Does this make sense here?
 	// Prevent detection when page is not scrolled to the initial viewport.
 	if ( doc.documentElement.scrollTop > 0 ) {
-		if ( isDebug ) {
-			warn(
-				'Aborted detection since initial scroll position of page is not at the top.'
-			);
-		}
+		logger.warn(
+			'Aborted detection since initial scroll position of page is not at the top.'
+		);
 		return;
 	}
 
-	if ( isDebug ) {
-		log( 'Proceeding with detection' );
-	}
+	logger.log( 'Proceeding with detection' );
 
 	/** @type {Map<string, Extension>} */
 	const extensions = new Map();
@@ -487,10 +500,16 @@ export default async function detect( {
 			/** @type {Extension} */
 			const extension = await import( extensionModuleUrl );
 			extensions.set( extensionModuleUrl, extension );
+
+			const extensionLogger = createLogger( isDebug );
+			extensionLogger.prefix =
+				extension.consoleLogPrefix || '[Extension]';
+
 			// TODO: There should to be a way to pass additional args into the module. Perhaps extensionModuleUrls should be a mapping of URLs to args.
 			if ( extension.initialize instanceof Function ) {
 				const initializePromise = extension.initialize( {
 					isDebug,
+					logger: extensionLogger,
 					onTTFB,
 					onFCP,
 					onLCP,
@@ -503,7 +522,7 @@ export default async function detect( {
 				}
 			}
 		} catch ( err ) {
-			error(
+			logger.error(
 				`Failed to start initializing extension '${ extensionModuleUrl }':`,
 				err
 			);
@@ -519,7 +538,7 @@ export default async function detect( {
 		settledInitializePromise,
 	] of settledInitializePromises.entries() ) {
 		if ( settledInitializePromise.status === 'rejected' ) {
-			error(
+			logger.error(
 				`Failed to initialize extension '${ initializingExtensionModuleUrls[ i ] }':`,
 				settledInitializePromise.reason
 			);
@@ -607,9 +626,7 @@ export default async function detect( {
 
 	// Stop observing.
 	disconnectIntersectionObserver();
-	if ( isDebug ) {
-		log( 'Detection is stopping.' );
-	}
+	logger.log( 'Detection is stopping.' );
 
 	urlMetric = {
 		url: currentUrl,
@@ -626,7 +643,7 @@ export default async function detect( {
 		const xpath = breadcrumbedElementsMap.get( elementIntersection.target );
 		if ( ! xpath ) {
 			if ( isDebug ) {
-				error( 'Unable to look up XPath for element' );
+				logger.error( 'Unable to look up XPath for element' );
 			}
 			continue;
 		}
@@ -657,9 +674,7 @@ export default async function detect( {
 		elementsByXPath.set( elementData.xpath, elementData );
 	}
 
-	if ( isDebug ) {
-		log( 'Current URL Metric:', urlMetric );
-	}
+	logger.log( 'Current URL Metric:', urlMetric );
 
 	// Wait for the page to be hidden.
 	await new Promise( ( resolve ) => {
@@ -680,11 +695,9 @@ export default async function detect( {
 	// Only proceed with submitting the URL Metric if viewport stayed the same size. Changing the viewport size (e.g. due
 	// to resizing a window or changing the orientation of a device) will result in unexpected metrics being collected.
 	if ( didWindowResize ) {
-		if ( isDebug ) {
-			log(
-				'Aborting URL Metric collection due to viewport size change.'
-			);
-		}
+		logger.log(
+			'Aborting URL Metric collection due to viewport size change.'
+		);
 		return;
 	}
 
@@ -701,9 +714,14 @@ export default async function detect( {
 			extension,
 		] of extensions.entries() ) {
 			if ( extension.finalize instanceof Function ) {
+				const extensionLogger = createLogger( isDebug );
+				extensionLogger.prefix =
+					extension.consoleLogPrefix || '[Extension]';
+
 				try {
 					const finalizePromise = extension.finalize( {
 						isDebug,
+						logger: extensionLogger,
 						getRootData,
 						getElementData,
 						extendElementData,
@@ -716,7 +734,7 @@ export default async function detect( {
 						);
 					}
 				} catch ( err ) {
-					error(
+					logger.error(
 						`Unable to start finalizing extension '${ extensionModuleUrl }':`,
 						err
 					);
@@ -733,7 +751,7 @@ export default async function detect( {
 			settledFinalizePromise,
 		] of settledFinalizePromises.entries() ) {
 			if ( settledFinalizePromise.status === 'rejected' ) {
-				error(
+				logger.error(
 					`Failed to finalize extension '${ finalizingExtensionModuleUrls[ i ] }':`,
 					settledFinalizePromise.reason
 				);
@@ -761,7 +779,7 @@ export default async function detect( {
 	 */
 	if ( jsonBody.length > maxBodyLengthBytes ) {
 		if ( isDebug ) {
-			error(
+			logger.error(
 				`Unable to send URL Metric because it is ${ jsonBody.length.toLocaleString() } bytes, ${ Math.round(
 					percentOfBudget
 				) }% of ${ maxBodyLengthKiB } KiB limit:`,
@@ -781,17 +799,15 @@ export default async function detect( {
 		String( getCurrentTime() )
 	);
 
-	if ( isDebug ) {
-		const message = `Sending URL Metric (${ jsonBody.length.toLocaleString() } bytes, ${ Math.round(
-			percentOfBudget
-		) }% of ${ maxBodyLengthKiB } KiB limit):`;
+	const message = `Sending URL Metric (${ jsonBody.length.toLocaleString() } bytes, ${ Math.round(
+		percentOfBudget
+	) }% of ${ maxBodyLengthKiB } KiB limit):`;
 
-		// The threshold of 50% is used because the limit for all beacons combined is 64 KiB, not just the data for one beacon.
-		if ( percentOfBudget < 50 ) {
-			log( message, urlMetric );
-		} else {
-			warn( message, urlMetric );
-		}
+	// The threshold of 50% is used because the limit for all beacons combined is 64 KiB, not just the data for one beacon.
+	if ( percentOfBudget < 50 ) {
+		logger.log( message, urlMetric );
+	} else {
+		logger.warn( message, urlMetric );
 	}
 
 	const url = new URL( restApiEndpoint );

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -1,13 +1,13 @@
 // h/t https://stackoverflow.com/a/59801602/93579
 type ExcludeProps< T > = { [ k: string ]: any } & { [ K in keyof T ]?: never };
 
-import { onTTFB, onFCP, onLCP, onINP, onCLS } from 'web-vitals';
+import { onCLS, onFCP, onINP, onLCP, onTTFB } from 'web-vitals';
 import {
-	onTTFB as onTTFBWithAttribution,
-	onFCP as onFCPWithAttribution,
-	onLCP as onLCPWithAttribution,
-	onINP as onINPWithAttribution,
 	onCLS as onCLSWithAttribution,
+	onFCP as onFCPWithAttribution,
+	onINP as onINPWithAttribution,
+	onLCP as onLCPWithAttribution,
+	onTTFB as onTTFBWithAttribution,
 } from 'web-vitals/attribution';
 
 export interface ElementData {
@@ -59,7 +59,9 @@ export interface Logger {
 
 export type InitializeArgs = {
 	readonly isDebug: boolean;
-	readonly logger: Logger;
+	readonly log: LogFunction;
+	readonly warn: LogFunction;
+	readonly error: LogFunction;
 	readonly onTTFB: OnTTFBFunction | OnTTFBWithAttributionFunction;
 	readonly onFCP: OnFCPFunction | OnFCPWithAttributionFunction;
 	readonly onLCP: OnLCPFunction | OnLCPWithAttributionFunction;
@@ -78,7 +80,9 @@ export type FinalizeArgs = {
 		properties: ExtendedElementData
 	) => void;
 	readonly isDebug: boolean;
-	readonly logger: Logger;
+	readonly log: LogFunction;
+	readonly warn: LogFunction;
+	readonly error: LogFunction;
 };
 
 export type FinalizeCallback = ( args: FinalizeArgs ) => Promise< void >;

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -49,8 +49,18 @@ export type OnLCPWithAttributionFunction = typeof onLCPWithAttribution;
 export type OnINPWithAttributionFunction = typeof onINPWithAttribution;
 export type OnCLSWithAttributionFunction = typeof onCLSWithAttribution;
 
+export type LogFunction = ( ...message: any[] ) => void;
+
+export interface Logger {
+	prefix: string;
+	log: LogFunction;
+	warn: LogFunction;
+	error: LogFunction;
+}
+
 export type InitializeArgs = {
 	readonly isDebug: boolean;
+	readonly logger: Logger;
 	readonly onTTFB: OnTTFBFunction | OnTTFBWithAttributionFunction;
 	readonly onFCP: OnFCPFunction | OnFCPWithAttributionFunction;
 	readonly onLCP: OnLCPFunction | OnLCPWithAttributionFunction;
@@ -69,11 +79,13 @@ export type FinalizeArgs = {
 		properties: ExtendedElementData
 	) => void;
 	readonly isDebug: boolean;
+	readonly logger: Logger;
 };
 
 export type FinalizeCallback = ( args: FinalizeArgs ) => Promise< void >;
 
 export interface Extension {
+	readonly consoleLogPrefix?: string;
 	initialize?: InitializeCallback;
 	finalize?: FinalizeCallback;
 }

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -53,6 +53,7 @@ export type LogFunction = ( ...message: any[] ) => void;
 
 export interface Logger {
 	log: LogFunction;
+	info: LogFunction;
 	warn: LogFunction;
 	error: LogFunction;
 }

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -92,6 +92,6 @@ export type FinalizeCallback = ( args: FinalizeArgs ) => Promise< void >;
 
 export interface Extension {
 	readonly name?: string;
-	initialize?: InitializeCallback;
-	finalize?: FinalizeCallback;
+	readonly initialize?: InitializeCallback;
+	readonly finalize?: FinalizeCallback;
 }

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -52,7 +52,6 @@ export type OnCLSWithAttributionFunction = typeof onCLSWithAttribution;
 export type LogFunction = ( ...message: any[] ) => void;
 
 export interface Logger {
-	prefix: string;
 	log: LogFunction;
 	warn: LogFunction;
 	error: LogFunction;

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -61,6 +61,7 @@ export interface Logger {
 export type InitializeArgs = {
 	readonly isDebug: boolean;
 	readonly log: LogFunction;
+	readonly info: LogFunction;
 	readonly warn: LogFunction;
 	readonly error: LogFunction;
 	readonly onTTFB: OnTTFBFunction | OnTTFBWithAttributionFunction;
@@ -82,6 +83,7 @@ export type FinalizeArgs = {
 	) => void;
 	readonly isDebug: boolean;
 	readonly log: LogFunction;
+	readonly info: LogFunction;
 	readonly warn: LogFunction;
 	readonly error: LogFunction;
 };

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -85,7 +85,7 @@ export type FinalizeArgs = {
 export type FinalizeCallback = ( args: FinalizeArgs ) => Promise< void >;
 
 export interface Extension {
-	readonly consoleLogPrefix?: string;
+	readonly name?: string;
 	initialize?: InitializeCallback;
 	finalize?: FinalizeCallback;
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1886 

## Relevant technical choices

<!-- Please describe your changes. -->
- Introduced a `logger` object that encapsulates `log`, `info`, `warn`, and `error` methods.
- The logging functions automatically respect the value of `isDebug` coming from `WP_DEBUG` in PHP.
- Exposed logging functions to client-side extensions' `initialize()` and `finalize()` functions.
- Errors (`error()`) always log regardless of `isDebug`, since most existing calls didn't check for it.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
