### PR TITLE
Fix view transitions setting values not being saved

### DIFF
--- a/plugins/view-transitions/includes/settings.php
+++ b/plugins/view-transitions/includes/settings.php
@@ -128,8 +128,8 @@ function plvt_sanitize_setting( $input ): array {
 		'post_content_selector',
 	);
 	foreach ( $selector_options as $selector_option ) {
-		if ( isset( $value[ $selector_option ] ) && is_string( $value[ $selector_option ] ) ) {
-			$selector_option_value = trim( sanitize_text_field( $value[ $selector_option ] ) );
+		if ( isset( $input[ $selector_option ] ) && is_string( $input[ $selector_option ] ) ) {
+			$selector_option_value = trim( sanitize_text_field( $input[ $selector_option ] ) );
 			if ( '' !== $selector_option_value ) {
 				$value[ $selector_option ] = $selector_option_value;
 			}

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.8
-Stable tag:   1.0.0
+Stable tag:   1.0.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, view transitions, smooth transitions, animations
@@ -50,6 +50,10 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.0.1 =
+
+* Fix view transitions setting values not being saved. ([2036](https://github.com/WordPress/performance/pull/2036))
 
 = 1.0.0 =
 

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -5,7 +5,7 @@
  * Description: Adds smooth transitions between navigations to your WordPress site.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'VIEW_TRANSITIONS_VERSION' ) ) {
 	return;
 }
 
-define( 'VIEW_TRANSITIONS_VERSION', '1.0.0' );
+define( 'VIEW_TRANSITIONS_VERSION', '1.0.1' );
 define( 'VIEW_TRANSITIONS_MAIN_FILE', __FILE__ );
 
 require_once __DIR__ . '/includes/class-plvt-view-transition-animation.php';


### PR DESCRIPTION
## Summary

The `plvt_sanitize_setting()` function of the `view transitions` plugin sanitizes the default values, not the input values. Currently, the new input values of the selectors are not saved. This PR fixes the problem.