### PR TITLE
Add an After activation section as part of installation instructions for plugins with settings UI

### DIFF
--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -44,7 +44,7 @@ _This plugin was formerly known as Speculation Rules._
 
 = After activation =
 
-1. Visit the new **Settings > Reading** menu.
+1. Visit the **Settings > Reading** admin screen.
 2. Use the controls in the **Speculative Loading** section to configure speculative loading.
 
 == Frequently Asked Questions ==

--- a/plugins/speculation-rules/readme.txt
+++ b/plugins/speculation-rules/readme.txt
@@ -42,6 +42,11 @@ _This plugin was formerly known as Speculation Rules._
 2. Visit **Plugins**.
 3. Activate the **Speculative Loading** plugin.
 
+= After activation =
+
+1. Visit the new **Settings > Reading** menu.
+2. Use the controls in the **Speculative Loading** section to configure speculative loading.
+
 == Frequently Asked Questions ==
 
 = How can I prevent certain URLs from being prefetched and prerendered? =

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -33,6 +33,11 @@ Cross-document view transitions are supported in a variety of browsers, includin
 2. Visit **Plugins**.
 3. Activate the **View Transitions** plugin.
 
+= After activation =
+
+1. Visit the new **Settings > Reading** menu.
+2. Use the controls in the **View Transitions** section to configure view transitions.
+
 == Frequently Asked Questions ==
 
 = Where can I submit my plugin feedback? =

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -35,7 +35,7 @@ Cross-document view transitions are supported in a variety of browsers, includin
 
 = After activation =
 
-1. Visit the new **Settings > Reading** menu.
+1. Visit the **Settings > Reading** admin screen.
 2. Use the controls in the **View Transitions** section to configure view transitions.
 
 == Frequently Asked Questions ==

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -31,6 +31,11 @@ _This plugin was formerly known as WebP Uploads._
 2. Visit **Plugins**.
 3. Activate the **Modern Image Formats** plugin.
 
+= After activation =
+
+1. Visit the new **Settings > Media** menu.
+2. Use the controls in the **Modern Image Formats** section to configure modern image formats.
+
 == Frequently Asked Questions ==
 
 = Where can I submit my plugin feedback? =

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -33,7 +33,7 @@ _This plugin was formerly known as WebP Uploads._
 
 = After activation =
 
-1. Visit the new **Settings > Media** menu.
+1. Visit the **Settings > Media** admin screen.
 2. Use the controls in the **Modern Image Formats** section to configure modern image formats.
 
 == Frequently Asked Questions ==


### PR DESCRIPTION
Originally raised here: https://wordpress.org/support/topic/requested-features-6/

This does not only apply to View Transitions though, but also to Speculative Loading and Modern Image Formats.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
