### PR TITLE
Account for `OPTIMIZATION_DETECTIVE_VERSION` not always being defined for Embed Optimizer

### DIFF
--- a/plugins/embed-optimizer/hooks.php
+++ b/plugins/embed-optimizer/hooks.php
@@ -190,7 +190,7 @@ function embed_optimizer_update_markup( WP_HTML_Tag_Processor $html_processor, b
 
 	// As of 1.0.0-beta3, next_tag() allows $query and is beginning to migrate to skip tag closers by default.
 	// In versions prior to this, the method always visited closers and passing a $query actually threw an exception.
-	$tag_query = version_compare( OPTIMIZATION_DETECTIVE_VERSION, '1.0.0-beta3', '>=' )
+	$tag_query = ! defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) || version_compare( OPTIMIZATION_DETECTIVE_VERSION, '1.0.0-beta3', '>=' )
 		? array( 'tag_closers' => 'visit' ) : null;
 	try {
 		/*


### PR DESCRIPTION
I was doing some testing with Optimization Detective deactivated but with Embed Optimizer active. I started getting a fatal error:

```
PHP Fatal error:  Uncaught Error: Undefined constant "OPTIMIZATION_DETECTIVE_VERSION" in /code/wp-content/plugins/embed-optimizer/hooks.php:193
```

This issue was introduced in #1872. It is an issue unique to Embed Optimizer because it does not _require_ Optimization Detective but merely suggests it. This means the `OPTIMIZATION_DETECTIVE_VERSION` constant is not guaranteed to be defined. It's not needed by Image Prioritizer since it initializes at the `od_init` action so we guaranteed that the constant will be available.