### PR TITLE
Prepare the Accurate Sizes changes for release as part of the `auto-sizes` plugin

### DIFF
--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -5,7 +5,7 @@
  * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
  * Requires at least: 6.8
  * Requires PHP: 7.2
- * Version: 1.4.0
+ * Version: 1.5.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ if ( defined( 'IMAGE_AUTO_SIZES_VERSION' ) ) {
 	return;
 }
 
-define( 'IMAGE_AUTO_SIZES_VERSION', '1.4.0' );
+define( 'IMAGE_AUTO_SIZES_VERSION', '1.5.0' );
 
 require_once __DIR__ . '/includes/auto-sizes.php';
 require_once __DIR__ . '/includes/improve-calculate-sizes.php';

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -54,10 +54,6 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.5.0 =
 
-**Features**
-
-* Add E2E tests setup for Auto Sizes. ([1988](https://github.com/WordPress/performance/pull/1988))
-
 **Enhancements**
 
 * Accurate sizes: Add ancestor block context for image and cover block that help in sizes calculate. ([1795](https://github.com/WordPress/performance/pull/1795))

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.8
-Stable tag:   1.4.0
+Stable tag:   1.5.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, auto-sizes

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -52,6 +52,17 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 == Changelog ==
 
+= 1.5.0 =
+
+**Features**
+
+* Add E2E tests setup for Auto Sizes. ([1988](https://github.com/WordPress/performance/pull/1988))
+
+**Enhancements**
+
+* Accurate sizes: Add ancestor block context for image and cover block that help in sizes calculate. ([1795](https://github.com/WordPress/performance/pull/1795))
+* Accurate sizes: Calculate sizes base on ancestor block context. ([1818](https://github.com/WordPress/performance/pull/1818))
+
 = 1.4.0 =
 
 **Features**


### PR DESCRIPTION
## Summary

- **Bump plugin versions**
- **Update readme changelogs**

Plugins included in this release:
- auto-sizes 1.5.0

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
