### PR TITLE
Ensure URL Metric is initially constructed with all elements prior to initializing extensions

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -789,17 +789,58 @@ export default async function detect( {
 		elements: [],
 	};
 
+	const lcpMetric = lcpMetricCandidates.at( -1 );
+
+	// Populate the elements in the URL Metric.
+	for ( const elementIntersection of elementIntersections ) {
+		const xpath = breadcrumbedElementsMap.get( elementIntersection.target );
+		if ( ! xpath ) {
+			warn( 'Unable to look up XPath for element' );
+			continue;
+		}
+
+		const element = /** @type {Element|null} */ (
+			lcpMetric?.entries[ 0 ]?.element
+		);
+		const isLCP = elementIntersection.target === element;
+
+		/** @type {ElementData} */
+		const elementData = {
+			isLCP,
+			isLCPCandidate: !! lcpMetricCandidates.find(
+				( lcpMetricCandidate ) => {
+					const candidateElement = /** @type {Element|null} */ (
+						lcpMetricCandidate.entries[ 0 ]?.element
+					);
+					return candidateElement === elementIntersection.target;
+				}
+			),
+			xpath,
+			intersectionRatio: elementIntersection.intersectionRatio,
+			intersectionRect: elementIntersection.intersectionRect,
+			boundingClientRect: elementIntersection.boundingClientRect,
+		};
+
+		urlMetric.elements.push( elementData );
+		elementsByXPath.set( elementData.xpath, elementData );
+	}
+	breadcrumbedElementsMap.clear(); // No longer needed.
+
+	/**
+	 * Initialize extensions.
+	 */
+
 	/** @type {Map<string, Extension>} */
 	const extensions = new Map();
+
+	/** @type {boolean} */
+	let extensionHasFinalize = false;
 
 	/** @type {Promise[]} */
 	const extensionInitializePromises = [];
 
 	/** @type {string[]} */
 	const initializingExtensionModuleUrls = [];
-
-	/** @type {boolean} */
-	let extensionHasFinalize = false;
 
 	for ( const extensionModuleUrl of extensionModuleUrls ) {
 		try {
@@ -851,13 +892,6 @@ export default async function detect( {
 		}
 	}
 
-	if ( compressionEnabled && extensionHasFinalize ) {
-		compressionEnabled = false;
-		warn(
-			'URL Metric compression is disabled because one or more extensions use the deprecated finalize function.'
-		);
-	}
-
 	// Wait for all extensions to finish initializing.
 	const settledInitializePromises = await Promise.allSettled(
 		extensionInitializePromises
@@ -874,44 +908,12 @@ export default async function detect( {
 		}
 	}
 
-	const lcpMetric = lcpMetricCandidates.at( -1 );
-
-	for ( const elementIntersection of elementIntersections ) {
-		const xpath = breadcrumbedElementsMap.get( elementIntersection.target );
-		if ( ! xpath ) {
-			warn( 'Unable to look up XPath for element' );
-			continue;
-		}
-
-		const element = /** @type {Element|null} */ (
-			lcpMetric?.entries[ 0 ]?.element
+	if ( compressionEnabled && extensionHasFinalize ) {
+		compressionEnabled = false;
+		warn(
+			'URL Metric compression is disabled because one or more extensions use the deprecated finalize function.'
 		);
-		const isLCP = elementIntersection.target === element;
-
-		/** @type {ElementData} */
-		const elementData = {
-			isLCP,
-			isLCPCandidate: !! lcpMetricCandidates.find(
-				( lcpMetricCandidate ) => {
-					const candidateElement = /** @type {Element|null} */ (
-						lcpMetricCandidate.entries[ 0 ]?.element
-					);
-					return candidateElement === elementIntersection.target;
-				}
-			),
-			xpath,
-			intersectionRatio: elementIntersection.intersectionRatio,
-			intersectionRect: elementIntersection.intersectionRect,
-			boundingClientRect: elementIntersection.boundingClientRect,
-		};
-
-		urlMetric.elements.push( elementData );
-		elementsByXPath.set( elementData.xpath, elementData );
 	}
-	breadcrumbedElementsMap.clear();
-
-	// Clean up.
-	breadcrumbedElementsMap.clear();
 
 	log( 'Current URL Metric:', urlMetric );
 


### PR DESCRIPTION
## Summary

This is a follow-up to #1951.

When testing the plugin I noticed an error in the console:

```
Optimization Detective] Failed to initialize extension 'http://localhost:8888/wp-content/plugins/od-intrinsic-dimensions/detect.js?ver=0.2.0': Error: Unknown element with XPath: /HTML/BODY/DIV[@class='wp-site-blocks']/*[2][self::MAIN]/*[1][self::DIV]/*[3][self::DIV]/*[1][self::FIGURE]/*[1][self::VIDEO]
    at extendElementData (detect.js?ver=1.0.0-beta4:403:9)
    at captureIntrinsicDimensions (detect.js?ver=0.2.0:34:3)
    at Module.initialize (detect.js?ver=0.2.0:72:4)
    at detect (detect.js?ver=1.0.0-beta4:821:41)
```

The error coming from the Intrinsic Dimensions extension started occurring after https://github.com/westonruter/od-intrinsic-dimensions/pull/4 where I updated it to use `initialize` instead of `finalize` since it was deprecated in https://github.com/WordPress/performance/pull/1951 in order to facilitate gzip compression in https://github.com/WordPress/performance/pull/1959. However, I realized that the location where extensions are initialized means that they cannot call `extendElementData()` because the URL Metric object has not been populated yet with its `elements`. This causes calls to `extendElementData()` to always fail if they are performed while the `initialize()` function is being called (and not after a delay, for example).

The fix is simply to move the extension initialization logic after the URL Metric data has been initially constructed with all of the tags (`elements`) being tracked.
