### PR TITLE
Revert WP version to latest

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,5 +1,5 @@
 {
-  "core": "WordPress/WordPress#master",
+  "core": null,
   "plugins": [
     "./plugins/optimization-detective",
     "./plugins/auto-sizes",

--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Enhanced Responsive Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
  * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
- * Requires at least: 6.6
+ * Requires at least: 6.8
  * Requires PHP: 7.2
  * Version: 1.4.0
  * Author: WordPress Performance Team


### PR DESCRIPTION
## Summary

- Revert the `.wp-env.json` changes to latest WP version.
- Bump Requires at least to 6.8 for `auto-sizes` plugin

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
