### PR TITLE
Update plugin authors to `performanceteam`

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.8
  * Requires PHP: 7.2
  * Version: 1.4.0
- * Author: WordPress Performance Team
+ * Author: performanceteam
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.6
  * Requires PHP: 7.2
  * Version: 1.0.1
- * Author: WordPress Performance Team
+ * Author: performanceteam
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary

This pull request includes minor updates to the author information in two plugin files. The changes standardize the author name from "WordPress Performance Team" to "performanceteam."

Updated author information:

* [`plugins/auto-sizes/auto-sizes.php`](diffhunk://#diff-dc82eae3e21aba9ebc7a029122731b358cb8f1b30a326578f02b80fe781c75c5L9-R9): Changed the author name to "performanceteam."
* [`plugins/view-transitions/view-transitions.php`](diffhunk://#diff-1557aeb915346af4a52ae6795d25b9fe754d50153941419606ddfa4b8a4278beL9-R9): Changed the author name to "performanceteam."

## Relevant technical choices

Note that after updating these on WPORG that @felixarntz and @joemcgill will also need to follow the steps on https://developer.wordpress.org/plugins/wordpress-org/transferring-your-plugin-to-a-new-owner/ so that https://wordpress.org/plugins/view-transitions/ && https://wordpress.org/plugins/auto-sizes/ respectively get transferred to the `performanceteam` user and properly represented as "By WordPress Performance Team".



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
