### PR TITLE
Allow background image URLs for file types the web server doesn't know about, e.g. when AVIF is sent as `application/octet-stream`

### DIFF
--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -235,6 +235,15 @@ function image_prioritizer_validate_background_image_url( string $url ) {
 	// Validate that the Content-Type is an image.
 	$content_type = (array) wp_remote_retrieve_header( $r, 'content-type' );
 	if ( ! is_string( $content_type[0] ) || ! str_starts_with( $content_type[0], 'image/' ) ) {
+		// This is a special case for images that are not served with the correct Content-Type.
+		if ( is_string( $content_type[0] ) && 'application/octet-stream' === $content_type[0] ) {
+			$file_extension              = pathinfo( (string) wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
+			$valid_image_file_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'heic', 'heif', 'svg' );
+			if ( '' !== $file_extension && in_array( strtolower( $file_extension ), $valid_image_file_extensions, true ) ) {
+				return true;
+			}
+		}
+
 		return new WP_Error(
 			'background_image_response_not_image',
 			sprintf(

--- a/plugins/image-prioritizer/helper.php
+++ b/plugins/image-prioritizer/helper.php
@@ -234,16 +234,15 @@ function image_prioritizer_validate_background_image_url( string $url ) {
 
 	// Validate that the Content-Type is an image.
 	$content_type = (array) wp_remote_retrieve_header( $r, 'content-type' );
-	if ( ! is_string( $content_type[0] ) || ! str_starts_with( $content_type[0], 'image/' ) ) {
+	if ( 'application/octet-stream' === $content_type[0] ) {
 		// This is a special case for images that are not served with the correct Content-Type.
-		if ( is_string( $content_type[0] ) && 'application/octet-stream' === $content_type[0] ) {
-			$file_extension              = pathinfo( (string) wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
-			$valid_image_file_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'heic', 'heif', 'svg' );
-			if ( '' !== $file_extension && in_array( strtolower( $file_extension ), $valid_image_file_extensions, true ) ) {
-				return true;
-			}
-		}
-
+		$file_extension              = pathinfo( (string) wp_parse_url( $url, PHP_URL_PATH ), PATHINFO_EXTENSION );
+		$valid_image_file_extensions = array( 'jpg', 'jpeg', 'png', 'gif', 'webp', 'avif', 'heic', 'heif', 'svg' );
+		$is_valid_content_type       = in_array( strtolower( $file_extension ), $valid_image_file_extensions, true );
+	} else {
+		$is_valid_content_type = is_string( $content_type[0] ) && str_starts_with( $content_type[0], 'image/' );
+	}
+	if ( ! $is_valid_content_type ) {
 		return new WP_Error(
 			'background_image_response_not_image',
 			sprintf(

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -449,20 +449,20 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 	 */
 	public function data_provider_to_test_image_prioritizer_validate_background_image_url(): array {
 		return array(
-			'bad_url_parse_error'         => array(
+			'bad_url_parse_error'                    => array(
 				'set_up'       => static function (): string {
 					return 'https:///www.example.com';
 				},
 				'expect_error' => 'background_image_url_lacks_host',
 			),
-			'bad_url_no_host'             => array(
+			'bad_url_no_host'                        => array(
 				'set_up'       => static function (): string {
 					return '/foo/bar?baz=1';
 				},
 				'expect_error' => 'background_image_url_lacks_host',
 			),
 
-			'bad_url_disallowed_origin'   => array(
+			'bad_url_disallowed_origin'              => array(
 				'set_up'       => static function (): string {
 					return 'https://bad.example.com/foo.jpg';
 				},
@@ -508,7 +508,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 				'expect_error' => null,
 			),
 
-			'good_url_allowed_cdn_origin' => array(
+			'good_url_allowed_cdn_origin'            => array(
 				'set_up'       => function (): string {
 					$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/car.jpeg' );
 					$this->assertIsInt( $attachment_id );
@@ -552,7 +552,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 				'expect_error' => null,
 			),
 
-			'bad_not_found'               => array(
+			'bad_not_found'                          => array(
 				'set_up'       => static function (): string {
 					$image_url = home_url( '/bad.jpg' );
 
@@ -583,7 +583,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 				'expect_error' => 'background_image_response_not_ok',
 			),
 
-			'bad_content_type'            => array(
+			'bad_content_type'                       => array(
 				'set_up'       => static function (): string {
 					$video_url = home_url( '/bad.mp4' );
 
@@ -614,7 +614,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 				'expect_error' => 'background_image_response_not_image',
 			),
 
-			'bad_content_length'          => array(
+			'bad_content_length'                     => array(
 				'set_up'       => static function (): string {
 					$image_url = home_url( '/massive-image.jpg' );
 
@@ -645,7 +645,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 				'expect_error' => 'background_image_content_length_too_large',
 			),
 
-			'bad_redirect'                => array(
+			'bad_redirect'                           => array(
 				'set_up'       => static function (): string {
 					$redirect_url = home_url( '/redirect.jpg' );
 
@@ -666,7 +666,7 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 				'expect_error' => 'http_request_failed',
 			),
 
-			'good_same_origin'            => array(
+			'good_same_origin'                       => array(
 				'set_up'       => static function (): string {
 					$image_url = home_url( '/good.jpg' );
 
@@ -695,6 +695,68 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 					return $image_url;
 				},
 				'expect_error' => null,
+			),
+
+			'good_image_with_octet_stream_mime_type' => array(
+				'set_up'       => static function (): string {
+					$image_url = home_url( '/test-image.avif' );
+
+					add_filter(
+						'pre_http_request',
+						static function ( $pre, $parsed_args, $url ) use ( $image_url ) {
+							if ( 'HEAD' !== $parsed_args['method'] || $image_url !== $url ) {
+								return $pre;
+							}
+							return array(
+								'headers'  => array(
+									'content-type'   => 'application/octet-stream',
+									'content-length' => '288449',
+								),
+								'body'     => '',
+								'response' => array(
+									'code'    => 200,
+									'message' => 'OK',
+								),
+							);
+						},
+						10,
+						3
+					);
+
+					return $image_url;
+				},
+				'expect_error' => null,
+			),
+
+			'bad_file_with_octet_stream_mime_type'   => array(
+				'set_up'       => static function (): string {
+					$image_url = home_url( '/test-document.pdf' );
+
+					add_filter(
+						'pre_http_request',
+						static function ( $pre, $parsed_args, $url ) use ( $image_url ) {
+							if ( 'HEAD' !== $parsed_args['method'] || $image_url !== $url ) {
+								return $pre;
+							}
+							return array(
+								'headers'  => array(
+									'content-type'   => 'application/octet-stream',
+									'content-length' => '288449',
+								),
+								'body'     => '',
+								'response' => array(
+									'code'    => 200,
+									'message' => 'OK',
+								),
+							);
+						},
+						10,
+						3
+					);
+
+					return $image_url;
+				},
+				'expect_error' => 'background_image_response_not_image',
 			),
 		);
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1952 

## Relevant technical choices

<!-- Please describe your changes. -->

This PR addresses an issue where the Image Prioritizer plugin fails to validate background image URLs when the server returns a Content-Type of `application/octet-stream` instead of an expected `image/*` Content-Type.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
