### PR TITLE
Set default view transition duration to 400 for better alignment with browser default

### DIFF
--- a/plugins/view-transitions/includes/settings.php
+++ b/plugins/view-transitions/includes/settings.php
@@ -65,7 +65,7 @@ function plvt_get_setting_default(): array {
 	return array(
 		'override_theme_config'                 => false,
 		'default_transition_animation'          => 'fade',
-		'default_transition_animation_duration' => 1000,
+		'default_transition_animation_duration' => 400,
 		'header_selector'                       => 'header',
 		'main_selector'                         => 'main',
 		'post_title_selector'                   => '.wp-block-post-title, .entry-title',
@@ -330,7 +330,7 @@ function plvt_add_setting_ui(): void {
 		'default_transition_animation_duration' => array(
 			'section'     => 'plvt_view_transitions',
 			'title'       => __( 'Transition Animation Duration', 'view-transitions' ),
-			'description' => __( 'Control the duration of the view transition. Enter the value in milliseconds (e.g., 1000, 1500, 2000).', 'view-transitions' ),
+			'description' => __( 'Control the duration of the view transition. Enter the value in milliseconds (e.g., 500, 1000, 2000).', 'view-transitions' ),
 		),
 		'header_selector'                       => array(
 			'section'     => 'plvt_view_transitions',

--- a/plugins/view-transitions/includes/theme.php
+++ b/plugins/view-transitions/includes/theme.php
@@ -77,7 +77,7 @@ function plvt_sanitize_view_transitions_theme_support(): void {
 			'.wp-block-post-content, .entry-content' => 'post-content',
 		),
 		'default-animation'          => 'fade',
-		'default-animation-duration' => 1000,
+		'default-animation-duration' => 400,
 	);
 
 	// If no specific `$args` were provided, simply use the defaults.


### PR DESCRIPTION
## Summary

#2051 implemented control over the view transition duration via theme support and a corresponding setting, with a default of 1000 (1 second).

While doing further smoke testing (for #2080), I noticed that this is far slower than the browser default when not specifying any duration. Therefore this PR aligns more closely with the browser default, which gives a better experience out of the box than a slower-moving animation, which can look a bit too janky sometimes.

It seems there is no clear single value that the browser uses, but it's a range between 0.15-0.4s. When I compared assigning 0.4s with no value, I could barely tell any difference, so I think this works well for now, certainly better than a default of 1s.