### PR TITLE
Fix PHPUnit tests failing for dominant-color-images

### DIFF
--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
@@ -168,34 +168,4 @@ class Test_Dominant_Color_Image_Editor_Imagick extends TestCase {
 
 		$this->assertTrue( $result );
 	}
-
-	/**
-	 * @covers ::has_transparency
-	 */
-	public function test_has_transparency_no_alpha_channel_method(): void {
-		// Mock the Imagick object to simulate when getImageAlphaChannel method doesn't exist.
-		$imagick_mock = $this->getMockBuilder( Imagick::class )
-							->disableOriginalConstructor()
-							->getMock();
-
-		$imagick_mock->method( 'getImageWidth' )->willReturn( 1 );
-		$imagick_mock->method( 'getImageHeight' )->willReturn( 1 );
-
-		$pixel = $this->getMockBuilder( ImagickPixel::class )
-						->disableOriginalConstructor()
-						->getMock();
-		$pixel->method( 'getColor' )->willReturn( array( 'a' => 0 ) );
-
-		$imagick_mock->method( 'getImagePixelColor' )->willReturn( $pixel );
-
-		$editor     = new Dominant_Color_Image_Editor_Imagick( null );
-		$reflection = new ReflectionClass( $editor );
-		$property   = $reflection->getProperty( 'image' );
-		$property->setAccessible( true );
-		$property->setValue( $editor, $imagick_mock );
-
-		$result = $editor->has_transparency();
-
-		$this->assertFalse( $result );
-	}
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1987 

<!-- 
## Relevant technical choices

Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
