### PR TITLE
Add admin pointers to promote new Performance Lab features

### DIFF
--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -178,7 +178,7 @@ function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 
 	$args['content'] .= '<p>' . sprintf(
 		/* translators: %s: settings page link */
-		esc_html__( 'Open %s to individually toggle the performance features and access their settings (if any).', 'performance-lab' ),
+		esc_html__( 'Open %s to individually toggle the performance features and access any relevant settings.', 'performance-lab' ),
 		'<a href="' . esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) ) . '">' . esc_html__( 'Settings > Performance', 'performance-lab' ) . '</a>'
 	) . '</p>';
 

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -159,7 +159,7 @@ function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 	if ( ! in_array( $new_install_pointer_id, $dismissed_pointer_ids, true ) ) {
 		$needed_pointer_ids = array( $new_install_pointer_id );
 	} else {
-		$needed_pointer_ids = array_diff( array_keys( $admin_pointers ), $dismissed_pointer_ids );
+		$needed_pointer_ids = array_diff( $admin_pointer_ids, $dismissed_pointer_ids );
 	}
 
 	$args = array(
@@ -190,7 +190,7 @@ function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 		'strong' => array(),
 	);
 
-	$pointer_ids_to_dismiss = array_values( array_diff( array_keys( $admin_pointers ), $dismissed_pointer_ids ) );
+	$pointer_ids_to_dismiss = array_values( array_diff( $admin_pointer_ids, $dismissed_pointer_ids ) );
 
 	ob_start();
 	?>

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -123,12 +123,13 @@ function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 	if ( is_network_admin() || is_user_admin() ) {
 		return;
 	}
-	$current_user = get_current_user_id();
-	$pointers     = array_keys( perflab_get_admin_pointers() );
-	$dismissed    = perflab_get_dismissed_admin_pointer_ids();
+
+	$admin_pointers        = perflab_get_admin_pointers();
+	$admin_pointer_ids     = array_keys( $admin_pointers );
+	$dismissed_pointer_ids = perflab_get_dismissed_admin_pointer_ids();
 
 	// All pointers have been dismissed already.
