### PR TITLE
Prepare view-transitions 1.1.0 release

### DIFF
--- a/plugins/view-transitions/includes/admin.php
+++ b/plugins/view-transitions/includes/admin.php
@@ -3,7 +3,7 @@
  * Admin related functions for View Transitions.
  *
  * @package view-transitions
- * @since n.e.x.t
+ * @since 1.1.0
  */
 
 // @codeCoverageIgnoreStart
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * It should be hooked to an appropriate action to ensure the styles
  * are included in the page output.
  *
- * @since n.e.x.t
+ * @since 1.1.0
  */
 function plvt_print_view_transitions_admin_style(): void {
 	$options = plvt_get_stored_setting_value();

--- a/plugins/view-transitions/includes/settings.php
+++ b/plugins/view-transitions/includes/settings.php
@@ -52,7 +52,6 @@ function plvt_get_view_transition_animation_labels(): array {
  *                                                         the other frontend specific settings won't be applied.
  *     @type string $default_transition_animation          Default view transition animation.
  *     @type int    $default_transition_animation_duration Default transition animation duration in milliseconds.
- *                                                         Added in n.e.x.t
  *     @type string $header_selector                       CSS selector for the global header element.
  *     @type string $main_selector                         CSS selector for the global main element.
  *     @type string $post_title_selector                   CSS selector for the post title element.
@@ -87,7 +86,6 @@ function plvt_get_setting_default(): array {
  *                                                         the other frontend specific settings won't be applied.
  *     @type string $default_transition_animation          Default view transition animation.
  *     @type int    $default_transition_animation_duration Default transition animation duration in milliseconds.
- *                                                         Added in n.e.x.t
  *     @type string $header_selector                       CSS selector for the global header element.
  *     @type string $main_selector                         CSS selector for the global main element.
  *     @type string $post_title_selector                   CSS selector for the post title element.
@@ -113,7 +111,6 @@ function plvt_get_stored_setting_value(): array {
  *                                                         the other frontend specific settings won't be applied.
  *     @type string $default_transition_animation          Default view transition animation.
  *     @type int    $default_transition_animation_duration Default transition animation duration in milliseconds.
- *                                                         Added in n.e.x.t
  *     @type string $header_selector                       CSS selector for the global header element.
  *     @type string $main_selector                         CSS selector for the global main element.
  *     @type string $post_title_selector                   CSS selector for the post title element.

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -369,7 +369,7 @@ function plvt_load_view_transitions(): void {
 /**
  * Injects the animation duration placeholder in the provided CSS with a value based on the transition duration.
  *
- * @since n.e.x.t
+ * @since 1.1.0
  * @access private
  *
  * @param string $css                The raw CSS string containing the placeholder `plvt-view-transition-duration;`.

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -58,6 +58,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.1.0 =
 
+**Features**
+
+* Add view transitions for WP Admin. ([2038](https://github.com/WordPress/performance/pull/2038))
+
 **Enhancements**
 
 * Allow control over view transition animation duration. ([2051](https://github.com/WordPress/performance/pull/2051))
@@ -67,6 +71,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 **Bug Fixes**
 
 * Inform the user if the current theme explicitly supports view transitions with its own configuration, and add a UI control to make overriding that configuration via settings optional. ([2037](https://github.com/WordPress/performance/pull/2037))
+* Set default view transition duration to 400 for better alignment with browser default. ([2081](https://github.com/WordPress/performance/pull/2081))
 * Respect prefers-reduced-motion settings. ([2068](https://github.com/WordPress/performance/pull/2068))
 
 = 1.0.1 =

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.8
-Stable tag:   1.0.1
+Stable tag:   1.1.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, view transitions, smooth transitions, animations
@@ -55,6 +55,19 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.1.0 =
+
+**Enhancements**
+
+* Allow control over view transition animation duration. ([2051](https://github.com/WordPress/performance/pull/2051))
+* Make `plvt_inject_animation_duration()` reusable for all transition types, including default fade. ([2078](https://github.com/WordPress/performance/pull/2078))
+* Make settings section title properly translatable. ([2042](https://github.com/WordPress/performance/pull/2042))
+
+**Bug Fixes**
+
+* Inform the user if the current theme explicitly supports view transitions with its own configuration, and add a UI control to make overriding that configuration via settings optional. ([2037](https://github.com/WordPress/performance/pull/2037))
+* Respect prefers-reduced-motion settings. ([2068](https://github.com/WordPress/performance/pull/2068))
 
 = 1.0.1 =
 

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -5,7 +5,7 @@
  * Description: Adds smooth transitions between navigations to your WordPress site.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.0.1
+ * Version: 1.1.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'VIEW_TRANSITIONS_VERSION' ) ) {
 	return;
 }
 
-define( 'VIEW_TRANSITIONS_VERSION', '1.0.1' );
+define( 'VIEW_TRANSITIONS_VERSION', '1.1.0' );
 define( 'VIEW_TRANSITIONS_MAIN_FILE', __FILE__ );
 
 require_once __DIR__ . '/includes/admin.php';


### PR DESCRIPTION
This PR prepares for the release of View Transitions version 1.1.0, which I plan to publish tomorrow, July 15.

Milestone is clear, see: https://github.com/WordPress/performance/milestone/117
