### PR TITLE
Fix unpredictable LCP element being identified in a URL Metric Group

### DIFF
--- a/bin/test-php-watch.sh
+++ b/bin/test-php-watch.sh
@@ -13,5 +13,5 @@ while true; do
 	echo "Running phpunit tests for $(tput bold)$plugin_slug$(tput sgr0):"
 	# TODO: Interrupt when a change is made while running tests or re-run if change made since tests started running.
 	# Note: This is calling phpunit directly and not the composer script due to extra noise it outputs.
-	npm run wp-env --silent -- run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance -- vendor/bin/phpunit --testsuite "$plugin_slug" "$@"
+	npm run wp-env --silent -- run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance -- vendor/bin/phpunit --testsuite "$plugin_slug" --verbose "$@"
 done

--- a/bin/test-php-watch.sh
+++ b/bin/test-php-watch.sh
@@ -13,5 +13,5 @@ while true; do
 	echo "Running phpunit tests for $(tput bold)$plugin_slug$(tput sgr0):"
 	# TODO: Interrupt when a change is made while running tests or re-run if change made since tests started running.
 	# Note: This is calling phpunit directly and not the composer script due to extra noise it outputs.
-	npm run wp-env --silent -- run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance -- vendor/bin/phpunit --testsuite "$plugin_slug" --verbose "$@"
+	npm run wp-env --silent -- run tests-cli --env-cwd=/var/www/html/wp-content/plugins/performance -- vendor/bin/phpunit --testsuite "$plugin_slug" "$@"
 done

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/buffer.html
@@ -1,0 +1,36 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+	</head>
+	<body>
+		<div class="wp-site-blocks">
+			<header></header>
+			<main>
+				<div></div>
+				<div>
+					<ul>
+						<li>
+							<div>
+								<figure>
+									<a href="https://example.net/foo/">
+										<img src="https://example.net/wp-content/uploads/foo.jpg" width="1600" height="1000" alt="Foo">
+									</a>
+								</figure>
+							</div>
+						</li>
+						<li>
+							<div>
+								<figure>
+									<a href="https://example.net/bar/">
+										<img src="https://example.net/wp-content/uploads/bar.jpg" width="1600" height="1000" alt="Bar">
+									</a>
+								</figure>
+							</div>
+						</li>
+					</ul>
+				</div>
+			</main>
+		</div>
+	</body>
+</html>

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
@@ -2,8 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.net/wp-content/uploads/foo.jpg" media="screen and (width &lt;= 600px)">
-<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.net/wp-content/uploads/foo.jpg" media="screen and (782px &lt; width)">
+	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.net/wp-content/uploads/foo.jpg" media="screen">
 </head>
 	<body>
 		<div class="wp-site-blocks">
@@ -16,7 +15,7 @@
 							<div>
 								<figure>
 									<a href="https://example.net/foo/">
