### PR TITLE
Add workflow to update WordPress `Tested up to` version on .org

### DIFF
--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -20,14 +20,15 @@ jobs:
 
       - name: Configure plugin matrix
         id: set-matrix
+        env:
+          PLUGIN_SLUG: ${{ inputs.plugin }}
         run: |
           PLUGINS=$(jq -r '.plugins' plugins.json)
-          if [[ -n "${{ inputs.plugin }}" ]]; then
-            SLUG="${{ inputs.plugin }}"
-            if echo $PLUGINS | jq -e '.[] | select(. == "'$SLUG'")' > /dev/null; then
-              PLUGINS="[ \"$SLUG\" ]"
+          if [[ -n "$PLUGIN_SLUG" ]]; then
+            if echo $PLUGINS | jq -e '.[] | select(. == "'$PLUGIN_SLUG'")' > /dev/null; then
+              PLUGINS="[ \"$PLUGIN_SLUG\" ]"
             else
-              echo "::error::Plugin '$SLUG' not found in plugins.json"
+              echo "::error::Plugin '$PLUGIN_SLUG' not found in plugins.json"
               exit 1
             fi
           fi
@@ -79,14 +80,17 @@ jobs:
 
       - name: Prepare and update readme.txt
         if: steps.version-compare.outputs.needs_update == 'true'
+        env:
+          PLUGIN_SLUG: ${{ matrix.plugin }}
+          REPO_VERSION: ${{ steps.version-compare.outputs.repo_version }}
         run: |
           # Replace local readme.txt with WordPress.org version, updating only compatibility.
-          cp /tmp/wp-org-readme.txt ./plugins/${{ matrix.plugin }}/readme.txt
-          sed -i -E 's/^(Tested up to:[[:space:]]*).+/\1${{ steps.version-compare.outputs.repo_version }}/' ./plugins/${{ matrix.plugin }}/readme.txt
+          cp /tmp/wp-org-readme.txt "./plugins/$PLUGIN_SLUG/readme.txt"
+          sed -i -E 's/^(Tested up to:[[:space:]]*).+/\1'"$REPO_VERSION"'/' "./plugins/$PLUGIN_SLUG/readme.txt"
 
           # Show the diff of what's being updated.
           echo "Changes made to readme.txt:"
-          diff -u /tmp/wp-org-readme.txt ./plugins/${{ matrix.plugin }}/readme.txt || true
+          diff -u /tmp/wp-org-readme.txt "./plugins/$PLUGIN_SLUG/readme.txt" || true
 
       - name: Push to WordPress.org
         if: steps.version-compare.outputs.needs_update == 'true'

--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -46,45 +46,36 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Compare versions
-        id: version-compare
-        run: |
-          # Get WordPress.org version.
-          curl -sSL --retry 3 --retry-delay 5 --retry-all-errors --fail -o /tmp/wp-org-readme.txt "https://plugins.svn.wordpress.org/${{ matrix.plugin }}/trunk/readme.txt"
-          if [ $? -ne 0 ]; then
-            echo "::error::Could not fetch readme.txt from WordPress.org for ${{ matrix.plugin }}"
-            exit 1
-          fi
-
-          WP_ORG_VERSION=$(grep -E "^Tested up to:" /tmp/wp-org-readme.txt | awk -F ': +' '{print $2}')
-          REPO_VERSION=$(grep -E "^Tested up to:" ./plugins/${{ matrix.plugin }}/readme.txt | awk -F ': +' '{print $2}')
-
-          if [ -z "$WP_ORG_VERSION" ]; then
-            echo "Unable to parse WP_ORG_VERSION"
-            exit 1
-          fi
-          if [ -z "$REPO_VERSION" ]; then
-            echo "Unable to parse REPO_VERSION"
-            exit 1
-          fi
-          echo "wp_org_version=$WP_ORG_VERSION" >> $GITHUB_OUTPUT
-          echo "repo_version=$REPO_VERSION" >> $GITHUB_OUTPUT
-
-          if [ "$WP_ORG_VERSION" = "$REPO_VERSION" ]; then
-            echo "Versions match ($WP_ORG_VERSION). No update needed."
-            echo "needs_update=false" >> $GITHUB_OUTPUT
-          else
-            echo "Version mismatch: WordPress.org=$WP_ORG_VERSION, Repo=$REPO_VERSION"
-            echo "needs_update=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Prepare and update readme.txt
-        if: steps.version-compare.outputs.needs_update == 'true'
+      - name: Download WordPress.org readme
         env:
           PLUGIN_SLUG: ${{ matrix.plugin }}
