### PR TITLE
Prevent effective asset cache headers audit from running on local/development environments

### DIFF
--- a/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
+++ b/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
@@ -22,20 +22,21 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array{direct: array<string, array{label: string, test: string}>} Amended tests.
  */
 function perflab_effective_asset_cache_headers_add_test( array $tests ): array {
+	/*
+	 * Static assets are expected to not have effective cache headers in non-production environments.
+	 * Hence bail early.
+	 *
+	 * GH Issue: https://github.com/WordPress/performance/issues/2031
+	 */
+	if ( in_array( wp_get_environment_type(), array( 'local', 'development' ), true ) ) {
+		return $tests;
+	}
+
 	$tests['direct']['effective_asset_cache_headers'] = array(
 		'label' => __( 'Effective Caching Headers', 'performance-lab' ),
 		'test'  => 'perflab_effective_asset_cache_headers_assets_test',
 	);
 
-	/**
-	 * Static assets are expected to not have effective cache headers in non-production environments.
-	 *
-	 * GH Issue: https://github.com/WordPress/performance/issues/2031
-	 */
-	if ( in_array( wp_get_environment_type(), array( 'local', 'development' ), true ) ) {
-		unset( $tests['direct']['effective_asset_cache_headers'] );
-	}
-
 	return $tests;
 }
-add_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test', 100 );
+add_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test' );

--- a/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
+++ b/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
@@ -24,18 +24,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 function perflab_effective_asset_cache_headers_add_test( array $tests ): array {
 	/*
 	 * Static assets are expected to not have effective cache headers in non-production environments.
-	 * Hence bail early.
 	 *
 	 * GH Issue: https://github.com/WordPress/performance/issues/2031
 	 */
-	if ( in_array( wp_get_environment_type(), array( 'local', 'development' ), true ) ) {
-		return $tests;
+	if ( ! in_array( wp_get_environment_type(), array( 'local', 'development' ), true ) ) {
+		$tests['direct']['effective_asset_cache_headers'] = array(
+			'label' => __( 'Effective Caching Headers', 'performance-lab' ),
+			'test'  => 'perflab_effective_asset_cache_headers_assets_test',
+		);
 	}
-
-	$tests['direct']['effective_asset_cache_headers'] = array(
-		'label' => __( 'Effective Caching Headers', 'performance-lab' ),
-		'test'  => 'perflab_effective_asset_cache_headers_assets_test',
-	);
 
 	return $tests;
 }

--- a/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
+++ b/plugins/performance-lab/includes/site-health/effective-asset-cache-headers/hooks.php
@@ -26,6 +26,16 @@ function perflab_effective_asset_cache_headers_add_test( array $tests ): array {
 		'label' => __( 'Effective Caching Headers', 'performance-lab' ),
 		'test'  => 'perflab_effective_asset_cache_headers_assets_test',
 	);
+
+	/**
+	 * Static assets are expected to not have effective cache headers in non-production environments.
+	 *
+	 * GH Issue: https://github.com/WordPress/performance/issues/2031
+	 */
+	if ( in_array( wp_get_environment_type(), array( 'local', 'development' ), true ) ) {
+		unset( $tests['direct']['effective_asset_cache_headers'] );
+	}
+
 	return $tests;
 }
-add_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test' );
+add_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test', 100 );

