### PR TITLE
Add support for dynamic view transition names for global elements, and certain post elements to View Transitions plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,10 @@ const config = {
 		{
 			files: [ 'plugins/view-transitions/js/**/*.js' ],
 			rules: {
-				'jsdoc/no-undefined-types': 'off',
+				'jsdoc/no-undefined-types': [
+					'error',
+					{ definedTypes: [ 'PageSwapEvent', 'PageRevealEvent' ] },
+				],
 			},
 		},
 	],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,6 +25,15 @@ const config = {
 		'/dist',
 		'/**/*.min.js',
 	],
+	overrides: [
+		...( wpConfig?.overrides || [] ),
+		{
+			files: [ 'plugins/view-transitions/js/**/*.js' ],
+			rules: {
+				'jsdoc/no-undefined-types': 'off',
+			},
+		},
+	],
 };
 
 module.exports = config;

--- a/plugins/view-transitions/hooks.php
+++ b/plugins/view-transitions/hooks.php
@@ -29,4 +29,5 @@ add_action( 'wp_head', 'plvt_render_generator' );
  * Filters related to the View Transitions functionality.
  */
 add_action( 'after_setup_theme', 'plvt_polyfill_theme_support', PHP_INT_MAX );
+add_action( 'init', 'plvt_sanitize_view_transitions_theme_support', 1 );
 add_action( 'wp_enqueue_scripts', 'plvt_load_view_transitions' );

