### PR TITLE
Add support for different view transition animations for the default transition type

### DIFF
--- a/plugins/view-transitions/css/view-transition-animation-slide.css
+++ b/plugins/view-transitions/css/view-transition-animation-slide.css
@@ -1,0 +1,35 @@
+@property --wp-view-transition-animation-slide-horizontal-offset {
+	syntax: "<number>";
+	initial-value: 1;
+	inherits: false;
+}
+
+@property --wp-view-transition-animation-slide-vertical-offset {
+	syntax: "<number>";
+	initial-value: 0;
+	inherits: false;
+}
+
+@keyframes wp-view-transition-animation-slide-old {
+	to {
+		translate: calc(100vw * var(--wp-view-transition-animation-slide-horizontal-offset) * -1) calc(100vw * var(--wp-view-transition-animation-slide-vertical-offset) * -1);
+	}
+}
+
+@keyframes wp-view-transition-animation-slide-new {
+	from {
+		translate: calc(100vw * var(--wp-view-transition-animation-slide-horizontal-offset)) calc(100vw * var(--wp-view-transition-animation-slide-vertical-offset));
+	}
+}
+
+::view-transition-group(*) {
+	animation-duration: 1s;
+}
+
+::view-transition-old(*) {
+	animation-name: wp-view-transition-animation-slide-old;
+}
+
+::view-transition-new(*) {
+	animation-name: wp-view-transition-animation-slide-new;
+}

