### PR TITLE
Remove experimental from Enhanced Responsive Images readme.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [Optimization Detective][33]    | `optimization-detective`  | No           | [Source][34], [Issues][35], [PRs][36]
 [Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
 [Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
-[Enhanced Responsive Images][6] | `auto-sizes`              | Yes          | [Source][14], [Issues][22], [PRs][30]
+[Enhanced Responsive Images][6] | `auto-sizes`              | No           | [Source][14], [Issues][22], [PRs][30]
 [View Transitions][37]          | `view-transitions`        | Yes          | [Source][38], [Issues][39], [PRs][40]
 [Web Worker Offloading][8]      | `web-worker-offloading`   | Yes          | [Source][16], [Issues][24], [PRs][32]
 

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The feature plugins which are currently featured by this plugin are:
 Plugin                          | Slug                      | Experimental | Links
 --------------------------------|---------------------------|--------------|-------------
 [Embed Optimizer][5]            | `embed-optimizer`         | No           | [Source][13], [Issues][21], [PRs][29]
+[Enhanced Responsive Images][6] | `auto-sizes`              | No           | [Source][14], [Issues][22], [PRs][30]
 [Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][9],  [Issues][17], [PRs][25]
 [Image Prioritizer][7]          | `image-prioritizer`       | No           | [Source][15], [Issues][23], [PRs][31]
 [Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
 [Optimization Detective][33]    | `optimization-detective`  | No           | [Source][34], [Issues][35], [PRs][36]
 [Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
 [Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
-[Enhanced Responsive Images][6] | `auto-sizes`              | No           | [Source][14], [Issues][22], [PRs][30]
 [View Transitions][37]          | `view-transitions`        | Yes          | [Source][38], [Issues][39], [PRs][40]
 [Web Worker Offloading][8]      | `web-worker-offloading`   | Yes          | [Source][16], [Issues][24], [PRs][32]
 

--- a/plugins/auto-sizes/readme.txt
+++ b/plugins/auto-sizes/readme.txt
@@ -11,7 +11,7 @@ Improvements for responsive images in WordPress.
 
 == Description ==
 
-This plugin implements experimental enhancements for the responsive images functionality in WordPress. Currently, this includes:
+This plugin implements enhancements for the responsive images functionality in WordPress. Currently, this includes:
 
 1. Improvements to the accuracy of the `sizes` attribute by using available layout information in the theme.
 2. Implementation of the new HTML spec for adding `sizes="auto"` to lazy-loaded images. See the HTML spec issue [Add "auto sizes" for lazy-loaded images](https://github.com/whatwg/html/issues/4654).

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -97,7 +97,7 @@ function perflab_get_standalone_plugin_data(): array {
 	return array(
 		'auto-sizes'              => array(
 			'constant'     => 'IMAGE_AUTO_SIZES_VERSION',
-			'experimental' => true,
+			'experimental' => false,
 		),
 		'dominant-color-images'   => array(
 			'constant' => 'DOMINANT_COLOR_IMAGES_VERSION',

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -22,7 +22,7 @@ The feature plugins which are currently featured by this plugin are:
 * [Optimization Detective](https://wordpress.org/plugins/optimization-detective/) (dependency for Embed Optimizer and Image Prioritizer)
 * [Performant Translations](https://wordpress.org/plugins/performant-translations/)
 * [Speculative Loading](https://wordpress.org/plugins/speculation-rules/)
-* [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/) _(experimental)_
+* [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/)
 * [View Transitions](https://wordpress.org/plugins/view-transitions/) _(experimental)_
 * [Web Worker Offloading](https://wordpress.org/plugins/web-worker-offloading/) _(experimental)_
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -16,13 +16,13 @@ The Performance Lab plugin is a collection of features focused on enhancing perf
 The feature plugins which are currently featured by this plugin are:
 
 * [Embed Optimizer](https://wordpress.org/plugins/embed-optimizer/)
+* [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/)
 * [Image Placeholders](https://wordpress.org/plugins/dominant-color-images/)
 * [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/)
 * [Modern Image Formats](https://wordpress.org/plugins/webp-uploads/)
 * [Optimization Detective](https://wordpress.org/plugins/optimization-detective/) (dependency for Embed Optimizer and Image Prioritizer)
 * [Performant Translations](https://wordpress.org/plugins/performant-translations/)
 * [Speculative Loading](https://wordpress.org/plugins/speculation-rules/)
-* [Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/)
 * [View Transitions](https://wordpress.org/plugins/view-transitions/) _(experimental)_
 * [Web Worker Offloading](https://wordpress.org/plugins/web-worker-offloading/) _(experimental)_
 


### PR DESCRIPTION
## Summary
[Enhanced Responsive Images](https://wordpress.org/plugins/auto-sizes/) has demonstrated stability and reliability through:

- Version 1.5.0 with stable tag already established
- 40,000+ active installations indicating widespread adoption and trust
- Comprehensive changelog showing ongoing development and stability improvements

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2075

## Relevant technical choices
This PR removes the "experimental" label from the Enhanced Responsive Images plugin, reflecting its mature status with over 40,000 active installations and stable version 1.5.0.

### Changes Made

- **readme.txt**: Updated the description to remove "**experimental**" from "_This plugin implements **experimental** enhancements for the responsive images functionality in WordPress_" → "This plugin implements enhancements for the responsive images functionality in WordPress"





<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