--- a/plugins/view-transitions/includes/functions.php
+++ b/plugins/view-transitions/includes/functions.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Utility functions for View Transitions.
+ *
+ * @package view-transitions
+ * @since 1.0.0
+ */
+
+/**
+ * Gets the path to a script or stylesheet.
+ *
+ * @since 1.0.0
+ * @access private
+ *
+ * @param string      $src_path Source path, relative to plugin root.
+ * @param string|null $min_path Minified path. If not supplied, then '.min' is injected before the file extension in the source path.
+ * @return string Full path to script or stylesheet.
+ *
+ * @noinspection PhpDocMissingThrowsInspection
+ */
+function plvt_get_asset_path( string $src_path, ?string $min_path = null ): string {
+	if ( null === $min_path ) {
+		// Note: wp_scripts_get_suffix() is not used here because we need access to both the source and minified paths.
+		$min_path = (string) preg_replace( '/(?=\.\w+$)/', '.min', $src_path );
+	}
+
+	$plugin_dir = trailingslashit( dirname( __DIR__ ) );
+
+	$force_src = false;
+	if ( WP_DEBUG && ! file_exists( $plugin_dir . $min_path ) ) {
+		$force_src = true;
+		/**
+		 * No WP_Exception is thrown by wp_trigger_error() since E_USER_ERROR is not passed as the error level.
+		 *
+		 * @noinspection PhpUnhandledExceptionInspection
+		 */
+		wp_trigger_error(
+			__FUNCTION__,
+			sprintf(
+				/* translators: %s is the minified asset path */
+				__( 'Minified asset has not been built: %s', 'view-transitions' ),
+				$min_path
+			),
+			E_USER_WARNING
+		);
+	}
+
+	if ( SCRIPT_DEBUG || $force_src ) {
+		return $plugin_dir . $src_path;
+	}
+
+	return $plugin_dir . $min_path;
+}

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -28,6 +28,67 @@ function plvt_polyfill_theme_support(): void {
 }
 
 /**
+ * Sanitizes theme support arguments for the 'view-transitions' feature.
+ *
+ * If the feature was part of WordPress Core, the logic of this function would become part of the `add_theme_support()`
+ * function instead. There is no action or filter that could be used though, hence it is implemented here in a separate
+ * function that runs after `after_setup_theme`, but before the 'view-transitions' feature arguments are possibly used.
+ *
+ * @since 1.0.0
+ *
+ * @global array<string, mixed> $_wp_theme_features Theme support features added and their arguments.
+ */
+function plvt_sanitize_view_transitions_theme_support(): void {
+	global $_wp_theme_features;
+
+	if ( ! isset( $_wp_theme_features['view-transitions'] ) ) {
+		return;
+	}
+
+	$args = $_wp_theme_features['view-transitions'];
+
+	$defaults = array(
+		'post-selector'           => '.wp-block-post.post, article.post, body.single main',
+		'global-transition-names' => array(
+			'header' => 'header',
+			'main'   => 'main',
+		),
+		'post-transition-names'   => array(
+			'.wp-block-post-title, .entry-title'     => 'post-title',
+			'.wp-post-image'                         => 'post-thumbnail',
+			'.wp-block-post-content, .entry-content' => 'post-content',
+		),
+	);
+
+	// If no specific `$args` were provided, simply use the defaults.
+	if ( true === $args ) {
+		$args = $defaults;
+	} else {
+		/*
+		 * By default, `add_theme_support()` will take all function parameters as `$args`, but for the
+		 * 'view-transitions' feature, only a single associative array of arguments is relevant, which is expected as
+		 * the sole (optional) parameter.
+		 */
+		if ( count( $args ) === 1 && isset( $args[0] ) && is_array( $args[0] ) ) {
+			$args = $args[0];
+		}
+
+		$args = wp_parse_args( $args, $defaults );
+
+		// Enforce correct types.
+		if ( ! is_array( $args['global-transition-names'] ) ) {
+			$args['global-transition-names'] = array();
+		}
+		if ( ! is_array( $args['post-transition-names'] ) ) {
+			$args['post-transition-names'] = array();
+		}
+	}
+
+	// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+	$_wp_theme_features['view-transitions'] = $args;
+}
+
+/**
  * Loads view transitions based on the current configuration.
  *
  * @since 1.0.0
@@ -42,4 +103,44 @@ function plvt_load_view_transitions(): void {
 	wp_register_style( 'wp-view-transitions', false, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_add_inline_style( 'wp-view-transitions', $stylesheet );
 	wp_enqueue_style( 'wp-view-transitions' );
+
+	$theme_support = get_theme_support( 'view-transitions' );
+
+	/*
+	 * No point in loading the script if no specific view transition names are configured.
+	 */
+	if (
+		( ! is_array( $theme_support['global-transition-names'] ) || count( $theme_support['global-transition-names'] ) === 0 ) &&
+		( ! is_array( $theme_support['post-transition-names'] ) || count( $theme_support['post-transition-names'] ) === 0 )
+	) {
+		return;
+	}
+
+	$config = array(
+		'postSelector'          => $theme_support['post-selector'],
+		'globalTransitionNames' => $theme_support['global-transition-names'],
+		'postTransitionNames'   => $theme_support['post-transition-names'],
+	);
+
+	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	$src_script = file_get_contents( plvt_get_asset_path( 'js/view-transitions.js' ) );
+	if ( false === $src_script || '' === $src_script ) {
+		// This clause should never be entered, but is needed to please PHPStan. Can't hurt to be safe.
+		return;
+	}
+
+	$init_script = sprintf(
+		'plvtInitViewTransitions( %s )',
+		wp_json_encode( $config, JSON_FORCE_OBJECT )
+	);
+
+	/*
+	 * This must be in the <head>, not in the footer.
+	 * This is because the pagereveal event listener must be added before the first rAF occurs since that is when the event fires. See <https://issues.chromium.org/issues/40949146#comment10>.
+	 * An inline script is used to avoid an extra request.
+	 */
+	wp_register_script( 'wp-view-transitions', false, array(), null, array() ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	wp_add_inline_script( 'wp-view-transitions', $src_script );
+	wp_add_inline_script( 'wp-view-transitions', $init_script );
+	wp_enqueue_script( 'wp-view-transitions' );
 }

--- a/plugins/view-transitions/js/types.ts
+++ b/plugins/view-transitions/js/types.ts
@@ -8,13 +8,14 @@ export type InitViewTransitionsFunction = (
 	config: ViewTransitionsConfig
 ) => void;
 
-export type ExtendedWindow = Window &
-	typeof globalThis & {
+declare global {
+	interface Window {
 		plvtInitViewTransitions?: InitViewTransitionsFunction;
 		navigation?: {
 			activation: NavigationActivation;
 		};
-	};
+	}
+}
 
 export type PageSwapListenerFunction = ( event: PageSwapEvent ) => void;
 export type PageRevealListenerFunction = ( event: PageRevealEvent ) => void;

