### PR TITLE
Use `win` and `doc` aliases consistently

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -244,7 +244,7 @@ async function getAlreadySubmittedSessionStorageKey(
 	urlMetricGroupStatus,
 	{ warn, error }
 ) {
-	if ( ! window.crypto || ! window.crypto.subtle ) {
+	if ( ! win.crypto || ! win.crypto.subtle ) {
 		warn(
 			'Unable to generate sessionStorage key for already-submitted URL since crypto is not available, likely due to to the page not being served via HTTPS.'
 		);
@@ -580,7 +580,7 @@ export default async function detect( {
 		return;
 	}
 
-	if ( document.visibilityState === 'hidden' && ! document.prerendering ) {
+	if ( doc.visibilityState === 'hidden' && ! doc.prerendering ) {
 		log( 'Page opened in background tab so URL Metric is not collected.' );
 		return;
 	}
@@ -671,7 +671,7 @@ export default async function detect( {
 
 	// Keep track of whether the window resized. If it resized, we abort sending the URLMetric.
 	let didWindowResize = false;
-	window.addEventListener(
+	win.addEventListener(
 		'resize',
 		() => {
 			didWindowResize = true;
@@ -927,7 +927,7 @@ export default async function detect( {
 		doc.addEventListener(
 			'visibilitychange',
 			() => {
-				if ( document.visibilityState === 'hidden' ) {
+				if ( doc.visibilityState === 'hidden' ) {
 					// TODO: This will fire even when switching tabs.
 					resolve();
 				}


### PR DESCRIPTION
In `detect.js`, there are `win` and `doc` constants which are aliased to `window` and `document` respectively, with the intention that the constant could be further minified (e.g. to `w` and `d`) to further compress the output. This additional symbol minification is not currently being done, but at least we should be consistent about using these aliases.

This was discovered as part of https://github.com/WordPress/performance/pull/1999#discussion_r2074267554.