-          REPO_VERSION: ${{ steps.version-compare.outputs.repo_version }}
         run: |
-          # Replace local readme.txt with WordPress.org version, updating only compatibility.
+          # Download the current readme.txt from WordPress.org
+          curl -sSL --retry 3 --retry-delay 5 --retry-all-errors --fail -o /tmp/wp-org-readme.txt "https://plugins.svn.wordpress.org/$PLUGIN_SLUG/trunk/readme.txt"
+          if [ $? -ne 0 ]; then
+            echo "::error::Could not fetch readme.txt from WordPress.org for $PLUGIN_SLUG"
+            exit 1
+          fi
+
+      - name: Extract repository version
+        env:
+          PLUGIN_SLUG: ${{ matrix.plugin }}
+        id: repo-version
+        run: |
+          REPO_VERSION=$(grep -E "^Tested up to:" "./plugins/$PLUGIN_SLUG/readme.txt" | awk -F ': +' '{print $2}')
+          if [ -z "$REPO_VERSION" ]; then
+            echo "::error::Unable to parse Tested up to version from repository readme.txt"
+            exit 1
+          fi
+
+          echo "repo_version=$REPO_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Prepare and update readme.txt
+        env:
+          PLUGIN_SLUG: ${{ matrix.plugin }}
+          REPO_VERSION: ${{ steps.repo-version.outputs.repo_version }}
+        run: |
+          # Replace local readme.txt with WordPress.org version, updating only the "Tested up to" line.
           cp /tmp/wp-org-readme.txt "./plugins/$PLUGIN_SLUG/readme.txt"
           sed -i -E 's/^(Tested up to:[[:space:]]*).+/\1'"$REPO_VERSION"'/' "./plugins/$PLUGIN_SLUG/readme.txt"
 
@@ -93,7 +84,6 @@ jobs:
           diff -u /tmp/wp-org-readme.txt "./plugins/$PLUGIN_SLUG/readme.txt" || true
 
       - name: Push to WordPress.org
-        if: steps.version-compare.outputs.needs_update == 'true'
         uses: 10up/action-wordpress-plugin-asset-update@stable
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -57,27 +57,27 @@ jobs:
             exit 1
           fi
 
-      - name: Extract repository version
+      - name: Extract "Tested up to" version from repository
         env:
           PLUGIN_SLUG: ${{ matrix.plugin }}
-        id: repo-version
+        id: extract-tested-up-to
         run: |
-          REPO_VERSION=$(grep -E "^Tested up to:" "./plugins/$PLUGIN_SLUG/readme.txt" | awk -F ': +' '{print $2}')
-          if [ -z "$REPO_VERSION" ]; then
+          LOCAL_TESTED_UP_TO=$(grep -E "^Tested up to:" "./plugins/$PLUGIN_SLUG/readme.txt" | awk -F ': +' '{print $2}')
+          if [ -z "$LOCAL_TESTED_UP_TO" ]; then
             echo "::error::Unable to parse Tested up to version from repository readme.txt"
             exit 1
           fi
 
-          echo "repo_version=$REPO_VERSION" >> $GITHUB_OUTPUT
+          echo "version=$LOCAL_TESTED_UP_TO" >> $GITHUB_OUTPUT
 
       - name: Prepare and update readme.txt
         env:
           PLUGIN_SLUG: ${{ matrix.plugin }}
-          REPO_VERSION: ${{ steps.repo-version.outputs.repo_version }}
+          LOCAL_TESTED_UP_TO: ${{ steps.extract-tested-up-to.outputs.version }}
         run: |
           # Replace local readme.txt with WordPress.org version, updating only the "Tested up to" line.
           cp /tmp/wp-org-readme.txt "./plugins/$PLUGIN_SLUG/readme.txt"
-          sed -i -E 's/^(Tested up to:[[:space:]]*).+/\1'"$REPO_VERSION"'/' "./plugins/$PLUGIN_SLUG/readme.txt"
+          sed -i -E 's/^(Tested up to:[[:space:]]*).+/\1'"$LOCAL_TESTED_UP_TO"'/' "./plugins/$PLUGIN_SLUG/readme.txt"
 
           # Show the diff of what's being updated.
           echo "Changes made to readme.txt:"

--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -39,6 +39,8 @@ jobs:
     name: Update "Tested up to" value for ${{ matrix.plugin }}
     needs: prepare-matrix
     runs-on: ubuntu-latest
+    env:
+      PLUGIN_SLUG: ${{ matrix.plugin }}
     strategy:
       matrix:
         plugin: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
