### PR TITLE
Fix TypeError in `perflab_aao_query_autoloaded_options()` by serializing non-scalar option values

### DIFF
--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -150,7 +150,7 @@ function perflab_aao_query_autoloaded_options(): array {
 		if ( is_array( $option_value ) || is_object( $option_value ) ) {
 			$option_value = serialize( $option_value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
 		}
-		if ( strlen( $serialized_value ) > $option_threshold ) {
+		if ( strlen( $option_value ) > $option_threshold ) {
 			$large_options[] = (object) array(
 				'option_name'         => $option_name,
 				'option_value_length' => strlen( $option_value ),

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -147,10 +147,11 @@ function perflab_aao_query_autoloaded_options(): array {
 	$large_options = array();
 
 	foreach ( $all_options as $option_name => $option_value ) {
-		if ( strlen( $option_value ) > $option_threshold ) {
+		$serialized_value = maybe_serialize( $option_value );
+		if ( strlen( $serialized_value ) > $option_threshold ) {
 			$large_options[] = (object) array(
 				'option_name'         => $option_name,
-				'option_value_length' => strlen( $option_value ),
+				'option_value_length' => strlen( $serialized_value ),
 			);
 		}
 	}

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -153,7 +153,7 @@ function perflab_aao_query_autoloaded_options(): array {
 		if ( strlen( $serialized_value ) > $option_threshold ) {
 			$large_options[] = (object) array(
 				'option_name'         => $option_name,
-				'option_value_length' => strlen( $serialized_value ),
+				'option_value_length' => strlen( $option_value ),
 			);
 		}
 	}

--- a/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-autoloaded-options/helper.php
@@ -147,7 +147,9 @@ function perflab_aao_query_autoloaded_options(): array {
 	$large_options = array();
 
 	foreach ( $all_options as $option_name => $option_value ) {
-		$serialized_value = maybe_serialize( $option_value );
+		if ( is_array( $option_value ) || is_object( $option_value ) ) {
+			$option_value = serialize( $option_value ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_serialize
+		}
 		if ( strlen( $serialized_value ) > $option_threshold ) {
 			$large_options[] = (object) array(
 				'option_name'         => $option_name,

--- a/plugins/performance-lab/tests/includes/site-health/audit-autoloaded-options/test-audit-autoloaded-options.php
+++ b/plugins/performance-lab/tests/includes/site-health/audit-autoloaded-options/test-audit-autoloaded-options.php
@@ -115,6 +115,92 @@ class Test_Audit_Autoloaded_Options extends WP_UnitTestCase {
 		$this->assertSame( $autoloaded_options_size + $expected_size_increase, perflab_aao_autoloaded_options_size() );
 	}
 
+	/**
+	 * Data provider.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function data_provider_test_perflab_aao_query_autoloaded_options(): array {
+		return array(
+			'none_over_threshold'           => array(
+				'alloptions' => array(
+					'foo'  => 'bar',
+					'o100' => str_repeat( 'a', 100 ),
+				),
+				'threshold'  => null,
+				'expected'   => array(),
+			),
+			'one_over_threshold'            => array(
+				'alloptions' => array(
+					'foo'  => 'bar',
+					'o101' => str_repeat( 'a', 101 ),
+				),
+				'threshold'  => null,
+				'expected'   => array( 'o101' ),
+			),
+			'three_over_custom_threshold'   => array(
+				'alloptions' => array(
+					'foo'  => 'bar',
+					'o51'  => str_repeat( 'a', 51 ),
+					'o100' => str_repeat( 'a', 100 ),
+					'o101' => str_repeat( 'a', 101 ),
+					'int'  => 123,
+					'bool' => true,
+				),
+				'threshold'  => 50,
+				'expected'   => array( 'o51', 'o100', 'o101' ),
+			),
+			'two_non_scalar_over_threshold' => array(
+				'alloptions' => array(
+					'foo'    => 'bar',
+					'array'  => array(
+						'key' => str_repeat( 'a', 101 ),
+					),
+					'object' => (object) array(
+						'key' => str_repeat( 'a', 101 ),
+					),
+				),
+				'threshold'  => null,
+				'expected'   => array( 'array', 'object' ),
+			),
+		);
+	}
+
+	/**
+	 * Tests perflab_aao_query_autoloaded_options().
+	 *
+	 * @dataProvider data_provider_test_perflab_aao_query_autoloaded_options
+	 * @covers ::perflab_aao_query_autoloaded_options
+	 *
+	 * @param array<string, mixed> $alloptions All options.
+	 * @param int|null             $threshold  Custom threshold.
+	 * @param string[]             $expected   Expected option names to be over the threshold.
+	 */
+	public function test_perflab_aao_query_autoloaded_options( array $alloptions, ?int $threshold, array $expected ): void {
+		add_filter(
+			'pre_wp_load_alloptions',
+			static function () use ( $alloptions ): array {
+				return $alloptions;
+			}
+		);
+
+		if ( isset( $threshold ) ) {
+			add_filter(
+				'perflab_aao_autoloaded_options_table_threshold',
+				static function () use ( $threshold ): int {
+					return $threshold;
+				}
+			);
+		}
+
+		$query = perflab_aao_query_autoloaded_options();
+		$this->assertCount( count( $expected ), $query );
+		$this->assertSameSets( $expected, wp_list_pluck( $query, 'option_name' ) );
+		foreach ( wp_list_pluck( $query, 'option_value_length' ) as $option_value_length ) {
+			$this->assertIsInt( $option_value_length );
+		}
+	}
+
 	public function test_perflab_aao_autoloaded_options_disable_revert_functionality(): void {
 
 		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );


### PR DESCRIPTION
## Summary

While running PHP 8.2.5, and visiting `/wp-admin/site-health.php`, the following fatal error occurred in our instance:

`strlen(): Argument #1 ($string) must be of type string, array given
`

this was triggered in `perflab_aao_query_autoloaded_options()` whenever `wp_load_alloptions()` returned an array or object, and the code called `strlen()` on that non-string, and since some object caching solutions can return unserialized data, it caused the fatal error above in PHP 8+


Addresses #

this PR updates `perflab_aao_query_autoloaded_options()` to wrap `$option_value` with `maybe_serialize()` before measuring its length to make sure it’s always a valid string

## Relevant technical choices

if the value is already a string, the function does nothing, if it’s an array or object, it gets validly serialized

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
