### PR TITLE
Improve wording in README.md for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Details about the Performance Lab plugin, including instructions for getting sta
 
 For WordPress and PHP version requirements, please see the [CONTRIBUTING.md file here](https://github.com/WordPress/performance/blob/trunk/CONTRIBUTING.md).
 
-The feature plugins which are currently featured by this plugin are:
+The plugins currently included in the Performance Lab plugin are:
 
 Plugin                          | Slug                      | Experimental | Links
 --------------------------------|---------------------------|--------------|-------------


### PR DESCRIPTION
## Summary

This PR improves the wording in the README.md file for better clarity and readability when listing the included plugins.

## Relevant technical choices

- Reworded the sentence "The feature plugins which are currently featured by this plugin are:" to "The plugins currently included in the Performance Lab plugin are:".
- This change improves clarity and removes redundancy.

## Testing Instructions

- View the README.md file.
- Confirm that the new wording is clear and correctly reflects the list of included plugins.