--- a/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
+++ b/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
@@ -29,6 +29,21 @@ class Test_Effective_Asset_Cache_Headers extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the effective caching headers test is added to the site health tests.
+	 *
+	 * @covers ::perflab_effective_asset_cache_headers_add_test
+	 */
+	public function test_perflab_effective_asset_cache_headers_add_test(): void {
+		$tests = array(
+			'direct' => array(),
+		);
+
+		$tests = perflab_effective_asset_cache_headers_add_test( $tests );
+
+		$this->assertArrayNotHasKey( 'effective_asset_cache_headers', $tests['direct'] );
+	}
+
+	/**
 	 * Test that the effective caching headers test is attached to the site status tests.
 	 *
 	 * @covers ::perflab_effective_asset_cache_headers_add_test

--- a/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
+++ b/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
@@ -40,14 +40,6 @@ class Test_Effective_Asset_Cache_Headers extends WP_UnitTestCase {
 
 		$tests = perflab_effective_asset_cache_headers_add_test( $tests );
 
-		// Test for local env.
-		$this->assertArrayNotHasKey( 'effective_asset_cache_headers', $tests['direct'] );
-
-		// Mock the env to production and call test again.
-		// @todo Mock wp_get_environment_type here.
-		$tests = perflab_effective_asset_cache_headers_add_test( $tests );
-
-		// Test for production env.
 		$this->assertArrayHasKey( 'effective_asset_cache_headers', $tests['direct'] );
 		$this->assertEquals( 'Effective Caching Headers', $tests['direct']['effective_asset_cache_headers']['label'] );
 		$this->assertEquals( 'perflab_effective_asset_cache_headers_assets_test', $tests['direct']['effective_asset_cache_headers']['test'] );

--- a/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
+++ b/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
@@ -29,23 +29,6 @@ class Test_Effective_Asset_Cache_Headers extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the effective caching headers test is added to the site health tests.
-	 *
-	 * @covers ::perflab_effective_asset_cache_headers_add_test
-	 */
-	public function test_perflab_effective_asset_cache_headers_add_test(): void {
-		$tests = array(
-			'direct' => array(),
-		);
-
-		$tests = perflab_effective_asset_cache_headers_add_test( $tests );
-
-		$this->assertArrayHasKey( 'effective_asset_cache_headers', $tests['direct'] );
-		$this->assertEquals( 'Effective Caching Headers', $tests['direct']['effective_asset_cache_headers']['label'] );
-		$this->assertEquals( 'perflab_effective_asset_cache_headers_assets_test', $tests['direct']['effective_asset_cache_headers']['test'] );
-	}
-
-	/**
 	 * Test that the effective caching headers test is attached to the site status tests.
 	 *
 	 * @covers ::perflab_effective_asset_cache_headers_add_test

--- a/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
+++ b/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
@@ -40,6 +40,14 @@ class Test_Effective_Asset_Cache_Headers extends WP_UnitTestCase {
 
 		$tests = perflab_effective_asset_cache_headers_add_test( $tests );
 
+		// Test for local env.
+		$this->assertArrayNotHasKey( 'effective_asset_cache_headers', $tests['direct'] );
+
+		// Mock the env to production and call test again.
+		// @todo Mock wp_get_environment_type here.
+		$tests = perflab_effective_asset_cache_headers_add_test( $tests );
+
+		// Test for production env.
 		$this->assertArrayHasKey( 'effective_asset_cache_headers', $tests['direct'] );
 		$this->assertEquals( 'Effective Caching Headers', $tests['direct']['effective_asset_cache_headers']['label'] );
 		$this->assertEquals( 'perflab_effective_asset_cache_headers_assets_test', $tests['direct']['effective_asset_cache_headers']['test'] );
@@ -51,7 +59,7 @@ class Test_Effective_Asset_Cache_Headers extends WP_UnitTestCase {
 	 * @covers ::perflab_effective_asset_cache_headers_add_test
 	 */
 	public function test_perflab_effective_asset_cache_headers_add_test_is_attached_to_site_status_tests(): void {
-		$this->assertNotFalse( has_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test' ) );
+		$this->assertEquals( 100, has_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test' ) );
 	}
 
 	/**

--- a/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
+++ b/plugins/performance-lab/tests/includes/site-health/effective-asset-cache-headers/test-effective-asset-cache-headers.php
@@ -49,7 +49,7 @@ class Test_Effective_Asset_Cache_Headers extends WP_UnitTestCase {
 	 * @covers ::perflab_effective_asset_cache_headers_add_test
 	 */
 	public function test_perflab_effective_asset_cache_headers_add_test_is_attached_to_site_status_tests(): void {
-		$this->assertEquals( 100, has_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test' ) );
+		$this->assertNotFalse( has_filter( 'site_status_tests', 'perflab_effective_asset_cache_headers_add_test' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2031 

## Relevant technical choices

<!-- Please describe your changes. -->

1. Update the `site_status_tests` filter to unset the `effective_asset_cache_headers` for local and development env.
2. Tests are not updated as unable to mock the `wp_get_environment_type` to support for 2 different scenarios.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
