### PR TITLE
Add No-cache BFCache to list of performance feature plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][9],  [Issues][17], [PRs][25]
 [Image Prioritizer][7]          | `image-prioritizer`       | No           | [Source][15], [Issues][23], [PRs][31]
 [Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
+[No-Cache BFCache][41]          | `nocache-bfcache`         | No           | [Source][42], [Issues][43], [PRs][44]
 [Optimization Detective][33]    | `optimization-detective`  | No           | [Source][34], [Issues][35], [PRs][36]
 [Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
 [Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
@@ -34,6 +35,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [8]: https://wordpress.org/plugins/web-worker-offloading/
 [33]: https://wordpress.org/plugins/optimization-detective/
 [37]: https://wordpress.org/plugins/view-transitions/
+[41]: https://wordpress.org/plugins/nocache-bfcache/
 
 [9]: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
 [10]: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
@@ -45,6 +47,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [16]: https://github.com/WordPress/performance/tree/trunk/plugins/web-worker-offloading
 [34]: https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective
 [38]: https://github.com/WordPress/performance/tree/trunk/plugins/view-transitions
+[42]: https://github.com/westonruter/nocache-bfcache
 
 [17]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
 [18]: https://github.com/WordPress/performance/issues?q=is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
@@ -56,6 +59,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [24]: https://github.com/WordPress/performance/issues?q=is%3Aopen%20label%3A%22%5BPlugin%5D%20Web%20Worker%20Offloading%22
 [35]: https://github.com/WordPress/performance/issues?q=is%3Aopen%20label%3A%22%5BPlugin%5D%20Optimization%20Detective%22
 [39]: https://github.com/WordPress/performance/issues?q=is%3Aopen%20label%3A%22%5BPlugin%5D%20View%20Transitions%22
+[43]: https://github.com/westonruter/nocache-bfcache/issues
 
 [25]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Image+Placeholders%22
 [26]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Modern+Image+Formats%22
@@ -67,5 +71,6 @@ Plugin                          | Slug                      | Experimental | Lin
 [32]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Web%20Worker%20Offloading%22
 [36]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Optimization%20Detective%22
 [40]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+View%20Transitions%22
+[44]: https://github.com/westonruter/nocache-bfcache/pulls
 
 Note that the plugin names sometimes diverge from the plugin slugs due to scope changes. For example, a plugin's purpose may change as some of its features are merged into WordPress core.

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -94,6 +94,7 @@ function perflab_get_admin_pointers(): array {
 	$pointers = array(
 		'perflab-admin-pointer'            => __( 'You can now test upcoming WordPress performance features.', 'performance-lab' ),
 		'perflab-feature-view-transitions' => __( 'New <strong>View Transitions</strong> feature now available.', 'performance-lab' ),
+		'perflab-feature-nocache-bfcache'  => __( 'New <strong>No-cache BFCache</strong> feature now available.', 'performance-lab' ),
 	);
 
 	if (

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -113,6 +113,9 @@ function perflab_get_standalone_plugin_data(): array {
 		'performant-translations' => array(
 			'constant' => 'PERFORMANT_TRANSLATIONS_VERSION',
 		),
+		'nocache-bfcache'         => array(
+			'constant' => 'WestonRuter\NocacheBFCache\VERSION',
+		),
 		'speculation-rules'       => array(
 			'constant' => 'SPECULATION_RULES_VERSION',
 		),

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -613,7 +613,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = n.e.x.t =
 
-This release introduces a new feature plugin called View Transitions which adds smooth transitions between navigations on your site.
+This release introduces two new features: View Transitions which adds smooth transitions between navigations on your site, and No-cache BFCache which enables back/forward cache (bfcache) for instant history navigations.
 
 = 3.2.0 =
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -20,6 +20,7 @@ The feature plugins which are currently featured by this plugin are:
 * [Image Placeholders](https://wordpress.org/plugins/dominant-color-images/)
 * [Image Prioritizer](https://wordpress.org/plugins/image-prioritizer/)
 * [Modern Image Formats](https://wordpress.org/plugins/webp-uploads/)
+* [No-cache BFCache](https://wordpress.org/plugins/nocache-bfcache/)
 * [Optimization Detective](https://wordpress.org/plugins/optimization-detective/) (dependency for Embed Optimizer and Image Prioritizer)
 * [Performant Translations](https://wordpress.org/plugins/performant-translations/)
 * [Speculative Loading](https://wordpress.org/plugins/speculation-rules/)


### PR DESCRIPTION
This proposes adding [No-cache BFCache](https://wordpress.org/plugins/nocache-bfcache/) to the list of performance feature plugins installable via Performance Lab, similar as the non-monorepo Performant Translations plugin is made available:

<img width="1380" height="745" alt="Screenshot 2025-08-05 at 17 22 50" src="https://github.com/user-attachments/assets/1b318ed8-70a0-4d70-aee8-ba15a469d29e" />

I brought this up at [our last Performance Chat office hours](https://make.wordpress.org/core/2025/07/29/performance-chat-summary-29-july-2025/):

> [@westonruter](https://profiles.wordpress.org/westonruter/) suggested considering the [No-cache BFCache plugin](https://wordpress.org/plugins/nocache-bfcache/) for inclusion in the list of Performance Lab plugins, similar as Performant Translations is.

Enabling bfcache in core is something I'm hoping to include in 6.9 (via Core-63636), so getting additional installations via Performance Lab will be very helpful to get more testing.

With #2122, an admin pointer is also added for this feature:

<img width="623" height="297" alt="Screenshot 2025-08-11 at 13 36 21" src="https://github.com/user-attachments/assets/69bb84dd-65fd-4616-bbd8-bc86a2bc9ae6" />