--- a/plugins/view-transitions/css/view-transition-animation-slide.css
+++ b/plugins/view-transitions/css/view-transition-animation-slide.css
@@ -1,24 +1,24 @@
-@property --wp-view-transition-animation-slide-horizontal-offset {
+@property --plvt-view-transition-animation-slide-horizontal-offset {
 	syntax: "<number>";
 	initial-value: 1;
 	inherits: false;
 }
 
-@property --wp-view-transition-animation-slide-vertical-offset {
+@property --plvt-view-transition-animation-slide-vertical-offset {
 	syntax: "<number>";
 	initial-value: 0;
 	inherits: false;
 }
 
-@keyframes wp-view-transition-animation-slide-old {
+@keyframes plvt-view-transition-animation-slide-old {
 	to {
-		translate: calc(100vw * var(--wp-view-transition-animation-slide-horizontal-offset) * -1) calc(100vw * var(--wp-view-transition-animation-slide-vertical-offset) * -1);
+		translate: calc(100vw * var(--plvt-view-transition-animation-slide-horizontal-offset) * -1) calc(100vw * var(--plvt-view-transition-animation-slide-vertical-offset) * -1);
 	}
 }
 
-@keyframes wp-view-transition-animation-slide-new {
+@keyframes plvt-view-transition-animation-slide-new {
 	from {
-		translate: calc(100vw * var(--wp-view-transition-animation-slide-horizontal-offset)) calc(100vw * var(--wp-view-transition-animation-slide-vertical-offset));
+		translate: calc(100vw * var(--plvt-view-transition-animation-slide-horizontal-offset)) calc(100vw * var(--plvt-view-transition-animation-slide-vertical-offset));
 	}
 }
 
@@ -27,9 +27,9 @@
 }
 
 ::view-transition-old(*) {
-	animation-name: wp-view-transition-animation-slide-old;
+	animation-name: plvt-view-transition-animation-slide-old;
 }
 
 ::view-transition-new(*) {
-	animation-name: wp-view-transition-animation-slide-new;
+	animation-name: plvt-view-transition-animation-slide-new;
 }

--- a/plugins/view-transitions/css/view-transition-animation-swipe.css
+++ b/plugins/view-transitions/css/view-transition-animation-swipe.css
@@ -1,26 +1,26 @@
-@property --wp-view-transition-animation-swipe-horizontal-offset {
+@property --plvt-view-transition-animation-swipe-horizontal-offset {
 	syntax: "<number>";
 	initial-value: 1;
 	inherits: false;
 }
 
-@property --wp-view-transition-animation-swipe-vertical-offset {
+@property --plvt-view-transition-animation-swipe-vertical-offset {
 	syntax: "<number>";
 	initial-value: 0;
 	inherits: false;
 }
 
-@keyframes wp-view-transition-animation-swipe-old {
+@keyframes plvt-view-transition-animation-swipe-old {
 	to {
 		opacity: 0;
-		translate: calc(100vw * var(--wp-view-transition-animation-swipe-horizontal-offset) * -1) calc(100vw * var(--wp-view-transition-animation-swipe-vertical-offset) * -1);
+		translate: calc(100vw * var(--plvt-view-transition-animation-swipe-horizontal-offset) * -1) calc(100vw * var(--plvt-view-transition-animation-swipe-vertical-offset) * -1);
 	}
 }
 
-@keyframes wp-view-transition-animation-swipe-new {
+@keyframes plvt-view-transition-animation-swipe-new {
 	from {
 		opacity: 0;
-		translate: calc(100vw * var(--wp-view-transition-animation-swipe-horizontal-offset)) calc(100vw * var(--wp-view-transition-animation-swipe-vertical-offset));
+		translate: calc(100vw * var(--plvt-view-transition-animation-swipe-horizontal-offset)) calc(100vw * var(--plvt-view-transition-animation-swipe-vertical-offset));
 	}
 }
 
@@ -29,9 +29,9 @@
 }
 
 ::view-transition-old(*) {
-	animation-name: wp-view-transition-animation-swipe-old;
+	animation-name: plvt-view-transition-animation-swipe-old;
 }
 
 ::view-transition-new(*) {
-	animation-name: wp-view-transition-animation-swipe-new;
+	animation-name: plvt-view-transition-animation-swipe-new;
 }

--- a/plugins/view-transitions/css/view-transition-animation-swipe.css
+++ b/plugins/view-transitions/css/view-transition-animation-swipe.css
@@ -1,0 +1,37 @@
+@property --wp-view-transition-animation-swipe-horizontal-offset {
+	syntax: "<number>";
+	initial-value: 1;
+	inherits: false;
+}
+
+@property --wp-view-transition-animation-swipe-vertical-offset {
+	syntax: "<number>";
+	initial-value: 0;
+	inherits: false;
+}
+
+@keyframes wp-view-transition-animation-swipe-old {
+	to {
+		opacity: 0;
+		translate: calc(100vw * var(--wp-view-transition-animation-swipe-horizontal-offset) * -1) calc(100vw * var(--wp-view-transition-animation-swipe-vertical-offset) * -1);
+	}
+}
+
+@keyframes wp-view-transition-animation-swipe-new {
+	from {
+		opacity: 0;
+		translate: calc(100vw * var(--wp-view-transition-animation-swipe-horizontal-offset)) calc(100vw * var(--wp-view-transition-animation-swipe-vertical-offset));
+	}
+}
+
+::view-transition-group(*) {
+	animation-duration: 1s;
+}
+
+::view-transition-old(*) {
+	animation-name: wp-view-transition-animation-swipe-old;
+}
+
+::view-transition-new(*) {
+	animation-name: wp-view-transition-animation-swipe-new;
+}

--- a/plugins/view-transitions/css/view-transition-animation-wipe.css
+++ b/plugins/view-transitions/css/view-transition-animation-wipe.css
@@ -1,0 +1,43 @@
+@property --wp-view-transition-animation-wipe-angle {
+	syntax: "<angle>";
+	initial-value: 270deg;
+	inherits: false;
+}
+
+@property --wp-view-transition-animation-wipe-progress {
+	syntax: "<number>";
+	initial-value: 0;
+	inherits: false;
+}
+
+@keyframes wp-view-transition-animation-wipe-new {
+	from {
+		--wp-view-transition-animation-wipe-progress: 0;
+	}
+	to {
+		--wp-view-transition-animation-wipe-progress: 1;
+	}
+}
+
+::view-transition-old(*),
+::view-transition-new(*) {
+	mix-blend-mode: normal;
+	backface-visibility: hidden;
+}
+
+::view-transition-old(root) {
+	opacity: 1;
+	transform: none;
+	animation: none 1.2s cubic-bezier(0.45, 0, 0.35, 1.0);
+	animation-fill-mode: both;
+	animation-delay: 0s;
+}
+
+::view-transition-new(root) {
+	opacity: 1;
+	transform: none;
+	animation: wp-view-transition-animation-wipe-new 1.2s cubic-bezier(0.45, 0, 0.35, 1.0);
+	animation-fill-mode: both;
+	-webkit-mask-image: linear-gradient(var(--wp-view-transition-animation-wipe-angle), #000 calc(-70% + calc(170% * var(--wp-view-transition-animation-wipe-progress, 0))), transparent calc(170% * var(--wp-view-transition-animation-wipe-progress, 0)));
+	mask-image: linear-gradient(var(--wp-view-transition-animation-wipe-angle), #000 calc(-70% + calc(170% * var(--wp-view-transition-animation-wipe-progress, 0))), transparent calc(170% * var(--wp-view-transition-animation-wipe-progress, 0)));
+}

--- a/plugins/view-transitions/css/view-transition-animation-wipe.css
+++ b/plugins/view-transitions/css/view-transition-animation-wipe.css
@@ -1,21 +1,21 @@
-@property --wp-view-transition-animation-wipe-angle {
+@property --plvt-view-transition-animation-wipe-angle {
 	syntax: "<angle>";
 	initial-value: 270deg;
 	inherits: false;
 }
 
-@property --wp-view-transition-animation-wipe-progress {
+@property --plvt-view-transition-animation-wipe-progress {
 	syntax: "<number>";
 	initial-value: 0;
 	inherits: false;
 }
 
-@keyframes wp-view-transition-animation-wipe-new {
+@keyframes plvt-view-transition-animation-wipe-new {
 	from {
-		--wp-view-transition-animation-wipe-progress: 0;
+		--plvt-view-transition-animation-wipe-progress: 0;
 	}
 	to {
-		--wp-view-transition-animation-wipe-progress: 1;
+		--plvt-view-transition-animation-wipe-progress: 1;
 	}
 }
 
@@ -36,8 +36,8 @@
 ::view-transition-new(root) {
 	opacity: 1;
 	transform: none;
-	animation: wp-view-transition-animation-wipe-new 1.2s cubic-bezier(0.45, 0, 0.35, 1.0);
+	animation: plvt-view-transition-animation-wipe-new 1.2s cubic-bezier(0.45, 0, 0.35, 1.0);
 	animation-fill-mode: both;
-	-webkit-mask-image: linear-gradient(var(--wp-view-transition-animation-wipe-angle), #000 calc(-70% + calc(170% * var(--wp-view-transition-animation-wipe-progress, 0))), transparent calc(170% * var(--wp-view-transition-animation-wipe-progress, 0)));
-	mask-image: linear-gradient(var(--wp-view-transition-animation-wipe-angle), #000 calc(-70% + calc(170% * var(--wp-view-transition-animation-wipe-progress, 0))), transparent calc(170% * var(--wp-view-transition-animation-wipe-progress, 0)));
+	-webkit-mask-image: linear-gradient(var(--plvt-view-transition-animation-wipe-angle), #000 calc(-70% + calc(170% * var(--plvt-view-transition-animation-wipe-progress, 0))), transparent calc(170% * var(--plvt-view-transition-animation-wipe-progress, 0)));
+	mask-image: linear-gradient(var(--plvt-view-transition-animation-wipe-angle), #000 calc(-70% + calc(170% * var(--plvt-view-transition-animation-wipe-progress, 0))), transparent calc(170% * var(--plvt-view-transition-animation-wipe-progress, 0)));
 }

--- a/plugins/view-transitions/includes/class-plvt-view-transition-animation-registry.php
+++ b/plugins/view-transitions/includes/class-plvt-view-transition-animation-registry.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Class 'PLVT_View_Transition_Animation_Registry'.
+ *
+ * @package view-transitions
+ * @since 1.0.0
+ */
+
+/**
+ * Class representing a view transition animation registry.
+ *
+ * @since 1.0.0
+ */
+final class PLVT_View_Transition_Animation_Registry {
+
+	/**
+	 * Registered animation class instances, keyed by slug.
+	 *
+	 * @since 1.0.0
+	 * @var array<string, PLVT_View_Transition_Animation>
+	 */
+	private $registered_animations = array();
+
+	/**
+	 * Map of aliases to their animation slugs.
+	 *
+	 * Includes the animation slug itself to avoid unnecessary conditionals.
+	 *
+	 * @since 1.0.0
+	 * @var array<string, string>
+	 */
+	private $alias_map = array();
+
+	/**
+	 * Registers a view transition animation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $slug         Unique animation slug.
+	 * @param array<string, mixed> $config       Animation configuration. See
+	 *                                           {@see PLVT_View_Transition_Animation::__construct()} for possible
+	 *                                           values.
+	 * @param array<string, mixed> $default_args Optional. Default animation arguments. Default empty array.
+	 * @return bool True on success, false on failure.
+	 */
+	public function register_animation( string $slug, array $config, array $default_args = array() ): bool {
+		// Check slug conflict.
+		if ( isset( $this->alias_map[ $slug ] ) ) {
+			_doing_it_wrong(
+				__METHOD__,
+				sprintf(
+					/* translators: %s: duplicate slug */
+					esc_html__( 'The animation slug "%s" conflicts with an existing slug or alias.', 'view-transitions' ),
+					esc_html( $slug )
+				),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		try {
+			$animation = new PLVT_View_Transition_Animation( $slug, $config, $default_args );
+		} catch ( InvalidArgumentException $e ) {
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html( $e->getMessage() ),
+				'1.0.0'
+			);
+			return false;
+		}
+
+		// Check alias conflicts.
+		$aliases = $animation->get_aliases();
+		foreach ( $aliases as $alias ) {
+			if ( isset( $this->alias_map[ $alias ] ) ) {
+				_doing_it_wrong(
+					__METHOD__,
+					sprintf(
+						/* translators: %s: duplicate alias */
+						esc_html__( 'The animation alias "%s" conflicts with an existing slug or alias.', 'view-transitions' ),
+						esc_html( $alias )
+					),
+					'1.0.0'
+				);
+				return false;
+			}
+		}
+
+		$this->registered_animations[ $slug ] = $animation;
+		$this->alias_map[ $slug ]             = $slug;
+		foreach ( $aliases as $alias ) {
+			$this->alias_map[ $alias ] = $slug;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Gets the animation stylesheet for the given alias, as inline CSS.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $alias Slug or alias to reference the animation with. May be used to alter the
+	 *                                    animation's behavior.
+	 * @param array<string, mixed> $args  Optional. Animation arguments. Default is the animation's default arguments.
+	 * @return string Animation stylesheet, as inline CSS, or empty string if none.
+	 */
+	public function get_animation_stylesheet( string $alias, array $args = array() ): string {
+		if ( ! isset( $this->alias_map[ $alias ] ) ) {
+			return '';
+		}
+
+		return $this->registered_animations[ $this->alias_map[ $alias ] ]->get_stylesheet( $alias, $args );
+	}
+
+	/**
+	 * Returns whether to apply the global view transition names for the given animation alias.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $alias Slug or alias to reference the animation with. May be used to alter the
+	 *                                    animation's behavior.
+	 * @param array<string, mixed> $args  Optional. Animation arguments. Default is the animation's default arguments.
+	 * @return bool True if the global view transition names should be applied, false otherwise.
+	 */
+	public function use_animation_global_transition_names( string $alias, array $args = array() ): bool {
+		if ( ! isset( $this->alias_map[ $alias ] ) ) {
+			return true;
+		}
+
+		return $this->registered_animations[ $this->alias_map[ $alias ] ]->use_global_transition_names( $alias, $args );
+	}
+
+	/**
+	 * Returns whether to apply the post specific view transition names for the given animation alias.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $alias Slug or alias to reference the animation with. May be used to alter the
+	 *                                    animation's behavior.
+	 * @param array<string, mixed> $args  Optional. Animation arguments. Default is the animation's default arguments.
+	 * @return bool True if the post specific view transition names should be applied, false otherwise.
+	 */
+	public function use_animation_post_transition_names( string $alias, array $args = array() ): bool {
+		if ( ! isset( $this->alias_map[ $alias ] ) ) {
+			return true;
+		}
+
+		return $this->registered_animations[ $this->alias_map[ $alias ] ]->use_post_transition_names( $alias, $args );
+	}
+}

--- a/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
+++ b/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
@@ -100,7 +100,7 @@ final class PLVT_View_Transition_Animation {
 	 *                                                      Default true.
 	 *     @type bool|callable $use_post_transition_names   Whether to apply the post specific view transition names
 	 *                                                      while using this animation. Alternatively to a concrete
-	 *                                                      value, acallback can be specified to determine it
+	 *                                                      value, a callback can be specified to determine it
 	 *                                                      dynamically. Default true.
 	 *     @type callable|null $get_stylesheet_callback     Callback to get the stylesheet for the animation, as
 	 *                                                      inline CSS. This can be used if the animation CSS requires

--- a/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
+++ b/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
@@ -1,0 +1,283 @@
+<?php
+/**
+ * Class 'PLVT_View_Transition_Animation'.
+ *
+ * @package view-transitions
+ * @since 1.0.0
+ */
+
+/**
+ * Class representing a view transition animation.
+ *
+ * @since 1.0.0
+ * @access private
+ */
+final class PLVT_View_Transition_Animation {
+
+	/**
+	 * The unique animation slug.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	private $slug;
+
+	/**
+	 * Unique aliases for the animation, if any.
+	 *
+	 * @since 1.0.0
+	 * @var string[]
+	 */
+	private $aliases = array();
+
+	/**
+	 * Whether the animation uses a stylesheet.
+	 *
+	 * If so, the stylesheet will be `/wp-includes/css/view-transitions-animation-{$slug}.css`.
+	 *
+	 * @since 1.0.0
+	 * @var bool
+	 */
+	private $use_stylesheet = false;
+
+	/**
+	 * Whether to apply the global view transition names while using this animation.
+	 *
+	 * @since 1.0.0
+	 * @var bool|callable
+	 */
+	private $use_global_transition_names = true;
+
+	/**
+	 * Whether to apply the post specific view transition names while using this animation.
+	 *
+	 * @since 1.0.0
+	 * @var bool|callable
+	 */
+	private $use_post_transition_names = true;
+
+	/**
+	 * Callback to get the stylesheet for the animation, as inline CSS.
+	 *
+	 * This can be used if the animation CSS requires further preparation other than simply loading its stylesheet from
+	 * the animation's corresponding CSS file.
+	 *
+	 * If the animation is configured with `$use_stylesheet = true`, the callback will receive the CSS from that file,
+	 * and the `$alias` and `$args` used as parameters. Otherwise, the callback will receive the `$alias` and `$args`
+	 * used as parameters.
+	 *
+	 * @since 1.0.0
+	 * @var callable|null
+	 */
+	private $get_stylesheet_callback = null;
+
+	/**
+	 * Default animation arguments.
+	 *
+	 * These are provided during registration, and they are used if no specific arguments are provided when using the
+	 * animation.
+	 *
+	 * @since 1.0.0
+	 * @var array<string, mixed>
+	 */
+	private $default_args = array();
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $slug         Unique animation slug.
+	 * @param array<string, mixed> $config       {
+	 *     Animation configuration.
+	 *
+	 *     @type string[]      $aliases                     Unique aliases for the animation, if any. Default empty
+	 *                                                      array.
+	 *     @type bool          $use_stylesheet              Whether the animation uses a stylesheet. Default false.
+	 *     @type bool|callable $use_global_transition_names Whether to apply the global view transition names while
+	 *                                                      using this animation. Alternatively to a concrete value, a
+	 *                                                      callback can be specified to determine it dynamically.
+	 *                                                      Default true.
+	 *     @type bool|callable $use_post_transition_names   Whether to apply the post specific view transition names
+	 *                                                      while using this animation. Alternatively to a concrete
+	 *                                                      value, acallback can be specified to determine it
+	 *                                                      dynamically. Default true.
+	 *     @type callable|null $get_stylesheet_callback     Callback to get the stylesheet for the animation, as
+	 *                                                      inline CSS. This can be used if the animation CSS requires
+	 *                                                      further preparation other than simply loading its
+	 *                                                      stylesheet from the animation's corresponding CSS file.
+	 *                                                      Default null.
+	 * }
+	 * @param array<string, mixed> $default_args Optional. Default animation arguments. Default empty array.
+	 *
+	 * @throws InvalidArgumentException Thrown if the slug or an alias is invalid.
+	 */
+	public function __construct( string $slug, array $config, array $default_args = array() ) {
+		if ( ! $this->is_valid_slug( $slug ) ) {
+			throw new InvalidArgumentException(
+				sprintf(
+					/* translators: %s: invalid slug */
+					esc_html__( 'The animation slug "%s" is invalid.', 'view-transitions' ),
+					esc_html( $slug )
+				)
+			);
+		}
+
+		$this->slug = $slug;
+
+		$this->apply_config( $config );
+
+		$this->default_args = $default_args;
+	}
+
+	/**
+	 * Gets the unique animation slug.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string Unique animation slug.
+	 */
+	public function get_slug(): string {
+		return $this->slug;
+	}
+
+	/**
+	 * Gets the unique aliases for the animation, if any.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string[] Unique aliases for the animation, or empty array if none.
+	 */
+	public function get_aliases(): array {
+		return $this->aliases;
+	}
+
+	/**
+	 * Gets the animation stylesheet, as inline CSS.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $alias Optional. Slug or alias to reference the animation with. May be used to alter
+	 *                                    the animation's behavior. Default is the animation's slug.
+	 * @param array<string, mixed> $args  Optional. Animation arguments. Default is the animation's default arguments.
+	 * @return string Animation stylesheet, as inline CSS, or empty string if none.
+	 */
+	public function get_stylesheet( string $alias = '', array $args = array() ): string {
+		if ( $this->use_stylesheet ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$css = file_get_contents( plvt_get_asset_path( "css/view-transition-animation-{$this->slug}.css" ) );
+			if ( false === $css || '' === $css ) {
+				// This clause should never be entered, but is needed to please PHPStan. Can't hurt to be safe.
+				return '';
+			}
+		}
+		if ( is_callable( $this->get_stylesheet_callback ) ) {
+			if ( '' === $alias ) {
+				$alias = $this->slug;
+			}
+			$args = wp_parse_args( $args, $this->default_args );
+			return (string) call_user_func_array(
+				$this->get_stylesheet_callback,
+				isset( $css ) ? array( $css, $alias, $args ) : array( $alias, $args )
+			);
+		}
+		return '';
+	}
+
+	/**
+	 * Returns whether to apply the global view transition names while using this animation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $alias Optional. Slug or alias to reference the animation with. May be used to alter
+	 *                                    the animation's behavior. Default is the animation's slug.
+	 * @param array<string, mixed> $args  Optional. Animation arguments. Default is the animation's default arguments.
+	 * @return bool True if the global view transition names should be applied, false otherwise.
+	 */
+	public function use_global_transition_names( string $alias = '', array $args = array() ): bool {
+		if ( is_bool( $this->use_global_transition_names ) ) {
+			return $this->use_global_transition_names;
+		}
+		if ( '' === $alias ) {
+			$alias = $this->slug;
+		}
+		$args = wp_parse_args( $args, $this->default_args );
+		return call_user_func( $this->use_global_transition_names, $alias, $args );
+	}
+
+	/**
+	 * Returns whether to apply the post specific view transition names while using this animation.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string               $alias Optional. Slug or alias to reference the animation with. May be used to alter
+	 *                                    the animation's behavior. Default is the animation's slug.
+	 * @param array<string, mixed> $args  Optional. Animation arguments. Default is the animation's default arguments.
+	 * @return bool True if the post specific view transition names should be applied, false otherwise.
+	 */
+	public function use_post_transition_names( string $alias = '', array $args = array() ): bool {
+		if ( is_bool( $this->use_post_transition_names ) ) {
+			return $this->use_post_transition_names;
+		}
+		if ( '' === $alias ) {
+			$alias = $this->slug;
+		}
+		$args = wp_parse_args( $args, $this->default_args );
+		return call_user_func( $this->use_post_transition_names, $alias, $args );
+	}
+
+	/**
+	 * Applies the given configuration to the class properties.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array<string, mixed> $config Animation configuration. See
+	 *                                     {@see PLVT_View_Transition_Animation::__construct()} for possible values.
+	 *
+	 * @throws InvalidArgumentException Thrown when an invalid alias is provided.
+	 */
+	private function apply_config( array $config ): void {
+		if ( isset( $config['aliases'] ) ) {
+			$this->aliases = (array) $config['aliases'];
+			foreach ( $this->aliases as $alias ) {
+				if ( ! $this->is_valid_slug( $alias ) ) {
+					throw new InvalidArgumentException(
+						sprintf(
+							/* translators: %s: invalid alias */
+							esc_html__( 'The animation alias "%s" is invalid.', 'view-transitions' ),
+							esc_html( $alias )
+						)
+					);
+				}
+			}
+		}
+		if ( isset( $config['use_stylesheet'] ) ) {
+			$this->use_stylesheet = (bool) $config['use_stylesheet'];
+		}
+		if ( isset( $config['use_global_transition_names'] ) ) {
+			$this->use_global_transition_names = is_callable( $config['use_global_transition_names'] ) ?
+				$config['use_global_transition_names'] :
+				(bool) $config['use_global_transition_names'];
+		}
+		if ( isset( $config['use_post_transition_names'] ) ) {
+			$this->use_post_transition_names = is_callable( $config['use_post_transition_names'] ) ?
+				$config['use_post_transition_names'] :
+				(bool) $config['use_post_transition_names'];
+		}
+		if ( isset( $config['get_stylesheet_callback'] ) && is_callable( $config['get_stylesheet_callback'] ) ) {
+			$this->get_stylesheet_callback = $config['get_stylesheet_callback'];
+		}
+	}
+
+	/**
+	 * Checks whether the given slug (or alias) is valid.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param string $slug Animation slug or alias.
+	 * @return bool True if the ID is valid, false otherwise.
+	 */
+	private function is_valid_slug( string $slug ): bool {
+		return (bool) preg_match( '/^[a-z][a-z0-9_-]+$/', $slug );
+	}
+}

--- a/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
+++ b/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
@@ -31,12 +31,13 @@ final class PLVT_View_Transition_Animation {
 	private $aliases = array();
 
 	/**
-	 * Whether the animation uses a stylesheet.
+	 * Whether the animation uses a stylesheet, optionally a concrete file path.
 	 *
-	 * If so, the stylesheet will be `/css/view-transitions-animation-{$slug}.css`.
+	 * If no concrete path is provided, it is assumed to be internal to the plugin, in
+	 * `css/view-transition-animation-{$slug}.css`.
 	 *
 	 * @since 1.0.0
-	 * @var bool
+	 * @var bool|string
 	 */
 	private $use_stylesheet = false;
 
@@ -92,7 +93,10 @@ final class PLVT_View_Transition_Animation {
 	 *
 	 *     @type string[]      $aliases                     Unique aliases for the animation, if any. Default empty
 	 *                                                      array.
-	 *     @type bool          $use_stylesheet              Whether the animation uses a stylesheet. Default false.
+	 *     @type bool|string   $use_stylesheet              Whether the animation uses a stylesheet, optionally a
+	 *                                                      concrete file path. If no concrete path is provided, it is
+	 *                                                      assumed to be internal to the plugin, in
+	 *                                                      `css/view-transition-animation-{$slug}.css`. Default false.
 	 *     @type bool|callable $use_global_transition_names Whether to apply the global view transition names while
 	 *                                                      using this animation. Alternatively to a concrete value, a
 	 *                                                      callback can be specified to determine it dynamically.
@@ -163,9 +167,13 @@ final class PLVT_View_Transition_Animation {
 	 */
 	public function get_stylesheet( string $alias = '', array $args = array() ): string {
 		$css = '';
-		if ( $this->use_stylesheet ) {
+		if ( (bool) $this->use_stylesheet ) {
+			$stylesheet_path = $this->use_stylesheet;
+			if ( ! is_string( $stylesheet_path ) ) {
+				$stylesheet_path = plvt_get_asset_path( "css/view-transition-animation-{$this->slug}.css" );
+			}
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			$css = file_get_contents( plvt_get_asset_path( "css/view-transition-animation-{$this->slug}.css" ) );
+			$css = file_get_contents( $stylesheet_path );
 			if ( false === $css || '' === $css ) {
 				// This clause should never be entered, but is needed to please PHPStan. Can't hurt to be safe.
 				return '';
@@ -254,7 +262,7 @@ final class PLVT_View_Transition_Animation {
 			}
 		}
 		if ( isset( $config['use_stylesheet'] ) ) {
-			$this->use_stylesheet = (bool) $config['use_stylesheet'];
+			$this->use_stylesheet = is_string( $config['use_stylesheet'] ) ? $config['use_stylesheet'] : (bool) $config['use_stylesheet'];
 		}
 		if ( isset( $config['use_global_transition_names'] ) ) {
 			$this->use_global_transition_names = is_callable( $config['use_global_transition_names'] ) ?

--- a/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
+++ b/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
@@ -33,7 +33,7 @@ final class PLVT_View_Transition_Animation {
 	/**
 	 * Whether the animation uses a stylesheet.
 	 *
-	 * If so, the stylesheet will be `/wp-includes/css/view-transitions-animation-{$slug}.css`.
+	 * If so, the stylesheet will be `/css/view-transitions-animation-{$slug}.css`.
 	 *
 	 * @since 1.0.0
 	 * @var bool

--- a/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
+++ b/plugins/view-transitions/includes/class-plvt-view-transition-animation.php
@@ -62,9 +62,8 @@ final class PLVT_View_Transition_Animation {
 	 * This can be used if the animation CSS requires further preparation other than simply loading its stylesheet from
 	 * the animation's corresponding CSS file.
 	 *
-	 * If the animation is configured with `$use_stylesheet = true`, the callback will receive the CSS from that file,
-	 * and the `$alias` and `$args` used as parameters. Otherwise, the callback will receive the `$alias` and `$args`
-	 * used as parameters.
+	 * The callback will receive the CSS from the assigned stylesheet (or empty string if none), and the `$alias` and
+	 * `$args` used as parameters.
 	 *
 	 * @since 1.0.0
 	 * @var callable|null
@@ -163,6 +162,7 @@ final class PLVT_View_Transition_Animation {
 	 * @return string Animation stylesheet, as inline CSS, or empty string if none.
 	 */
 	public function get_stylesheet( string $alias = '', array $args = array() ): string {
+		$css = '';
 		if ( $this->use_stylesheet ) {
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			$css = file_get_contents( plvt_get_asset_path( "css/view-transition-animation-{$this->slug}.css" ) );
@@ -171,6 +171,7 @@ final class PLVT_View_Transition_Animation {
 				return '';
 			}
 		}
+
 		if ( is_callable( $this->get_stylesheet_callback ) ) {
 			if ( '' === $alias ) {
 				$alias = $this->slug;
@@ -178,10 +179,11 @@ final class PLVT_View_Transition_Animation {
 			$args = wp_parse_args( $args, $this->default_args );
 			return (string) call_user_func_array(
 				$this->get_stylesheet_callback,
-				isset( $css ) ? array( $css, $alias, $args ) : array( $alias, $args )
+				array( $css, $alias, $args )
 			);
 		}
-		return '';
+
+		return $css;
 	}
 
 	/**

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -143,7 +143,7 @@ function plvt_register_view_transition_animations( PLVT_View_Transition_Animatio
 
 				// Inject offsets as CSS variable to take effect.
 				$css .= sprintf(
-					'::view-transition-old(*), ::view-transition-new(*) { --wp-view-transition-animation-slide-horizontal-offset: %d; --wp-view-transition-animation-slide-vertical-offset: %d; }',
+					'::view-transition-old(*), ::view-transition-new(*) { --plvt-view-transition-animation-slide-horizontal-offset: %d; --plvt-view-transition-animation-slide-vertical-offset: %d; }',
 					$args['horizontal-offset'],
 					$args['vertical-offset']
 				);
@@ -198,7 +198,7 @@ function plvt_register_view_transition_animations( PLVT_View_Transition_Animatio
 
 				// Inject offsets as CSS variable to take effect.
 				$css .= sprintf(
-					'::view-transition-old(*), ::view-transition-new(*) { --wp-view-transition-animation-swipe-horizontal-offset: %d; --wp-view-transition-animation-swipe-vertical-offset: %d; }',
+					'::view-transition-old(*), ::view-transition-new(*) { --plvt-view-transition-animation-swipe-horizontal-offset: %d; --plvt-view-transition-animation-swipe-vertical-offset: %d; }',
 					$args['horizontal-offset'],
 					$args['vertical-offset']
 				);
@@ -243,7 +243,7 @@ function plvt_register_view_transition_animations( PLVT_View_Transition_Animatio
 
 				// Inject angle as CSS variable to take effect.
 				$css .= sprintf(
-					'::view-transition-new(root) { --wp-view-transition-animation-wipe-angle: %ddeg; }',
+					'::view-transition-new(root) { --plvt-view-transition-animation-wipe-angle: %ddeg; }',
 					$args['angle']
 				);
 
@@ -283,9 +283,9 @@ function plvt_load_view_transitions(): void {
 
 	// Use an inline style to avoid an extra request.
 	$stylesheet = '@view-transition { navigation: auto; }';
-	wp_register_style( 'wp-view-transitions', false, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-	wp_add_inline_style( 'wp-view-transitions', $stylesheet );
-	wp_enqueue_style( 'wp-view-transitions' );
+	wp_register_style( 'plvt-view-transitions', false, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	wp_add_inline_style( 'plvt-view-transitions', $stylesheet );
+	wp_enqueue_style( 'plvt-view-transitions' );
 
 	$theme_support = get_theme_support( 'view-transitions' );
 
@@ -295,7 +295,7 @@ function plvt_load_view_transitions(): void {
 	$default_animation_args       = isset( $theme_support['default-animation-args'] ) ? (array) $theme_support['default-animation-args'] : array();
 	$default_animation_stylesheet = $animation_registry->get_animation_stylesheet( $theme_support['default-animation'], $default_animation_args );
 	if ( '' !== $default_animation_stylesheet ) {
-		wp_add_inline_style( 'wp-view-transitions', $default_animation_stylesheet );
+		wp_add_inline_style( 'plvt-view-transitions', $default_animation_stylesheet );
 	}
 
 	/*
@@ -339,8 +339,8 @@ function plvt_load_view_transitions(): void {
 	 * This is because the pagereveal event listener must be added before the first rAF occurs since that is when the event fires. See <https://issues.chromium.org/issues/40949146#comment10>.
 	 * An inline script is used to avoid an extra request.
 	 */
-	wp_register_script( 'wp-view-transitions', false, array(), null, array() ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-	wp_add_inline_script( 'wp-view-transitions', $src_script );
-	wp_add_inline_script( 'wp-view-transitions', $init_script );
-	wp_enqueue_script( 'wp-view-transitions' );
+	wp_register_script( 'plvt-view-transitions', false, array(), null, array() ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	wp_add_inline_script( 'plvt-view-transitions', $src_script );
+	wp_add_inline_script( 'plvt-view-transitions', $init_script );
+	wp_enqueue_script( 'plvt-view-transitions' );
 }

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -98,6 +98,37 @@ function plvt_sanitize_view_transitions_theme_support(): void {
  * @param PLVT_View_Transition_Animation_Registry $animation_registry Registry instance to register animations on.
  */
 function plvt_register_view_transition_animations( PLVT_View_Transition_Animation_Registry $animation_registry ): void {
+	/*
+	 * This callback is used for certain kinds of animations that move content around, to determine whether specific
+	 * view transition names should be applied for an animation or not. If a specific target name (i.e. not '*') is
+	 * provided, they should be applied. But if the entire page is the target, they would visually mess with the
+	 * animation.
+	 */
+	$is_specific_target_name = static function ( string $alias, array $args ): bool {
+		return '*' === $args['target-name'] ? false : true;
+	};
+
+	/*
+	 * This callback is used to return horizontal and vertical offsets (-1, 0, or 1) based on whether the given alias
+	 * ends in a certain directional term ('left', 'top', 'bottom', 'right'). If none is used, the callback returns
+	 * `null` for both offsets.
+	 */
+	$get_hv_offsets_based_on_alias = static function ( string $alias ): array {
+		if ( str_ends_with( $alias, 'left' ) ) {
+			return array( -1, 0 );
+		}
+		if ( str_ends_with( $alias, 'top' ) ) {
+			return array( 0, -1 );
+		}
+		if ( str_ends_with( $alias, 'bottom' ) ) {
+			return array( 0, 1 );
+		}
+		if ( str_ends_with( $alias, 'right' ) ) {
+			return array( 1, 0 );
+		}
+		return array( null, null );
+	};
+
 	// Register default animations.
 	$animation_registry->register_animation(
 		'fade', // This is how view transitions are animated without any extra CSS.
@@ -117,28 +148,14 @@ function plvt_register_view_transition_animations( PLVT_View_Transition_Animatio
 				'slide-from-top',
 			),
 			'use_stylesheet'              => true,
-			'use_global_transition_names' => static function ( string $alias, array $args ) {
-				// If no specific element is targeted, the entire screen should be moved.
-				return '*' === $args['target-name'] ? false : true;
-			},
-			'use_post_transition_names'   => static function ( string $alias, array $args ) {
-				// If no specific element is targeted, the entire screen should be moved.
-				return '*' === $args['target-name'] ? false : true;
-			},
-			'get_stylesheet_callback'     => static function ( string $css, string $alias, array $args ) {
+			'use_global_transition_names' => $is_specific_target_name,
+			'use_post_transition_names'   => $is_specific_target_name,
+			'get_stylesheet_callback'     => static function ( string $css, string $alias, array $args ) use ( $get_hv_offsets_based_on_alias ) {
 				// Set offsets based on alias, if relevant.
-				if ( str_ends_with( $alias, 'left' ) ) {
-					$args['horizontal-offset'] = -1;
-					$args['vertical-offset']   = 0;
-				} elseif ( str_ends_with( $alias, 'top' ) ) {
-					$args['horizontal-offset'] = 0;
-					$args['vertical-offset']   = -1;
-				} elseif ( str_ends_with( $alias, 'bottom' ) ) {
-					$args['horizontal-offset'] = 0;
-					$args['vertical-offset']   = 1;
-				} elseif ( str_ends_with( $alias, 'right' ) ) {
-					$args['horizontal-offset'] = 1;
-					$args['vertical-offset']   = 0;
+				list( $horizontal_offset, $vertical_offset ) = $get_hv_offsets_based_on_alias( $alias );
+				if ( null !== $horizontal_offset && null !== $vertical_offset ) {
+					$args['horizontal-offset'] = $horizontal_offset;
+					$args['vertical-offset']   = $vertical_offset;
 				}
 
 				// Inject offsets as CSS variable to take effect.
@@ -172,28 +189,14 @@ function plvt_register_view_transition_animations( PLVT_View_Transition_Animatio
 				'swipe-from-top',
 			),
 			'use_stylesheet'              => true,
-			'use_global_transition_names' => static function ( string $alias, array $args ) {
-				// If no specific element is targeted, the entire screen should be moved.
-				return '*' === $args['target-name'] ? false : true;
-			},
-			'use_post_transition_names'   => static function ( string $alias, array $args ) {
-				// If no specific element is targeted, the entire screen should be moved.
-				return '*' === $args['target-name'] ? false : true;
-			},
-			'get_stylesheet_callback'     => static function ( string $css, string $alias, array $args ) {
+			'use_global_transition_names' => $is_specific_target_name,
+			'use_post_transition_names'   => $is_specific_target_name,
+			'get_stylesheet_callback'     => static function ( string $css, string $alias, array $args ) use ( $get_hv_offsets_based_on_alias ) {
 				// Set offsets based on alias, if relevant.
-				if ( str_ends_with( $alias, 'left' ) ) {
-					$args['horizontal-offset'] = -1;
-					$args['vertical-offset']   = 0;
-				} elseif ( str_ends_with( $alias, 'top' ) ) {
-					$args['horizontal-offset'] = 0;
-					$args['vertical-offset']   = -1;
-				} elseif ( str_ends_with( $alias, 'bottom' ) ) {
-					$args['horizontal-offset'] = 0;
-					$args['vertical-offset']   = 1;
-				} elseif ( str_ends_with( $alias, 'right' ) ) {
-					$args['horizontal-offset'] = 1;
-					$args['vertical-offset']   = 0;
+				list( $horizontal_offset, $vertical_offset ) = $get_hv_offsets_based_on_alias( $alias );
+				if ( null !== $horizontal_offset && null !== $vertical_offset ) {
+					$args['horizontal-offset'] = $horizontal_offset;
+					$args['vertical-offset']   = $vertical_offset;
 				}
 
 				// Inject offsets as CSS variable to take effect.

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -58,6 +58,7 @@ function plvt_sanitize_view_transitions_theme_support(): void {
 			'.wp-post-image'                         => 'post-thumbnail',
 			'.wp-block-post-content, .entry-content' => 'post-content',
 		),
+		'default-animation'       => 'wipe-from-left',
 	);
 
 	// If no specific `$args` were provided, simply use the defaults.
@@ -89,6 +90,184 @@ function plvt_sanitize_view_transitions_theme_support(): void {
 }
 
 /**
+ * Registers the default view transition animations and fires an action to register additional ones.
+ *
+ * @since 1.0.0
+ * @access private
+ *
+ * @param PLVT_View_Transition_Animation_Registry $animation_registry Registry instance to register animations on.
+ */
+function plvt_register_view_transition_animations( PLVT_View_Transition_Animation_Registry $animation_registry ): void {
+	// Register default animations.
+	$animation_registry->register_animation(
+		'fade', // This is how view transitions are animated without any extra CSS.
+		array(
+			'use_stylesheet'              => false,
+			'use_global_transition_names' => true,
+			'use_post_transition_names'   => true,
+		)
+	);
+	$animation_registry->register_animation(
+		'slide',
+		array(
+			'aliases'                     => array(
+				'slide-from-right',
+				'slide-from-bottom',
+				'slide-from-left',
+				'slide-from-top',
+			),
+			'use_stylesheet'              => true,
+			'use_global_transition_names' => static function ( string $alias, array $args ) {
+				// If no specific element is targeted, the entire screen should be moved.
+				return '*' === $args['target-name'] ? false : true;
+			},
+			'use_post_transition_names'   => static function ( string $alias, array $args ) {
+				// If no specific element is targeted, the entire screen should be moved.
+				return '*' === $args['target-name'] ? false : true;
+			},
+			'get_stylesheet_callback'     => static function ( string $css, string $alias, array $args ) {
+				// Set offsets based on alias, if relevant.
+				if ( str_ends_with( $alias, 'left' ) ) {
+					$args['horizontal-offset'] = -1;
+					$args['vertical-offset']   = 0;
+				} elseif ( str_ends_with( $alias, 'top' ) ) {
+					$args['horizontal-offset'] = 0;
+					$args['vertical-offset']   = -1;
+				} elseif ( str_ends_with( $alias, 'bottom' ) ) {
+					$args['horizontal-offset'] = 0;
+					$args['vertical-offset']   = 1;
+				} elseif ( str_ends_with( $alias, 'right' ) ) {
+					$args['horizontal-offset'] = 1;
+					$args['vertical-offset']   = 0;
+				}
+
+				// Inject offsets as CSS variable to take effect.
+				$css .= sprintf(
+					'::view-transition-old(*), ::view-transition-new(*) { --wp-view-transition-animation-slide-horizontal-offset: %d; --wp-view-transition-animation-slide-vertical-offset: %d; }',
+					$args['horizontal-offset'],
+					$args['vertical-offset']
+				);
+
+				// If a specific element view transition name is targeted, scope the animation to only that name.
+				if ( '*' !== $args['target-name'] ) {
+					$css = str_replace( '(*)', "({$args['target-name']})", $css );
+				}
+
+				return $css;
+			},
+		),
+		array(
+			'horizontal-offset' => 1,
+			'vertical-offset'   => 0,
+			'target-name'       => '*',
+		)
+	);
+	$animation_registry->register_animation(
+		'swipe',
+		array(
+			'aliases'                     => array(
+				'swipe-from-right',
+				'swipe-from-bottom',
+				'swipe-from-left',
+				'swipe-from-top',
+			),
+			'use_stylesheet'              => true,
+			'use_global_transition_names' => static function ( string $alias, array $args ) {
+				// If no specific element is targeted, the entire screen should be moved.
+				return '*' === $args['target-name'] ? false : true;
+			},
+			'use_post_transition_names'   => static function ( string $alias, array $args ) {
+				// If no specific element is targeted, the entire screen should be moved.
+				return '*' === $args['target-name'] ? false : true;
+			},
+			'get_stylesheet_callback'     => static function ( string $css, string $alias, array $args ) {
+				// Set offsets based on alias, if relevant.
+				if ( str_ends_with( $alias, 'left' ) ) {
+					$args['horizontal-offset'] = -1;
+					$args['vertical-offset']   = 0;
+				} elseif ( str_ends_with( $alias, 'top' ) ) {
+					$args['horizontal-offset'] = 0;
+					$args['vertical-offset']   = -1;
+				} elseif ( str_ends_with( $alias, 'bottom' ) ) {
+					$args['horizontal-offset'] = 0;
+					$args['vertical-offset']   = 1;
+				} elseif ( str_ends_with( $alias, 'right' ) ) {
+					$args['horizontal-offset'] = 1;
+					$args['vertical-offset']   = 0;
+				}
+
+				// Inject offsets as CSS variable to take effect.
+				$css .= sprintf(
+					'::view-transition-old(*), ::view-transition-new(*) { --wp-view-transition-animation-swipe-horizontal-offset: %d; --wp-view-transition-animation-swipe-vertical-offset: %d; }',
+					$args['horizontal-offset'],
+					$args['vertical-offset']
+				);
+
+				// If a specific element view transition name is targeted, scope the animation to only that name.
+				if ( '*' !== $args['target-name'] ) {
+					$css = str_replace( '(*)', "({$args['target-name']})", $css );
+				}
+
+				return $css;
+			},
+		),
+		array(
+			'horizontal-offset' => 1,
+			'vertical-offset'   => 0,
+			'target-name'       => '*',
+		)
+	);
+	$animation_registry->register_animation(
+		'wipe',
+		array(
+			'aliases'                     => array(
+				'wipe-from-right',
+				'wipe-from-bottom',
+				'wipe-from-left',
+				'wipe-from-top',
+			),
+			'use_stylesheet'              => true,
+			'use_global_transition_names' => false,
+			'use_post_transition_names'   => true,
+			'get_stylesheet_callback'     => static function ( string $css, string $alias, array $args ) {
+				// Set angle based on alias, if relevant.
+				if ( str_ends_with( $alias, 'left' ) ) {
+					$args['angle'] = 90;
+				} elseif ( str_ends_with( $alias, 'top' ) ) {
+					$args['angle'] = 180;
+				} elseif ( str_ends_with( $alias, 'bottom' ) ) {
+					$args['angle'] = 0;
+				} elseif ( str_ends_with( $alias, 'right' ) ) {
+					$args['angle'] = 270;
+				}
+
+				// Inject angle as CSS variable to take effect.
+				$css .= sprintf(
+					'::view-transition-new(root) { --wp-view-transition-animation-wipe-angle: %ddeg; }',
+					$args['angle']
+				);
+
+				return $css;
+			},
+		),
+		array( 'angle' => 270 )
+	);
+
+	/**
+	 * Fires when view transition animations are being registered.
+	 *
+	 * This is only triggered if the theme supports view transitions, as otherwise the functionality is not relevant.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param PLVT_View_Transition_Animation_Registry $animation_registry Registry instance on which to register view
+	 *                                                                    transition animations which can be used by
+	 *                                                                    the theme.
+	 */
+	do_action( 'plvt_register_view_transition_animations', $animation_registry );
+}
+
+/**
  * Loads view transitions based on the current configuration.
  *
  * @since 1.0.0
@@ -98,6 +277,10 @@ function plvt_load_view_transitions(): void {
 		return;
 	}
 
+	// Instantiate transition animation registry and register available animations on it.
+	$animation_registry = new PLVT_View_Transition_Animation_Registry();
+	plvt_register_view_transition_animations( $animation_registry );
+
 	// Use an inline style to avoid an extra request.
 	$stylesheet = '@view-transition { navigation: auto; }';
 	wp_register_style( 'wp-view-transitions', false, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
@@ -105,6 +288,15 @@ function plvt_load_view_transitions(): void {
 	wp_enqueue_style( 'wp-view-transitions' );
 
 	$theme_support = get_theme_support( 'view-transitions' );
+
+	/*
+	 * Add the animation stylesheet for the default animation, if any.
+	 */
+	$default_animation_args       = isset( $theme_support['default-animation-args'] ) ? (array) $theme_support['default-animation-args'] : array();
+	$default_animation_stylesheet = $animation_registry->get_animation_stylesheet( $theme_support['default-animation'], $default_animation_args );
+	if ( '' !== $default_animation_stylesheet ) {
+		wp_add_inline_style( 'wp-view-transitions', $default_animation_stylesheet );
+	}
 
 	/*
 	 * No point in loading the script if no specific view transition names are configured.
@@ -116,10 +308,18 @@ function plvt_load_view_transitions(): void {
 		return;
 	}
 
+	$animations_js_config = array(
+		'default' => array(
+			'useGlobalTransitionNames' => $animation_registry->use_animation_global_transition_names( $theme_support['default-animation'], $default_animation_args ),
+			'usePostTransitionNames'   => $animation_registry->use_animation_post_transition_names( $theme_support['default-animation'], $default_animation_args ),
+		),
+	);
+
 	$config = array(
 		'postSelector'          => $theme_support['post-selector'],
 		'globalTransitionNames' => $theme_support['global-transition-names'],
 		'postTransitionNames'   => $theme_support['post-transition-names'],
+		'animations'            => $animations_js_config,
 	);
 
 	// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -22,27 +22,37 @@ window.plvtInitViewTransitions = ( config ) => {
 	/**
 	 * Gets all view transition entries relevant for a view transition.
 	 *
+	 * @param {string}       transitionType View transition type. Only 'default' is supported so far, but more to be added.
 	 * @param {Element}      bodyElement    The body element.
 	 * @param {Element|null} articleElement The post element relevant for the view transition, if any.
 	 * @return {Array[]} View transition entries with each one containing the element and its view transition name.
 	 */
-	const getViewTransitionEntries = ( bodyElement, articleElement ) => {
-		const globalEntries = Object.entries(
-			config.globalTransitionNames || {}
-		).map( ( [ selector, name ] ) => {
-			const element = bodyElement.querySelector( selector );
-			return [ element, name ];
-		} );
-
-		const postEntries = articleElement
-			? Object.entries( config.postTransitionNames || {} ).map(
+	const getViewTransitionEntries = (
+		transitionType,
+		bodyElement,
+		articleElement
+	) => {
+		const globalEntries = config.animations[ transitionType ]
+			.useGlobalTransitionNames
+			? Object.entries( config.globalTransitionNames || {} ).map(
 					( [ selector, name ] ) => {
-						const element =
-							articleElement.querySelector( selector );
+						const element = bodyElement.querySelector( selector );
 						return [ element, name ];
 					}
 			  )
 			: [];
+
+		const postEntries =
+			config.animations[ transitionType ].usePostTransitionNames &&
+			articleElement
+				? Object.entries( config.postTransitionNames || {} ).map(
+						( [ selector, name ] ) => {
+							const element =
+								articleElement.querySelector( selector );
+							return [ element, name ];
+						}
+				  )
+				: [];
 
 		return [ ...globalEntries, ...postEntries ];
 	};
@@ -131,9 +141,13 @@ window.plvtInitViewTransitions = ( config ) => {
 		'pageswap',
 		( /** @type {PageSwapEvent} */ event ) => {
 			if ( event.viewTransition ) {
+				const transitionType = 'default'; // Only 'default' is supported so far, but more to be added.
+				event.viewTransition.types.add( transitionType );
+
 				let viewTransitionEntries;
 				if ( document.body.classList.contains( 'single' ) ) {
 					viewTransitionEntries = getViewTransitionEntries(
+						transitionType,
 						document.body,
 						getArticle()
 					);
@@ -142,6 +156,7 @@ window.plvtInitViewTransitions = ( config ) => {
 					document.body.classList.contains( 'archive' )
 				) {
 					viewTransitionEntries = getViewTransitionEntries(
+						transitionType,
 						document.body,
 						getArticleForUrl( event.activation.entry.url )
 					);
@@ -166,9 +181,13 @@ window.plvtInitViewTransitions = ( config ) => {
 		'pagereveal',
 		( /** @type {PageRevealEvent} */ event ) => {
 			if ( event.viewTransition ) {
+				const transitionType = 'default'; // Only 'default' is supported so far, but more to be added.
+				event.viewTransition.types.add( transitionType );
+
 				let viewTransitionEntries;
 				if ( document.body.classList.contains( 'single' ) ) {
 					viewTransitionEntries = getViewTransitionEntries(
+						transitionType,
 						document.body,
 						getArticle()
 					);
@@ -177,6 +196,7 @@ window.plvtInitViewTransitions = ( config ) => {
 					document.body.classList.contains( 'archive' )
 				) {
 					viewTransitionEntries = getViewTransitionEntries(
+						transitionType,
 						document.body,
 						window.navigation.activation.from
 							? getArticleForUrl(

--- a/plugins/view-transitions/tests/test-theme.php
+++ b/plugins/view-transitions/tests/test-theme.php
@@ -24,21 +24,21 @@ class Test_ViewTransitions_Theme extends WP_UnitTestCase {
 
 	public function test_plvt_load_view_transitions(): void {
 		// Clear up style if it is already registered.
-		if ( wp_style_is( 'wp-view-transitions', 'registered' ) ) {
-			unset( wp_styles()->registered['wp-view-transitions'] );
+		if ( wp_style_is( 'plvt-view-transitions', 'registered' ) ) {
+			unset( wp_styles()->registered['plvt-view-transitions'] );
 		}
 
 		// Test that without theme support this does nothing.
 		remove_theme_support( 'view-transitions' );
 		plvt_load_view_transitions();
-		$this->assertFalse( wp_style_is( 'wp-view-transitions', 'registered' ) );
-		$this->assertFalse( wp_style_is( 'wp-view-transitions', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'plvt-view-transitions', 'registered' ) );
+		$this->assertFalse( wp_style_is( 'plvt-view-transitions', 'enqueued' ) );
 
 		// Test that with theme support it registers and enqueues the style.
 		add_theme_support( 'view-transitions' );
 		plvt_sanitize_view_transitions_theme_support(); // This must be called to sanitize the arguments (normally on 'init').
 		plvt_load_view_transitions();
-		$this->assertTrue( wp_style_is( 'wp-view-transitions', 'registered' ) );
-		$this->assertTrue( wp_style_is( 'wp-view-transitions', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'plvt-view-transitions', 'registered' ) );
+		$this->assertTrue( wp_style_is( 'plvt-view-transitions', 'enqueued' ) );
 	}
 }

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -27,6 +27,8 @@ if ( defined( 'VIEW_TRANSITIONS_VERSION' ) ) {
 
 define( 'VIEW_TRANSITIONS_VERSION', '1.0.0' );
 
+require_once __DIR__ . '/includes/class-plvt-view-transition-animation.php';
+require_once __DIR__ . '/includes/class-plvt-view-transition-animation-registry.php';
 require_once __DIR__ . '/includes/functions.php';
 require_once __DIR__ . '/includes/theme.php';
 require_once __DIR__ . '/hooks.php';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -252,6 +252,30 @@ const viewTransitions = ( env ) => {
 						from: `${ destination }/js/view-transitions.js`,
 						to: `${ destination }/js/view-transitions.min.js`,
 					},
+					{
+						from: `${ destination }/css/view-transition-animation-slide.css`,
+						to: `${ destination }/css/view-transition-animation-slide.min.css`,
+						transform: {
+							transformer: cssMinifyTransformer,
+							cache: false,
+						},
+					},
+					{
+						from: `${ destination }/css/view-transition-animation-swipe.css`,
+						to: `${ destination }/css/view-transition-animation-swipe.min.css`,
+						transform: {
+							transformer: cssMinifyTransformer,
+							cache: false,
+						},
+					},
+					{
+						from: `${ destination }/css/view-transition-animation-wipe.css`,
+						to: `${ destination }/css/view-transition-animation-wipe.min.css`,
+						transform: {
+							transformer: cssMinifyTransformer,
+							cache: false,
+						},
+					},
 				],
 			} ),
 			// @ts-expect-error TS2351: WebpackBar is constructable when using require(), type definitions might be geared towards ESM.


### PR DESCRIPTION
## Summary

See #1997

## Relevant technical choices

* Adds new `default-animation` argument (and optional `default-animation-args` argument) to the `view-transitions` theme support arguments.
* Adds a view transition animation class and corresponding registry to handle view transition animations. Each view transition animation consists of:
    * A unique slug
    * CSS to be loaded
    * Whether the global view transition names should be applied for this animation
    * Whether the post-specific view transition names should be applied for this animation
    * Optional arguments for fine tuning (e.g. exact angle from which a wipe animation occurs)
    * Optional aliases (can also be used as a "short hand" for certain common argument values; e.g. "wipe-from-bottom" is an alias for the general "wipe", but as indicated will then configure the angle so that the wipe comes from the bottom of the screen)
* By default, the follow animations are available: `fade` (default), `slide`, `swipe`, `wipe`.

As with the other changes, all of this code was already implemented before in https://github.com/WordPress/wordpress-develop/pull/8370. See https://github.com/WordPress/wordpress-develop/pull/8370#issuecomment-2822669911 for additional information on the available animations (ignore the points on the other transition types than `default` for now).

To test this locally, you can either add theme support with the arguments in your current theme, or temporarily alter the default that the plugin adds by itself. Make sure to run `npm run build:plugin:view-transitions` first, to ensure the built CSS and JavaScript is available.

A follow up PR will add a settings UI to change this default transition animation, to make it easy to modify for end users of the plugin, without touching code.