### PR TITLE
Amend URL metrics to the generator meta tag content

### DIFF
--- a/plugins/embed-optimizer/tests/test-cases/all-embeds-inside-viewport/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/all-embeds-inside-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/all-embeds-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/all-embeds-inside-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/all-embeds-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/all-embeds-inside-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/nested-figure-embed/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/nested-figure-embed/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/nested-figure-embed/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/nested-figure-embed/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/nested-figure-embed/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/nested-figure-embed/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-spotify-embed-outside-viewport-with-subsequent-script/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-one-group/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-one-group/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-one-group/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-one-group/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; }
 </style>

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-one-group/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-one-group/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; }

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<link data-od-added-tag rel="preconnect" href="https://pbs.twimg.com">
 <link data-od-added-tag rel="preconnect" href="https://syndication.twitter.com">
 </head>

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport-without-resized-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<link data-od-added-tag rel="preconnect" href="https://pbs.twimg.com">
 <link data-od-added-tag rel="preconnect" href="https://syndication.twitter.com">

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-inside-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport-on-mobile/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport-on-mobile/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport-on-mobile/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport-on-mobile/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 600px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport-on-mobile/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport-on-mobile/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-twitter-embed-outside-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-inside-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport-on-mobile/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport-on-mobile/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport-on-mobile/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport-on-mobile/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 600px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport-on-mobile/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport-on-mobile/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-wordpress-tv-embed-outside-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport-with-only-mobile-url-metrics/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport-with-only-mobile-url-metrics/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport-with-only-mobile-url-metrics/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport-with-only-mobile-url-metrics/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 </style>

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport-with-only-mobile-url-metrics/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport-with-only-mobile-url-metrics/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-inside-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-on-mobile/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-on-mobile/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-on-mobile/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-on-mobile/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-on-mobile/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-on-mobile/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 </style>

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport-with-only-mobile-url-metrics/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }
 @media (480px < width <= 600px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/single-youtube-embed-outside-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	<style>
 @media (width <= 480px) { #embed-optimizer-6040306707fb51ccaafa915c2da8f412 { min-height: 500px; } }

--- a/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body data-od-xpath="/HTML/BODY">

--- a/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/too-many-bookmarks/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
 	</head>
 	<body data-od-xpath="/HTML/BODY">
 		<div class="wp-site-blocks">

--- a/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-on-all-breakpoints-but-not-desktop-with-fully-populated-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-on-all-breakpoints-but-not-desktop-with-fully-populated-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-on-all-breakpoints-but-not-desktop-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-on-all-breakpoints-but-not-desktop-with-fully-populated-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-on-all-breakpoints-but-not-desktop-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-on-all-breakpoints-but-not-desktop-with-fully-populated-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-with-desktop-metrics-missing/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-with-desktop-metrics-missing/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-with-desktop-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-with-desktop-metrics-missing/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-with-desktop-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/background-image-outside-viewport-with-desktop-metrics-missing/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-and-lazy-loaded-background-image-outside-viewport-with-fully-populated-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-and-lazy-loaded-background-image-outside-viewport-with-fully-populated-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-and-lazy-loaded-background-image-outside-viewport-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-and-lazy-loaded-background-image-outside-viewport-with-fully-populated-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<style>
 @media (scripting:enabled){.od-lazy-bg-image{background-image:none!important}}

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-and-lazy-loaded-background-image-outside-viewport-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-and-lazy-loaded-background-image-outside-viewport-with-fully-populated-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<style>
 @media (scripting:enabled){.od-lazy-bg-image{background-image:none!important}}
 </style>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-with-fully-populated-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-with-fully-populated-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-with-fully-populated-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo-bg.jpg" media="screen">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-background-image-with-fully-populated-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo-bg.jpg" media="screen">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo1.jpg" imagesrcset="https://example.com/foo1-480w.jpg 480w, https://example.com/foo1-800w.jpg 800w" imagesizes="(width &lt;= 480px) 432px, (480px &lt; width &lt;= 600px) 540px, (600px &lt; width &lt;= 782px) 703px, (782px &lt; width) 900px" crossorigin="anonymous" media="screen">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-and-lazy-loaded-image-outside-viewport-with-fully-populated-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo1.jpg" imagesrcset="https://example.com/foo1-480w.jpg 480w, https://example.com/foo1-800w.jpg 800w" imagesizes="(width &lt;= 480px) 432px, (480px &lt; width &lt;= 600px) 540px, (600px &lt; width &lt;= 782px) 703px, (782px &lt; width) 900px" crossorigin="anonymous" media="screen">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (782px &lt; width)">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-fully-incomplete-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (782px &lt; width)">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-old-xpath-format/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-old-xpath-format/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-old-xpath-format/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-old-xpath-format/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-old-xpath-format/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-old-xpath-format/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-stale-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-stale-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-stale-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-stale-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-stale-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/common-lcp-image-with-stale-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-all-breakpoints/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-all-breakpoints/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-all-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-all-breakpoints/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated, 1000: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" crossorigin="anonymous" media="screen and (width &lt;= 480px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/phablet-logo.png" crossorigin="anonymous" referrerpolicy="no-referrer" media="screen and (480px &lt; width &lt;= 600px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/tablet-logo.png" crossorigin="anonymous" referrerpolicy="no-referrer-when-downgrade" media="screen and (600px &lt; width &lt;= 782px)">

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-all-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-all-breakpoints/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated, 1000: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated, 1000:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" crossorigin="anonymous" media="screen and (width &lt;= 480px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/phablet-logo.png" crossorigin="anonymous" referrerpolicy="no-referrer" media="screen and (480px &lt; width &lt;= 600px)">

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" media="screen and (480px &lt; width &lt;= 600px)">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints-and-one-is-stale/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" media="screen and (480px &lt; width &lt;= 600px)">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop-logo.png" media="screen and (600px &lt; width &lt;= 782px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" media="screen and (width &lt;= 480px)">

--- a/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/different-lcp-elements-for-two-non-consecutive-breakpoints/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/desktop-logo.png" media="screen and (600px &lt; width &lt;= 782px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-logo.png" media="screen and (width &lt;= 480px)">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-already-on-common-lcp-image-with-fully-populated-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-already-on-common-lcp-image-with-fully-populated-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-already-on-common-lcp-image-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-already-on-common-lcp-image-with-fully-populated-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-already-on-common-lcp-image-with-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-already-on-common-lcp-image-with-fully-populated-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: empty, 600: empty, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:empty, 600:empty, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (width &lt;= 480px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (782px &lt; width)">

--- a/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/fetch-priority-high-on-lcp-image-common-on-mobile-and-desktop-with-url-metrics-missing-in-other-groups/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: empty, 600: empty, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (width &lt;= 480px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (782px &lt; width)">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/images-located-above-or-along-initial-viewport/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/images-located-above-or-along-initial-viewport/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">
@@ -9,7 +11,7 @@
 			<img src="https://example.com/bad-left-of-viewport.jpg" alt="Left of Viewport" width="10" height="10" fetchpriority="high">
 			<img src="https://example.com/bad-above-viewport.jpg" alt="Above viewport" width="10" height="10" loading="lazy">
 			<img src="https://example.com/bad-right-of-viewport.jpg" alt="Right of viewport" width="10" height="10">
-	
+
 			<!-- The only one that should get loading=lazy since user should be able to scroll to it. -->
 			<img src="https://example.com/bad-below-viewport.jpg" alt="Below viewport" width="10" height="10">
 		</div>

--- a/plugins/image-prioritizer/tests/test-cases/images-located-above-or-along-initial-viewport/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/images-located-above-or-along-initial-viewport/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/images-located-above-or-along-initial-viewport/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/images-located-above-or-along-initial-viewport/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">
@@ -9,7 +11,7 @@
 			<img data-od-replaced-fetchpriority="high" src="https://example.com/bad-left-of-viewport.jpg" alt="Left of Viewport" width="10" height="10" fetchpriority="low">
 			<img data-od-added-fetchpriority data-od-removed-loading="lazy" fetchpriority="low" src="https://example.com/bad-above-viewport.jpg" alt="Above viewport" width="10" height="10" >
 			<img data-od-added-fetchpriority fetchpriority="low" src="https://example.com/bad-right-of-viewport.jpg" alt="Right of viewport" width="10" height="10">
-	
+
 			<!-- The only one that should get loading=lazy since user should be able to scroll to it. -->
 			<img data-od-added-loading loading="lazy" src="https://example.com/bad-below-viewport.jpg" alt="Below viewport" width="10" height="10">
 		</div>

--- a/plugins/image-prioritizer/tests/test-cases/multiple-videos-on-all-breakpoints/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/multiple-videos-on-all-breakpoints/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/multiple-videos-on-all-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/multiple-videos-on-all-breakpoints/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster1.jpg" media="screen">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/multiple-videos-on-all-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/multiple-videos-on-all-breakpoints/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster1.jpg" media="screen">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/multiple-videos-with-desktop-metrics-missing/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/multiple-videos-with-desktop-metrics-missing/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/multiple-videos-with-desktop-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/multiple-videos-with-desktop-metrics-missing/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster1.jpg" media="screen and (width &lt;= 782px)">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/multiple-videos-with-desktop-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/multiple-videos-with-desktop-metrics-missing/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster1.jpg" media="screen and (width &lt;= 782px)">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/no-lcp-image-or-background-image-outside-viewport-with-populated-url-metrics/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-lcp-image-or-background-image-outside-viewport-with-populated-url-metrics/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-lcp-image-or-background-image-outside-viewport-with-populated-url-metrics/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-lcp-image-or-background-image-outside-viewport-with-populated-url-metrics/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/no-lcp-image-or-background-image-outside-viewport-with-populated-url-metrics/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-lcp-image-or-background-image-outside-viewport-with-populated-url-metrics/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-but-server-side-heuristics-added-fetchpriority-high/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-but-server-side-heuristics-added-fetchpriority-high/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-but-server-side-heuristics-added-fetchpriority-high/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-but-server-side-heuristics-added-fetchpriority-high/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-but-server-side-heuristics-added-fetchpriority-high/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-but-server-side-heuristics-added-fetchpriority-high/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-for-image-without-src/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-for-image-without-src/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-for-image-without-src/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-for-image-without-src/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-for-image-without-src/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-for-image-without-src/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-image/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-image/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-image/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-image/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-image/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-image/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-non-background-image-style/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-non-background-image-style/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-non-background-image-style/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-non-background-image-style/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-non-background-image-style/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-non-background-image-style/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: empty, 600: empty, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<style>
 @media (scripting:enabled){.od-lazy-bg-image{background-image:none!important}}
 </style>

--- a/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/only-mobile-and-desktop-groups-are-populated/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: empty, 600: empty, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:empty, 600:empty, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<style>
 @media (scripting:enabled){.od-lazy-bg-image{background-image:none!important}}

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-as-lcp-tablet-and-desktop-metrics-missing/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-as-lcp-tablet-and-desktop-metrics-missing/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-as-lcp-tablet-and-desktop-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-as-lcp-tablet-and-desktop-metrics-missing/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:empty, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" imagesrcset="https://example.com/foo-300x225.avif 300w, https://example.com/foo-1024x768.avif 1024w, https://example.com/foo-768x576.avif 768w, https://example.com/foo-1536x1152.avif 1536w, https://example.com/foo-2048x1536.avif 2048w" imagesizes="(max-width: 600px) 480px, 800px" type="image/avif" media="screen and (width &lt;= 600px)">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-as-lcp-tablet-and-desktop-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-as-lcp-tablet-and-desktop-metrics-missing/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: empty, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" imagesrcset="https://example.com/foo-300x225.avif 300w, https://example.com/foo-1024x768.avif 1024w, https://example.com/foo-768x576.avif 768w, https://example.com/foo-1536x1152.avif 1536w, https://example.com/foo-2048x1536.avif 2048w" imagesizes="(max-width: 600px) 480px, 800px" type="image/avif" media="screen and (width &lt;= 600px)">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-lcp-image-and-fully-populated-sample-data/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-lcp-image-and-fully-populated-sample-data/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-lcp-image-and-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-lcp-image-and-fully-populated-sample-data/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" imagesrcset="https://example.com/foo-300x225.avif 300w, https://example.com/foo-1024x768.avif 1024w, https://example.com/foo-768x576.avif 768w, https://example.com/foo-1536x1152.avif 1536w, https://example.com/foo-2048x1536.avif 2048w" imagesizes="(max-width: 600px) 480px, 800px" type="image/avif" crossorigin="anonymous" referrerpolicy="no-referrer" media="screen">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-lcp-image-and-fully-populated-sample-data/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-lcp-image-and-fully-populated-sample-data/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" imagesrcset="https://example.com/foo-300x225.avif 300w, https://example.com/foo-1024x768.avif 1024w, https://example.com/foo-768x576.avif 768w, https://example.com/foo-1536x1152.avif 1536w, https://example.com/foo-2048x1536.avif 2048w" imagesizes="(max-width: 600px) 480px, 800px" type="image/avif" crossorigin="anonymous" referrerpolicy="no-referrer" media="screen">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-having-media-attribute/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-having-media-attribute/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-having-media-attribute/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-having-media-attribute/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-having-media-attribute/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-having-media-attribute/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-missing-type-attribute/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-missing-type-attribute/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-missing-type-attribute/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-missing-type-attribute/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-missing-type-attribute/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/picture-element-with-source-missing-type-attribute/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div class="wp-site-blocks">

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.net/wp-content/uploads/foo.jpg" media="screen">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/preload-links-with-one-half-stale-group/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.net/wp-content/uploads/foo.jpg" media="screen">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-collected/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-missing/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-missing/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-missing/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:empty}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-missing/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-large-poster-and-desktop-url-metrics-missing/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: empty}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-all-breakpoints/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-all-breakpoints/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-all-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-all-breakpoints/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-all-breakpoints/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-all-breakpoints/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen">
 </head>
 	<body>

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-desktop-only/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-desktop-only/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-desktop-only/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-desktop-only/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-header.jpg" crossorigin="anonymous" media="screen and (width &lt;= 782px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen and (782px &lt; width)" crossorigin="anonymous">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-desktop-only/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-desktop-only/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-header.jpg" crossorigin="anonymous" media="screen and (width &lt;= 782px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen and (782px &lt; width)" crossorigin="anonymous">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-mobile-and-desktop-but-not-tablet/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-mobile-and-desktop-but-not-tablet/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-mobile-and-desktop-but-not-tablet/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-mobile-and-desktop-but-not-tablet/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen and (width &lt;= 480px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen and (782px &lt; width)">

--- a/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-mobile-and-desktop-but-not-tablet/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-with-poster-lcp-element-on-mobile-and-desktop-but-not-tablet/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen and (width &lt;= 480px)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/poster.jpg" media="screen and (782px &lt; width)">
 <link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/tablet-header.jpg" media="screen and (480px &lt; width &lt;= 782px)">

--- a/plugins/image-prioritizer/tests/test-cases/video-without-poster-lcp-element-on-desktop-only/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-without-poster-lcp-element-on-desktop-only/buffer.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/image-prioritizer/tests/test-cases/video-without-poster-lcp-element-on-desktop-only/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-without-poster-lcp-element-on-desktop-only/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-header.jpg" media="screen and (width &lt;= 782px)">
 </head>

--- a/plugins/image-prioritizer/tests/test-cases/video-without-poster-lcp-element-on-desktop-only/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/video-without-poster-lcp-element-on-desktop-only/expected.html
@@ -2,6 +2,8 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta name="generator" content="image-prioritizer 0.0.0">
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/mobile-header.jpg" media="screen and (width &lt;= 782px)">
 </head>
 	<body>

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -340,7 +340,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 					$status = 'populated';
 				}
 
-				$viewport_group_status[] = sprintf( '%s: %s', $min_width, $status );
+				$viewport_group_status[] = sprintf( '%s:%s', $min_width, $status );
 			}
 			$content .= '; url_metric_groups={' . implode( ', ', $viewport_group_status ) . '}';
 			$processor->set_attribute( 'content', $content );

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -326,7 +326,7 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 			! $did_amend_meta_generator &&
 			'meta' === strtolower( $processor->get_tag() ) &&
 			'generator' === $processor->get_attribute( 'name' ) &&
-			str_starts_with( (string) $processor->get_attribute( 'content' ), 'optimization-detective' )
+			str_starts_with( (string) $processor->get_attribute( 'content' ), 'optimization-detective ' )
 		) {
 			$content               = (string) $processor->get_attribute( 'content' );
 			$viewport_group_status = array();

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -308,8 +308,8 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 	$visitors             = iterator_to_array( $tag_visitor_registry );
 
 	// Whether we need to add the data-od-xpath attribute to elements and whether the detection script should be injected.
-	$needs_detection = ! $group_collection->is_every_group_complete();
-
+	$needs_detection          = ! $group_collection->is_every_group_complete();
+	$did_amend_meta_generator = false;
 	do {
 		// Never process anything inside NOSCRIPT since it will never show up in the DOM when scripting is enabled, and thus it can never be detected nor measured.
 		// Similarly, elements in the Admin Bar are not relevant for optimization, so this loop ensures that no tags in the Admin Bar are visited.
@@ -319,6 +319,32 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 			$processor->is_admin_bar()
 		) {
 			continue;
+		}
+
+		// Amend the META generator tag if it's the right one and hasn't been amended already.
+		if (
+			! $did_amend_meta_generator &&
+			'meta' === strtolower( $processor->get_tag() ) &&
+			'generator' === $processor->get_attribute( 'name' ) &&
+			str_starts_with( (string) $processor->get_attribute( 'content' ), 'optimization-detective' )
+		) {
+			$content               = (string) $processor->get_attribute( 'content' );
+			$viewport_group_status = array();
+			foreach ( $group_collection as $group ) {
+				$min_width = $group->get_minimum_viewport_width();
+
+				$status = 'empty';
+				if ( $group->is_complete() ) {
+					$status = 'complete';
+				} elseif ( $group->count() > 0 ) {
+					$status = 'populated';
+				}
+
+				$viewport_group_status[] = sprintf( '%s: %s', $min_width, $status );
+			}
+			$content .= '; url_metric_groups={' . implode( ', ', $viewport_group_status ) . '}';
+			$processor->set_attribute( 'content', $content );
+			$did_amend_meta_generator = true;
 		}
 
 		$tracked_in_url_metrics = false;

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -323,8 +323,8 @@ function od_optimize_template_output_buffer( string $buffer ): string {
 
 		// Amend the META generator tag if it's the right one and hasn't been amended already.
 		if (
-			! $did_amend_meta_generator &&
-			'meta' === strtolower( $processor->get_tag() ) &&
+			! $did_amend_meta_generator && // @phpstan-ignore booleanNot.alwaysTrue, booleanAnd.alwaysFalse, booleanAnd.alwaysFalse, booleanAnd.alwaysFalse (False positives in PHPStan due to the following line.)
+			'META' === $processor->get_tag() && // @phpstan-ignore identical.alwaysFalse (False positive in PHPStan since it isn't aware of the do/while loop apparently.)
 			'generator' === $processor->get_attribute( 'name' ) &&
 			str_starts_with( (string) $processor->get_attribute( 'content' ), 'optimization-detective ' )
 		) {

--- a/plugins/optimization-detective/tests/test-cases/admin-bar/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/admin-bar/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
 	</head>
 	<body>
 		<div id="wpadminbar" class="nojq nojs">

--- a/plugins/optimization-detective/tests/test-cases/admin-bar/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/admin-bar/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/admin-bar/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/admin-bar/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/complete-url-metrics/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/complete-url-metrics/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/complete-url-metrics/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/complete-url-metrics/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/complete-url-metrics/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/complete-url-metrics/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: complete, 480: complete, 600: complete, 782: complete}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/many-images/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/many-images/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/many-images/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/many-images/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/many-images/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/many-images/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/no-url-metrics/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/no-url-metrics/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0; rest_api_unavailable">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/no-url-metrics/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/no-url-metrics/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0; rest_api_unavailable" name="generator" content="optimization-detective 0.0.0; rest_api_unavailable; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0; rest_api_unavailable" name="generator" content="optimization-detective 0.0.0; rest_api_unavailable; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/no-url-metrics/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/no-url-metrics/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0; rest_api_unavailable" name="generator" content="optimization-detective 0.0.0; rest_api_unavailable; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/noscript/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/noscript/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/noscript/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/noscript/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/noscript/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/noscript/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/preload-link/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/preload-link/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/preload-link/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/preload-link/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
 	<link data-od-added-tag rel="preload" as="image" href="https://example.com/image.jpg">
 <link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>

--- a/plugins/optimization-detective/tests/test-cases/preload-link/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/preload-link/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 	<link data-od-added-tag rel="preload" as="image" href="https://example.com/image.jpg">
 <link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>

--- a/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/tag-track-opt-in/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/video/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/video/buffer.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/video/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/video/expected.html
@@ -2,7 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/video/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/video/expected.html
@@ -2,6 +2,7 @@
 	<head>
 		<meta charset="utf-8">
 		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: populated, 480: populated, 600: populated, 782: populated}">
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/xhtml-response/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/xhtml-response/buffer.html
@@ -2,8 +2,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 	<head>
-	  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
-	  <title>XHTML 1.0 Strict Example</title>
+		<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
+		<title>XHTML 1.0 Strict Example</title>
+		<meta name="generator" content="optimization-detective 0.0.0" />
 	</head>
 	<body>
 		<div id="page">

--- a/plugins/optimization-detective/tests/test-cases/xhtml-response/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/xhtml-response/expected.html
@@ -2,8 +2,9 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 	<head>
-	  <meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
-	  <title>XHTML 1.0 Strict Example</title>
+		<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
+		<title>XHTML 1.0 Strict Example</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}" />
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>

--- a/plugins/optimization-detective/tests/test-cases/xhtml-response/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/xhtml-response/expected.html
@@ -4,7 +4,7 @@
 	<head>
 		<meta http-equiv="Content-Type" content="application/xhtml+xml; charset=utf-8" />
 		<title>XHTML 1.0 Strict Example</title>
-		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0: empty, 480: empty, 600: empty, 782: empty}" />
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:empty, 480:empty, 600:empty, 782:empty}" />
 	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
 </head>
 	<body>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1953

## Relevant technical choices

- Updated the function `od_optimize_template_output_buffer` to include the URL metric groups data in the generator's META tag.
- This adds additional information about each breakpoint's minimum viewport width and the corresponding URL metrics status for that viewport group.
- The generator's META tag is updated from:

  ```html
  <meta name="generator" content="optimization-detective 1.0.0;" />
  ```

  to:

  ```html
  <meta name="generator" content="optimization-detective 1.0.0; url_metric_groups={0:complete, 480:empty, 600:populated, 782:complete}" />
  ```

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
