### PR TITLE
View Transitions: Fix admin opt-in checkbox appears stretched on mobile

### DIFF
--- a/plugins/view-transitions/includes/settings.php
+++ b/plugins/view-transitions/includes/settings.php
@@ -469,7 +469,6 @@ function plvt_render_settings_field( array $args ): void {
 				type="checkbox"
 				value="1"
 				<?php checked( $value, 1 ); ?>
-				class="regular-text code"
 			>
 			<?php echo esc_html( $args['description'] ); ?>
 		</label>


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2087

## Screenshots

### Before
<img width="413" height="479" alt="Screenshot 2025-07-18 at 9 39 56 AM" src="https://github.com/user-attachments/assets/d414f486-9309-4897-a588-0d575f4785db" />

### After
<img width="417" height="390" alt="Screenshot 2025-07-18 at 9 39 45 AM" src="https://github.com/user-attachments/assets/df414144-57d2-47c3-9ad6-32b51a3bf224" />




<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
