### PR TITLE
Implement opt-in `PERFLAB_PLACE_OBJECT_CACHE_DROPIN` for  Server-Timing `object-cache.php` placement

### DIFF
--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -151,6 +151,7 @@ function perflab_get_standalone_plugin_version_constants(): array {
  *
  * @since 1.8.0
  * @since 2.1.0 No longer attempts to use two of the drop-ins together.
+ * @since n.e.x.t No longer places the drop-in on new sites by default, unless the `PERFLAB_PLACE_OBJECT_CACHE_DROPIN` constant is set to true.
  *
  * @global WP_Filesystem_Base $wp_filesystem WordPress filesystem subclass.
  */

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -145,8 +145,9 @@ function perflab_get_standalone_plugin_version_constants(): array {
  * the frontend.
  *
  * This function will short-circuit if at least one of the constants
- * 'PERFLAB_DISABLE_SERVER_TIMING' or 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is
- * set as true.
+ * 'PERFLAB_DISABLE_SERVER_TIMING' or
+ * 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' is set as true or if the
+ * 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN' constant is not set to a truthy value.
  *
  * @since 1.8.0
  * @since 2.1.0 No longer attempts to use two of the drop-ins together.
@@ -155,6 +156,11 @@ function perflab_get_standalone_plugin_version_constants(): array {
  */
 function perflab_maybe_set_object_cache_dropin(): void {
 	global $wp_filesystem;
+
+	// Bail if the drop-in is not enabled.
+	if ( ! defined( 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN' ) || ! PERFLAB_PLACE_OBJECT_CACHE_DROPIN ) {
+		return;
+	}
 
 	// Bail if Server-Timing is disabled entirely.
 	if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -157,17 +157,19 @@ function perflab_get_standalone_plugin_version_constants(): array {
 function perflab_maybe_set_object_cache_dropin(): void {
 	global $wp_filesystem;
 
-	// Bail if the drop-in is not enabled.
-	if ( ! defined( 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN' ) || ! PERFLAB_PLACE_OBJECT_CACHE_DROPIN ) {
-		return;
-	}
-
 	// Bail if Server-Timing is disabled entirely.
 	if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING ) {
 		return;
 	}
 
+	// Bail if the drop-in is not enabled.
+	if ( ! defined( 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN' ) || ! PERFLAB_PLACE_OBJECT_CACHE_DROPIN ) {
+		return;
+	}
+
 	// Bail if disabled via constant.
+	// This constant is maintained only for backward compatibility and should not be relied upon in new implementations.
+	// Use the 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN' constant instead to control drop-in placement.
 	if ( defined( 'PERFLAB_DISABLE_OBJECT_CACHE_DROPIN' ) && PERFLAB_DISABLE_OBJECT_CACHE_DROPIN ) {
 		return;
 	}

--- a/plugins/performance-lab/tests/test-load.php
+++ b/plugins/performance-lab/tests/test-load.php
@@ -13,6 +13,10 @@ class Test_Load extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
+		/*
+		 * This constant is not set by default in production.
+		 * However, it is needed for all tests that cover placement of the object cache drop-in.
+		 */
 		if ( ! defined( 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN' ) ) {
 			define( 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN', true );
 		}

--- a/plugins/performance-lab/tests/test-load.php
+++ b/plugins/performance-lab/tests/test-load.php
@@ -7,6 +7,17 @@
 
 class Test_Load extends WP_UnitTestCase {
 
+	/**
+	 * Runs the routine before each test is executed.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		if ( ! defined( 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN' ) ) {
+			define( 'PERFLAB_PLACE_OBJECT_CACHE_DROPIN', true );
+		}
+	}
+
 	public function test_perflab_get_generator_content(): void {
 		$expected = 'performance-lab ' . PERFLAB_VERSION . '; plugins: ';
 		$content  = perflab_get_generator_content();


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #1633 

## Relevant technical choices

<!-- Please describe your changes. -->
Introduce `PERFLAB_PLACE_OBJECT_CACHE_DROPIN` constant to opt-in to placing the Server-Timing `object-cache.php` drop-in.


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
