### PR TITLE
Keep timestamps current for URL Metrics in fixture

### DIFF
--- a/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
+++ b/plugins/optimization-detective/tests/test-class-od-url-metrics-group.php
@@ -450,6 +450,9 @@ class Test_OD_URL_Metric_Group extends WP_UnitTestCase {
 		$url_metrics = array();
 		$etag_counts = array();
 		foreach ( $url_metrics_data as $url_metric_data ) {
+			// Make sure the timestamp is always current as otherwise groups will never be complete, regardless of having a current ETag.
+			$url_metric_data['timestamp'] = microtime( true );
+
 			$url_metric = new OD_URL_Metric( $url_metric_data );
 			$etag       = $url_metric->get_etag();
 			if ( ! isset( $etag_counts[ $etag ] ) ) {


### PR DESCRIPTION
This addresses an oversight from #1903. When I captured the URL Metrics in the fixture, the `timestamp` values were all newer than 1 week, so they were all considered fresh. However, after a week `test_get_lcp_element_when_group_half_stale` started to fail because the URL Metrics would never be half stale anymore due to a different ETag: They would be completely stale due to having timestmaps older than the freshness TTL of one week.