### PR TITLE
Bump @wordpress/env from 10.26.0 to 10.27.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@playwright/test": "^1.54.1",
         "@types/node": "^24.0.10",
         "@wordpress/e2e-test-utils-playwright": "^1.26.0",
-        "@wordpress/env": "^10.26.0",
+        "@wordpress/env": "^10.27.0",
         "@wordpress/prettier-config": "^4.25.0",
         "@wordpress/scripts": "^30.19.0",
         "commander": "14.0.0",
@@ -5447,10 +5447,11 @@
       "license": "Apache-2.0"
     },
     "node_modules/@wordpress/env": {
-      "version": "10.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.26.0.tgz",
-      "integrity": "sha512-pEeQgYp5plWWB79/MgHthMB4bR/e6VKtP4KUzspZefZzbXuoOlrdWVGwzdEJfKSoxjaXg5WTm2pDyo2YVCkzCQ==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-10.27.0.tgz",
+      "integrity": "sha512-NEcfhdiTvc1TKyqzLFq94RAuB6XsyLCcj+YB1CaliIxaZ6mw3SEGM49/Z4JpgQKalqTjEYXgmAG/OQ+lLq0EgA==",
       "dev": true,
+      "license": "GPL-2.0-or-later",
       "dependencies": {
         "@inquirer/prompts": "^7.2.0",
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@playwright/test": "^1.54.1",
     "@types/node": "^24.0.10",
     "@wordpress/e2e-test-utils-playwright": "^1.26.0",
-    "@wordpress/env": "^10.26.0",
+    "@wordpress/env": "^10.27.0",
     "@wordpress/prettier-config": "^4.25.0",
     "@wordpress/scripts": "^30.19.0",
     "commander": "14.0.0",


### PR DESCRIPTION
## Summary

Bump @wordpress/env from 10.26.0 to 10.27.0

## Relevant technical choices

<!-- Please describe your changes. -->



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