-										<img data-od-xpath="/HTML/BODY/DIV[@class=&#039;wp-site-blocks&#039;]/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]" src="https://example.net/wp-content/uploads/foo.jpg" width="1600" height="1000" alt="Foo">
+										<img data-od-added-fetchpriority data-od-xpath="/HTML/BODY/DIV[@class=&#039;wp-site-blocks&#039;]/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]" fetchpriority="high" src="https://example.net/wp-content/uploads/foo.jpg" width="1600" height="1000" alt="Foo">
 									</a>
 								</figure>
 							</div>

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
@@ -1,0 +1,39 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.net/wp-content/uploads/foo.jpg" media="screen and (width &lt;= 600px)">
+<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.net/wp-content/uploads/foo.jpg" media="screen and (782px &lt; width)">
+</head>
+	<body>
+		<div class="wp-site-blocks">
+			<header></header>
+			<main>
+				<div></div>
+				<div>
+					<ul>
+						<li>
+							<div>
+								<figure>
+									<a href="https://example.net/foo/">
+										<img data-od-xpath="/HTML/BODY/DIV[@class=&#039;wp-site-blocks&#039;]/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]" src="https://example.net/wp-content/uploads/foo.jpg" width="1600" height="1000" alt="Foo">
+									</a>
+								</figure>
+							</div>
+						</li>
+						<li>
+							<div>
+								<figure>
+									<a href="https://example.net/bar/">
+										<img data-od-xpath="/HTML/BODY/DIV[@class=&#039;wp-site-blocks&#039;]/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]" src="https://example.net/wp-content/uploads/bar.jpg" width="1600" height="1000" alt="Bar">
+									</a>
+								</figure>
+							</div>
+						</li>
+					</ul>
+				</div>
+			</main>
+		</div>
+	<script type="module">/* import detect ... */</script>
+</body>
+</html>

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/set-up.php
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/set-up.php
@@ -1,0 +1,58 @@
+<?php
+return static function ( Test_Image_Prioritizer_Helper $test_case ): void {
+
+	$current_etag = 'f8527651f96776745f88cc49df70b62d';
+
+	$url_metrics_data = json_decode( file_get_contents( __DIR__ . '/url-metrics.json' ), true ); // TODO: Also do all of the below assertions with this sent through array_reverse()!
+	$collection       = new OD_URL_Metric_Group_Collection(
+		array_map(
+			static function ( array $url_metric_data ): OD_URL_Metric {
+				return new OD_URL_Metric( $url_metric_data );
+			},
+			$url_metrics_data
+		),
+		$current_etag,
+		array( 480, 600, 782 ),
+		3,
+		WEEK_IN_SECONDS
+	);
+
+	$expected_lcp_element_xpath = '/HTML/BODY/DIV[@class=\'wp-site-blocks\']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]';
+
+	$test_case->assertFalse( $collection->is_every_group_complete() );
+	$test_case->assertTrue( $collection->is_every_group_populated() );
+	$test_case->assertTrue( $collection->is_any_group_populated() );
+	$test_case->assertNull( $collection->get_common_lcp_element() ); // TODO: Actually it should not be!
+
+	$slug    = od_get_url_metrics_slug( array() );
+	$post_id = OD_URL_Metrics_Post_Type::update_post( $slug, $collection );
+	$test_case->assertIsInt( $post_id );
+
+	$mobile_group = $collection->get_group_for_viewport_width( 400 );
+	$test_case->assertCount( 3, $mobile_group );
+	$test_case->assertTrue( $mobile_group->is_complete() );
+	$lcp_element = $mobile_group->get_lcp_element();
+	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
+	$test_case->assertSame( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] );
+
+	$phablet_group = $collection->get_group_for_viewport_width( 500 );
+	$test_case->assertCount( 3, $phablet_group );
+	$test_case->assertTrue( $phablet_group->is_complete() );
+	$lcp_element = $phablet_group->get_lcp_element();
+	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
+	$test_case->assertSame( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] );
+
+	$tablet_group = $collection->get_group_for_viewport_width( 700 );
+	$test_case->assertCount( 2, $tablet_group );
+	$test_case->assertFalse( $tablet_group->is_complete() );
+	$lcp_element = $tablet_group->get_lcp_element();
+	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
+	$test_case->assertNotEquals( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] ); // TODO: This should actually be the same!
+
+	$desktop_group = $collection->get_group_for_viewport_width( 800 );
+	$test_case->assertCount( 3, $desktop_group );
+	$test_case->assertTrue( $desktop_group->is_complete() );
+	$lcp_element = $desktop_group->get_lcp_element();
+	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
+	$test_case->assertSame( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] );
+};

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/set-up.php
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/set-up.php
@@ -1,12 +1,16 @@
 <?php
 return static function ( Test_Image_Prioritizer_Helper $test_case ): void {
+	// Make sure we're using the same expected current ETag.
+	// Note: The args don't matter because od_current_url_metrics_etag_data is filtered to be an empty array in Test_Image_Prioritizer_Helper::set_up().
+	$current_etag = od_get_current_url_metrics_etag( new OD_Tag_Visitor_Registry(), null, null );
 
-	$current_etag = 'f8527651f96776745f88cc49df70b62d';
-
-	$url_metrics_data = json_decode( file_get_contents( __DIR__ . '/url-metrics.json' ), true ); // TODO: Also do all of the below assertions with this sent through array_reverse()!
+	$url_metrics_data = json_decode( file_get_contents( __DIR__ . '/url-metrics.json' ), true );
 	$collection       = new OD_URL_Metric_Group_Collection(
 		array_map(
-			static function ( array $url_metric_data ): OD_URL_Metric {
+			static function ( array $url_metric_data ) use ( $current_etag ): OD_URL_Metric {
+				if ( 'f8527651f96776745f88cc49df70b62d' === $url_metric_data['etag'] ) {
+					$url_metric_data['etag'] = $current_etag;
+				}
 				return new OD_URL_Metric( $url_metric_data );
 			},
 			$url_metrics_data
@@ -17,42 +21,12 @@ return static function ( Test_Image_Prioritizer_Helper $test_case ): void {
 		WEEK_IN_SECONDS
 	);
 
-	$expected_lcp_element_xpath = '/HTML/BODY/DIV[@class=\'wp-site-blocks\']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]';
-
 	$test_case->assertFalse( $collection->is_every_group_complete() );
 	$test_case->assertTrue( $collection->is_every_group_populated() );
 	$test_case->assertTrue( $collection->is_any_group_populated() );
-	$test_case->assertNull( $collection->get_common_lcp_element() ); // TODO: Actually it should not be!
+	$test_case->assertInstanceOf( OD_Element::class, $collection->get_common_lcp_element() );
 
 	$slug    = od_get_url_metrics_slug( array() );
 	$post_id = OD_URL_Metrics_Post_Type::update_post( $slug, $collection );
 	$test_case->assertIsInt( $post_id );
-
-	$mobile_group = $collection->get_group_for_viewport_width( 400 );
-	$test_case->assertCount( 3, $mobile_group );
-	$test_case->assertTrue( $mobile_group->is_complete() );
-	$lcp_element = $mobile_group->get_lcp_element();
-	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
-	$test_case->assertSame( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] );
-
-	$phablet_group = $collection->get_group_for_viewport_width( 500 );
-	$test_case->assertCount( 3, $phablet_group );
-	$test_case->assertTrue( $phablet_group->is_complete() );
-	$lcp_element = $phablet_group->get_lcp_element();
-	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
-	$test_case->assertSame( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] );
-
-	$tablet_group = $collection->get_group_for_viewport_width( 700 );
-	$test_case->assertCount( 2, $tablet_group );
-	$test_case->assertFalse( $tablet_group->is_complete() );
-	$lcp_element = $tablet_group->get_lcp_element();
-	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
-	$test_case->assertNotEquals( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] ); // TODO: This should actually be the same!
-
-	$desktop_group = $collection->get_group_for_viewport_width( 800 );
-	$test_case->assertCount( 3, $desktop_group );
-	$test_case->assertTrue( $desktop_group->is_complete() );
-	$lcp_element = $desktop_group->get_lcp_element();
-	$test_case->assertInstanceOf( OD_Element::class, $lcp_element );
-	$test_case->assertSame( $expected_lcp_element_xpath, $lcp_element->jsonSerialize()['xpath'] );
 };

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/url-metrics.json
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/url-metrics.json
@@ -1,0 +1,706 @@
+[
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 361,
+      "height": 640
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 30,
+          "y": 182.5,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 182.5,
+          "right": 330.83331298828125,
+          "bottom": 383.046875,
+          "left": 30
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 182.5,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 182.5,
+          "right": 330.83331298828125,
+          "bottom": 383.046875,
+          "left": 30
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 899.5572509765625,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 899.5572509765625,
+          "right": 330.83331298828125,
+          "bottom": 1100.1041259765625,
+          "left": 30
+        }
+      }
+    ],
+    "timestamp": 1740979411.720624,
+    "uuid": "0b233e98-13ce-4d65-826e-0fe91d8cc77c",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 361,
+      "height": 640
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 945.546875,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 945.546875,
+          "right": 330.83331298828125,
+          "bottom": 1146.09375,
+          "left": 30
+        }
+      }
+    ],
+    "timestamp": 1740979341.748015,
+    "uuid": "ddbed624-809a-42f4-bf8b-22329d971c1a",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 361,
+      "height": 640
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 945.546875,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 945.546875,
+          "right": 330.83331298828125,
+          "bottom": 1146.09375,
+          "left": 30
+        }
+      }
+    ],
+    "timestamp": 1740979334.440874,
+    "uuid": "7dfaa404-bab1-41ff-9e10-a0e8c855d586",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 515,
+      "height": 989
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.047670286148786545,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 14.470663070678711,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 988.8333339691162,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 1277.9199829101562,
+          "left": 29.9921875
+        }
+      }
+    ],
+    "timestamp": 1741036649.040944,
+    "uuid": "bea2a673-4d47-4130-bb82-44b00a2320d8",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 515,
+      "height": 989
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.047670286148786545,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 14.470663070678711,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 988.8333339691162,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 1277.9199829101562,
+          "left": 29.9921875
+        }
+      }
+    ],
+    "timestamp": 1741036626.712007,
+    "uuid": "254baf71-09e8-49a2-a618-3769a368effc",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 515,
+      "height": 989
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.047670286148786545,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 14.470663070678711,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 988.8333339691162,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 1277.9199829101562,
+          "left": 29.9921875
+        }
+      }
+    ],
+    "timestamp": 1741036623.711509,
+    "uuid": "55238abc-4df6-46be-99cc-720162fa1f8c",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 763,
+      "height": 662
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/*[1][self::HTML]/*[2][self::BODY]/*[4][self::MAIN]/*[1][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::DIV]/*[1][self::IMG]",
+        "intersectionRatio": 0.42582622170448303,
+        "intersectionRect": {
+          "x": 40,
+          "y": 448.0375061035156,
+          "width": 666.4000244140625,
+          "height": 213.5625,
+          "top": 448.0375061035156,
+          "right": 706.4000244140625,
+          "bottom": 661.6000061035156,
+          "left": 40
+        },
+        "boundingClientRect": {
+          "x": 40,
+          "y": 448.0375061035156,
+          "width": 666.4000244140625,
+          "height": 501.5249938964844,
+          "top": 448.0375061035156,
+          "right": 706.4000244140625,
+          "bottom": 949.5625,
+          "left": 40
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/*[1][self::HTML]/*[2][self::BODY]/*[4][self::MAIN]/*[3][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::DIV]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 40,
+          "y": 1752.7249755859375,
+          "width": 666.4000244140625,
+          "height": 363.7375183105469,
+          "top": 1752.7249755859375,
+          "right": 706.4000244140625,
+          "bottom": 2116.4624938964844,
+          "left": 40
+        }
+      }
+    ],
+    "timestamp": 1735486574.110401,
+    "uuid": "fac03146-08a4-4a7a-b35e-21a5c38a33ab",
+    "etag": "6e99d09fd521c3ff0062effdbf0bf4c7"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 763,
+      "height": 1451
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 59.217529296875,
+          "y": 302.1798095703125,
+          "width": 644.98828125,
+          "height": 429.9874267578125,
+          "top": 302.1798095703125,
+          "right": 704.205810546875,
+          "bottom": 732.167236328125,
+          "left": 59.217529296875
+        },
+        "boundingClientRect": {
+          "x": 59.217529296875,
+          "y": 302.1798095703125,
+          "width": 644.98828125,
+          "height": 429.9874267578125,
+          "top": 302.1798095703125,
+          "right": 704.205810546875,
+          "bottom": 732.167236328125,
+          "left": 59.217529296875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.698041558265686,
+        "intersectionRect": {
+          "x": 59.217529296875,
+          "y": 1151.291015625,
+          "width": 644.98828125,
+          "height": 300.14910888671875,
+          "top": 1151.291015625,
+          "right": 704.205810546875,
+          "bottom": 1451.4401245117188,
+          "left": 59.217529296875
+        },
+        "boundingClientRect": {
+          "x": 59.217529296875,
+          "y": 1151.291015625,
+          "width": 644.98828125,
+          "height": 429.9874267578125,
+          "top": 1151.291015625,
+          "right": 704.205810546875,
+          "bottom": 1581.2784423828125,
+          "left": 59.217529296875
+        }
+      }
+    ],
+    "timestamp": 1741036601.139181,
+    "uuid": "0dd8be19-93ff-4260-8e4e-bf7c609714ac",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 3201,
+      "height": 1632
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.8512294292449951,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 366.02862548828125,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1631.6665649414062,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 430,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1695.637939453125,
+          "left": 1277.9166259765625
+        }
+      }
+    ],
+    "timestamp": 1740979111.957028,
+    "uuid": "7b8cd550-cede-4598-b338-fc6beef6d39c",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 3201,
+      "height": 1632
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.8512294292449951,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 366.02862548828125,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1631.6665649414062,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 430,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1695.637939453125,
+          "left": 1277.9166259765625
+        }
+      }
+    ],
+    "timestamp": 1740979088.926424,
+    "uuid": "67820ee7-1b05-46c9-b6bf-c54c036efecb",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 3201,
+      "height": 1632
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.8512294292449951,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 366.02862548828125,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1631.6665649414062,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 430,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1695.637939453125,
+          "left": 1277.9166259765625
+        }
+      }
+    ],
+    "timestamp": 1740979065.498644,
+    "uuid": "953829d8-3711-46f2-ab85-a1a6589d113f",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  }
+]

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -360,7 +360,20 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 			 */
 			$breadcrumb_element = array();
 
