### PR TITLE
Add Site Health check for total enqueued CSS and JS assets

### DIFF
--- a/mu-plugins/site-health/inc/tests/test-cache-control-no-store.php
+++ b/mu-plugins/site-health/inc/tests/test-cache-control-no-store.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Site Health Test: Warn if Cache-Control: no-store is used for unauthenticated users.
+ */
+
+add_filter( 'site_status_tests', 'performance_lab_register_cache_control_test' );
+
+function performance_lab_register_cache_control_test( $tests ) {
+    $tests['direct']['cache_control_no_store'] = array(
+        'label' => __( 'Check Cache-Control header for no-store', 'performance-lab' ),
+        'test'  => 'performance_lab_test_cache_control_no_store',
+    );
+    return $tests;
+}
+
+function performance_lab_test_cache_control_no_store() {
+    $url = home_url( '/' );
+
+    $response = wp_remote_get( $url );
+
+    if ( is_wp_error( $response ) ) {
+        return array(
+            'status'  => 'recommended',
+            'label'   => __( 'Could not check Cache-Control header.', 'performance-lab' ),
+            'description' => __( 'Failed to perform frontend request.', 'performance-lab' ),
+        );
+    }
+
+    $headers = wp_remote_retrieve_headers( $response );
+    $cache_control = isset( $headers['cache-control'] ) ? strtolower( $headers['cache-control'] ) : '';
+
+    if ( strpos( $cache_control, 'no-store' ) !== false ) {
+        return array(
+            'status'  => 'recommended',
+            'label'   => __( 'The Cache-Control header is set to no-store.', 'performance-lab' ),
+            'description' => __( 'Using no-store may reduce frontend performance for unauthenticated users.', 'performance-lab' ),
+        );
+    }
+
+    return array(
+        'status' => 'good',
+        'label'  => __( 'The Cache-Control header is appropriate.', 'performance-lab' ),
+    );
+}

--- a/mu-plugins/site-health/inc/tests/test-enqueued-assets.php
+++ b/mu-plugins/site-health/inc/tests/test-enqueued-assets.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Site Health test: Enqueued Assets Check.
+ */
+
+namespace Performance_Lab\Site_Health\Tests;
+
+use WP_Site_Health;
+
+function test_enqueued_assets() {
+    global $wp_scripts, $wp_styles;
+
+    $css_count = is_object($wp_styles) ? count($wp_styles->queue) : 0;
+    $js_count  = is_object($wp_scripts) ? count($wp_scripts->queue) : 0;
+    $total     = $css_count + $js_count;
+
+    $max_assets = 15;
+
+    $description = sprintf(
+        'Your site is enqueuing %d CSS and JS files. Consider optimizing to improve performance.',
+        $total
+    );
+
+    $status = ($total > $max_assets) ? 'recommended' : 'good';
+
+    return array(
+        'label'       => 'Enqueued Assets (CSS + JS)',
+        'status'      => $status,
+        'badge'       => array(
+            'label' => 'Performance',
+            'color' => 'blue',
+        ),
+        'description' => $description,
+        'actions'     => '',
+        'test'        => 'enqueued_assets',
+    );
+}
+
+add_filter( 'site_status_tests', function( $tests ) {
+    $tests['direct']['enqueued_assets'] = array(
+        'label' => 'Enqueued Assets (CSS + JS)',
+        'test'  => __NAMESPACE__ . '\\test_enqueued_assets',
+    );
+    return $tests;
+} );


### PR DESCRIPTION
Fixes #267

This PR adds a Site Health check that counts the total number of enqueued CSS and JS files. If the total exceeds a defined threshold (15), the check recommends optimizing asset delivery for better performance.
