### PR TITLE
Bump WordPress Tested up to versions of all plugins to 6.8.

### DIFF
--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -1,7 +1,7 @@
 === Enhanced Responsive Images ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.4.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/dominant-color-images/readme.txt
+++ b/plugins/dominant-color-images/readme.txt
@@ -1,7 +1,7 @@
 === Image Placeholders ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -1,7 +1,7 @@
 === Embed Optimizer ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.0.0-beta2
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -1,7 +1,7 @@
 === Image Prioritizer ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.0.0-beta2
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -1,7 +1,7 @@
 === Optimization Detective ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.0.0-beta3
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -1,7 +1,7 @@
 === Performance Lab ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   3.9.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -1,7 +1,7 @@
 === Speculative Loading ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   1.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/web-worker-offloading/readme.txt
+++ b/plugins/web-worker-offloading/readme.txt
@@ -1,7 +1,7 @@
 === Web Worker Offloading ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   0.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -1,7 +1,7 @@
 === Modern Image Formats ===
 
 Contributors: wordpressdotorg
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag:   2.5.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary

See #1960

Once this is merged, we should deploy it using the new workflow from #1969. 🎉 