-			foreach ( $this->url_metrics as $url_metric ) {
+			// Prefer to use URL Metrics which have a current ETag.
+			$url_metrics = array_filter(
+				$this->url_metrics,
+				function ( OD_URL_Metric $url_metric ): bool {
+					return $url_metric->get_etag() === $this->get_collection()->get_current_etag();
+				}
+			);
+
+			// Otherwise, if no URL Metrics have a current ETag, fall back to using all the stale ones.
+			if ( count( $url_metrics ) === 0 ) {
+				$url_metrics = $this->url_metrics;
+			}
+
+			foreach ( $url_metrics as $url_metric ) {
 				foreach ( $url_metric->get_elements() as $element ) {
 					if ( ! $element->is_lcp() ) {
 						continue;

--- a/plugins/optimization-detective/tests/data/url-metrics/tablet-viewport-half-stale.json
+++ b/plugins/optimization-detective/tests/data/url-metrics/tablet-viewport-half-stale.json
@@ -1,0 +1,706 @@
+[
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 361,
+      "height": 640
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 30,
+          "y": 182.5,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 182.5,
+          "right": 330.83331298828125,
+          "bottom": 383.046875,
+          "left": 30
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 182.5,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 182.5,
+          "right": 330.83331298828125,
+          "bottom": 383.046875,
+          "left": 30
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 899.5572509765625,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 899.5572509765625,
+          "right": 330.83331298828125,
+          "bottom": 1100.1041259765625,
+          "left": 30
+        }
+      }
+    ],
+    "timestamp": 1740979411.720624,
+    "uuid": "0b233e98-13ce-4d65-826e-0fe91d8cc77c",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 361,
+      "height": 640
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 945.546875,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 945.546875,
+          "right": 330.83331298828125,
+          "bottom": 1146.09375,
+          "left": 30
+        }
+      }
+    ],
+    "timestamp": 1740979341.748015,
+    "uuid": "ddbed624-809a-42f4-bf8b-22329d971c1a",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 361,
+      "height": 640
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 228.4895782470703,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 228.4895782470703,
+          "right": 330.83331298828125,
+          "bottom": 429.0364532470703,
+          "left": 30
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 30,
+          "y": 945.546875,
+          "width": 300.83331298828125,
+          "height": 200.546875,
+          "top": 945.546875,
+          "right": 330.83331298828125,
+          "bottom": 1146.09375,
+          "left": 30
+        }
+      }
+    ],
+    "timestamp": 1740979334.440874,
+    "uuid": "7dfaa404-bab1-41ff-9e10-a0e8c855d586",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 515,
+      "height": 989
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.047670286148786545,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 14.470663070678711,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 988.8333339691162,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 1277.9199829101562,
+          "left": 29.9921875
+        }
+      }
+    ],
+    "timestamp": 1741036649.040944,
+    "uuid": "bea2a673-4d47-4130-bb82-44b00a2320d8",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 515,
+      "height": 989
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.047670286148786545,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 14.470663070678711,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 988.8333339691162,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 1277.9199829101562,
+          "left": 29.9921875
+        }
+      }
+    ],
+    "timestamp": 1741036626.712007,
+    "uuid": "254baf71-09e8-49a2-a618-3769a368effc",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 515,
+      "height": 989
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 242.94808959960938,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 242.94808959960938,
+          "right": 485.328125,
+          "bottom": 546.5054016113281,
+          "left": 29.9921875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.047670286148786545,
+        "intersectionRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 14.470663070678711,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 988.8333339691162,
+          "left": 29.9921875
+        },
+        "boundingClientRect": {
+          "x": 29.9921875,
+          "y": 974.3626708984375,
+          "width": 455.3359375,
+          "height": 303.55731201171875,
+          "top": 974.3626708984375,
+          "right": 485.328125,
+          "bottom": 1277.9199829101562,
+          "left": 29.9921875
+        }
+      }
+    ],
+    "timestamp": 1741036623.711509,
+    "uuid": "55238abc-4df6-46be-99cc-720162fa1f8c",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 763,
+      "height": 662
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/*[1][self::HTML]/*[2][self::BODY]/*[4][self::MAIN]/*[1][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::DIV]/*[1][self::IMG]",
+        "intersectionRatio": 0.42582622170448303,
+        "intersectionRect": {
+          "x": 40,
+          "y": 448.0375061035156,
+          "width": 666.4000244140625,
+          "height": 213.5625,
+          "top": 448.0375061035156,
+          "right": 706.4000244140625,
+          "bottom": 661.6000061035156,
+          "left": 40
+        },
+        "boundingClientRect": {
+          "x": 40,
+          "y": 448.0375061035156,
+          "width": 666.4000244140625,
+          "height": 501.5249938964844,
+          "top": 448.0375061035156,
+          "right": 706.4000244140625,
+          "bottom": 949.5625,
+          "left": 40
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/*[1][self::HTML]/*[2][self::BODY]/*[4][self::MAIN]/*[3][self::ARTICLE]/*[2][self::FIGURE]/*[1][self::DIV]/*[1][self::IMG]",
+        "intersectionRatio": 0,
+        "intersectionRect": {
+          "x": 0,
+          "y": 0,
+          "width": 0,
+          "height": 0,
+          "top": 0,
+          "right": 0,
+          "bottom": 0,
+          "left": 0
+        },
+        "boundingClientRect": {
+          "x": 40,
+          "y": 1752.7249755859375,
+          "width": 666.4000244140625,
+          "height": 363.7375183105469,
+          "top": 1752.7249755859375,
+          "right": 706.4000244140625,
+          "bottom": 2116.4624938964844,
+          "left": 40
+        }
+      }
+    ],
+    "timestamp": 1735486574.110401,
+    "uuid": "fac03146-08a4-4a7a-b35e-21a5c38a33ab",
+    "etag": "6e99d09fd521c3ff0062effdbf0bf4c7"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 763,
+      "height": 1451
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 59.217529296875,
+          "y": 302.1798095703125,
+          "width": 644.98828125,
+          "height": 429.9874267578125,
+          "top": 302.1798095703125,
+          "right": 704.205810546875,
+          "bottom": 732.167236328125,
+          "left": 59.217529296875
+        },
+        "boundingClientRect": {
+          "x": 59.217529296875,
+          "y": 302.1798095703125,
+          "width": 644.98828125,
+          "height": 429.9874267578125,
+          "top": 302.1798095703125,
+          "right": 704.205810546875,
+          "bottom": 732.167236328125,
+          "left": 59.217529296875
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.698041558265686,
+        "intersectionRect": {
+          "x": 59.217529296875,
+          "y": 1151.291015625,
+          "width": 644.98828125,
+          "height": 300.14910888671875,
+          "top": 1151.291015625,
+          "right": 704.205810546875,
+          "bottom": 1451.4401245117188,
+          "left": 59.217529296875
+        },
+        "boundingClientRect": {
+          "x": 59.217529296875,
+          "y": 1151.291015625,
+          "width": 644.98828125,
+          "height": 429.9874267578125,
+          "top": 1151.291015625,
+          "right": 704.205810546875,
+          "bottom": 1581.2784423828125,
+          "left": 59.217529296875
+        }
+      }
+    ],
+    "timestamp": 1741036601.139181,
+    "uuid": "0dd8be19-93ff-4260-8e4e-bf7c609714ac",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 3201,
+      "height": 1632
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.8512294292449951,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 366.02862548828125,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1631.6665649414062,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 430,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1695.637939453125,
+          "left": 1277.9166259765625
+        }
+      }
+    ],
+    "timestamp": 1740979111.957028,
+    "uuid": "7b8cd550-cede-4598-b338-fc6beef6d39c",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 3201,
+      "height": 1632
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.8512294292449951,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 366.02862548828125,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1631.6665649414062,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 430,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1695.637939453125,
+          "left": 1277.9166259765625
+        }
+      }
+    ],
+    "timestamp": 1740979088.926424,
+    "uuid": "67820ee7-1b05-46c9-b6bf-c54c036efecb",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  },
+  {
+    "url": "https://example.net/",
+    "viewport": {
+      "width": 3201,
+      "height": 1632
+    },
+    "elements": [
+      {
+        "isLCP": true,
+        "isLCPCandidate": true,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 1,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 331.61456298828125,
+          "width": 645,
+          "height": 430,
+          "top": 331.61456298828125,
+          "right": 1922.9166259765625,
+          "bottom": 761.6145629882812,
+          "left": 1277.9166259765625
+        }
+      },
+      {
+        "isLCP": false,
+        "isLCPCandidate": false,
+        "xpath": "/HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[2][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]",
+        "intersectionRatio": 0.8512294292449951,
+        "intersectionRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 366.02862548828125,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1631.6665649414062,
+          "left": 1277.9166259765625
+        },
+        "boundingClientRect": {
+          "x": 1277.9166259765625,
+          "y": 1265.637939453125,
+          "width": 645,
+          "height": 430,
+          "top": 1265.637939453125,
+          "right": 1922.9166259765625,
+          "bottom": 1695.637939453125,
+          "left": 1277.9166259765625
+        }
+      }
+    ],
+    "timestamp": 1740979065.498644,
+    "uuid": "953829d8-3711-46f2-ab85-a1a6589d113f",
+    "etag": "f8527651f96776745f88cc49df70b62d"
+  }
+]

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -443,20 +443,26 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 	 * @param bool $order_reversed Whether the order of URL Metrics should be reversed.
 	 */
 	public function test_get_lcp_element_when_group_half_stale( bool $order_reversed ): void {
-		$current_etag = 'f8527651f96776745f88cc49df70b62d';
-
 		$url_metrics_data = json_decode( file_get_contents( __DIR__ . '/data/url-metrics/tablet-viewport-half-stale.json' ), true );
 		if ( $order_reversed ) {
 			$url_metrics_data = array_reverse( $url_metrics_data );
 		}
+		$url_metrics = array();
+		$etag_counts = array();
+		foreach ( $url_metrics_data as $url_metric_data ) {
+			$url_metric = new OD_URL_Metric( $url_metric_data );
+			$etag       = $url_metric->get_etag();
+			if ( ! isset( $etag_counts[ $etag ] ) ) {
+				$etag_counts[ $etag ] = 0;
+			}
+			++$etag_counts[ $etag ];
+			$url_metrics[] = $url_metric;
+		}
+		arsort( $etag_counts );
+		$current_etag = key( $etag_counts ); // The ETag used most often.
 
 		$collection = new OD_URL_Metric_Group_Collection(
-			array_map(
-				static function ( array $url_metric_data ): OD_URL_Metric {
-					return new OD_URL_Metric( $url_metric_data );
-				},
-				$url_metrics_data
-			),
+			$url_metrics,
 			$current_etag,
 			array( 480, 600, 782 ),
 			3,

--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -418,6 +418,84 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Data provider for test_get_lcp_element_when_group_half_stale.
+	 *
+	 * @return array<string, array{order_reversed: bool}> Data.
+	 */
+	public function data_provider_test_get_lcp_element_when_group_half_stale(): array {
+		return array(
+			'original_order' => array(
+				'order_reversed' => false,
+			),
+			'reverse_order'  => array(
+				'order_reversed' => true,
+			),
+		);
+	}
+
+	/**
+	 * Test get_lcp_element() when half of the URL Metrics in a group are stale.
+	 *
+	 * @covers ::get_lcp_element
+	 * @covers OD_URL_Metric_Group_Collection::get_common_lcp_element
+	 * @dataProvider data_provider_test_get_lcp_element_when_group_half_stale
+	 *
+	 * @param bool $order_reversed Whether the order of URL Metrics should be reversed.
+	 */
+	public function test_get_lcp_element_when_group_half_stale( bool $order_reversed ): void {
+		$current_etag = 'f8527651f96776745f88cc49df70b62d';
+
+		$url_metrics_data = json_decode( file_get_contents( __DIR__ . '/data/url-metrics/tablet-viewport-half-stale.json' ), true );
+		if ( $order_reversed ) {
+			$url_metrics_data = array_reverse( $url_metrics_data );
+		}
+
+		$collection = new OD_URL_Metric_Group_Collection(
+			array_map(
+				static function ( array $url_metric_data ): OD_URL_Metric {
+					return new OD_URL_Metric( $url_metric_data );
+				},
+				$url_metrics_data
+			),
+			$current_etag,
+			array( 480, 600, 782 ),
+			3,
+			WEEK_IN_SECONDS
+		);
+
+		$this->assertFalse( $collection->is_every_group_complete() );
+		$this->assertTrue( $collection->is_every_group_populated() );
+		$this->assertTrue( $collection->is_any_group_populated() );
+		$common_lcp_element = $collection->get_common_lcp_element();
+		$this->assertInstanceOf( OD_Element::class, $collection->get_common_lcp_element() );
+		$this->assertSame(
+			'/HTML/BODY/DIV[@class=\'wp-site-blocks\']/*[2][self::MAIN]/*[2][self::DIV]/*[1][self::UL]/*[1][self::LI]/*[1][self::DIV]/*[1][self::FIGURE]/*[1][self::A]/*[1][self::IMG]',
+			$common_lcp_element->jsonSerialize()['xpath'] // TODO: Not using get_xpath() directly since it is currently normalized. This can be changed after <https://github.com/WordPress/performance/pull/1820> is merged.
+		);
+
+		// The tablet group is the only one that is not complete.
+		$tablet_group = $collection->get_group_for_viewport_width( 700 );
+		$this->assertCount( 2, $tablet_group );
+		$this->assertFalse( $tablet_group->is_complete() );
+
+		// All non-tablet groups should be complete.
+		$this->assertCount( 4, $collection );
+		foreach ( $collection as $group ) {
+			if ( $group !== $tablet_group ) {
+				$this->assertCount( 3, $group );
+				$this->assertTrue( $group->is_complete() );
+			}
+		}
+
+		// All groups should have the same LCP element.
+		foreach ( $collection as $group ) {
+			$lcp_element = $group->get_lcp_element();
+			$this->assertInstanceOf( OD_Element::class, $lcp_element );
+			$this->assertSame( $common_lcp_element->get_xpath(), $lcp_element->get_xpath() );
+		}
+	}
+
+	/**
 	 * Test jsonSerialize().
 	 *
 	 * @covers ::jsonSerialize


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1896
See #1902

## Relevant technical choices

<!-- Please describe your changes. -->

Now `\OD_URL_Metric_Group::get_lcp_element()` will prefer to use URL Metrics which have a current ETag. If there are none, then it falls back to using all of the stale URL Metrics. This ensures that if a URL Metric group has two URL Metrics, one with a mismatched ETag and another with an ETag that matches the current ETag, that the logic will not possibly result in the LCP element being pulled from the URL Metric with the stale ETag, which can currently happen if there are an equal number of stale and fresh URL Metrics in a group.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
