### PR TITLE
Enable testing for PHP 8.4

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -47,6 +47,8 @@ jobs:
             wp: '6.6'
           - php: '8.3'
             wp: 'trunk'
+          - php: '8.4'
+            wp: 'trunk'
           - php: '8.2'
             phpunit: '9.6'
             wp: 'latest'


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->

This change enables PHP 8.4 testing throughout GitHub Action workflows to ensure no new problems are introduced going forward.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
