### PR TITLE
Add workaround for action-wordpress-plugin-asset-update requiring `readme.txt` at workspace root

### DIFF
--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -68,9 +68,6 @@ jobs:
 
           echo "version=$LOCAL_TESTED_UP_TO" >> $GITHUB_OUTPUT
 
-      - name: Copy readme.txt to workspace root for SVN upload
-        run: cp "./plugins/$PLUGIN_SLUG/readme.txt" "$GITHUB_WORKSPACE/readme.txt"
-
       - name: Prepare and update readme.txt
         env:
           LOCAL_TESTED_UP_TO: ${{ steps.extract-tested-up-to.outputs.version }}
@@ -82,6 +79,9 @@ jobs:
           # Show the diff of what's being updated.
           echo "Changes made to readme.txt:"
           diff -u /tmp/wp-org-readme.txt "./plugins/$PLUGIN_SLUG/readme.txt" || true
+
+      - name: Copy readme.txt to workspace root for SVN upload
+        run: cp "./plugins/$PLUGIN_SLUG/readme.txt" "$GITHUB_WORKSPACE/readme.txt"
 
       - name: Push to WordPress.org
         uses: 10up/action-wordpress-plugin-asset-update@stable

--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -68,6 +68,9 @@ jobs:
 
           echo "version=$LOCAL_TESTED_UP_TO" >> $GITHUB_OUTPUT
 
+      - name: Copy readme.txt to workspace root for SVN upload
+        run: cp "./plugins/$PLUGIN_SLUG/readme.txt" "$GITHUB_WORKSPACE/readme.txt"
+
       - name: Prepare and update readme.txt
         env:
           LOCAL_TESTED_UP_TO: ${{ steps.extract-tested-up-to.outputs.version }}
@@ -88,4 +91,3 @@ jobs:
           SLUG: ${{ matrix.plugin }}
           SKIP_ASSETS: true
           IGNORE_OTHER_FILES: true
-          README_NAME: ./plugins/${{ matrix.plugin }}/readme.txt


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
See #1960



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
