### PR TITLE
Add URL Metric mutation helpers to extension initialization API

### DIFF
--- a/plugins/embed-optimizer/detect.js
+++ b/plugins/embed-optimizer/detect.js
@@ -26,17 +26,11 @@ export const name = 'Embed Optimizer';
  * @param {InitializeArgs} args Args.
  */
 export async function initialize( {
-	log: _log,
-	error: _error,
+	log,
+	error,
 	getElementData,
 	extendElementData,
 } ) {
-	/* eslint-disable no-console */
-	// TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
-	const log = _log || console.log;
-	const error = _error || console.error;
-	/* eslint-enable no-console */
-
 	/** @type NodeListOf<HTMLDivElement> */
 	const embedWrappers = document.querySelectorAll(
 		'.wp-block-embed > .wp-block-embed__wrapper[data-od-xpath]'

--- a/plugins/embed-optimizer/detect.js
+++ b/plugins/embed-optimizer/detect.js
@@ -13,18 +13,9 @@ export const name = 'Embed Optimizer';
  * @typedef {import("../optimization-detective/types.ts").Extension} Extension
  * @typedef {import("../optimization-detective/types.ts").InitializeCallback} InitializeCallback
  * @typedef {import("../optimization-detective/types.ts").InitializeArgs} InitializeArgs
- * @typedef {import("../optimization-detective/types.ts").FinalizeArgs} FinalizeArgs
- * @typedef {import("../optimization-detective/types.ts").FinalizeCallback} FinalizeCallback
  * @typedef {import("../optimization-detective/types.ts").ExtendedElementData} ExtendedElementData
  * @typedef {import("../optimization-detective/types.ts").LogFunction} LogFunction
  */
-
-/**
- * Embed element heights.
- *
- * @type {Map<string, DOMRectReadOnly>}
- */
-const loadedElementContentRects = new Map();
 
 /**
  * Initializes extension.
@@ -32,29 +23,7 @@ const loadedElementContentRects = new Map();
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { log: _log } ) {
-	// eslint-disable-next-line no-console
-	const log = _log || console.log; // TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
-
-	/** @type NodeListOf<HTMLDivElement> */
-	const embedWrappers = document.querySelectorAll(
-		'.wp-block-embed > .wp-block-embed__wrapper[data-od-xpath]'
-	);
-
-	for ( /** @type {HTMLElement} */ const embedWrapper of embedWrappers ) {
-		monitorEmbedWrapperForResizes( embedWrapper, log );
-	}
-
-	log( 'Loaded embed content rects:', loadedElementContentRects );
-}
-
-/**
- * Finalizes extension.
- *
- * @type {FinalizeCallback}
- * @param {FinalizeArgs} args Args.
- */
-export async function finalize( {
+export async function initialize( {
 	log: _log,
 	error: _error,
 	getElementData,
@@ -66,43 +35,63 @@ export async function finalize( {
 	const error = _error || console.error;
 	/* eslint-enable no-console */
 
-	for ( const [ xpath, domRect ] of loadedElementContentRects.entries() ) {
-		try {
-			extendElementData( xpath, {
-				resizedBoundingClientRect: domRect,
-			} );
-			const elementData = getElementData( xpath );
-			log(
-				`boundingClientRect for ${ xpath } resized:`,
-				elementData.boundingClientRect,
-				'=>',
-				domRect
-			);
-		} catch ( err ) {
-			error(
-				`Failed to extend element data for ${ xpath } with resizedBoundingClientRect:`,
-				domRect,
-				err
-			);
-		}
+	/** @type NodeListOf<HTMLDivElement> */
+	const embedWrappers = document.querySelectorAll(
+		'.wp-block-embed > .wp-block-embed__wrapper[data-od-xpath]'
+	);
+
+	for ( /** @type {HTMLElement} */ const embedWrapper of embedWrappers ) {
+		monitorEmbedWrapperForResizes(
+			embedWrapper,
+			extendElementData,
+			getElementData,
+			log,
+			error
+		);
 	}
 }
 
 /**
  * Monitors embed wrapper for resizes.
  *
- * @param {HTMLDivElement} embedWrapper Embed wrapper DIV.
- * @param {LogFunction}    log          The function to call with log messages.
+ * @param {HTMLDivElement} embedWrapper      Embed wrapper DIV.
+ * @param {Function}       extendElementData Function to extend element data with.
+ * @param {Function}       getElementData    Function to get element data.
+ * @param {LogFunction}    log               The function to call with log messages.
+ * @param {LogFunction}    error             The function to call with error messages.
  */
-function monitorEmbedWrapperForResizes( embedWrapper, log ) {
+function monitorEmbedWrapperForResizes(
+	embedWrapper,
+	extendElementData,
+	getElementData,
+	log,
+	error
+) {
 	if ( ! ( 'odXpath' in embedWrapper.dataset ) ) {
 		throw new Error( 'Embed wrapper missing data-od-xpath attribute.' );
 	}
 	const xpath = embedWrapper.dataset.odXpath;
 	const observer = new ResizeObserver( ( entries ) => {
 		const [ entry ] = entries;
-		loadedElementContentRects.set( xpath, entry.contentRect );
-		log( `Resized element ${ xpath }:`, entry.contentRect );
+
+		try {
+			extendElementData( xpath, {
+				resizedBoundingClientRect: entry.contentRect,
+			} );
+			const elementData = getElementData( xpath );
+			log(
+				`Resized element ${ xpath }:`,
+				elementData.boundingClientRect,
+				'=>',
+				entry.contentRect
+			);
+		} catch ( err ) {
+			error(
+				`Failed to extend element data for ${ xpath } with resizedBoundingClientRect:`,
+				entry.contentRect,
+				err
+			);
+		}
 	} );
 	observer.observe( embedWrapper, { box: 'content-box' } );
 }

--- a/plugins/embed-optimizer/detect.js
+++ b/plugins/embed-optimizer/detect.js
@@ -13,6 +13,8 @@ export const name = 'Embed Optimizer';
  * @typedef {import("../optimization-detective/types.ts").Extension} Extension
  * @typedef {import("../optimization-detective/types.ts").InitializeCallback} InitializeCallback
  * @typedef {import("../optimization-detective/types.ts").InitializeArgs} InitializeArgs
+ * @typedef {import("../optimization-detective/types.ts").GetElementDataFunction} GetElementDataFunction
+ * @typedef {import("../optimization-detective/types.ts").ExtendElementDataFunction} ExtendElementDataFunction
  * @typedef {import("../optimization-detective/types.ts").ExtendedElementData} ExtendedElementData
  * @typedef {import("../optimization-detective/types.ts").LogFunction} LogFunction
  */
@@ -54,11 +56,11 @@ export async function initialize( {
 /**
  * Monitors embed wrapper for resizes.
  *
- * @param {HTMLDivElement} embedWrapper      Embed wrapper DIV.
- * @param {Function}       extendElementData Function to extend element data with.
- * @param {Function}       getElementData    Function to get element data.
- * @param {LogFunction}    log               The function to call with log messages.
- * @param {LogFunction}    error             The function to call with error messages.
+ * @param {HTMLDivElement}            embedWrapper      - Embed wrapper DIV.
+ * @param {ExtendElementDataFunction} extendElementData - Function to extend element data with.
+ * @param {GetElementDataFunction}    getElementData    - Function to get element data.
+ * @param {LogFunction}               log               - The function to call with log messages.
+ * @param {LogFunction}               error             - The function to call with error messages.
  */
 function monitorEmbedWrapperForResizes(
 	embedWrapper,

--- a/plugins/embed-optimizer/helper.php
+++ b/plugins/embed-optimizer/helper.php
@@ -46,8 +46,8 @@ function embed_optimizer_add_non_optimization_detective_hooks(): void {
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */
 function embed_optimizer_init_optimization_detective( string $optimization_detective_version ): void {
-	$required_od_version = '0.9.0';
-	if ( version_compare( (string) strtok( $optimization_detective_version, '-' ), $required_od_version, '<' ) ) {
+	$required_od_version = '1.0.0-beta4';
+	if ( ! version_compare( $optimization_detective_version, $required_od_version, '>=' ) ) {
 		add_action(
 			'admin_notices',
 			static function (): void {

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -12,23 +12,9 @@
 export const name = 'Image Prioritizer';
 
 /**
- * Detected LCP external background image candidates.
- *
- * @type {Array<{
- *     url: string,
- *     tag: string,
- *     id: string|null,
- *     class: string|null,
- * }>}
- */
-const externalBackgroundImages = [];
-
-/**
  * @typedef {import("web-vitals").LCPMetric} LCPMetric
  * @typedef {import("../optimization-detective/types.ts").InitializeCallback} InitializeCallback
  * @typedef {import("../optimization-detective/types.ts").InitializeArgs} InitializeArgs
- * @typedef {import("../optimization-detective/types.ts").FinalizeArgs} FinalizeArgs
- * @typedef {import("../optimization-detective/types.ts").FinalizeCallback} FinalizeCallback
  * @typedef {import("../optimization-detective/types.ts").LogFunction} LogFunction
  */
 
@@ -40,13 +26,13 @@ const externalBackgroundImages = [];
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { log: _log, onLCP } ) {
+export async function initialize( { log: _log, onLCP, extendRootData } ) {
 	// eslint-disable-next-line no-console
 	const log = _log || console.log; // TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
 
 	onLCP(
 		( metric ) => {
-			handleLCPMetric( metric, log );
+			handleLCPMetric( metric, extendRootData, log );
 		},
 		{
 			// This avoids needing to click to finalize LCP candidate. While this is helpful for testing, it also
@@ -62,10 +48,23 @@ export async function initialize( { log: _log, onLCP } ) {
  *
  * @since 0.3.0
  *
- * @param {LCPMetric}   metric - LCP Metric.
- * @param {LogFunction} log    - The function to call with log messages.
+ * @param {LCPMetric}   metric         - LCP Metric.
+ * @param {Function}    extendRootData - Function to extend root data with.
+ * @param {LogFunction} log            - The function to call with log messages.
  */
-function handleLCPMetric( metric, log ) {
+function handleLCPMetric( metric, extendRootData, log ) {
+	/**
+	 * Detected LCP external background image candidates.
+	 *
+	 * @type {Array<{
+	 *     url: string,
+	 *     tag: string,
+	 *     id: string|null,
+	 *     class: string|null,
+	 * }>}
+	 */
+	const externalBackgroundImages = [];
+
 	for ( const entry of metric.entries ) {
 		// Look only for LCP entries that have a URL and a corresponding element which is not an IMG or VIDEO.
 		if (
@@ -130,19 +129,6 @@ function handleLCPMetric( metric, log ) {
 
 		externalBackgroundImages.push( externalBackgroundImage );
 	}
-}
-
-/**
- * Finalizes extension.
- *
- * @since 0.3.0
- *
- * @type {FinalizeCallback}
- * @param {FinalizeArgs} args Args.
- */
-export async function finalize( { extendRootData, log: _log } ) {
-	// eslint-disable-next-line no-console
-	const log = _log || console.log; // TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
 
 	if ( externalBackgroundImages.length === 0 ) {
 		return;

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -27,10 +27,7 @@ export const name = 'Image Prioritizer';
  * @type {InitializeCallback}
  * @param {InitializeArgs} args Args.
  */
-export async function initialize( { log: _log, onLCP, extendRootData } ) {
-	// eslint-disable-next-line no-console
-	const log = _log || console.log; // TODO: Remove once Optimization Detective likely updated, or when strict version requirement added in od_init action.
-
+export async function initialize( { log, onLCP, extendRootData } ) {
 	onLCP(
 		( metric ) => {
 			handleLCPMetric( metric, extendRootData, log );

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -16,6 +16,7 @@ export const name = 'Image Prioritizer';
  * @typedef {import("../optimization-detective/types.ts").InitializeCallback} InitializeCallback
  * @typedef {import("../optimization-detective/types.ts").InitializeArgs} InitializeArgs
  * @typedef {import("../optimization-detective/types.ts").LogFunction} LogFunction
+ * @typedef {import("../optimization-detective/types.ts").ExtendRootDataFunction} ExtendRootDataFunction
  */
 
 /**
@@ -48,9 +49,9 @@ export async function initialize( { log: _log, onLCP, extendRootData } ) {
  *
  * @since 0.3.0
  *
- * @param {LCPMetric}   metric         - LCP Metric.
- * @param {Function}    extendRootData - Function to extend root data with.
- * @param {LogFunction} log            - The function to call with log messages.
+ * @param {LCPMetric}              metric         - LCP Metric.
+ * @param {ExtendRootDataFunction} extendRootData - Function to extend root data with.
+ * @param {LogFunction}            log            - The function to call with log messages.
  */
 function handleLCPMetric( metric, extendRootData, log ) {
 	for ( const entry of metric.entries ) {

--- a/plugins/image-prioritizer/detect.js
+++ b/plugins/image-prioritizer/detect.js
@@ -53,18 +53,6 @@ export async function initialize( { log: _log, onLCP, extendRootData } ) {
  * @param {LogFunction} log            - The function to call with log messages.
  */
 function handleLCPMetric( metric, extendRootData, log ) {
-	/**
-	 * Detected LCP external background image candidates.
-	 *
-	 * @type {Array<{
-	 *     url: string,
-	 *     tag: string,
-	 *     id: string|null,
-	 *     class: string|null,
-	 * }>}
-	 */
-	const externalBackgroundImages = [];
-
 	for ( const entry of metric.entries ) {
 		// Look only for LCP entries that have a URL and a corresponding element which is not an IMG or VIDEO.
 		if (
@@ -126,21 +114,8 @@ function handleLCPMetric( metric, extendRootData, log ) {
 			'Detected external LCP background image:',
 			externalBackgroundImage
 		);
-
-		externalBackgroundImages.push( externalBackgroundImage );
+		extendRootData( {
+			lcpElementExternalBackgroundImage: externalBackgroundImage,
+		} );
 	}
-
-	if ( externalBackgroundImages.length === 0 ) {
-		return;
-	}
-
-	// Get the last detected external background image which is going to be for the LCP element (or very likely will be).
-	const lcpElementExternalBackgroundImage = externalBackgroundImages.pop();
-
-	log(
-		'Sending external background image for LCP element:',
-		lcpElementExternalBackgroundImage
-	);
-
-	extendRootData( { lcpElementExternalBackgroundImage } );
 }

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -292,7 +292,6 @@ function image_prioritizer_validate_background_image_url( string $url ) {
  *
  * @return WP_REST_Response|WP_HTTP_Response|WP_Error|mixed Result to send to the client.
  * @noinspection PhpDocMissingThrowsInspection
- * @noinspection PhpDeprecationInspection
  */
 function image_prioritizer_filter_rest_request_before_callbacks( $response, array $handler, WP_REST_Request $request ) {
 	unset( $handler ); // Unused.

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -21,8 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @param string $optimization_detective_version Current version of the optimization detective plugin.
  */
 function image_prioritizer_init( string $optimization_detective_version ): void {
-	$required_od_version = '0.9.0';
-	if ( ! version_compare( (string) strtok( $optimization_detective_version, '-' ), $required_od_version, '>=' ) ) {
+	$required_od_version = '1.0.0-beta4';
+	if ( ! version_compare( $optimization_detective_version, $required_od_version, '>=' ) ) {
 		add_action(
 			'admin_notices',
 			static function (): void {

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -19,6 +19,10 @@
  * @typedef {import("./types.ts").Extension} Extension
  * @typedef {import("./types.ts").ExtendedRootData} ExtendedRootData
  * @typedef {import("./types.ts").ExtendedElementData} ExtendedElementData
+ * @typedef {import("./types.ts").GetRootDataFunction} GetRootDataFunction
+ * @typedef {import("./types.ts").ExtendRootDataFunction} ExtendRootDataFunction
+ * @typedef {import("./types.ts").GetElementDataFunction} GetElementDataFunction
+ * @typedef {import("./types.ts").ExtendElementDataFunction} ExtendElementDataFunction
  * @typedef {import("./types.ts").Logger} Logger
  */
 
@@ -247,6 +251,7 @@ const reservedRootPropertyKeys = new Set( [ 'url', 'viewport', 'elements' ] );
 /**
  * Gets root URL Metric data.
  *
+ * @type {GetRootDataFunction}
  * @return {URLMetric} URL Metric.
  */
 function getRootData() {
@@ -258,6 +263,7 @@ function getRootData() {
 /**
  * Extends root URL Metric data.
  *
+ * @type {ExtendRootDataFunction}
  * @param {ExtendedRootData} properties
  */
 function extendRootData( properties ) {
@@ -295,6 +301,7 @@ const reservedElementPropertyKeys = new Set( [
 /**
  * Gets element data.
  *
+ * @type {GetElementDataFunction}
  * @param {string} xpath - XPath.
  * @return {ElementData|null} Element data, or null if no element for the XPath exists.
  */
@@ -311,6 +318,7 @@ function getElementData( xpath ) {
 /**
  * Extends element data.
  *
+ * @type {ExtendElementDataFunction}
  * @param {string}              xpath      - XPath.
  * @param {ExtendedElementData} properties - Properties.
  */

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -711,6 +711,9 @@ export default async function detect( {
 		elementsByXPath.set( elementData.xpath, elementData );
 	}
 
+	// Clean up.
+	breadcrumbedElementsMap.clear();
+
 	log( 'Current URL Metric:', urlMetric );
 
 	// Wait for the page to be hidden.
@@ -862,7 +865,4 @@ export default async function detect( {
 	}
 	url.searchParams.set( 'hmac', urlMetricHMAC );
 	navigator.sendBeacon( url, payloadBlob );
-
-	// Clean up.
-	breadcrumbedElementsMap.clear();
 }

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -610,9 +610,6 @@ export default async function detect( {
 		elements: [],
 	};
 
-	/** @type {Map<string, Extension>} */
-	const extensions = new Map();
-
 	/** @type {Promise[]} */
 	const extensionInitializePromises = [];
 
@@ -623,7 +620,6 @@ export default async function detect( {
 		try {
 			/** @type {Extension} */
 			const extension = await import( extensionModuleUrl );
-			extensions.set( extensionModuleUrl, extension );
 
 			const extensionLogger = createLogger(
 				isDebug,
@@ -737,67 +733,6 @@ export default async function detect( {
 	if ( didWindowResize ) {
 		log( 'Aborting URL Metric collection due to viewport size change.' );
 		return;
-	}
-
-	// Finalize extensions.
-	if ( extensions.size > 0 ) {
-		/** @type {Promise[]} */
-		const extensionFinalizePromises = [];
-
-		/** @type {string[]} */
-		const finalizingExtensionModuleUrls = [];
-
-		for ( const [
-			extensionModuleUrl,
-			extension,
-		] of extensions.entries() ) {
-			if ( extension.finalize instanceof Function ) {
-				const extensionLogger = createLogger(
-					isDebug,
-					`[Optimization Detective: ${
-						extension.name || 'Unnamed Extension'
-					}]`
-				);
-
-				try {
-					const finalizePromise = extension.finalize( {
-						isDebug,
-						...extensionLogger,
-						getRootData,
-						getElementData,
-						extendElementData,
-						extendRootData,
-					} );
-					if ( finalizePromise instanceof Promise ) {
-						extensionFinalizePromises.push( finalizePromise );
-						finalizingExtensionModuleUrls.push(
-							extensionModuleUrl
-						);
-					}
-				} catch ( err ) {
-					error(
-						`Unable to start finalizing extension '${ extensionModuleUrl }':`,
-						err
-					);
-				}
-			}
-		}
-
-		// Wait for all extensions to finish finalizing.
-		const settledFinalizePromises = await Promise.allSettled(
-			extensionFinalizePromises
-		);
-		for ( const [
-			i,
-			settledFinalizePromise,
-		] of settledFinalizePromises.entries() ) {
-			if ( settledFinalizePromise.status === 'rejected' ) {
-				error(
-					`Failed to finalize extension '${ finalizingExtensionModuleUrls[ i ] }':`,
-					settledFinalizePromise.reason
-				);
-			}
-		}
 	}
 
 	/*

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -519,72 +519,6 @@ export default async function detect( {
 
 	log( 'Proceeding with detection' );
 
-	/** @type {Map<string, Extension>} */
-	const extensions = new Map();
-
-	/** @type {Promise[]} */
-	const extensionInitializePromises = [];
-
-	/** @type {string[]} */
-	const initializingExtensionModuleUrls = [];
-
-	for ( const extensionModuleUrl of extensionModuleUrls ) {
-		try {
-			/** @type {Extension} */
-			const extension = await import( extensionModuleUrl );
-			extensions.set( extensionModuleUrl, extension );
-
-			const extensionLogger = createLogger(
-				isDebug,
-				`[Optimization Detective: ${
-					extension.name || 'Unnamed Extension'
-				}]`
-			);
-
-			// TODO: There should to be a way to pass additional args into the module. Perhaps extensionModuleUrls should be a mapping of URLs to args.
-			if ( extension.initialize instanceof Function ) {
-				const initializePromise = extension.initialize( {
-					isDebug,
-					...extensionLogger,
-					onTTFB,
-					onFCP,
-					onLCP,
-					onINP,
-					onCLS,
-					getRootData,
-					extendRootData,
-					getElementData,
-					extendElementData,
-				} );
-				if ( initializePromise instanceof Promise ) {
-					extensionInitializePromises.push( initializePromise );
-					initializingExtensionModuleUrls.push( extensionModuleUrl );
-				}
-			}
-		} catch ( err ) {
-			error(
-				`Failed to start initializing extension '${ extensionModuleUrl }':`,
-				err
-			);
-		}
-	}
-
-	// Wait for all extensions to finish initializing.
-	const settledInitializePromises = await Promise.allSettled(
-		extensionInitializePromises
-	);
-	for ( const [
-		i,
-		settledInitializePromise,
-	] of settledInitializePromises.entries() ) {
-		if ( settledInitializePromise.status === 'rejected' ) {
-			error(
-				`Failed to initialize extension '${ initializingExtensionModuleUrls[ i ] }':`,
-				settledInitializePromise.reason
-			);
-		}
-	}
-
 	const breadcrumbedElements = doc.body.querySelectorAll( '[data-od-xpath]' );
 
 	/** @type {Map<Element, string>} */
@@ -675,6 +609,72 @@ export default async function detect( {
 		},
 		elements: [],
 	};
+
+	/** @type {Map<string, Extension>} */
+	const extensions = new Map();
+
+	/** @type {Promise[]} */
+	const extensionInitializePromises = [];
+
+	/** @type {string[]} */
+	const initializingExtensionModuleUrls = [];
+
+	for ( const extensionModuleUrl of extensionModuleUrls ) {
+		try {
+			/** @type {Extension} */
+			const extension = await import( extensionModuleUrl );
+			extensions.set( extensionModuleUrl, extension );
+
+			const extensionLogger = createLogger(
+				isDebug,
+				`[Optimization Detective: ${
+					extension.name || 'Unnamed Extension'
+				}]`
+			);
+
+			// TODO: There should to be a way to pass additional args into the module. Perhaps extensionModuleUrls should be a mapping of URLs to args.
+			if ( extension.initialize instanceof Function ) {
+				const initializePromise = extension.initialize( {
+					isDebug,
+					...extensionLogger,
+					onTTFB,
+					onFCP,
+					onLCP,
+					onINP,
+					onCLS,
+					getRootData,
+					extendRootData,
+					getElementData,
+					extendElementData,
+				} );
+				if ( initializePromise instanceof Promise ) {
+					extensionInitializePromises.push( initializePromise );
+					initializingExtensionModuleUrls.push( extensionModuleUrl );
+				}
+			}
+		} catch ( err ) {
+			error(
+				`Failed to start initializing extension '${ extensionModuleUrl }':`,
+				err
+			);
+		}
+	}
+
+	// Wait for all extensions to finish initializing.
+	const settledInitializePromises = await Promise.allSettled(
+		extensionInitializePromises
+	);
+	for ( const [
+		i,
+		settledInitializePromise,
+	] of settledInitializePromises.entries() ) {
+		if ( settledInitializePromise.status === 'rejected' ) {
+			error(
+				`Failed to initialize extension '${ initializingExtensionModuleUrls[ i ] }':`,
+				settledInitializePromise.reason
+			);
+		}
+	}
 
 	const lcpMetric = lcpMetricCandidates.at( -1 );
 

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -551,6 +551,10 @@ export default async function detect( {
 					onLCP,
 					onINP,
 					onCLS,
+					getRootData,
+					extendRootData,
+					getElementData,
+					extendElementData,
 				} );
 				if ( initializePromise instanceof Promise ) {
 					extensionInitializePromises.push( initializePromise );

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -664,9 +664,8 @@ export default async function detect( {
 		);
 	} );
 
-	// Stop observing.
+	// Stop observing initial viewport.
 	disconnectIntersectionObserver();
-	log( 'Detection is stopping.' );
 
 	urlMetric = {
 		url: currentUrl,

--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -610,6 +610,9 @@ export default async function detect( {
 		elements: [],
 	};
 
+	/** @type {Map<string, Extension>} */
+	const extensions = new Map();
+
 	/** @type {Promise[]} */
 	const extensionInitializePromises = [];
 
@@ -620,6 +623,7 @@ export default async function detect( {
 		try {
 			/** @type {Extension} */
 			const extension = await import( extensionModuleUrl );
+			extensions.set( extensionModuleUrl, extension );
 
 			const extensionLogger = createLogger(
 				isDebug,
@@ -733,6 +737,71 @@ export default async function detect( {
 	if ( didWindowResize ) {
 		log( 'Aborting URL Metric collection due to viewport size change.' );
 		return;
+	}
+
+	// Finalize extensions.
+	if ( extensions.size > 0 ) {
+		/** @type {Promise[]} */
+		const extensionFinalizePromises = [];
+
+		/** @type {string[]} */
+		const finalizingExtensionModuleUrls = [];
+
+		for ( const [
+			extensionModuleUrl,
+			extension,
+		] of extensions.entries() ) {
+			if ( extension.finalize instanceof Function ) {
+				const extensionLogger = createLogger(
+					isDebug,
+					`[Optimization Detective: ${
+						extension.name || 'Unnamed Extension'
+					}]`
+				);
+
+				extensionLogger.warn(
+					'Use of the finalize function in extensions is deprecated. Please refactor your extension to use the initialize function instead, and update the URL Metric data as soon as a change is detected rather than waiting until finalization.'
+				);
+
+				try {
+					const finalizePromise = extension.finalize( {
+						isDebug,
+						...extensionLogger,
+						getRootData,
+						getElementData,
+						extendElementData,
+						extendRootData,
+					} );
+					if ( finalizePromise instanceof Promise ) {
+						extensionFinalizePromises.push( finalizePromise );
+						finalizingExtensionModuleUrls.push(
+							extensionModuleUrl
+						);
+					}
+				} catch ( err ) {
+					error(
+						`Unable to start finalizing extension '${ extensionModuleUrl }':`,
+						err
+					);
+				}
+			}
+		}
+
+		// Wait for all extensions to finish finalizing.
+		const settledFinalizePromises = await Promise.allSettled(
+			extensionFinalizePromises
+		);
+		for ( const [
+			i,
+			settledFinalizePromise,
+		] of settledFinalizePromises.entries() ) {
+			if ( settledFinalizePromise.status === 'rejected' ) {
+				error(
+					`Failed to finalize extension '${ finalizingExtensionModuleUrls[ i ] }':`,
+					settledFinalizePromise.reason
+				);
+			}
+		}
 	}
 
 	/*

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'optimization_detective_pending_plugin',
-	'1.0.0-beta3',
+	'1.0.0-beta4',
 	static function ( string $version ): void {
 		if ( defined( 'OPTIMIZATION_DETECTIVE_VERSION' ) ) {
 			return;

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -5,7 +5,7 @@
  * Description: Provides a framework for leveraging real user metrics to detect optimizations for improving page performance.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.0.0-beta3
+ * Version: 1.0.0-beta4
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -80,7 +80,25 @@ export type InitializeArgs = {
 
 export type InitializeCallback = ( args: InitializeArgs ) => Promise< void >;
 
+export type FinalizeArgs = {
+	readonly getRootData: () => URLMetric;
+	readonly extendRootData: ( properties: ExtendedRootData ) => void;
+	readonly getElementData: ( xpath: string ) => ElementData | null;
+	readonly extendElementData: (
+		xpath: string,
+		properties: ExtendedElementData
+	) => void;
+	readonly isDebug: boolean;
+	readonly log: LogFunction;
+	readonly info: LogFunction;
+	readonly warn: LogFunction;
+	readonly error: LogFunction;
+};
+
+export type FinalizeCallback = ( args: FinalizeArgs ) => Promise< void >;
+
 export interface Extension {
 	readonly name?: string;
 	readonly initialize?: InitializeCallback;
+	readonly finalize?: FinalizeCallback;
 }

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -69,6 +69,13 @@ export type InitializeArgs = {
 	readonly onLCP: OnLCPFunction | OnLCPWithAttributionFunction;
 	readonly onINP: OnINPFunction | OnINPWithAttributionFunction;
 	readonly onCLS: OnCLSFunction | OnCLSWithAttributionFunction;
+	readonly getRootData: () => URLMetric;
+	readonly extendRootData: ( properties: ExtendedRootData ) => void;
+	readonly getElementData: ( xpath: string ) => ElementData | null;
+	readonly extendElementData: (
+		xpath: string,
+		properties: ExtendedElementData
+	) => void;
 };
 
 export type InitializeCallback = ( args: InitializeArgs ) => Promise< void >;

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -80,25 +80,7 @@ export type InitializeArgs = {
 
 export type InitializeCallback = ( args: InitializeArgs ) => Promise< void >;
 
-export type FinalizeArgs = {
-	readonly getRootData: () => URLMetric;
-	readonly extendRootData: ( properties: ExtendedRootData ) => void;
-	readonly getElementData: ( xpath: string ) => ElementData | null;
-	readonly extendElementData: (
-		xpath: string,
-		properties: ExtendedElementData
-	) => void;
-	readonly isDebug: boolean;
-	readonly log: LogFunction;
-	readonly info: LogFunction;
-	readonly warn: LogFunction;
-	readonly error: LogFunction;
-};
-
-export type FinalizeCallback = ( args: FinalizeArgs ) => Promise< void >;
-
 export interface Extension {
 	readonly name?: string;
 	readonly initialize?: InitializeCallback;
-	readonly finalize?: FinalizeCallback;
 }

--- a/plugins/optimization-detective/types.ts
+++ b/plugins/optimization-detective/types.ts
@@ -58,6 +58,14 @@ export interface Logger {
 	error: LogFunction;
 }
 
+export type GetRootDataFunction = () => URLMetric;
+export type ExtendRootDataFunction = ( properties: ExtendedRootData ) => void;
+export type GetElementDataFunction = ( xpath: string ) => ElementData | null;
+export type ExtendElementDataFunction = (
+	xpath: string,
+	properties: ExtendedElementData
+) => void;
+
 export type InitializeArgs = {
 	readonly isDebug: boolean;
 	readonly log: LogFunction;
@@ -69,25 +77,19 @@ export type InitializeArgs = {
 	readonly onLCP: OnLCPFunction | OnLCPWithAttributionFunction;
 	readonly onINP: OnINPFunction | OnINPWithAttributionFunction;
 	readonly onCLS: OnCLSFunction | OnCLSWithAttributionFunction;
-	readonly getRootData: () => URLMetric;
-	readonly extendRootData: ( properties: ExtendedRootData ) => void;
-	readonly getElementData: ( xpath: string ) => ElementData | null;
-	readonly extendElementData: (
-		xpath: string,
-		properties: ExtendedElementData
-	) => void;
+	readonly getRootData: GetRootDataFunction;
+	readonly extendRootData: ExtendRootDataFunction;
+	readonly getElementData: GetElementDataFunction;
+	readonly extendElementData: ExtendElementDataFunction;
 };
 
 export type InitializeCallback = ( args: InitializeArgs ) => Promise< void >;
 
 export type FinalizeArgs = {
-	readonly getRootData: () => URLMetric;
-	readonly extendRootData: ( properties: ExtendedRootData ) => void;
-	readonly getElementData: ( xpath: string ) => ElementData | null;
-	readonly extendElementData: (
-		xpath: string,
-		properties: ExtendedElementData
-	) => void;
+	readonly getRootData: GetRootDataFunction;
+	readonly extendRootData: ExtendRootDataFunction;
+	readonly getElementData: GetElementDataFunction;
+	readonly extendElementData: ExtendElementDataFunction;
 	readonly isDebug: boolean;
 	readonly log: LogFunction;
 	readonly info: LogFunction;


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1930 

## Relevant technical choices

<!-- Please describe your changes. -->
- Exposed URL Metric mutation helpers (`getRootData`, `extendRootData`, `getElementData`, `extendElementData`) in the `initialize` args to match what was already available in `finalize` args
- Moved client extension initialization logic down to occur after the `urlMetric` definition
- Updated extensions (Image Prioritizer and Embed Optimizer) to use these helpers directly during initialization
- Eliminated need for storing temporary data and the `finalize` phase in extensions
- Emits a deprecation warning if the client extensions includes a `finalize` function


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
