### PR TITLE
Accurate sizes: Add support for `core/post-featured-image` block

### DIFF
--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -40,5 +40,6 @@ if ( ! function_exists( 'wp_img_tag_add_auto_sizes' ) ) {
 add_filter( 'the_content', 'auto_sizes_prime_attachment_caches', 9 ); // This must run before 'do_blocks', which runs at priority 9.
 add_filter( 'render_block_core/image', 'auto_sizes_filter_image_tag', 10, 3 );
 add_filter( 'render_block_core/cover', 'auto_sizes_filter_image_tag', 10, 3 );
+add_filter( 'render_block_core/post-featured-image', 'auto_sizes_filter_image_tag', 10, 3 );
 add_filter( 'get_block_type_uses_context', 'auto_sizes_filter_uses_context', 10, 2 );
 add_filter( 'render_block_context', 'auto_sizes_filter_render_block_context', 10, 3 );

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -105,7 +105,7 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 			 * See https://github.com/WordPress/wordpress-develop/blob/3f9c6fce666ed2ea0d56c21f6235c37db3d91392/src/wp-includes/blocks/post-featured-image.php#L65
 			 */
 			if ( 'core/post-featured-image' === $block->name && isset( $block->context['postId'] ) ) {
-				$id = auto_sizes_get_featured_image_id_from_block( $block );
+				$id = auto_sizes_get_featured_image_id_from_block( $block->context['postId'] );
 			}
 
 			/*
@@ -133,7 +133,7 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 		 * See https://github.com/WordPress/wordpress-develop/blob/3f9c6fce666ed2ea0d56c21f6235c37db3d91392/src/wp-includes/blocks/post-featured-image.php#L65
 		 */
 		if ( 'core/post-featured-image' === $block->name && isset( $block->context['postId'] ) ) {
-			$id = auto_sizes_get_featured_image_id_from_block( $block );
+			$id = auto_sizes_get_featured_image_id_from_block( $block->context['postId'] );
 		}
 
 		$sizes = wp_calculate_image_sizes(
@@ -386,17 +386,13 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
  *
  * @since n.e.x.t
  *
- * @param WP_Block $block The block instance.
+ * @param int $post_id The post id.
  * @return int The featured image ID or 0 if not found.
  */
-function auto_sizes_get_featured_image_id_from_block( WP_Block $block ): int {
-	$post_id = $block->context['postId'];
-
-	$post = get_post( $post_id );
-
-	if ( ! ( $post instanceof WP_Post ) ) {
+function auto_sizes_get_featured_image_id_from_block( int $post_id ): int {
+	if ( 0 === $post_id ) {
 		return 0;
 	}
 
-	return (int) get_post_thumbnail_id( $post );
+	return (int) get_post_thumbnail_id( $post_id );
 }

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -390,8 +390,7 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
  * @return int The featured image ID or 0 if not found.
  */
 function auto_sizes_get_featured_image_id_from_block( WP_Block $block ): int {
-	$image_size = $block->attributes['sizeSlug'] ?? 'full';
-	$post_id    = $block->context['postId'];
+	$post_id = $block->context['postId'];
 
 	$post = get_post( $post_id );
 

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -384,7 +384,7 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 /**
  * Retrieves the featured image attachment ID for a given post ID.
  *
- * @since 1.4.0
+ * @since n.e.x.t
  *
  * @param int $post_id The post ID.
  * @return int The featured image attachment ID or 0 if not found.

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -105,7 +105,7 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 			 * See https://github.com/WordPress/wordpress-develop/blob/3f9c6fce666ed2ea0d56c21f6235c37db3d91392/src/wp-includes/blocks/post-featured-image.php#L65
 			 */
 			if ( 'core/post-featured-image' === $block->name && isset( $block->context['postId'] ) ) {
-				$id = auto_sizes_get_featured_image_id_from_block( $block->context['postId'] );
+				$id = auto_sizes_get_featured_image_attachment_id( $block->context['postId'] );
 			}
 
 			/*
@@ -133,7 +133,7 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 		 * See https://github.com/WordPress/wordpress-develop/blob/3f9c6fce666ed2ea0d56c21f6235c37db3d91392/src/wp-includes/blocks/post-featured-image.php#L65
 		 */
 		if ( 'core/post-featured-image' === $block->name && isset( $block->context['postId'] ) ) {
-			$id = auto_sizes_get_featured_image_id_from_block( $block->context['postId'] );
+			$id = auto_sizes_get_featured_image_attachment_id( $block->context['postId'] );
 		}
 
 		$sizes = wp_calculate_image_sizes(
@@ -382,14 +382,14 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 }
 
 /**
- * Retrieves the featured image ID for a post featured image block.
+ * Retrieves the featured image attachment ID for a given post ID.
  *
- * @since n.e.x.t
+ * @since 1.4.0
  *
- * @param int $post_id The post id.
- * @return int The featured image ID or 0 if not found.
+ * @param int $post_id The post ID.
+ * @return int The featured image attachment ID or 0 if not found.
  */
-function auto_sizes_get_featured_image_id_from_block( int $post_id ): int {
+function auto_sizes_get_featured_image_attachment_id( int $post_id ): int {
 	if ( 0 === $post_id ) {
 		return 0;
 	}

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -94,12 +94,19 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 		 * @param string $size  The image size data.
 		 */
 		$filter = static function ( $sizes, $size ) use ( $block ) {
-
 			$id                       = isset( $block->attributes['id'] ) ? (int) $block->attributes['id'] : 0;
 			$alignment                = $block->attributes['align'] ?? '';
 			$width                    = isset( $block->attributes['width'] ) ? (int) $block->attributes['width'] : 0;
 			$max_alignment            = $block->context['max_alignment'] ?? '';
 			$container_relative_width = $block->context['container_relative_width'] ?? 1.0;
+
+			/*
+			 * For the post featured image block, use the post ID to get the featured image attachment ID.
+			 * See https://github.com/WordPress/wordpress-develop/blob/3f9c6fce666ed2ea0d56c21f6235c37db3d91392/src/wp-includes/blocks/post-featured-image.php#L65
+			 */
+			if ( 'core/post-featured-image' === $block->name && isset( $block->context['postId'] ) ) {
+				$id = auto_sizes_get_featured_image_id_from_block( $block );
+			}
 
 			/*
 			 * Update width for cover block.
@@ -118,12 +125,23 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 		// Hook this filter early, before default filters are run.
 		add_filter( 'wp_calculate_image_sizes', $filter, 9, 2 );
 
+		// Get the image ID from the block attributes or context.
+		$id = $parsed_block['attrs']['id'] ?? 0;
+
+		/*
+		 * For the post featured image block, use the post ID to get the featured image attachment ID.
+		 * See https://github.com/WordPress/wordpress-develop/blob/3f9c6fce666ed2ea0d56c21f6235c37db3d91392/src/wp-includes/blocks/post-featured-image.php#L65
+		 */
+		if ( 'core/post-featured-image' === $block->name && isset( $block->context['postId'] ) ) {
+			$id = auto_sizes_get_featured_image_id_from_block( $block );
+		}
+
 		$sizes = wp_calculate_image_sizes(
 			// If we don't have a size slug, assume the full size was used.
 			$parsed_block['attrs']['sizeSlug'] ?? 'full',
 			null,
 			null,
-			$parsed_block['attrs']['id'] ?? 0
+			$id
 		);
 
 		remove_filter( 'wp_calculate_image_sizes', $filter, 9 );
@@ -284,11 +302,12 @@ function auto_sizes_get_layout_width( string $alignment ): string {
 function auto_sizes_filter_uses_context( array $uses_context, WP_Block_Type $block_type ): array {
 	// Define block-specific context usage.
 	$block_specific_context = array(
-		'core/cover'   => array( 'max_alignment', 'container_relative_width' ),
-		'core/image'   => array( 'max_alignment', 'container_relative_width' ),
-		'core/group'   => array( 'max_alignment' ),
-		'core/columns' => array( 'max_alignment', 'container_relative_width' ),
-		'core/column'  => array( 'max_alignment', 'column_count' ),
+		'core/cover'               => array( 'max_alignment', 'container_relative_width' ),
+		'core/image'               => array( 'max_alignment', 'container_relative_width' ),
+		'core/post-featured-image' => array( 'max_alignment', 'container_relative_width' ),
+		'core/group'               => array( 'max_alignment' ),
+		'core/columns'             => array( 'max_alignment', 'container_relative_width' ),
+		'core/column'              => array( 'max_alignment', 'column_count' ),
 	);
 
 	if ( isset( $block_specific_context[ $block_type->name ] ) ) {
@@ -316,6 +335,7 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 	$provider_blocks = array(
 		'core/columns',
 		'core/group',
+		'core/post-featured-image',
 	);
 
 	if ( in_array( $block['blockName'], $provider_blocks, true ) ) {
@@ -359,4 +379,25 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 		}
 	}
 	return $context;
+}
+
+/**
+ * Retrieves the featured image ID for a post featured image block.
+ *
+ * @since n.e.x.t
+ *
+ * @param WP_Block $block The block instance.
+ * @return int The featured image ID or 0 if not found.
+ */
+function auto_sizes_get_featured_image_id_from_block( WP_Block $block ): int {
+	$image_size = $block->attributes['sizeSlug'] ?? 'full';
+	$post_id    = $block->context['postId'];
+
+	$post = get_post( $post_id );
+
+	if ( ! ( $post instanceof WP_Post ) ) {
+		return 0;
+	}
+
+	return (int) get_post_thumbnail_id( $post );
 }

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -121,7 +121,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<array<string>> The image sizes.
 	 */
-	public function data_image_sizes(): array {
+	public static function data_image_sizes(): array {
 		return array(
 			'Return full or wideSize 1280px instead of medium size 300px'  => array(
 				'medium',
@@ -177,7 +177,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, bool|string>> The image sizes.
 	 */
-	public function data_image_sizes_for_default_alignment(): array {
+	public static function data_image_sizes_for_default_alignment(): array {
 		return array(
 			'Return medium image size 300px instead of contentSize 620px'                          => array(
 				'medium',
@@ -252,7 +252,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, bool|string>> The image sizes and alignments.
 	 */
-	public function data_image_sizes_for_left_right_center_alignment(): array {
+	public static function data_image_sizes_for_left_right_center_alignment(): array {
 		return array(
 			'Return medium image size 300px with left alignment'                                    => array(
 				'medium',
@@ -382,7 +382,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<array<string>> The image sizes.
 	 */
-	public function data_image_left_right_center_alignment(): array {
+	public static function data_image_left_right_center_alignment(): array {
 		return array(
 			array( 'left', 'sizes="(max-width: 420px) 100vw, 420px' ),
 			array( 'right', 'sizes="(max-width: 420px) 100vw, 420px' ),
@@ -430,7 +430,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, bool|string>> The ancestor and image alignments.
 	 */
-	public function data_ancestor_and_image_block_alignment(): array {
+	public static function data_ancestor_and_image_block_alignment(): array {
 		return array(
 			// Parent default alignment.
 			'Return contentSize 620px, parent block default alignment, image block default alignment' => array(
@@ -559,7 +559,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, bool|string>> The ancestor and image alignments.
 	 */
-	public function data_image_blocks_with_relative_alignment(): array {
+	public static function data_image_blocks_with_relative_alignment(): array {
 		return array(
 			// Parent default alignment.
 			'Return contentSize 50vw, parent block default alignment, image block default alignment' => array(
@@ -649,7 +649,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<array<string>> The ancestor and image alignments.
 	 */
-	public function data_image_blocks_with_relative_alignment_for_classic_theme(): array {
+	public static function data_image_blocks_with_relative_alignment_for_classic_theme(): array {
 		return array(
 			array( '' ),
 			array( 'wide' ),
@@ -686,7 +686,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, bool|string>> The ancestor and image alignments.
 	 */
-	public function data_image_block_with_column_block(): array {
+	public static function data_image_block_with_column_block(): array {
 		return array(
 			// Parent default alignment.
 			'Return contentSize 620px, parent block default alignment, image block default alignment' => array(
@@ -822,7 +822,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, bool|string>> The ancestor and image alignments.
 	 */
-	public function data_image_block_with_two_equal_column_block(): array {
+	public static function data_image_block_with_two_equal_column_block(): array {
 		return array(
 			// Parent default alignment.
 			'Return half size of contentSize 310px, parent block default alignment, image block default alignment' => array(
@@ -958,7 +958,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, bool|string>> The ancestor and image alignments.
 	 */
-	public function data_image_block_with_two_different_width_column_block(): array {
+	public static function data_image_block_with_two_different_width_column_block(): array {
 		return array(
 			// Parent default alignment.
 			'Return 66.66% width of contentSize 413px, parent block default alignment, image block default alignment' => array(
@@ -1100,7 +1100,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array<int, string>> The ancestor and image alignments.
 	 */
-	public function data_image_block_with_parent_columns_and_its_parent_group_block(): array {
+	public static function data_image_block_with_parent_columns_and_its_parent_group_block(): array {
 		return array(
 			// Parent default alignment.
 			'Return 66.66% width of contentSize 413px, group block default alignment, columns block default alignment, image block default alignment' => array(
@@ -1322,7 +1322,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<array<string>> The image sizes.
 	 */
-	public function data_post_featured_image_block_image_sizes(): array {
+	public static function data_post_featured_image_block_image_sizes(): array {
 		return array(
 			'Return medium image size 300px' => array(
 				'medium',
@@ -1371,7 +1371,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 *
 	 * @return array<array<string>> The image sizes.
 	 */
-	public function data_post_featured_image_block_alignment(): array {
+	public static function data_post_featured_image_block_alignment(): array {
 		return array(
 			'Return contentSize 620px instead of image size 1080px, block default alignment'  => array(
 				'',

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -16,6 +16,12 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	public static $image_id;
 
 	/**
+	 * Post ID.
+	 *
+	 * @var int
+	 */
+	public static $post_id;
+	/**
 	 * Set up the environment for the tests.
 	 */
 	public static function set_up_before_class(): void {
@@ -24,6 +30,13 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 		switch_theme( 'twentytwentyfour' );
 
 		self::$image_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+
+		self::$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_name'   => 'test-post',
+			)
+		);
 	}
 
 	public function set_up(): void {
@@ -1257,6 +1270,24 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 853px) 100vw, 853px" ',
 			),
 		);
+	}
+
+	/**
+	 * Verifies that the post featured image block does not render when no featured image is set for the post.
+	 */
+	public function test_post_featured_image_block_without_featured_image(): void {
+		$block_content = '<!-- wp:post-featured-image /-->';
+
+		// Set up global $post so 'the_content' filter works as expected.
+		global $post;
+		$post = get_post( self::$post_id );
+		setup_postdata( $post );
+
+		$result = apply_filters( 'the_content', $block_content );
+
+		$this->assertStringContainsString( '', $result );
+
+		wp_reset_postdata();
 	}
 
 	/**

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -1291,6 +1291,55 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the post featured image block renders correctly with different image sizes.
+	 *
+	 * @dataProvider data_post_featured_image_block_image_sizes
+	 *
+	 * @param string $image_size Image size.
+	 * @param string $expected   Expected output.
+	 */
+	public function test_post_featured_image_block_with_different_image_size( string $image_size, string $expected ): void {
+		update_post_meta( self::$post_id, '_thumbnail_id', self::$image_id );
+
+		$block_content = '<!-- wp:post-featured-image {"sizeSlug":"' . $image_size . '"} /-->';
+
+		// Set up global $post so 'the_content' filter works as expected.
+		global $post;
+		$post = get_post( self::$post_id );
+		setup_postdata( $post );
+
+		$result = apply_filters( 'the_content', $block_content );
+
+		// Check that the featured image block renders the image and has a sizes attribute.
+		$this->assertStringContainsString( 'wp-block-post-featured-image', $result );
+		$this->assertStringContainsString( $expected, $result );
+
+		wp_reset_postdata();
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<array<string>> The image sizes.
+	 */
+	public function data_post_featured_image_block_image_sizes(): array {
+		return array(
+			'Return full or wideSize 1280px instead of medium size 300px'  => array(
+				'medium',
+				'sizes="(max-width: 300px) 100vw, 300px" ',
+			),
+			'Return full or wideSize 1280px instead of large size 1024px'  => array(
+				'large',
+				'sizes="(max-width: 620px) 100vw, 620px" ',
+			),
+			'Return full or wideSize 1280px instead of full size 1080px'  => array(
+				'full',
+				'sizes="(max-width: 620px) 100vw, 620px" ',
+			),
+		);
+	}
+
+	/**
 	 * Filter the theme.json data to include relative layout sizes.
 	 *
 	 * @param WP_Theme_JSON_Data $theme_json Theme JSON object.

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -1324,16 +1324,77 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 */
 	public function data_post_featured_image_block_image_sizes(): array {
 		return array(
-			'Return full or wideSize 1280px instead of medium size 300px'  => array(
+			'Return medium image size 300px' => array(
 				'medium',
 				'sizes="(max-width: 300px) 100vw, 300px" ',
 			),
-			'Return full or wideSize 1280px instead of large size 1024px'  => array(
+			'Return contentSize 620px instead of large size 1024px' => array(
 				'large',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
-			'Return full or wideSize 1280px instead of full size 1080px'  => array(
+			'Return contentSize 620px instead of full size 1080px' => array(
 				'full',
+				'sizes="(max-width: 620px) 100vw, 620px" ',
+			),
+		);
+	}
+
+	/**
+	 * Test that the post featured image block renders correctly with different alignment.
+	 *
+	 * @dataProvider data_post_featured_image_block_alignment
+	 *
+	 * @param string $alignment Alignment of the image.
+	 * @param string $expected  Expected output.
+	 */
+	public function test_post_featured_image_block_with_different_alignment( string $alignment, string $expected ): void {
+		update_post_meta( self::$post_id, '_thumbnail_id', self::$image_id );
+
+		$block_content = '<!-- wp:post-featured-image {"align":"' . $alignment . '"} /-->';
+
+		// Set up global $post so 'the_content' filter works as expected.
+		global $post;
+		$post = get_post( self::$post_id );
+		setup_postdata( $post );
+
+		$result = apply_filters( 'the_content', $block_content );
+
+		// Check that the featured image block renders the image and has a sizes attribute.
+		$this->assertStringContainsString( 'wp-block-post-featured-image', $result );
+		$this->assertStringContainsString( $expected, $result );
+
+		wp_reset_postdata();
+	}
+
+	/**
+	 * Data provider.
+	 *
+	 * @return array<array<string>> The image sizes.
+	 */
+	public function data_post_featured_image_block_alignment(): array {
+		return array(
+			'Return contentSize 620px instead of image size 1080px, block default alignment'  => array(
+				'',
+				'sizes="(max-width: 620px) 100vw, 620px" ',
+			),
+			'Return wideSize 1280px instead of image size 1080px, block wide alignment'  => array(
+				'wide',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
+			'Return full size instead of image size 1080px, block full alignment'  => array(
+				'full',
+				'sizes="100vw" ',
+			),
+			'Return image size 1080px, block left alignment'  => array(
+				'left',
+				'sizes="(max-width: 1080px) 100vw, 1080px" ',
+			),
+			'Return image size 1080px, block right alignment'  => array(
+				'right',
+				'sizes="(max-width: 1080px) 100vw, 1080px" ',
+			),
+			'Return contentSize 620px instead of image size 1080px, block center alignment'  => array(
+				'center',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
 		);


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

See #1511 

This PR updates the sizes for `core/post-featured-image` block.

- [x] Add unit tests


<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
