### PR TITLE
Use `wp_is_rest_endpoint()` to detect if we are handling a REST API request

### DIFF
--- a/plugins/performance-lab/includes/server-timing/hooks.php
+++ b/plugins/performance-lab/includes/server-timing/hooks.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function perflab_rest_post_dispatch_add_server_timing( $response ) {
 	// TODO: Change condition to use wp_is_rest_endpoint() once minimum-supported version is WordPress 6.5.
-	if ( ! defined( 'REST_REQUEST' ) || ! REST_REQUEST || ! $response instanceof WP_REST_Response ) {
+	if ( ! wp_is_rest_endpoint() || ! $response instanceof WP_REST_Response ) {
 		return $response;
 	}
 

--- a/plugins/performance-lab/includes/server-timing/hooks.php
+++ b/plugins/performance-lab/includes/server-timing/hooks.php
@@ -22,7 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return WP_REST_Response|WP_Error Filtered response.
  */
 function perflab_rest_post_dispatch_add_server_timing( $response ) {
-	// TODO: Change condition to use wp_is_rest_endpoint() once minimum-supported version is WordPress 6.5.
 	if ( ! wp_is_rest_endpoint() || ! $response instanceof WP_REST_Response ) {
 		return $response;
 	}


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

Follow-up to #1206 implementation:

We bumped the WordPress minimum version to 6.6 in #1683, so in `perflab_rest_post_dispatch_add_server_timing()`, we can now safely use the core WordPress function `wp_is_rest_endpoint ()` mentioned in the TODO comment.

In the PR i update the code to use that function and remove the TODO.



## Relevant technical choices

<!-- Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
