### PR TITLE
Avoid possible error when reading groups in debug mode

### DIFF
--- a/plugins/optimization-detective/detect.js
+++ b/plugins/optimization-detective/detect.js
@@ -555,7 +555,7 @@ export default async function detect( {
 	const { log, warn, error } = logger;
 	compressionEnabled = gzdecodeAvailable;
 
-	if ( isDebug ) {
+	if ( isDebug && Array.isArray( urlMetricGroupCollection?.groups ) ) {
 		const allUrlMetrics = /** @type Array<UrlMetricDebugData> */ [];
 		for ( const group of urlMetricGroupCollection.groups ) {
 			for ( const otherUrlMetric of group.url_metrics ) {


### PR DESCRIPTION
This addresses a [support forum topic](https://wordpress.org/support/topic/cannot-read-properties-of-undefined-reading-groups/):

> ## Cannot read properties of undefined (reading ‘groups’)
> detect.min.js?ver=1.0.0-beta3:1 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading ‘groups’)
> at detect (detect.min.js?ver=1.0.0-beta3:1:3066)
> at :2:127

The location where this error is occurring:

https://github.com/WordPress/performance/blob/85001b9f74034d960ddff1c3bbd9eb85b54c0dab/plugins/optimization-detective/detect.js#L558-L560

Normally the `urlMetricGroupCollection` is always populated when `WP_DEBUG` is true:

https://github.com/WordPress/performance/blob/85001b9f74034d960ddff1c3bbd9eb85b54c0dab/plugins/optimization-detective/detection.php#L148-L150

However, it seems at least in this case here, the HTML had been mutated to remove that object being passed to `detect()`. So this PR hardens the logic to prevent an error from happening.

Additionally, there is another benefit. Often when debugging Optimization Detective for sites in the wild, I'll use local overrides in Chrome to modify the HTML as follows:

1. Set `isDebug` to `true`
2. Replace `detect.min.js` with `detect.js`

However, when I do this, I then also need to open up `detect.js` and add another override to comment out this same line that tries to read from the `group`. By checking first to make sure that the property exists and is an array, then this will no longer be necessary when debugging sites in the field.