### PR TITLE
Add Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Performance Lab
 ![Performance Lab plugin banner with icon](https://github.com/WordPress/performance/assets/10103365/99d37ba5-27e3-47ea-8ab8-48de75ee69bf)
 
+[![codecov](https://codecov.io/gh/WordPress/performance/graph/badge.svg?token=zQv52K2LWz)](https://codecov.io/gh/WordPress/performance)
+
 Monorepo for the [WordPress Performance Team](https://make.wordpress.org/performance/), primarily for the Performance Lab plugin, which is a collection of standalone performance features.
 
 Details about the Performance Lab plugin, including instructions for getting started and contributing, are available in the [Performance Team Handbook here](https://make.wordpress.org/performance/handbook/performance-lab/).


### PR DESCRIPTION
Relates to #1789

It would be nice to add badges distinct for each plugin, and apparently this is possible if we configure flags: https://community.codecov.com/t/coverage-badge-on-a-per-directory-basis/3158

> ![image](https://github.com/user-attachments/assets/d16aa13f-1e81-4630-8fdd-4ea29bc71878)
