### PR TITLE
Make `test-php-watch` cross-platform compatible via `fswatch`

### DIFF
--- a/bin/test-php-watch.sh
+++ b/bin/test-php-watch.sh
@@ -1,13 +1,29 @@
 #!/bin/bash
-if ! which inotifywait >/dev/null 2>&1; then
-  echo "Error: the inotifywait command is not available. Make sure you have inotify-tools installed."
-  exit 1
+
+# Check for the fswatch command
+if ! which fswatch >/dev/null 2>&1; then
+	echo "Error: The fswatch command is not available."
+	echo "On macOS, you can install it with Homebrew: brew install fswatch"
+	exit 1
 fi
+
+cd "$(git rev-parse --show-toplevel)"
 
 while true; do
 	echo "Waiting for a change in the plugins directory..."
-	output=$(inotifywait -e modify,create,delete -r ./plugins  --include '.*(\.php$|/tests/.*)' 2> /dev/null)
-	plugin_slug=$(echo "$output" | awk -F/ '{print $3}')
+
+	file=$(fswatch -1 -r \
+		--event Created \
+		--event Updated \
+		--event Removed \
+		--include '\.php$' \
+		--include '/tests/' \
+		./plugins 2>/dev/null | head -n 1)
+
+	# Make the file path relative.
+	file="${file#"$PWD/"}"
+
+	plugin_slug=$(echo "$file" | awk -F/ '{print $2}')
 	sleep 1 # Give the user a chance to copy text from terminal before IDE auto-saves.
 	clear
 	echo "Running phpunit tests for $(tput bold)$plugin_slug$(tput sgr0):"

--- a/bin/test-php-watch.sh
+++ b/bin/test-php-watch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Check for the fswatch command
-if ! which fswatch >/dev/null 2>&1; then
+if ! command -v fswatch >/dev/null 2>&1; then
 	echo "Error: The fswatch command is not available."
 	echo "On macOS, you can install it with Homebrew: brew install fswatch"
 	exit 1


### PR DESCRIPTION
I first developed the `test-php-watch` command (#1401) when I was using Linux for my development environment. Since switching (back) to Mac, I discovered that `inotify-tools` is only for Linux. Therefore, this PR switches out the `inotifywait` command for the `fswatch` command which is cross-platform.