### PR TITLE
Fix URL encoding in Link HTTP response header

### DIFF
--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -325,19 +325,17 @@ final class OD_Link_Collection implements Countable {
 	 *
 	 * @since n.e.x.t
 	 *
-	 * @param string $url URL to percent encode. Any existing percent encodings will first be decoded.
+	 * @param string $url URL to percent encode.
 	 * @return string Percent-encoded URL.
 	 */
 	private function encode_url_for_response_header( string $url ): string {
-		$decoded_url = urldecode( $url );
-
 		// Encode characters not allowed in a URL per RFC 3986 (anything that is not among the reserved and unreserved characters).
 		$encoded_url = (string) preg_replace_callback(
-			'/[^A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=]/',
+			'/[^A-Za-z0-9\-._~:\/?#\[\]@!$&\'()*+,;=%]/',
 			static function ( $matches ) {
 				return rawurlencode( $matches[0] );
 			},
-			$decoded_url
+			$url
 		);
 		return esc_url_raw( $encoded_url );
 	}

--- a/plugins/optimization-detective/tests/test-class-od-link-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-link-collection.php
@@ -493,6 +493,57 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_count'  => 1,
 				'error'           => '',
 			),
+			'comma_in_query'                             => array(
+				'links_args'      => array(
+					array(
+						array(
+							'rel'  => 'preload',
+							'href' => 'https://example.com/wp-content/uploads/2025/02/example.png?resize=768,432&ssl=1',
+							'as'   => 'image',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag rel="preload" href="https://example.com/wp-content/uploads/2025/02/example.png?resize=768,432&amp;ssl=1" as="image">
+				',
+				'expected_header' => 'Link: <https://example.com/wp-content/uploads/2025/02/example.png?resize=768,432&ssl=1>; rel="preload"; as="image"',
+				'expected_count'  => 1,
+				'error'           => '',
+			),
+			'percent_encoded_comma_in_query'             => array(
+				'links_args'      => array(
+					array(
+						array(
+							'rel'  => 'preload',
+							'href' => 'https://example.com/wp-content/uploads/2025/02/example.png?resize=768%2C432&ssl=1',
+							'as'   => 'image',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag rel="preload" href="https://example.com/wp-content/uploads/2025/02/example.png?resize=768%2C432&amp;ssl=1" as="image">
+				',
+				'expected_header' => 'Link: <https://example.com/wp-content/uploads/2025/02/example.png?resize=768%2C432&ssl=1>; rel="preload"; as="image"',
+				'expected_count'  => 1,
+				'error'           => '',
+			),
+			'percent_encoded_extension'                  => array(
+				'links_args'      => array(
+					array(
+						array(
+							'rel'  => 'preload',
+							'href' => 'https://example.com/image.%6Apg',
+							'as'   => 'image',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag rel="preload" href="https://example.com/image.%6Apg" as="image">
+				',
+				'expected_header' => 'Link: <https://example.com/image.%6Apg>; rel="preload"; as="image"',
+				'expected_count'  => 1,
+				'error'           => '',
+			),
 		);
 	}
 

--- a/plugins/optimization-detective/tests/test-class-od-link-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-link-collection.php
@@ -489,7 +489,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_html'   => '
 					<link data-od-added-tag rel="preload" href="https://example.com/חנות/wp-content/uploads/2025/01/example.jpg?ver=1+2" as="image">
 				',
-				'expected_header' => 'Link: <https://example.com/%D7%97%D7%A0%D7%95%D7%AA/wp-content/uploads/2025/01/example.jpg?ver=1%202>; rel="preload"; as="image"',
+				'expected_header' => 'Link: <https://example.com/%D7%97%D7%A0%D7%95%D7%AA/wp-content/uploads/2025/01/example.jpg?ver=1+2>; rel="preload"; as="image"',
 				'expected_count'  => 1,
 				'error'           => '',
 			),


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1906 

## Relevant technical choices

<!-- Please describe your changes. -->
- Removed `urldecode()` to prevent double encoding.
- Adjusted regex in `encode_url_for_response_header()` to preserve existing percent-encoded sequences while properly encoding invalid characters.



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
