### PR TITLE
Make `plvt_inject_animation_duration()` reusable for all transition types, including default fade

### DIFF
--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -381,8 +381,8 @@ function plvt_inject_animation_duration( string $css, int $animation_duration ):
 
 	// Inject animation duration as CSS variable to take effect.
 	$css .= sprintf(
-		/* translators: %s is animation duration in seconds. */
-		'::view-transition-group(*) { %s: %ss; }',
+		/* translators: %1$s: CSS property name. %2$s: Animation duration in seconds. */
+		'::view-transition-group(*) { %1$s: %2$ss; }',
 		'' !== $css ? '--plvt-view-transition-animation-duration' : 'animation-duration',
 		$seconds
 	);

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -316,16 +316,7 @@ function plvt_load_view_transitions(): void {
 	 */
 	$default_animation_args       = isset( $theme_support['default-animation-args'] ) ? (array) $theme_support['default-animation-args'] : array();
 	$default_animation_stylesheet = $animation_registry->get_animation_stylesheet( $theme_support['default-animation'], $default_animation_args );
-	if ( '' !== $default_animation_stylesheet ) {
-		$default_animation_stylesheet = plvt_inject_animation_duration( $default_animation_stylesheet, absint( $theme_support['default-animation-duration'] ) );
-	} else {
-		$seconds                      = absint( $theme_support['default-animation-duration'] ) / 1000;
-		$default_animation_stylesheet = sprintf(
-			/* translators: %s is animation duration in seconds. */
-			'::view-transition-group(*) { animation-duration: %ss; }',
-			$seconds
-		);
-	}
+	$default_animation_stylesheet = plvt_inject_animation_duration( $default_animation_stylesheet, absint( $theme_support['default-animation-duration'] ) );
 	wp_add_inline_style( 'plvt-view-transitions', $default_animation_stylesheet );
 
 	/*

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -382,7 +382,8 @@ function plvt_inject_animation_duration( string $css, int $animation_duration ):
 	// Inject animation duration as CSS variable to take effect.
 	$css .= sprintf(
 		/* translators: %s is animation duration in seconds. */
-		'::view-transition-group(*) { --plvt-view-transition-animation-duration: %ss; }',
+		'::view-transition-group(*) { %s: %ss; }',
+		'' !== $css ? '--plvt-view-transition-animation-duration' : 'animation-duration',
 		$seconds
 	);
 


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

Follow-up to #2040

In #2051, we introduced the `plvt_inject_animation_duration()` function to support custom animation durations for non-fade transitions. For the default fade transition, however, we had to apply `animation-duration` directly since it doesn’t support the CSS variable `--plvt-view-transition-animation-duration`.

This PR refactors and improves the implementation by making `plvt_inject_animation_duration()` reusable across all transition types including the default fade effect. It ensures consistent handling of animation durations, whether via CSS variables or direct CSS properties, depending on what the browser supports for a given transition type.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