@@ -47,8 +49,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download WordPress.org readme
-        env:
-          PLUGIN_SLUG: ${{ matrix.plugin }}
         run: |
           # Download the current readme.txt from WordPress.org
           curl -sSL --retry 3 --retry-delay 5 --retry-all-errors --fail -o /tmp/wp-org-readme.txt "https://plugins.svn.wordpress.org/$PLUGIN_SLUG/trunk/readme.txt"
@@ -58,8 +58,6 @@ jobs:
           fi
 
       - name: Extract "Tested up to" version from repository
-        env:
-          PLUGIN_SLUG: ${{ matrix.plugin }}
         id: extract-tested-up-to
         run: |
           LOCAL_TESTED_UP_TO=$(grep -E "^Tested up to:" "./plugins/$PLUGIN_SLUG/readme.txt" | awk -F ': +' '{print $2}')
@@ -72,7 +70,6 @@ jobs:
 
       - name: Prepare and update readme.txt
         env:
-          PLUGIN_SLUG: ${{ matrix.plugin }}
           LOCAL_TESTED_UP_TO: ${{ steps.extract-tested-up-to.outputs.version }}
         run: |
           # Replace local readme.txt with WordPress.org version, updating only the "Tested up to" line.

--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -1,4 +1,4 @@
-name: Bump WordPress Compatibility Version
+name: Bump WordPress Tested up to
 
 on:
   workflow_dispatch:

--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -35,7 +35,7 @@ jobs:
           echo "plugins=$(echo $PLUGINS | jq -c .)" >> $GITHUB_OUTPUT
 
   update-compatibility:
-    name: Update ${{ matrix.plugin }} compatibility
+    name: Update "Tested up to" value for ${{ matrix.plugin }}
     needs: prepare-matrix
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/update-wp-compatibility.yml
+++ b/.github/workflows/update-wp-compatibility.yml
@@ -58,11 +58,11 @@ jobs:
           WP_ORG_VERSION=$(grep -E "^Tested up to:" /tmp/wp-org-readme.txt | awk -F ': +' '{print $2}')
           REPO_VERSION=$(grep -E "^Tested up to:" ./plugins/${{ matrix.plugin }}/readme.txt | awk -F ': +' '{print $2}')
 
-          if [ -n "$WP_ORG_VERSION" ]; then
+          if [ -z "$WP_ORG_VERSION" ]; then
             echo "Unable to parse WP_ORG_VERSION"
             exit 1
           fi
-          if [ -n "$REPO_VERSION" ]; then
+          if [ -z "$REPO_VERSION" ]; then
             echo "Unable to parse REPO_VERSION"
             exit 1
           fi

--- a/.github/workflows/update-wp-compatibility.yml
+++ b/.github/workflows/update-wp-compatibility.yml
@@ -1,0 +1,91 @@
+name: Bump WordPress Compatibility Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      plugin:
+        type: string
+        description: 'Plugin slug (leave empty for all plugins)'
+        required: false
+
+jobs:
+  prepare-matrix:
+    name: Prepare plugins matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.plugins }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure plugin matrix
+        id: set-matrix
+        run: |
+          PLUGINS=$(jq -r '.plugins' plugins.json)
+          if [[ -n "${{ inputs.plugin }}" ]]; then
+            SLUG="${{ inputs.plugin }}"
+            if echo $PLUGINS | jq -e '.[] | select(. == "'$SLUG'")' > /dev/null; then
+              PLUGINS="[ \"$SLUG\" ]"
+            else
+              echo "::error::Plugin '$SLUG' not found in plugins.json"
+              exit 1
+            fi
+          fi
+          echo "::notice::Updating plugins: $(echo ${PLUGINS[@]})"
+          echo "plugins=$(echo $PLUGINS | jq -c .)" >> $GITHUB_OUTPUT
+
+  update-compatibility:
+    name: Update ${{ matrix.plugin }} compatibility
+    needs: prepare-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        plugin: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compare versions
+        id: version-compare
+        run: |
+          # Get WordPress.org version.
+          curl -sSL --retry 3 --retry-delay 5 --retry-all-errors --fail -o /tmp/wp-org-readme.txt "https://plugins.svn.wordpress.org/${{ matrix.plugin }}/trunk/readme.txt"
+          if [ $? -ne 0 ]; then
+            echo "::error::Could not fetch readme.txt from WordPress.org for ${{ matrix.plugin }}"
+            exit 1
+          fi
+
+          WP_ORG_VERSION=$(grep -E "^Tested up to:" /tmp/wp-org-readme.txt | sed -E 's/Tested up to:[[:space:]]*([0-9.]+)/\1/')
+          REPO_VERSION=$(grep -E "^Tested up to:" ./plugins/${{ matrix.plugin }}/readme.txt | sed -E 's/Tested up to:[[:space:]]*([0-9.]+)/\1/')
+
+          echo "wp_org_version=$WP_ORG_VERSION" >> $GITHUB_OUTPUT
+          echo "repo_version=$REPO_VERSION" >> $GITHUB_OUTPUT
+
+          if [ "$WP_ORG_VERSION" = "$REPO_VERSION" ]; then
+            echo "Versions match ($WP_ORG_VERSION). No update needed."
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version mismatch: WordPress.org=$WP_ORG_VERSION, Repo=$REPO_VERSION"
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Prepare and update readme.txt
+        if: steps.version-compare.outputs.needs_update == 'true'
+        run: |
+          # Replace local readme.txt with WordPress.org version, updating only compatibility.
+          cp /tmp/wp-org-readme.txt ./plugins/${{ matrix.plugin }}/readme.txt
+          sed -i -E 's/^(Tested up to:)[[:space:]]*[0-9.]+/\1 ${{ steps.version-compare.outputs.repo_version }}/' ./plugins/${{ matrix.plugin }}/readme.txt
+
+          # Show the diff of what's being updated.
+          echo "Changes made to readme.txt:"
+          diff -u /tmp/wp-org-readme.txt ./plugins/${{ matrix.plugin }}/readme.txt || true
+
+      - name: Push to WordPress.org
+        if: steps.version-compare.outputs.needs_update == 'true'
+        uses: 10up/action-wordpress-plugin-asset-update@stable
+        env:
+          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+          SLUG: ${{ matrix.plugin }}
+          SKIP_ASSETS: true
+          IGNORE_OTHER_FILES: true

