### PR TITLE
Simplify get_post() and perflab_sanitize_plugin_slug() by removing unnecessary else blocks

### DIFF
--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -108,9 +108,8 @@ class OD_URL_Metrics_Post_Type {
 		$post = current( $post_query->posts );
 		if ( $post instanceof WP_Post ) {
 			return $post;
-		} else {
-			return null;
 		}
+		return null;
 	}
 
 	/**

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -284,9 +284,8 @@ function perflab_enqueue_features_page_scripts(): void {
 function perflab_sanitize_plugin_slug( $unsanitized_plugin_slug ): ?string {
 	if ( in_array( $unsanitized_plugin_slug, perflab_get_standalone_plugins(), true ) ) {
 		return $unsanitized_plugin_slug;
-	} else {
-		return null;
 	}
+	return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

This update refactors the `get_post()` and `perflab_sanitize_plugin_slug()` functions to improve code clarity. The unnecessary `else` blocks have been removed, and both functions now return `null` directly when conditions are not met. This change enhances readability and aligns the code with WordPress coding standards.

## Relevant technical choices

<!-- Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->