### PR TITLE
Add Milestone Events to Pull Request Validation Workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -9,6 +9,8 @@ on:
     types:
       - labeled
       - unlabeled
+      - milestoned
+      - demilestoned
       - opened
       - reopened
       - synchronize


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1941 

## Relevant technical choices

<!-- Please describe your changes. -->
This pull request modifies the `.github/workflows/pr-validation.yml` file to include the `milestoned` and `demilestoned` events in the `pull_request` trigger's `types` list. This change ensures that the validation workflow is also executed when a pull request's milestone is assigned or removed.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
