### PR TITLE
View-Transitions: Respect prefers-reduced-motion settings

### DIFF
--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -304,7 +304,7 @@ function plvt_load_view_transitions(): void {
 	plvt_register_view_transition_animations( $animation_registry );
 
 	// Use an inline style to avoid an extra request.
-	$stylesheet = '@view-transition { navigation: auto; }';
+	$stylesheet = '@media (prefers-reduced-motion: no-preference) { @view-transition { navigation: auto; } }';
 	wp_register_style( 'plvt-view-transitions', false, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_add_inline_style( 'plvt-view-transitions', $stylesheet );
 	wp_enqueue_style( 'plvt-view-transitions' );

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -304,7 +304,7 @@ function plvt_load_view_transitions(): void {
 	plvt_register_view_transition_animations( $animation_registry );
 
 	// Use an inline style to avoid an extra request.
-	$stylesheet = '@media (prefers-reduced-motion: no-preference) { @view-transition { navigation: auto; } }';
+	$stylesheet = '@view-transition { navigation: auto; }';
 	wp_register_style( 'plvt-view-transitions', false, array(), null ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_add_inline_style( 'plvt-view-transitions', $stylesheet );
 	wp_enqueue_style( 'plvt-view-transitions' );
@@ -317,7 +317,7 @@ function plvt_load_view_transitions(): void {
 	$default_animation_args       = isset( $theme_support['default-animation-args'] ) ? (array) $theme_support['default-animation-args'] : array();
 	$default_animation_stylesheet = $animation_registry->get_animation_stylesheet( $theme_support['default-animation'], $default_animation_args );
 	$default_animation_stylesheet = plvt_inject_animation_duration( $default_animation_stylesheet, absint( $theme_support['default-animation-duration'] ) );
-	wp_add_inline_style( 'plvt-view-transitions', $default_animation_stylesheet );
+	wp_add_inline_style( 'plvt-view-transitions', '@media (prefers-reduced-motion: no-preference) {' . $default_animation_stylesheet . '}' );
 
 	/*
 	 * No point in loading the script if no specific view transition names are configured.


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2067

## Relevant technical choices

<!-- Please describe your changes. -->
Wrapped the initializing `@view-transition` inline style with a check for `prefers-reduced-motion: no-preference`, so that the animation effects are NOT applied if `prefers-reduced-motion` is true.

https://github.com/user-attachments/assets/424beda6-7f9d-44d4-ac9c-70d8018f0ea2



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