-	if ( count( array_diff( $pointers, $dismissed ) ) === 0 ) {
+	if ( count( array_diff( $admin_pointer_ids, $dismissed_pointer_ids ) ) === 0 ) {
 		return;
 	}
 
@@ -138,11 +139,11 @@ function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 		// And if we're on the Performance screen, automatically dismiss the pointers.
 		if ( isset( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			update_user_meta(
-				$current_user,
+				get_current_user_id(),
 				'dismissed_wp_pointers',
 				implode(
 					',',
-					array_unique( array_merge( $dismissed, $pointers ) )
+					array_unique( array_merge( $dismissed_pointer_ids, $admin_pointer_ids ) )
 				)
 			);
 		}
@@ -153,30 +154,12 @@ function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 	// Enqueue pointer CSS and JS.
 	wp_enqueue_style( 'wp-pointer' );
 	wp_enqueue_script( 'wp-pointer' );
-	add_action( 'admin_print_footer_scripts', 'perflab_render_pointer', 10, 0 );
-}
-add_action( 'admin_enqueue_scripts', 'perflab_admin_pointer' );
 
-/**
- * Renders the Admin Pointer.
- *
- * Handles the rendering of the admin pointer.
- *
- * @todo Eliminate this function in favor of putting it inside of perflab_admin_pointer() which attaches an inline script.
- *
- * @since 1.0.0
- * @since 2.4.0 Optional arguments were added to make the function reusable for different pointers.
- * @since n.e.x.t Unused arguments removed.
- */
-function perflab_render_pointer(): void {
 	$new_install_pointer_id = 'perflab-admin-pointer';
-	$perflab_admin_pointers = perflab_get_admin_pointers();
-	$dismissed_pointer_ids  = perflab_get_dismissed_admin_pointer_ids();
-
 	if ( ! in_array( $new_install_pointer_id, $dismissed_pointer_ids, true ) ) {
 		$needed_pointer_ids = array( $new_install_pointer_id );
 	} else {
-		$needed_pointer_ids = array_diff( array_keys( $perflab_admin_pointers ), $dismissed_pointer_ids );
+		$needed_pointer_ids = array_diff( array_keys( $admin_pointers ), $dismissed_pointer_ids );
 	}
 
 	$args = array(
@@ -186,8 +169,8 @@ function perflab_render_pointer(): void {
 	$args['content'] = implode(
 		'',
 		array_map(
-			static function ( string $needed_pointer ) use ( $perflab_admin_pointers ): string {
-				return '<p>' . $perflab_admin_pointers[ $needed_pointer ] . '</p>';
+			static function ( string $needed_pointer ) use ( $admin_pointers ): string {
+				return '<p>' . $admin_pointers[ $needed_pointer ] . '</p>';
 			},
 			$needed_pointer_ids
 		)
@@ -207,7 +190,9 @@ function perflab_render_pointer(): void {
 		'strong' => array(),
 	);
 
-	$pointer_ids_to_dismiss = array_values( array_diff( array_keys( $perflab_admin_pointers ), $dismissed_pointer_ids ) );
+	$pointer_ids_to_dismiss = array_values( array_diff( array_keys( $admin_pointers ), $dismissed_pointer_ids ) );
+
+	ob_start();
 	?>
 	<script>
 		jQuery( function() {
@@ -246,7 +231,12 @@ function perflab_render_pointer(): void {
 		} );
 	</script>
 	<?php
+	$processor = new WP_HTML_Tag_Processor( (string) ob_get_clean() );
+	if ( $processor->next_tag( array( 'tag_name' => 'SCRIPT' ) ) ) {
+		wp_add_inline_script( 'wp-pointer', $processor->get_modifiable_text() );
+	}
 }
+add_action( 'admin_enqueue_scripts', 'perflab_admin_pointer' );
 
 /**
  * Adds a link to the features page to the plugin's entry in the plugins list table.

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -68,6 +68,36 @@ function perflab_render_settings_page(): void {
 }
 
 /**
+ * Gets dismissed admin pointer IDs.
+ *
+ * @since n.e.x.t
+ *
+ * @return non-empty-string[] Dismissed admin pointer IDs.
+ */
+function perflab_get_dismissed_admin_pointer_ids(): array {
+	return array_filter(
+		explode(
+			',',
+			(string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true )
+		)
+	);
+}
+
+/**
+ * Gets the admin pointers.
+ *
+ * @since n.e.x.t
+ *
+ * @return array<non-empty-string, string> Admin pointer messages with the admin pointer IDs as the keys.
+ */
+function perflab_get_admin_pointers(): array {
+	return array(
+		'perflab-admin-pointer'            => __( 'You can now test upcoming WordPress performance features.', 'performance-lab' ),
+		'perflab-feature-view-transitions' => __( 'New <strong>View Transitions</strong> feature now available.', 'performance-lab' ),
+	);
+}
+
+/**
  * Initializes admin pointer.
  *
  * Handles the bootstrapping of the admin pointer.
@@ -84,18 +114,27 @@ function perflab_admin_pointer( ?string $hook_suffix = '' ): void {
 		return;
 	}
 	$current_user = get_current_user_id();
-	$dismissed    = array_filter( explode( ',', (string) get_user_meta( get_current_user_id(), 'dismissed_wp_pointers', true ) ) );
+	$pointers     = array_keys( perflab_get_admin_pointers() );
+	$dismissed    = perflab_get_dismissed_admin_pointer_ids();
 
-	if ( in_array( 'perflab-admin-pointer', $dismissed, true ) ) {
+	// All pointers have been dismissed already.
+	if ( count( array_diff( $pointers, $dismissed ) ) === 0 ) {
 		return;
 	}
 
+	// Do not show the admin pointer when not on the dashboard or plugins list table.
 	if ( ! in_array( $hook_suffix, array( 'index.php', 'plugins.php' ), true ) ) {
 
-		// Do not show on the settings page and dismiss the pointer.
-		if ( isset( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] && ( ! in_array( 'perflab-admin-pointer', $dismissed, true ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$dismissed[] = 'perflab-admin-pointer';
-			update_user_meta( $current_user, 'dismissed_wp_pointers', implode( ',', $dismissed ) );
+		// And if we're on the Performance screen, automatically dismiss the pointers.
+		if ( isset( $_GET['page'] ) && PERFLAB_SCREEN === $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			update_user_meta(
+				$current_user,
+				'dismissed_wp_pointers',
+				implode(
+					',',
+					array_unique( array_merge( $dismissed, $pointers ) )
+				)
+			);
 		}
 
 		return;
@@ -113,53 +152,84 @@ add_action( 'admin_enqueue_scripts', 'perflab_admin_pointer' );
  *
  * Handles the rendering of the admin pointer.
  *
+ * @todo Eliminate this function in favor of putting it inside of perflab_admin_pointer() which attaches an inline script.
+ *
  * @since 1.0.0
  * @since 2.4.0 Optional arguments were added to make the function reusable for different pointers.
- *
- * @param string                                    $pointer_id Optional. ID of the pointer. Default 'perflab-admin-pointer'.
- * @param array{heading?: string, content?: string} $args       Optional. Pointer arguments. Supports 'heading' and 'content' entries.
- *                                                              Defaults are the heading and content for the 'perflab-admin-pointer'.
+ * @since n.e.x.t Unused arguments removed.
  */
-function perflab_render_pointer( string $pointer_id = 'perflab-admin-pointer', array $args = array() ): void {
-	if ( ! isset( $args['heading'] ) ) {
-		$args['heading'] = __( 'Performance Lab', 'performance-lab' );
-	}
-	if ( ! isset( $args['content'] ) ) {
-		$args['content'] = sprintf(
-			/* translators: %s: settings page link */
-			esc_html__( 'You can now test upcoming WordPress performance features. Open %s to individually toggle the performance features.', 'performance-lab' ),
-			'<a href="' . esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) ) . '">' . esc_html__( 'Settings > Performance', 'performance-lab' ) . '</a>'
-		);
+function perflab_render_pointer(): void {
+	$new_install_pointer_id = 'perflab-admin-pointer';
+	$perflab_admin_pointers = perflab_get_admin_pointers();
+	$dismissed_pointer_ids  = perflab_get_dismissed_admin_pointer_ids();
+
+	if ( ! in_array( $new_install_pointer_id, $dismissed_pointer_ids, true ) ) {
+		$needed_pointer_ids = array( $new_install_pointer_id );
+	} else {
+		$needed_pointer_ids = array_diff( array_keys( $perflab_admin_pointers ), $dismissed_pointer_ids );
 	}
 
-	$wp_kses_options = array(
-		'a' => array(
-			'href' => array(),
-		),
+	$args = array(
+		'heading' => __( 'Performance Lab', 'performance-lab' ),
 	);
 
+	$args['content'] = implode(
+		'',
+		array_map(
+			static function ( string $needed_pointer ) use ( $perflab_admin_pointers ): string {
+				return '<p>' . $perflab_admin_pointers[ $needed_pointer ] . '</p>';
+			},
+			$needed_pointer_ids
+		)
+	);
+
+	$args['content'] .= '<p>' . sprintf(
+		/* translators: %s: settings page link */
+		esc_html__( 'Open %s to individually toggle the performance features.', 'performance-lab' ),
+		'<a href="' . esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) ) . '">' . esc_html__( 'Settings > Performance', 'performance-lab' ) . '</a>'
+	) . '</p>';
+
+	$wp_kses_options = array(
+		'a'      => array(
+			'href' => array(),
+		),
+		'p'      => array(),
+		'strong' => array(),
+	);
+
+	$pointer_ids_to_dismiss = array_values( array_diff( array_keys( $perflab_admin_pointers ), $dismissed_pointer_ids ) );
 	?>
-	<script id="<?php echo esc_attr( $pointer_id ); ?>" type="text/javascript">
+	<script>
 		jQuery( function() {
+			const pointerIdsToDismiss = <?php echo wp_json_encode( $pointer_ids_to_dismiss, JSON_OBJECT_AS_ARRAY ); ?>;
+			const nonce = <?php echo wp_json_encode( wp_create_nonce( 'dismiss_pointer' ) ); ?>;
+
+			function dismissNextPointer() {
+				const pointerId = pointerIdsToDismiss.shift();
+				if ( ! pointerId ) {
+					return;
+				}
+
+				jQuery.post(
+					window.ajaxurl,
+					{
+						pointer: pointerId,
+						action:  'dismiss-wp-pointer',
+						_wpnonce: nonce,
+					}
+				).then( dismissNextPointer );
+			}
+
 			// Pointer Options.
 			const options = {
-				content: <?php echo wp_json_encode( '<h3>' . esc_html( $args['heading'] ) . '</h3><p>' . wp_kses( $args['content'], $wp_kses_options ) . '</p>' ); ?>,
+				content: <?php echo wp_json_encode( '<h3>' . esc_html( $args['heading'] ) . '</h3>' . wp_kses( $args['content'], $wp_kses_options ) ); ?>,
 				position: {
 					edge:  'left',
 					align: 'right',
 				},
 				pointerClass: 'wp-pointer arrow-top',
 				pointerWidth: 420,
-				close: function() {
-					jQuery.post(
-						window.ajaxurl,
-						{
-							pointer: <?php echo wp_json_encode( $pointer_id ); ?>,
-							action:  'dismiss-wp-pointer',
-							_wpnonce: <?php echo wp_json_encode( wp_create_nonce( 'dismiss_pointer' ) ); ?>,
-						}
-					);
-				}
+				close: dismissNextPointer
 			};
 
 			jQuery( '#menu-settings' ).pointer( options ).pointer( 'open' );
@@ -207,7 +277,11 @@ function perflab_plugin_action_links_add_settings( $links ) {
  * @since 2.3.0
  */
 function perflab_dismiss_wp_pointer_wrapper(): void {
-	if ( isset( $_POST['pointer'] ) && 'perflab-admin-pointer' !== $_POST['pointer'] ) {
+	if (
+		isset( $_POST['pointer'] )
+		&&
+		! in_array( $_POST['pointer'], array_keys( perflab_get_admin_pointers() ), true )
+	) {
 		// Another plugin's pointer, do nothing.
 		return;
 	}

--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -91,10 +91,20 @@ function perflab_get_dismissed_admin_pointer_ids(): array {
  * @return array<non-empty-string, string> Admin pointer messages with the admin pointer IDs as the keys.
  */
 function perflab_get_admin_pointers(): array {
-	return array(
+	$pointers = array(
 		'perflab-admin-pointer'            => __( 'You can now test upcoming WordPress performance features.', 'performance-lab' ),
 		'perflab-feature-view-transitions' => __( 'New <strong>View Transitions</strong> feature now available.', 'performance-lab' ),
 	);
+
+	if (
+		defined( 'SPECULATION_RULES_VERSION' )
+		&&
+		version_compare( SPECULATION_RULES_VERSION, '1.6.0', '>=' )
+	) {
+		$pointers['perflab-feature-speculation-rules-auth'] = __( '<strong>Speculative Loading</strong> now includes an opt-in setting for logged-in users.', 'performance-lab' );
+	}
+
+	return $pointers;
 }
 
 /**
@@ -185,7 +195,7 @@ function perflab_render_pointer(): void {
 
 	$args['content'] .= '<p>' . sprintf(
 		/* translators: %s: settings page link */
-		esc_html__( 'Open %s to individually toggle the performance features.', 'performance-lab' ),
+		esc_html__( 'Open %s to individually toggle the performance features and access their settings (if any).', 'performance-lab' ),
 		'<a href="' . esc_url( add_query_arg( 'page', PERFLAB_SCREEN, admin_url( 'options-general.php' ) ) ) . '">' . esc_html__( 'Settings > Performance', 'performance-lab' ) . '</a>'
 	) . '</p>';
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -610,6 +610,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 == Upgrade Notice ==
 
+= n.e.x.t =
+
+This release introduces a new feature plugin called View Transitions which adds smooth transitions between navigations on your site.
+
 = 3.2.0 =
 
 This release introduces a new feature plugin called Image Prioritizer which optimizes the loading of images to improve LCP.

--- a/plugins/performance-lab/tests/includes/admin/test-load.php
+++ b/plugins/performance-lab/tests/includes/admin/test-load.php
@@ -87,6 +87,37 @@ class Test_Admin_Load extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @covers ::perflab_get_dismissed_admin_pointer_ids
+	 */
+	public function test_perflab_get_dismissed_admin_pointer_ids(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		// No dismissed pointers.
+		$this->assertSame( array(), perflab_get_dismissed_admin_pointer_ids() );
+
+		// Dismiss a single pointer.
+		update_user_meta( $user_id, 'dismissed_wp_pointers', 'perflab-admin-pointer' );
+		$this->assertSame( array( 'perflab-admin-pointer' ), perflab_get_dismissed_admin_pointer_ids() );
+
+		// Dismiss multiple pointers.
+		update_user_meta( $user_id, 'dismissed_wp_pointers', 'perflab-admin-pointer,another-pointer' );
+		$this->assertSame( array( 'perflab-admin-pointer', 'another-pointer' ), perflab_get_dismissed_admin_pointer_ids() );
+
+		// Dismiss all pointers.
+		update_user_meta( $user_id, 'dismissed_wp_pointers', implode( ',', array_keys( perflab_get_admin_pointers() ) ) );
+		$this->assertSame( array_keys( perflab_get_admin_pointers() ), perflab_get_dismissed_admin_pointer_ids() );
+	}
+
+	/**
+	 * @covers ::perflab_get_admin_pointers
+	 */
+	public function test_perflab_get_admin_pointers(): void {
+		$pointers = perflab_get_admin_pointers();
+		$this->assertArrayHasKey( 'perflab-admin-pointer', $pointers );
+	}
+
+	/**
 	 * @return array<string, array{ hook_suffix: string|null, expected: bool }>
 	 */
 	public function data_provider_test_perflab_admin_pointer(): array {
@@ -119,14 +150,23 @@ class Test_Admin_Load extends WP_UnitTestCase {
 				'assert'                => null,
 				'dismissed_wp_pointers' => '',
 			),
-			'dashboard_yes_dismissed'    => array(
+			'dashboard_new_dismissed'    => array(
 				'set_up'                => static function (): void {
 					update_user_meta( wp_get_current_user()->ID, 'dismissed_wp_pointers', 'perflab-admin-pointer' );
 				},
 				'hook_suffix'           => 'index.php',
-				'expected'              => false,
+				'expected'              => true,
 				'assert'                => null,
 				'dismissed_wp_pointers' => 'perflab-admin-pointer',
+			),
+			'dashboard_all_dismissed'    => array(
+				'set_up'                => static function (): void {
+					update_user_meta( wp_get_current_user()->ID, 'dismissed_wp_pointers', implode( ',', array_keys( perflab_get_admin_pointers() ) ) );
+				},
+				'hook_suffix'           => 'index.php',
+				'expected'              => false,
+				'assert'                => null,
+				'dismissed_wp_pointers' => implode( ',', array_keys( perflab_get_admin_pointers() ) ),
 			),
 			'perflab_screen_first_time'  => array(
 				'set_up'                => static function (): void {
@@ -135,7 +175,7 @@ class Test_Admin_Load extends WP_UnitTestCase {
 				'hook_suffix'           => 'options-general.php',
 				'expected'              => false,
 				'assert'                => null,
-				'dismissed_wp_pointers' => 'perflab-admin-pointer',
+				'dismissed_wp_pointers' => implode( ',', array_keys( perflab_get_admin_pointers() ) ),
 			),
 			'perflab_screen_second_time' => array(
 				'set_up'                => static function (): void {
@@ -145,7 +185,7 @@ class Test_Admin_Load extends WP_UnitTestCase {
 				'hook_suffix'           => 'options-general.php',
 				'expected'              => false,
 				'assert'                => null,
-				'dismissed_wp_pointers' => 'perflab-admin-pointer',
+				'dismissed_wp_pointers' => implode( ',', array_keys( perflab_get_admin_pointers() ) ),
 			),
 		);
 	}

--- a/plugins/performance-lab/tests/includes/admin/test-load.php
+++ b/plugins/performance-lab/tests/includes/admin/test-load.php
@@ -208,7 +208,17 @@ class Test_Admin_Load extends WP_UnitTestCase {
 		}
 		$this->assertFalse( is_network_admin() || is_user_admin() );
 		perflab_admin_pointer( $hook_suffix );
-		$this->assertSame( $expected ? 10 : false, has_action( 'admin_print_footer_scripts', 'perflab_render_pointer' ) );
+
+		$after_script      = '';
+		$script_dependency = wp_scripts()->query( 'wp-pointer' );
+		if ( $script_dependency instanceof _WP_Dependency ) {
+			$after_script = implode( "\n", array_filter( $script_dependency->extra['after'] ?? array() ) );
+		}
+		if ( $expected ) {
+			$this->assertStringContainsString( 'pointerIdsToDismiss', $after_script );
+		} else {
+			$this->assertStringNotContainsString( 'pointerIdsToDismiss', $after_script );
+		}
 		$this->assertSame( $expected, wp_script_is( 'wp-pointer', 'enqueued' ) );
 		$this->assertSame( $expected, wp_style_is( 'wp-pointer', 'enqueued' ) );
 		$this->assertSame( $dismissed_wp_pointers, get_user_meta( $user_id, 'dismissed_wp_pointers', true ) );


### PR DESCRIPTION
## Summary

Fixes #1239

When activating the plugin for the first time, a simple generic admin pointer message is displayed about all the features and how they can be activated:

Before | After
--|--
<img width="616" height="228" alt="image" src="https://github.com/user-attachments/assets/3f9bdf40-af40-41e6-a534-db9485c54c52" /> | <img width="608" height="231" alt="Screenshot 2025-08-09 at 16 39 46" src="https://github.com/user-attachments/assets/d0e65fa8-b83f-421a-a3dd-307899664f56" />


If someone has the plugin already active (and previously dismissed this `perflab-admin-pointer` pointer, then when other PerfLab pointers have not already been dismissed, then they'll appear in a new admin pointer:

<img width="607" height="304" alt="Screenshot 2025-08-09 at 16 40 45" src="https://github.com/user-attachments/assets/6582daa6-b131-450e-a026-a53f1b854876" />

Two feature-specific admin pointers are introduced, one for the new View Transitions plugin and another for the new logged-in opt-in for the Speculative Loading plugin.

The logic for adding the admin pointer was also refactored, making use of inline scripts. This eliminated the need for the `perflab_render_pointer()` function.

This PR also includes an Upgrade Notice for Performance Lab to also promote the View Transitions plugin, which was done previously for Image Prioritizer.