--- a/.github/workflows/update-wp-compatibility.yml
+++ b/.github/workflows/update-wp-compatibility.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           # Replace local readme.txt with WordPress.org version, updating only compatibility.
           cp /tmp/wp-org-readme.txt ./plugins/${{ matrix.plugin }}/readme.txt
-          sed -i -E 's/^(Tested up to:)[[:space:]]*[0-9.]+/\1 ${{ steps.version-compare.outputs.repo_version }}/' ./plugins/${{ matrix.plugin }}/readme.txt
+          sed -i -E 's/^(Tested up to:[[:space:]]*).+/\1${{ steps.version-compare.outputs.repo_version }}/' ./plugins/${{ matrix.plugin }}/readme.txt
 
           # Show the diff of what's being updated.
           echo "Changes made to readme.txt:"

--- a/.github/workflows/update-wp-compatibility.yml
+++ b/.github/workflows/update-wp-compatibility.yml
@@ -55,9 +55,17 @@ jobs:
             exit 1
           fi
 
-          WP_ORG_VERSION=$(grep -E "^Tested up to:" /tmp/wp-org-readme.txt | sed -E 's/Tested up to:[[:space:]]*([0-9.]+)/\1/')
-          REPO_VERSION=$(grep -E "^Tested up to:" ./plugins/${{ matrix.plugin }}/readme.txt | sed -E 's/Tested up to:[[:space:]]*([0-9.]+)/\1/')
+          WP_ORG_VERSION=$(grep -E "^Tested up to:" /tmp/wp-org-readme.txt | awk -F ': +' '{print $2}')
+          REPO_VERSION=$(grep -E "^Tested up to:" ./plugins/${{ matrix.plugin }}/readme.txt | awk -F ': +' '{print $2}')
 
+          if [ -n "$WP_ORG_VERSION" ]; then
+            echo "Unable to parse WP_ORG_VERSION"
+            exit 1
+          fi
+          if [ -n "$REPO_VERSION" ]; then
+            echo "Unable to parse REPO_VERSION"
+            exit 1
+          fi
           echo "wp_org_version=$WP_ORG_VERSION" >> $GITHUB_OUTPUT
           echo "repo_version=$REPO_VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1960 

This PR introduces a new GitHub workflow to update the "Tested up to" WordPress version on WordPress.org without requiring a full plugin release. The workflow can be triggered manually for either a single plugin or all plugins.  

## Relevant technical choices

<!-- Please describe your changes. -->

- Updates the "Tested up to" version only if the repo version is higher than the WordPress.org version.  
- Downloads the latest `readme.txt` from WordPress.org and updates only the `Tested up to:` line, ensuring no other content is modified.  
- Uses the `action-wordpress-plugin-asset-update` GitHub action to handle the deployment process.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