--- a/plugins/view-transitions/js/types.ts
+++ b/plugins/view-transitions/js/types.ts
@@ -1,0 +1,20 @@
+export type ViewTransitionsConfig = {
+	postSelector?: string;
+	globalTransitionNames?: Record< string, string >;
+	postTransitionNames?: Record< string, string >;
+};
+
+export type InitViewTransitionsFunction = (
+	config: ViewTransitionsConfig
+) => void;
+
+export type ExtendedWindow = Window &
+	typeof globalThis & {
+		plvtInitViewTransitions?: InitViewTransitionsFunction;
+		navigation?: {
+			activation: NavigationActivation;
+		};
+	};
+
+export type PageSwapListenerFunction = ( event: PageSwapEvent ) => void;
+export type PageRevealListenerFunction = ( event: PageRevealEvent ) => void;

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -135,31 +135,34 @@ win.plvtInitViewTransitions = ( config ) => {
 	 * @type {PageSwapListenerFunction}
 	 * @param {PageSwapEvent} event - Event fired as the previous URL is about to unload.
 	 */
-	win.addEventListener( 'pageswap', ( event ) => {
-		if ( event.viewTransition ) {
-			let viewTransitionEntries;
-			if ( document.body.classList.contains( 'single' ) ) {
-				viewTransitionEntries = getViewTransitionEntries(
-					document.body,
-					getArticle()
-				);
-			} else if (
-				document.body.classList.contains( 'home' ) ||
-				document.body.classList.contains( 'archive' )
-			) {
-				viewTransitionEntries = getViewTransitionEntries(
-					document.body,
-					getArticleForUrl( event.activation.entry.url )
-				);
-			}
-			if ( viewTransitionEntries ) {
-				setTemporaryViewTransitionNames(
-					viewTransitionEntries,
-					event.viewTransition.finished
-				);
+	win.addEventListener(
+		'pageswap',
+		( /** @type {PageSwapEvent} */ event ) => {
+			if ( event.viewTransition ) {
+				let viewTransitionEntries;
+				if ( document.body.classList.contains( 'single' ) ) {
+					viewTransitionEntries = getViewTransitionEntries(
+						document.body,
+						getArticle()
+					);
+				} else if (
+					document.body.classList.contains( 'home' ) ||
+					document.body.classList.contains( 'archive' )
+				) {
+					viewTransitionEntries = getViewTransitionEntries(
+						document.body,
+						getArticleForUrl( event.activation.entry.url )
+					);
+				}
+				if ( viewTransitionEntries ) {
+					setTemporaryViewTransitionNames(
+						viewTransitionEntries,
+						event.viewTransition.finished
+					);
+				}
 			}
 		}
-	} );
+	);
 
 	/**
 	 * Customizes view transition behavior on the URL that is being navigated to.
@@ -167,31 +170,36 @@ win.plvtInitViewTransitions = ( config ) => {
 	 * @type {PageRevealListenerFunction}
 	 * @param {PageRevealEvent} event - Event fired as the new URL being navigated to is loaded.
 	 */
-	win.addEventListener( 'pagereveal', ( event ) => {
-		if ( event.viewTransition ) {
-			let viewTransitionEntries;
-			if ( document.body.classList.contains( 'single' ) ) {
-				viewTransitionEntries = getViewTransitionEntries(
-					document.body,
-					getArticle()
-				);
-			} else if (
-				document.body.classList.contains( 'home' ) ||
-				document.body.classList.contains( 'archive' )
-			) {
-				viewTransitionEntries = getViewTransitionEntries(
-					document.body,
-					win.navigation.activation.from
-						? getArticleForUrl( win.navigation.activation.from.url )
-						: null
-				);
-			}
-			if ( viewTransitionEntries ) {
-				setTemporaryViewTransitionNames(
-					viewTransitionEntries,
-					event.viewTransition.ready
-				);
+	win.addEventListener(
+		'pagereveal',
+		( /** @type {PageRevealEvent} */ event ) => {
+			if ( event.viewTransition ) {
+				let viewTransitionEntries;
+				if ( document.body.classList.contains( 'single' ) ) {
+					viewTransitionEntries = getViewTransitionEntries(
+						document.body,
+						getArticle()
+					);
+				} else if (
+					document.body.classList.contains( 'home' ) ||
+					document.body.classList.contains( 'archive' )
+				) {
+					viewTransitionEntries = getViewTransitionEntries(
+						document.body,
+						win.navigation.activation.from
+							? getArticleForUrl(
+									win.navigation.activation.from.url
+							  )
+							: null
+					);
+				}
+				if ( viewTransitionEntries ) {
+					setTemporaryViewTransitionNames(
+						viewTransitionEntries,
+						event.viewTransition.ready
+					);
+				}
 			}
 		}
-	} );
+	);
 };

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -1,5 +1,4 @@
 /**
- * @typedef {import("./types.ts").ExtendedWindow} ExtendedWindow
  * @typedef {import("./types.ts").ViewTransitionsConfig} ViewTransitionsConfig
  * @typedef {import("./types.ts").InitViewTransitionsFunction} InitViewTransitionsFunction
  * @typedef {import("./types.ts").PageSwapListenerFunction} PageSwapListenerFunction
@@ -7,21 +6,14 @@
  */
 
 /**
- * Window reference to reduce size when script is minified.
- *
- * @type {ExtendedWindow}
- */
-const win = window;
-
-/**
  * Initializes view transitions for the current URL.
  *
  * @type {InitViewTransitionsFunction}
  * @param {ViewTransitionsConfig} config - The view transitions configuration.
  */
-win.plvtInitViewTransitions = ( config ) => {
-	if ( ! win.navigation || ! ( 'CSSViewTransitionRule' in win ) ) {
-		win.console.warn(
+window.plvtInitViewTransitions = ( config ) => {
+	if ( ! window.navigation || ! ( 'CSSViewTransitionRule' in window ) ) {
+		window.console.warn(
 			'View transitions not loaded as the browser is lacking support.'
 		);
 		return;
@@ -135,7 +127,7 @@ win.plvtInitViewTransitions = ( config ) => {
 	 * @type {PageSwapListenerFunction}
 	 * @param {PageSwapEvent} event - Event fired as the previous URL is about to unload.
 	 */
-	win.addEventListener(
+	window.addEventListener(
 		'pageswap',
 		( /** @type {PageSwapEvent} */ event ) => {
 			if ( event.viewTransition ) {
@@ -170,7 +162,7 @@ win.plvtInitViewTransitions = ( config ) => {
 	 * @type {PageRevealListenerFunction}
 	 * @param {PageRevealEvent} event - Event fired as the new URL being navigated to is loaded.
 	 */
-	win.addEventListener(
+	window.addEventListener(
 		'pagereveal',
 		( /** @type {PageRevealEvent} */ event ) => {
 			if ( event.viewTransition ) {
@@ -186,9 +178,9 @@ win.plvtInitViewTransitions = ( config ) => {
 				) {
 					viewTransitionEntries = getViewTransitionEntries(
 						document.body,
-						win.navigation.activation.from
+						window.navigation.activation.from
 							? getArticleForUrl(
-									win.navigation.activation.from.url
+									window.navigation.activation.from.url
 							  )
 							: null
 					);

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -1,0 +1,186 @@
+/**
+ * Initializes view transitions for the current URL.
+ *
+ * @param {Object} config                       The view transitions configuration.
+ * @param {string} config.postSelector          General selector for post elements in the DOM.
+ * @param {Object} config.globalTransitionNames Map of selectors for global elements (queried relative to 'body')
+ *                                              and their view transition names.
+ * @param {Object} config.postTransitionNames   Map of selectors for post elements (queried relative to an element
+ *                                              identified by config.postSelector) and their view transition names.
+ */
+window.plvtInitViewTransitions = ( config ) => {
+	if ( ! window.navigation || ! ( 'CSSViewTransitionRule' in window ) ) {
+		window.console.warn(
+			'View transitions not loaded as the browser is lacking support.'
+		);
+		return;
+	}
+
+	/**
+	 * Gets all view transition entries relevant for a view transition.
+	 *
+	 * @param {Element}      bodyElement    The body element.
+	 * @param {Element|null} articleElement The post element relevant for the view transition, if any.
+	 * @return {Array[]} View transition entries with each one containing the element and its view transition name.
+	 */
+	const getViewTransitionEntries = ( bodyElement, articleElement ) => {
+		const globalEntries = Object.entries(
+			config.globalTransitionNames || {}
+		).map( ( [ selector, name ] ) => {
+			const element = bodyElement.querySelector( selector );
+			return [ element, name ];
+		} );
+
+		const postEntries = articleElement
+			? Object.entries( config.postTransitionNames || {} ).map(
+					( [ selector, name ] ) => {
+						const element =
+							articleElement.querySelector( selector );
+						return [ element, name ];
+					}
+			  )
+			: [];
+
+		return [ ...globalEntries, ...postEntries ];
+	};
+
+	/**
+	 * Temporarily sets view transition names for the given entries until the view transition has been completed.
+	 *
+	 * @param {Array[]}       entries   View transition entries as received from `getViewTransitionEntries()`.
+	 * @param {Promise<void>} vtPromise Promise that resolves after the view transition has been completed.
+	 * @return {Promise<void>} Promise that resolves after the view transition names were reset.
+	 */
+	const setTemporaryViewTransitionNames = async ( entries, vtPromise ) => {
+		for ( const [ element, name ] of entries ) {
+			if ( ! element ) {
+				continue;
+			}
+			element.style.viewTransitionName = name;
+		}
+
+		await vtPromise;
+
+		for ( const [ element ] of entries ) {
+			if ( ! element ) {
+				continue;
+			}
+			element.style.viewTransitionName = '';
+		}
+	};
+
+	/**
+	 * Appends a selector to another selector.
+	 *
+	 * This supports selectors which technically include multiple selectors (separated by comma).
+	 *
+	 * @param {string} selectors Main selector.
+	 * @param {string} append    Selector to append to the main selector.
+	 * @return {string} Combined selector.
+	 */
+	const appendSelectors = ( selectors, append ) => {
+		return selectors
+			.split( ',' )
+			.map( ( subselector ) => subselector.trim() + ' ' + append )
+			.join( ',' );
+	};
+
+	/**
+	 * Gets a post element (the first on the page, in case there are multiple).
+	 *
+	 * @return {Element|null} Post element, or null if none is found.
+	 */
+	const getArticle = () => {
+		if ( ! config.postSelector ) {
+			return null;
+		}
+		return document.querySelector( config.postSelector );
+	};
+
+	/**
+	 * Gets the post element for a specific post URL.
+	 *
+	 * @param {string} url Post URL (permalink) to find post element.
+	 * @return {Element|null} Post element, or null if none is found.
+	 */
+	const getArticleForUrl = ( url ) => {
+		if ( ! config.postSelector ) {
+			return null;
+		}
+		const postLinkSelector = appendSelectors(
+			config.postSelector,
+			'a[href="' + url + '"]'
+		);
+		const articleLink = document.querySelector( postLinkSelector );
+		if ( ! articleLink ) {
+			return null;
+		}
+		return articleLink.closest( config.postSelector );
+	};
+
+	/**
+	 * Customizes view transition behavior on the URL that is being navigated from.
+	 *
+	 * @param {Event} event Event fired as the previous URL is about to unload.
+	 */
+	window.addEventListener( 'pageswap', ( event ) => {
+		if ( event.viewTransition ) {
+			let viewTransitionEntries;
+			if ( document.body.classList.contains( 'single' ) ) {
+				viewTransitionEntries = getViewTransitionEntries(
+					document.body,
+					getArticle()
+				);
+			} else if (
+				document.body.classList.contains( 'home' ) ||
+				document.body.classList.contains( 'archive' )
+			) {
+				viewTransitionEntries = getViewTransitionEntries(
+					document.body,
+					getArticleForUrl( event.activation.entry.url )
+				);
+			}
+			if ( viewTransitionEntries ) {
+				setTemporaryViewTransitionNames(
+					viewTransitionEntries,
+					event.viewTransition.finished
+				);
+			}
+		}
+	} );
+
+	/**
+	 * Customizes view transition behavior on the URL that is being navigated to.
+	 *
+	 * @param {Event} event Event fired as the new URL being navigated to is loaded.
+	 */
+	window.addEventListener( 'pagereveal', ( event ) => {
+		if ( event.viewTransition ) {
+			let viewTransitionEntries;
+			if ( document.body.classList.contains( 'single' ) ) {
+				viewTransitionEntries = getViewTransitionEntries(
+					document.body,
+					getArticle()
+				);
+			} else if (
+				document.body.classList.contains( 'home' ) ||
+				document.body.classList.contains( 'archive' )
+			) {
+				viewTransitionEntries = getViewTransitionEntries(
+					document.body,
+					window.navigation.activation.from
+						? getArticleForUrl(
+								window.navigation.activation.from.url
+						  )
+						: null
+				);
+			}
+			if ( viewTransitionEntries ) {
+				setTemporaryViewTransitionNames(
+					viewTransitionEntries,
+					event.viewTransition.ready
+				);
+			}
+		}
+	} );
+};

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -1,16 +1,27 @@
 /**
+ * @typedef {import("./types.ts").ExtendedWindow} ExtendedWindow
+ * @typedef {import("./types.ts").ViewTransitionsConfig} ViewTransitionsConfig
+ * @typedef {import("./types.ts").InitViewTransitionsFunction} InitViewTransitionsFunction
+ * @typedef {import("./types.ts").PageSwapListenerFunction} PageSwapListenerFunction
+ * @typedef {import("./types.ts").PageRevealListenerFunction} PageRevealListenerFunction
+ */
+
+/**
+ * Window reference to reduce size when script is minified.
+ *
+ * @type {ExtendedWindow}
+ */
+const win = window;
+
+/**
  * Initializes view transitions for the current URL.
  *
- * @param {Object} config                       The view transitions configuration.
- * @param {string} config.postSelector          General selector for post elements in the DOM.
- * @param {Object} config.globalTransitionNames Map of selectors for global elements (queried relative to 'body')
- *                                              and their view transition names.
- * @param {Object} config.postTransitionNames   Map of selectors for post elements (queried relative to an element
- *                                              identified by config.postSelector) and their view transition names.
+ * @type {InitViewTransitionsFunction}
+ * @param {ViewTransitionsConfig} config - The view transitions configuration.
  */
-window.plvtInitViewTransitions = ( config ) => {
-	if ( ! window.navigation || ! ( 'CSSViewTransitionRule' in window ) ) {
-		window.console.warn(
+win.plvtInitViewTransitions = ( config ) => {
+	if ( ! win.navigation || ! ( 'CSSViewTransitionRule' in win ) ) {
+		win.console.warn(
 			'View transitions not loaded as the browser is lacking support.'
 		);
 		return;
@@ -121,9 +132,10 @@ window.plvtInitViewTransitions = ( config ) => {
 	/**
 	 * Customizes view transition behavior on the URL that is being navigated from.
 	 *
-	 * @param {Event} event Event fired as the previous URL is about to unload.
+	 * @type {PageSwapListenerFunction}
+	 * @param {PageSwapEvent} event - Event fired as the previous URL is about to unload.
 	 */
-	window.addEventListener( 'pageswap', ( event ) => {
+	win.addEventListener( 'pageswap', ( event ) => {
 		if ( event.viewTransition ) {
 			let viewTransitionEntries;
 			if ( document.body.classList.contains( 'single' ) ) {
@@ -152,9 +164,10 @@ window.plvtInitViewTransitions = ( config ) => {
 	/**
 	 * Customizes view transition behavior on the URL that is being navigated to.
 	 *
-	 * @param {Event} event Event fired as the new URL being navigated to is loaded.
+	 * @type {PageRevealListenerFunction}
+	 * @param {PageRevealEvent} event - Event fired as the new URL being navigated to is loaded.
 	 */
-	window.addEventListener( 'pagereveal', ( event ) => {
+	win.addEventListener( 'pagereveal', ( event ) => {
 		if ( event.viewTransition ) {
 			let viewTransitionEntries;
 			if ( document.body.classList.contains( 'single' ) ) {
@@ -168,10 +181,8 @@ window.plvtInitViewTransitions = ( config ) => {
 			) {
 				viewTransitionEntries = getViewTransitionEntries(
 					document.body,
-					window.navigation.activation.from
-						? getArticleForUrl(
-								window.navigation.activation.from.url
-						  )
+					win.navigation.activation.from
+						? getArticleForUrl( win.navigation.activation.from.url )
 						: null
 				);
 			}

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.8
-Stable tag:   1.4.0
+Stable tag:   1.0.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, view transitions, smooth transitions, animations

--- a/plugins/view-transitions/tests/test-hooks.php
+++ b/plugins/view-transitions/tests/test-hooks.php
@@ -11,6 +11,7 @@ class Test_ViewTransitions_Hooks extends WP_UnitTestCase {
 	public function test_hooks(): void {
 		$this->assertSame( 10, has_action( 'wp_head', 'plvt_render_generator' ) );
 		$this->assertSame( PHP_INT_MAX, has_action( 'after_setup_theme', 'plvt_polyfill_theme_support' ) );
+		$this->assertSame( 1, has_action( 'init', 'plvt_sanitize_view_transitions_theme_support' ) );
 		$this->assertSame( 10, has_action( 'wp_enqueue_scripts', 'plvt_load_view_transitions' ) );
 	}
 

--- a/plugins/view-transitions/tests/test-theme.php
+++ b/plugins/view-transitions/tests/test-theme.php
@@ -36,6 +36,7 @@ class Test_ViewTransitions_Theme extends WP_UnitTestCase {
 
 		// Test that with theme support it registers and enqueues the style.
 		add_theme_support( 'view-transitions' );
+		plvt_sanitize_view_transitions_theme_support(); // This must be called to sanitize the arguments (normally on 'init').
 		plvt_load_view_transitions();
 		$this->assertTrue( wp_style_is( 'wp-view-transitions', 'registered' ) );
 		$this->assertTrue( wp_style_is( 'wp-view-transitions', 'enqueued' ) );

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -27,6 +27,7 @@ if ( defined( 'VIEW_TRANSITIONS_VERSION' ) ) {
 
 define( 'VIEW_TRANSITIONS_VERSION', '1.0.0' );
 
+require_once __DIR__ . '/includes/functions.php';
 require_once __DIR__ . '/includes/theme.php';
 require_once __DIR__ . '/hooks.php';
 // @codeCoverageIgnoreEnd

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,13 @@ const {
  */
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
+/*
+ * Temporary workaround because 'view-transitions' should not be added to `plugins.json` just yet, since it is not
+ * ready to be released.
+ * TODO: Remove this workaround once the plugin is added to `plugins.json`.
+ */
+standalonePlugins.push( 'view-transitions' );
+
 const defaultBuildConfig = {
 	entry: {},
 	output: {
@@ -40,6 +47,7 @@ const pluginsWithBuild = [
 	'embed-optimizer',
 	'image-prioritizer',
 	'optimization-detective',
+	'view-transitions',
 	'web-worker-offloading',
 ];
 
@@ -218,6 +226,39 @@ const optimizationDetective = ( env ) => {
 };
 
 /**
+ * Webpack Config: View Transitions
+ *
+ * @param {*} env Webpack environment
+ * @return {Object} Webpack configuration
+ */
+const viewTransitions = ( env ) => {
+	if ( env.plugin && env.plugin !== 'view-transitions' ) {
+		return defaultBuildConfig;
+	}
+
+	const destination = path.resolve( __dirname, 'plugins/view-transitions' );
+
+	return {
+		...sharedConfig,
+		name: 'view-transitions',
+		plugins: [
+			new CopyWebpackPlugin( {
+				patterns: [
+					{
+						from: `${ destination }/js/view-transitions.js`,
+						to: `${ destination }/js/view-transitions.min.js`,
+					},
+				],
+			} ),
+			new WebpackBar( {
+				name: 'Building View Transitions Assets',
+				color: '#2196f3',
+			} ),
+		],
+	};
+};
+
+/**
  * Webpack Config: Web Worker Offloading
  *
  * @param {*} env Webpack environment
@@ -347,6 +388,7 @@ module.exports = [
 	embedOptimizer,
 	imagePrioritizer,
 	optimizationDetective,
+	viewTransitions,
 	webWorkerOffloading,
 	buildPlugin,
 ];


### PR DESCRIPTION
## Summary

See #1997.

## Relevant technical choices

* Follow up to #1998.
* Adds support for certain view transition names, some for global elements (e.g. `header`, `main`), others for post specific elements like post titles and post featured images.
* The specific element selectors and their view transition names can be optionally specified via `view-transitions` theme support. The defaults cover both block themes (standardized via Core blocks) and classic themes (via common conventions and partially Core CSS classes), and should work for the majority of themes.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
