### PR TITLE
Use modern image formats in background images for Cover blocks and Group blocks

### DIFF
--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -444,11 +444,12 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
 		$basename = wp_basename( $metadata['file'] );
 
 		if ( $src_basename === $basename ) {
-			return str_replace(
+			$result = str_replace(
 				$basename,
 				$metadata['sources'][ $mime ]['file'],
 				$src
 			);
+			return '' === $result ? null : $result;
 		}
 	}
 
@@ -471,11 +472,12 @@ function webp_uploads_get_mime_type_image( int $attachment_id, string $src, stri
 				continue;
 			}
 
-			return str_replace(
+			$result = str_replace(
 				$size_data['file'],
 				$size_data['sources'][ $mime ]['file'],
 				$src
 			);
+			return '' === $result ? null : $result;
 		}
 	}
 

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -432,10 +432,10 @@ function webp_uploads_should_generate_all_fallback_sizes(): bool {
  *
  * @since 2.2.0
  *
- * @param int    $attachment_id The ID of the attachment.
- * @param string $src           The original image src url.
- * @param string $mime          A mime type we are looking to get image url.
- * @return string|null Returns mime type image if available.
+ * @param int    $attachment_id  The ID of the attachment.
+ * @param string $src            The original image src url.
+ * @param string $mime           A mime type we are looking to get image url.
+ * @return non-empty-string|null Returns mime type image if available.
  */
 function webp_uploads_get_mime_type_image( int $attachment_id, string $src, string $mime ): ?string {
 	$metadata     = wp_get_attachment_metadata( $attachment_id );

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -748,12 +748,83 @@ function webp_uploads_render_generator(): void {
 add_action( 'wp_head', 'webp_uploads_render_generator' );
 
 /**
+ * Process a block's content to handle background images for specific block types.
+ *
+ * This function targets blocks like Cover and Group that may use background images,
+ * converting them to modern image formats when appropriate.
+ *
+ * @since n.e.x.t
+ *
+ * @param string               $block_content The block content.
+ * @param array<string, mixed> $block         The block.
+ * @return string The filtered block content.
+ */
+function webp_uploads_filter_block_background_images( string $block_content, array $block ): string {
+	// Only run on frontend.
+	if ( ! webp_uploads_in_frontend_body() || '' === $block_content ) {
+		return $block_content;
+	}
+
+	$attachment_id = null;
+	$image_url     = '';
+
+	// Process Cover block.
+	if ( 'core/cover' === $block['blockName'] && isset( $block['attrs']['id'] ) ) {
+		$attachment_id = $block['attrs']['id'];
+		$image_url     = isset( $block['attrs']['url'] ) ? $block['attrs']['url'] : '';
+	}
+
+	// Process Group block with background image.
+	if ( 'core/group' === $block['blockName'] && isset( $block['attrs']['style']['background']['backgroundImage'] ) ) {
+		$bg_image = $block['attrs']['style']['background']['backgroundImage'];
+
+		if ( isset( $bg_image['id'] ) ) {
+			$attachment_id = $bg_image['id'];
+			$image_url     = isset( $bg_image['url'] ) ? $bg_image['url'] : '';
+		}
+	}
+
+	// If we have a valid attachment and URL, process it.
+	if ( ! is_null( $attachment_id ) && '' !== $image_url ) {
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+
+		if ( is_array( $metadata ) ) {
+			$original_mime = get_post_mime_type( $attachment_id );
+
+			if ( null !== $original_mime && '' !== $original_mime ) {
+				$target_mimes = webp_uploads_get_content_image_mimes( $attachment_id, 'background_image' );
+
+				foreach ( $target_mimes as $target_mime ) {
+					if ( $target_mime === $original_mime ) {
+						continue;
+					}
+
+					$new_url = webp_uploads_get_mime_type_image( $attachment_id, $image_url, $target_mime );
+
+					if ( null !== $new_url && '' !== $new_url ) {
+						// Replace the URL in the content.
+						$block_content = str_replace( $image_url, $new_url, $block_content );
+					}
+				}
+			}
+		}
+	}
+
+	return $block_content;
+}
+
+/**
  * Initializes custom functionality for handling image uploads and content filters.
  *
  * @since 2.1.0
  */
 function webp_uploads_init(): void {
+	// Filter regular image tags.
 	add_filter( 'wp_content_img_tag', webp_uploads_is_picture_element_enabled() ? 'webp_uploads_wrap_image_in_picture' : 'webp_uploads_filter_image_tag', 10, 3 );
+
+	// Filter blocks that may contain background images.
+	add_filter( 'render_block_core/cover', 'webp_uploads_filter_block_background_images', 10, 2 );
+	add_filter( 'render_block_core/group', 'webp_uploads_filter_block_background_images', 10, 2 );
 }
 add_action( 'init', 'webp_uploads_init' );
 

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -822,18 +822,19 @@ function webp_uploads_filter_block_background_images( $block_content, array $blo
 
 		$new_url = webp_uploads_get_mime_type_image( $attachment_id, $image_url, $target_mime );
 
-		if ( is_string( $new_url ) ) {
+		if ( ! is_string( $new_url ) ) {
+			continue;
+		}
 
-			$processor = new WP_HTML_Tag_Processor( $block_content );
-			while ( $processor->next_tag() ) {
-				$style = $processor->get_attribute( 'style' );
+		$processor = new WP_HTML_Tag_Processor( $block_content );
+		while ( $processor->next_tag() ) {
+			$style = $processor->get_attribute( 'style' );
 
-				if ( is_string( $style ) && str_contains( $style, 'background-image:' ) && str_contains( $style, $image_url ) ) {
-					$updated_style = str_replace( $image_url, $new_url, $style );
-					$processor->set_attribute( 'style', $updated_style );
-					$block_content = $processor->get_updated_html();
-					break 2;
-				}
+			if ( is_string( $style ) && str_contains( $style, 'background-image:' ) && str_contains( $style, $image_url ) ) {
+				$updated_style = str_replace( $image_url, $new_url, $style );
+				$processor->set_attribute( 'style', $updated_style );
+				$block_content = $processor->get_updated_html();
+				break 2;
 			}
 		}
 	}

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -784,25 +784,24 @@ function webp_uploads_filter_block_background_images( $block_content, array $blo
 	}
 
 	$attachment_id = null;
-	$image_url     = '';
+	$image_url     = null;
 
-	// Process Cover block.
-	if ( 'core/cover' === $block['blockName'] && isset( $block['attrs']['id'] ) ) {
-		$attachment_id = $block['attrs']['id'];
-		$image_url     = $block['attrs']['url'] ?? '';
-	}
-
-	// Process Group block with background image.
-	if ( 'core/group' === $block['blockName'] && isset( $block['attrs']['style']['background']['backgroundImage'] ) ) {
-		$bg_image = $block['attrs']['style']['background']['backgroundImage'];
-		if ( isset( $bg_image['id'] ) ) {
-			$attachment_id = $bg_image['id'];
-			$image_url     = $bg_image['url'] ?? '';
+	if ( 'core/cover' === $block['blockName'] ) {
+		if ( isset( $block['attrs']['id'], $block['attrs']['url'] ) ) {
+			$attachment_id = $block['attrs']['id'];
+			$image_url     = $block['attrs']['url'];
+		}
+	} elseif ( 'core/group' === $block['blockName'] ) {
+		if ( isset( $block['attrs']['style']['background']['backgroundImage']['id'], $block['attrs']['style']['background']['backgroundImage']['url'] ) ) {
+			$attachment_id = $block['attrs']['style']['background']['backgroundImage']['id'];
+			$image_url     = $block['attrs']['style']['background']['backgroundImage']['url'];
 		}
 	}
 
 	// Abort if there is no associated background image.
-	if ( is_null( $attachment_id ) || '' === $image_url || ! is_array( wp_get_attachment_metadata( $attachment_id ) ) ) {
+	if (
+		! isset( $attachment_id, $image_url ) || $attachment_id <= 0 || '' === $image_url || ! is_array( wp_get_attachment_metadata( $attachment_id ) )
+	) {
 		return $block_content;
 	}
 

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -755,11 +755,29 @@ add_action( 'wp_head', 'webp_uploads_render_generator' );
  *
  * @since n.e.x.t
  *
- * @param string               $block_content The block content.
+ * @phpstan-param array{
+ *                    blockName: string|null,
+ *                    attrs: array{
+ *                        id?: positive-int,
+ *                        url?: string,
+ *                        style?: array{
+ *                            background?: array{
+ *                                backgroundImage?: string
+ *                            }
+ *                        }
+ *                    }
+ *                } $block
+ *
+ * @param string|mixed         $block_content The block content.
  * @param array<string, mixed> $block         The block.
  * @return string The filtered block content.
  */
-function webp_uploads_filter_block_background_images( string $block_content, array $block ): string {
+function webp_uploads_filter_block_background_images( $block_content, array $block ): string {
+	// Because plugins can do bad things.
+	if ( ! is_string( $block_content ) ) {
+		$block_content = '';
+	}
+
 	// Only run on frontend.
 	if ( ! webp_uploads_in_frontend_body() || '' === $block_content ) {
 		return $block_content;
@@ -771,7 +789,7 @@ function webp_uploads_filter_block_background_images( string $block_content, arr
 	// Process Cover block.
 	if ( 'core/cover' === $block['blockName'] && isset( $block['attrs']['id'] ) ) {
 		$attachment_id = $block['attrs']['id'];
-		$image_url     = isset( $block['attrs']['url'] ) ? $block['attrs']['url'] : '';
+		$image_url     = $block['attrs']['url'] ?? '';
 	}
 
 	// Process Group block with background image.
@@ -780,31 +798,41 @@ function webp_uploads_filter_block_background_images( string $block_content, arr
 
 		if ( isset( $bg_image['id'] ) ) {
 			$attachment_id = $bg_image['id'];
-			$image_url     = isset( $bg_image['url'] ) ? $bg_image['url'] : '';
+			$image_url     = $bg_image['url'] ?? '';
 		}
 	}
 
-	// If we have a valid attachment and URL, process it.
-	if ( ! is_null( $attachment_id ) && '' !== $image_url ) {
-		$metadata = wp_get_attachment_metadata( $attachment_id );
+	// Abort if there is no associated background image.
+	if ( is_null( $attachment_id ) || '' === $image_url || ! is_array( wp_get_attachment_metadata( $attachment_id ) ) ) {
+		return $block_content;
+	}
 
-		if ( is_array( $metadata ) ) {
-			$original_mime = get_post_mime_type( $attachment_id );
+	$original_mime = get_post_mime_type( $attachment_id );
 
-			if ( null !== $original_mime && '' !== $original_mime ) {
-				$target_mimes = webp_uploads_get_content_image_mimes( $attachment_id, 'background_image' );
+	if ( ! is_string( $original_mime ) ) {
+		return $block_content;
+	}
 
-				foreach ( $target_mimes as $target_mime ) {
-					if ( $target_mime === $original_mime ) {
-						continue;
-					}
+	$target_mimes = webp_uploads_get_content_image_mimes( $attachment_id, 'background_image' );
 
-					$new_url = webp_uploads_get_mime_type_image( $attachment_id, $image_url, $target_mime );
+	foreach ( $target_mimes as $target_mime ) {
+		if ( $target_mime === $original_mime ) {
+			continue;
+		}
 
-					if ( null !== $new_url && '' !== $new_url ) {
-						// Replace the URL in the content.
-						$block_content = str_replace( $image_url, $new_url, $block_content );
-					}
+		$new_url = webp_uploads_get_mime_type_image( $attachment_id, $image_url, $target_mime );
+
+		if ( is_string( $new_url ) ) {
+
+			$processor = new WP_HTML_Tag_Processor( $block_content );
+			while ( $processor->next_tag() ) {
+				$style = $processor->get_attribute( 'style' );
+
+				if ( is_string( $style ) && str_contains( $style, 'background-image:' ) && str_contains( $style, $image_url ) ) {
+					$updated_style = str_replace( $image_url, $new_url, $style );
+					$processor->set_attribute( 'style', $updated_style );
+					$block_content = $processor->get_updated_html();
+					break 2;
 				}
 			}
 		}

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -795,7 +795,6 @@ function webp_uploads_filter_block_background_images( $block_content, array $blo
 	// Process Group block with background image.
 	if ( 'core/group' === $block['blockName'] && isset( $block['attrs']['style']['background']['backgroundImage'] ) ) {
 		$bg_image = $block['attrs']['style']['background']['backgroundImage'];
-
 		if ( isset( $bg_image['id'] ) ) {
 			$attachment_id = $bg_image['id'];
 			$image_url     = $bg_image['url'] ?? '';
@@ -808,7 +807,6 @@ function webp_uploads_filter_block_background_images( $block_content, array $blo
 	}
 
 	$original_mime = get_post_mime_type( $attachment_id );
-
 	if ( ! is_string( $original_mime ) ) {
 		return $block_content;
 	}
@@ -821,7 +819,6 @@ function webp_uploads_filter_block_background_images( $block_content, array $blo
 		}
 
 		$new_url = webp_uploads_get_mime_type_image( $attachment_id, $image_url, $target_mime );
-
 		if ( ! is_string( $new_url ) ) {
 			continue;
 		}
@@ -829,7 +826,6 @@ function webp_uploads_filter_block_background_images( $block_content, array $blo
 		$processor = new WP_HTML_Tag_Processor( $block_content );
 		while ( $processor->next_tag() ) {
 			$style = $processor->get_attribute( 'style' );
-
 			if ( is_string( $style ) && str_contains( $style, 'background-image:' ) && str_contains( $style, $image_url ) ) {
 				$updated_style = str_replace( $image_url, $new_url, $style );
 				$processor->set_attribute( 'style', $updated_style );

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -800,7 +800,10 @@ function webp_uploads_filter_block_background_images( $block_content, array $blo
 
 	// Abort if there is no associated background image.
 	if (
-		! isset( $attachment_id, $image_url ) || $attachment_id <= 0 || '' === $image_url || ! is_array( wp_get_attachment_metadata( $attachment_id ) )
+		! isset( $attachment_id, $image_url ) ||
+		$attachment_id <= 0 ||
+		'' === $image_url ||
+		! is_array( wp_get_attachment_metadata( $attachment_id ) )
 	) {
 		return $block_content;
 	}

--- a/plugins/webp-uploads/tests/test-block-background-images.php
+++ b/plugins/webp-uploads/tests/test-block-background-images.php
@@ -141,7 +141,7 @@ class Test_WebP_Uploads_Block_Background_Images extends TestCase {
 			$transforms['image/jpeg'] = array( 'image/jpeg' );
 			return $transforms;
 		};
-		add_filter( 'webp_uploads_upload_image_mime_transforms', $filter, 10 );
+		add_filter( 'webp_uploads_upload_image_mime_transforms', $filter );
 
 		$attachment_id = $this->create_jpeg_attachment();
 		$original_url  = wp_get_attachment_image_url( $attachment_id, 'full' );
@@ -150,7 +150,7 @@ class Test_WebP_Uploads_Block_Background_Images extends TestCase {
 		$generated = $this->generate_block_with_background( 'core/cover', $attachment_id, $original_url );
 		$filtered  = webp_uploads_filter_block_background_images( $generated['block_content'], $generated['block'] );
 
-		remove_filter( 'webp_uploads_upload_image_mime_transforms', $filter, 10 );
+		remove_filter( 'webp_uploads_upload_image_mime_transforms', $filter );
 
 		$this->assertSame( $generated['block_content'], $filtered, 'Background image should remain unchanged when no WebP source exists.' );
 		$this->assertStringNotContainsString( '-jpg.webp', $filtered );

--- a/plugins/webp-uploads/tests/test-block-background-images.php
+++ b/plugins/webp-uploads/tests/test-block-background-images.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Tests for webp_uploads_filter_block_background_images().
+ *
+ * @group background-image
+ *
+ * @package webp-uploads
+ */
+
+use WebP_Uploads\Tests\TestCase;
+
+class Test_WebP_Uploads_Block_Background_Images extends TestCase {
+
+	/**
+	 * Temporary attachment IDs created during tests.
+	 *
+	 * @var array<int>
+	 */
+	private $temp_attachment_ids = array();
+
+	/**
+	 * Set up test environment.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Ensure we can generate both JPEG and WebP variants.
+		$this->opt_in_to_jpeg_and_webp();
+		update_option( 'perflab_modern_image_format', 'webp' );
+		update_option( 'perflab_generate_webp_and_jpeg', '1' );
+
+		// Satisfy webp_uploads_in_frontend_body() conditions.
+		$this->mock_frontend_body_hooks();
+	}
+
+	/**
+	 * Tear down and clean created artifacts.
+	 */
+	public function tear_down(): void {
+		foreach ( $this->temp_attachment_ids as $id ) {
+			wp_delete_attachment( $id, true );
+		}
+		$this->temp_attachment_ids = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper: Create a JPEG attachment and return its ID.
+	 */
+	private function create_jpeg_attachment(): int {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+		$this->assertNotWPError( $attachment_id );
+		$this->temp_attachment_ids[] = $attachment_id;
+		return $attachment_id;
+	}
+
+	/**
+	 * Generates block content markup and block array for a given block type using an attachment background image.
+	 *
+	 * @param string $block_name    Block name (e.g. 'core/cover' or 'core/group').
+	 * @param int    $attachment_id Attachment ID whose URL will be used as original background image.
+	 * @param string $original_url  The original full size image URL.
+	 * @param string $content       Inner content (optional).
+	 * @return array{block_content:string,block:array<string,mixed>} Array containing 'block_content' HTML and 'block' parsed block structure.
+	 */
+	private function generate_block_with_background( string $block_name, int $attachment_id, string $original_url, string $content = 'Content' ): array {
+		if ( 'core/cover' === $block_name ) {
+			$block_content = '<div class="wp-block-cover"><div style="background-image:url(' . esc_url( $original_url ) . ')"><span class="wp-block-cover__inner-container">' . esc_html( $content ) . '</span></div></div>';
+			$block         = array(
+				'blockName' => 'core/cover',
+				'attrs'     => array(
+					'id'  => $attachment_id,
+					'url' => $original_url,
+				),
+			);
+		} elseif ( 'core/group' === $block_name ) {
+			$block_content = '<div class="wp-block-group" style="background-image:url(' . esc_url( $original_url ) . ')"><div class="wp-block-group__inner-container">' . esc_html( $content ) . '</div></div>';
+			$block         = array(
+				'blockName' => 'core/group',
+				'attrs'     => array(
+					'style' => array(
+						'background' => array(
+							'backgroundImage' => array(
+								'id'  => $attachment_id,
+								'url' => $original_url,
+							),
+						),
+					),
+				),
+			);
+		} else {
+			$block_content = '';
+			$block         = array(
+				'blockName' => $block_name,
+				'attrs'     => array(),
+			);
+		}
+
+		return array(
+			'block_content' => $block_content,
+			'block'         => $block,
+		);
+	}
+
+	/**
+	 * It should replace a Cover block background image URL with a WebP variant when available.
+	 */
+	public function test_cover_block_background_image_replaced_with_webp(): void {
+		if ( ! wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {
+			$this->markTestSkipped( 'Mime type image/webp is not supported.' );
+		}
+
+		$attachment_id = $this->create_jpeg_attachment();
+		$original_url  = wp_get_attachment_image_url( $attachment_id, 'full' );
+		$this->assertIsString( $original_url );
+
+		$generated = $this->generate_block_with_background( 'core/cover', $attachment_id, $original_url );
+		$filtered  = webp_uploads_filter_block_background_images( $generated['block_content'], $generated['block'] );
+
+		$webp_url = webp_uploads_get_mime_type_image( $attachment_id, $original_url, 'image/webp' );
+		$this->assertNotNull( $webp_url, 'Expected a generated WebP URL.' );
+
+		if ( $webp_url !== $original_url ) {
+			$this->assertStringContainsString( $webp_url, $filtered, 'Filtered markup should reference WebP background image.' );
+		}
+	}
+
+	/**
+	 * It should not change background when no WebP source exists.
+	 */
+	public function test_cover_block_background_image_not_changed_without_webp_source(): void {
+		// Remove any transform filters added during set_up so we start clean.
+		remove_all_filters( 'webp_uploads_upload_image_mime_transforms' );
+
+		// Restrict transforms to only JPEG so no WebP is produced for this test.
+		$filter = static function ( $transforms ) {
+			$transforms['image/jpeg'] = array( 'image/jpeg' );
+			return $transforms;
+		};
+		add_filter( 'webp_uploads_upload_image_mime_transforms', $filter, 10 );
+
+		$attachment_id = $this->create_jpeg_attachment();
+		$original_url  = wp_get_attachment_image_url( $attachment_id, 'full' );
+		$this->assertIsString( $original_url );
+
+		$generated = $this->generate_block_with_background( 'core/cover', $attachment_id, $original_url );
+		$filtered  = webp_uploads_filter_block_background_images( $generated['block_content'], $generated['block'] );
+
+		remove_filter( 'webp_uploads_upload_image_mime_transforms', $filter, 10 );
+
+		$this->assertSame( $generated['block_content'], $filtered, 'Background image should remain unchanged when no WebP source exists.' );
+		$this->assertStringNotContainsString( '-jpg.webp', $filtered );
+	}
+
+	/**
+	 * It should replace a Group block background image URL with a WebP variant when available.
+	 */
+	public function test_group_block_background_image_replaced_with_webp(): void {
+		if ( ! wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {
+			$this->markTestSkipped( 'Mime type image/webp is not supported.' );
+		}
+
+		$attachment_id = $this->create_jpeg_attachment();
+		$original_url  = wp_get_attachment_image_url( $attachment_id, 'full' );
+		$this->assertIsString( $original_url );
+
+		$generated = $this->generate_block_with_background( 'core/group', $attachment_id, $original_url );
+		$filtered  = webp_uploads_filter_block_background_images( $generated['block_content'], $generated['block'] );
+
+		$webp_url = webp_uploads_get_mime_type_image( $attachment_id, $original_url, 'image/webp' );
+		$this->assertNotNull( $webp_url, 'Expected a generated WebP URL.' );
+
+		if ( $webp_url !== $original_url ) {
+			$this->assertStringContainsString( $webp_url, $filtered, 'Filtered group block should reference WebP background image.' );
+		}
+	}
+}

--- a/plugins/webp-uploads/tests/test-block-background-images.php
+++ b/plugins/webp-uploads/tests/test-block-background-images.php
@@ -104,6 +104,8 @@ class Test_WebP_Uploads_Block_Background_Images extends TestCase {
 
 	/**
 	 * It should replace a Cover block background image URL with a WebP variant when available.
+	 *
+	 * @covers ::webp_uploads_filter_block_background_images
 	 */
 	public function test_cover_block_background_image_replaced_with_webp(): void {
 		if ( ! wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {

--- a/plugins/webp-uploads/tests/test-block-background-images.php
+++ b/plugins/webp-uploads/tests/test-block-background-images.php
@@ -61,12 +61,11 @@ class Test_WebP_Uploads_Block_Background_Images extends TestCase {
 	 * @param string $block_name    Block name (e.g. 'core/cover' or 'core/group').
 	 * @param int    $attachment_id Attachment ID whose URL will be used as original background image.
 	 * @param string $original_url  The original full size image URL.
-	 * @param string $content       Inner content (optional).
 	 * @return array{block_content:string,block:array<string,mixed>} Array containing 'block_content' HTML and 'block' parsed block structure.
 	 */
-	private function generate_block_with_background( string $block_name, int $attachment_id, string $original_url, string $content = 'Content' ): array {
+	private function generate_block_with_background( string $block_name, int $attachment_id, string $original_url ): array {
 		if ( 'core/cover' === $block_name ) {
-			$block_content = '<div class="wp-block-cover"><div style="background-image:url(' . esc_url( $original_url ) . ')"><span class="wp-block-cover__inner-container">' . esc_html( $content ) . '</span></div></div>';
+			$block_content = '<div class="wp-block-cover"><div style="background-image:url(' . esc_url( $original_url ) . ')"><span class="wp-block-cover__inner-container">Content</span></div></div>';
 			$block         = array(
 				'blockName' => 'core/cover',
 				'attrs'     => array(
@@ -75,7 +74,7 @@ class Test_WebP_Uploads_Block_Background_Images extends TestCase {
 				),
 			);
 		} elseif ( 'core/group' === $block_name ) {
-			$block_content = '<div class="wp-block-group" style="background-image:url(' . esc_url( $original_url ) . ')"><div class="wp-block-group__inner-container">' . esc_html( $content ) . '</div></div>';
+			$block_content = '<div class="wp-block-group" style="background-image:url(' . esc_url( $original_url ) . ')"><div class="wp-block-group__inner-container">Content</div></div>';
 			$block         = array(
 				'blockName' => 'core/group',
 				'attrs'     => array(
@@ -128,6 +127,8 @@ class Test_WebP_Uploads_Block_Background_Images extends TestCase {
 
 	/**
 	 * It should not change background when no WebP source exists.
+	 *
+	 * @covers ::webp_uploads_filter_block_background_images
 	 */
 	public function test_cover_block_background_image_not_changed_without_webp_source(): void {
 		// Remove any transform filters added during set_up so we start clean.
@@ -155,6 +156,8 @@ class Test_WebP_Uploads_Block_Background_Images extends TestCase {
 
 	/**
 	 * It should replace a Group block background image URL with a WebP variant when available.
+	 *
+	 * @covers ::webp_uploads_filter_block_background_images
 	 */
 	public function test_group_block_background_image_replaced_with_webp(): void {
 		if ( ! wp_image_editor_supports( array( 'mime_type' => 'image/webp' ) ) ) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/WordPress/performance/issues/2111

## Relevant technical choices

Adds functionality to process background images used in Cover and Group blocks, particularly for cases with special styling options like fixed or repetitive backgrounds. Our current approach was limited to only processing `<img>` tags in content, but this missed background images applied through inline CSS styles.

When users set specific styling options in Cover blocks (such as fixed backgrounds) or Group blocks with background images, these images are added via inline styles rather than standard `<img>` tags. As a result, these images weren't being converted to modern formats.


