### PR TITLE
Add warning notice to Speculative Loading setting for authenticated users when persistent object cache is not present

### DIFF
--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -328,7 +328,7 @@ function plsr_render_settings_field( array $args ): void {
 		( function () {
 			const authRadios = document.querySelectorAll( '.plsr-auth-radio' );
 			const warningDiv = document.getElementById( 'plsr-auth-warning' );
-			const authenticatedOptions = <?php echo wp_json_encode( $authenticated_options ); ?>;
+			const authenticatedOptions = <?php echo wp_json_encode( $authenticated_options, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
 			
 			if ( ! authRadios.length || ! warningDiv ) {
 				return;

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -71,7 +71,7 @@ function plsr_get_field_description( string $field ): string {
 		'eagerness'      => __( 'The eagerness setting defines the heuristics based on which the loading is triggered. "Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'speculation-rules' ),
 		'authentication' => sprintf(
 			/* translators: %s: URL to persistent object cache documentation */
-			__( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. For optimal performance when enabling authenticated user support, ensure you have a <a href="%s" target="_blank">persistent object cache</a> configured. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
+			__( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. For optimal performance, regardless of the user authentication status but <em>especially</em> when logged-in, ensure you have a <a href="%s" target="_blank">persistent object cache</a> configured. This only applies to pages on the frontend; admin screens remain excluded.', 'speculation-rules' ),
 			'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching'
 		),
 	);
@@ -311,7 +311,7 @@ function plsr_render_settings_field( array $args ): void {
 					echo wp_kses(
 						sprintf(
 							/* translators: %s: URL to persistent object cache documentation */
-							__( 'Enabling speculative loading for authenticated users without a persistent object cache may significantly increase server load. Consider setting up a <a href="%s" target="_blank">persistent object cache</a> before enabling this feature for logged-in users.', 'speculation-rules' ),
+							__( 'Enabling speculative loading for authenticated users may significantly increase the server load. Consider setting up a <a href="%s" target="_blank">persistent object cache</a> before enabling this feature for logged-in users.', 'speculation-rules' ),
 							'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching'
 						),
 						array(
@@ -331,10 +331,11 @@ function plsr_render_settings_field( array $args ): void {
 			echo wp_kses(
 				$args['description'],
 				array(
-					'a' => array(
+					'a'  => array(
 						'href'   => array(),
 						'target' => array(),
 					),
+					'em' => array(),
 				)
 			);
 			?>

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -288,7 +288,7 @@ function plsr_render_settings_field( array $args ): void {
 	$show_notice  = 'authentication' === $args['field'] && ! wp_using_ext_object_cache();
 	$show_warning = $show_notice && 'logged_out' !== $value;
 	?>
-	<fieldset>
+	<fieldset id="<?php echo esc_attr( 'plsr-' . $args['field'] . '-setting' ); ?>">
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
 		<?php foreach ( $choices as $slug => $label ) : ?>
 			<p>
@@ -345,16 +345,18 @@ function plsr_render_settings_field( array $args ): void {
 	if ( $show_notice ) {
 		// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed -- Part of the PCP ruleset. Appealed in <https://github.com/WordPress/plugin-check/issues/792#issuecomment-3214985527>.
 		$js = <<<'JS'
-			const authRadios = /** @type {NodeListOf<HTMLInputElement>} */ ( document.querySelectorAll( "input[name='plsr_speculation_rules[authentication]']" ) );
-			const noticeDiv = document.getElementById( "plsr-auth-notice" );
-			if ( authRadios.length && noticeDiv ) {
-				for ( const authRadio of authRadios ) {
-					authRadio.addEventListener( "change", () => {
-						const isLoggedOut = ( authRadio.value === "logged_out" );
-						noticeDiv.classList.toggle( "notice-info", isLoggedOut )
-						noticeDiv.classList.toggle( "notice-warning", ! isLoggedOut )
-					} );
-				}
+			const authOptions = document.getElementById( 'plsr-authentication-setting' );
+			const noticeDiv = document.getElementById( 'plsr-auth-notice' );
+			if ( authOptions && noticeDiv ) {
+				authOptions.addEventListener( 'change', ( /** @type {Event} */ event ) => {
+					const target = event.target;
+					if ( ! ( target instanceof HTMLInputElement && 'radio' === target.type ) ) {
+						return;
+					}
+					const isLoggedOut = ( target.value === 'logged_out' );
+					noticeDiv.classList.toggle( 'notice-info', isLoggedOut );
+					noticeDiv.classList.toggle( 'notice-warning', ! isLoggedOut );
+				} );
 			}
 JS;
 		// 👆 This 'JS;' line can only be indented two tabs when minimum PHP version is increased to 7.3+.

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -308,7 +308,7 @@ function plsr_render_settings_field( array $args ): void {
 		<?php endforeach; ?>
 
 		<?php if ( $show_notice ) : ?>
-			<div id="plsr-auth-notice" class="notice <?php echo $show_warning ? 'notice-warning' : 'notice-info'; ?> inline">
+			<div id="plsr-auth-notice" class="notice <?php echo esc_attr( $show_warning ? 'notice-warning' : 'notice-info' ); ?> inline">
 				<p>
 					<?php
 					echo wp_kses(

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -267,37 +267,17 @@ function plsr_render_settings_field( array $args ): void {
 	}
 
 	$value                 = $option[ $args['field'] ];
-	$has_object_cache      = wp_using_ext_object_cache();
 	$authenticated_options = array( 'logged_out_and_admins', 'any' );
-	$show_warning          = 'authentication' === $args['field'] && ! $has_object_cache && in_array( $value, $authenticated_options, true );
+	$show_notice           = 'authentication' === $args['field'] && ! wp_using_ext_object_cache();
+	$show_warning          = $show_notice && in_array( $value, $authenticated_options, true );
 	?>
-	
-	<?php if ( 'authentication' === $args['field'] && ! $has_object_cache ) : ?>
-		<div id="plsr-auth-warning" class="notice notice-warning inline" <?php echo $show_warning ? '' : 'hidden'; ?>>
-			<p>
-				<strong><?php esc_html_e( 'Warning:', 'speculation-rules' ); ?></strong>
-				<?php
-				printf(
-					/* translators: %s: URL to persistent object cache documentation */
-					esc_html__( 'Enabling speculative loading for authenticated users without a persistent object cache may significantly increase server load. Consider setting up a %s before enabling this feature for logged-in users.', 'speculation-rules' ),
-					sprintf(
-						'<a href="%s" target="_blank">%s</a>',
-						'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching',
-						esc_html__( 'persistent object cache', 'speculation-rules' )
-					)
-				);
-				?>
-			</p>
-		</div>
-	<?php endif; ?>
-	
 	<fieldset>
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
 		<?php foreach ( $choices as $slug => $label ) : ?>
 			<p>
 				<label>
 					<input
-						class="plsr-auth-radio"
+						<?php echo $show_notice ? 'class="plsr-auth-radio"' : ''; ?>
 						name="<?php echo esc_attr( "plsr_speculation_rules[{$args['field']}]" ); ?>"
 						type="radio"
 						value="<?php echo esc_attr( $slug ); ?>"
@@ -321,28 +301,62 @@ function plsr_render_settings_field( array $args ): void {
 			);
 			?>
 		</p>
+
+		<?php if ( $show_notice ) : ?>
+			<div id="plsr-auth-notice" class="notice <?php echo $show_warning ? 'notice-warning' : 'notice-info'; ?> inline">
+				<p>
+					<strong id="plsr-notice-label" <?php echo $show_warning ? '' : 'hidden'; ?>><?php esc_html_e( 'Warning: ', 'speculation-rules' ); ?></strong>
+					<?php
+					echo wp_kses(
+						sprintf(
+							/* translators: %s: URL to persistent object cache documentation */
+							__( 'Enabling speculative loading for authenticated users without a persistent object cache may significantly increase server load. Consider setting up a <a href="%s" target="_blank">persistent object cache</a> before enabling this feature for logged-in users.', 'speculation-rules' ),
+							'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching'
+						),
+						array(
+							'a' => array(
+								'href'   => array(),
+								'target' => array(),
+							),
+						)
+					);
+					?>
+				</p>
+			</div>
+		<?php endif; ?>
 	</fieldset>
-	
-	<?php if ( 'authentication' === $args['field'] && ! $has_object_cache ) : ?>
-		<script>
-		( function () {
-			const authRadios = document.querySelectorAll( '.plsr-auth-radio' );
-			const warningDiv = document.getElementById( 'plsr-auth-warning' );
-			const authenticatedOptions = <?php echo wp_json_encode( $authenticated_options, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ); ?>;
-			
-			if ( ! authRadios.length || ! warningDiv ) {
-				return;
-			}
-			
-			authRadios.forEach( function ( radio ) {
-				radio.addEventListener( 'change', function ( e ) {
-					warningDiv.hidden = ! authenticatedOptions.includes( e.target.value );
-				} );
-			} );
-		} )();
-		</script>
-	<?php endif; ?>
+
 	<?php
+	if ( $show_notice ) {
+		wp_print_inline_script_tag(
+			sprintf(
+				'const authRadios = document.querySelectorAll( ".plsr-auth-radio" );
+				const noticeDiv = document.getElementById( "plsr-auth-notice" );
+				const noticeLabel = document.getElementById( "plsr-notice-label" );
+				const authenticatedOptions = %s;
+				
+				if ( authRadios.length && noticeDiv && noticeLabel ) {
+					authRadios.forEach( function ( radio ) {
+						radio.addEventListener( "change", function ( e ) {
+							const isAuthOption = authenticatedOptions.includes( e.target.value );
+
+							if ( isAuthOption ) {
+								noticeDiv.classList.remove( "notice-info" );
+								noticeDiv.classList.add( "notice-warning" );
+								noticeLabel.hidden = false;
+							} else {
+								noticeDiv.classList.remove( "notice-warning" );
+								noticeDiv.classList.add( "notice-info" );
+								noticeLabel.hidden = true;
+							}
+						} );
+					} );
+				}',
+				wp_json_encode( $authenticated_options, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
+			),
+			array( 'type' => 'module' )
+		);
+	}
 }
 
 /**

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -60,6 +60,7 @@ function plsr_get_authentication_labels(): array {
  * Returns translated description strings for settings fields.
  *
  * @since n.e.x.t
+ * @access private
  *
  * @param string $field The field name to get description for.
  * @param bool   $strip_tags Whether to strip HTML tags from the description.

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -57,6 +57,30 @@ function plsr_get_authentication_labels(): array {
 }
 
 /**
+ * Returns translated description strings for settings fields.
+ *
+ * @since n.e.x.t
+ *
+ * @param string $field The field name to get description for.
+ * @param bool   $strip_tags Whether to strip HTML tags from the description.
+ * @return string The translated description string.
+ */
+function plsr_get_field_description( string $field, bool $strip_tags = false ): string {
+	$descriptions = array(
+		'mode'           => __( 'Prerendering will lead to faster load times than prefetching. However, in case of interactive content, prefetching may be a safer choice.', 'speculation-rules' ),
+		'eagerness'      => __( 'The eagerness setting defines the heuristics based on which the loading is triggered. "Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'speculation-rules' ),
+		'authentication' => sprintf(
+			/* translators: %s: URL to persistent object cache documentation */
+			__( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. For optimal performance when enabling authenticated user support, ensure you have a <a href="%s" target="_blank">persistent object cache</a> configured. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
+			'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching'
+		),
+	);
+	$description  = $descriptions[ $field ] ?? '';
+
+	return $strip_tags ? wp_strip_all_tags( $description ) : $description;
+}
+
+/**
  * Returns the default setting value for Speculative Loading configuration.
  *
  * @since 1.0.0
@@ -153,17 +177,17 @@ function plsr_register_setting(): void {
 					'type'                 => 'object',
 					'properties'           => array(
 						'mode'           => array(
-							'description' => __( 'Whether to prefetch or prerender URLs.', 'speculation-rules' ),
+							'description' => plsr_get_field_description( 'mode', true ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_mode_labels() ),
 						),
 						'eagerness'      => array(
-							'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered. "Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'speculation-rules' ),
+							'description' => plsr_get_field_description( 'eagerness', true ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_eagerness_labels() ),
 						),
 						'authentication' => array(
-							'description' => __( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. For optimal performance when enabling authenticated user support, ensure you have a persistent object cache configured. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
+							'description' => plsr_get_field_description( 'authentication', true ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_authentication_labels() ),
 						),
@@ -203,19 +227,15 @@ function plsr_add_setting_ui(): void {
 	$fields = array(
 		'mode'           => array(
 			'title'       => __( 'Speculation Mode', 'speculation-rules' ),
-			'description' => __( 'Prerendering will lead to faster load times than prefetching. However, in case of interactive content, prefetching may be a safer choice.', 'speculation-rules' ),
+			'description' => plsr_get_field_description( 'mode' ),
 		),
 		'eagerness'      => array(
 			'title'       => __( 'Eagerness', 'speculation-rules' ),
-			'description' => __( 'The eagerness setting defines the heuristics based on which the loading is triggered. "Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'speculation-rules' ),
+			'description' => plsr_get_field_description( 'eagerness' ),
 		),
 		'authentication' => array(
 			'title'       => __( 'User Authentication Status', 'speculation-rules' ),
-			'description' => sprintf(
-				/* translators: %s: URL to persistent object cache documentation */
-				__( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. For optimal performance when enabling authenticated user support, ensure you have a <a href="%s" target="_blank">persistent object cache</a> configured. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
-				'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching'
-			),
+			'description' => plsr_get_field_description( 'authentication' ),
 		),
 	);
 	foreach ( $fields as $slug => $args ) {

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -349,27 +349,19 @@ function plsr_render_settings_field( array $args ): void {
 		// TODO: Unsure why this is not allowed in PHPCS since not mentioned in WP coding standards and heredocs/nowdocs are use in core: <https://github.com/search?q=repo%3AWordPress%2Fwordpress-develop+%2F%3C%3C%3C%27%3F%5BA-Z%5D%2B%2F&type=code>.
 		// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
 		$js = <<<'JS'
-			const authRadios = document.querySelectorAll( "input[name='plsr_speculation_rules[authentication]']" );
+			const authRadios = /** @type {NodeListOf<HTMLInputElement>} */ ( document.querySelectorAll( "input[name='plsr_speculation_rules[authentication]']" ) );
 			const noticeDiv = document.getElementById( "plsr-auth-notice" );
-
 			if ( authRadios.length && noticeDiv ) {
-				authRadios.forEach( function ( radio, index ) {
-					radio.addEventListener( "change", function ( e ) {
-						// Index 0 is logged_out, any other index is authenticated option.
-						const isAuthOption = index > 0;
-
-						if ( isAuthOption ) {
-							noticeDiv.classList.remove( "notice-info" );
-							noticeDiv.classList.add( "notice-warning" );
-						} else {
-							noticeDiv.classList.remove( "notice-warning" );
-							noticeDiv.classList.add( "notice-info" );
-						}
+				for ( const authRadio of authRadios ) {
+					authRadio.addEventListener( "change", () => {
+						const isLoggedOut = ( authRadio.value === "logged_out" );
+						noticeDiv.classList.toggle( "notice-info", isLoggedOut )
+						noticeDiv.classList.toggle( "notice-warning", ! isLoggedOut )
 					} );
-				} );
+				}
 			}
 JS;
-		// 👆 This can only be indented two tabs when minimum PHP version is increased to 7.3+.
+		// 👆 This 'JS;' line can only be indented two tabs when minimum PHP version is increased to 7.3+.
 		wp_print_inline_script_tag( $js, array( 'type' => 'module' ) );
 	}
 }

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -288,9 +288,8 @@ function plsr_render_settings_field( array $args ): void {
 	}
 
 	$value                 = $option[ $args['field'] ];
-	$authenticated_options = array( 'logged_out_and_admins', 'any' );
 	$show_notice           = 'authentication' === $args['field'] && ! wp_using_ext_object_cache();
-	$show_warning          = $show_notice && in_array( $value, $authenticated_options, true );
+	$show_warning          = $show_notice && 'logged_out' !== $value;
 	?>
 	<fieldset>
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
@@ -298,7 +297,6 @@ function plsr_render_settings_field( array $args ): void {
 			<p>
 				<label>
 					<input
-						<?php echo $show_notice ? 'class="plsr-auth-radio"' : ''; ?>
 						name="<?php echo esc_attr( "plsr_speculation_rules[{$args['field']}]" ); ?>"
 						type="radio"
 						value="<?php echo esc_attr( $slug ); ?>"
@@ -351,7 +349,7 @@ function plsr_render_settings_field( array $args ): void {
 	if ( $show_notice ) {
 		wp_print_inline_script_tag(
 			sprintf(
-				'const authRadios = document.querySelectorAll( ".plsr-auth-radio" );
+				'const authRadios = document.querySelectorAll( "input[name=\'plsr_speculation_rules[authentication]\']" );
 				const noticeDiv = document.getElementById( "plsr-auth-notice" );
 				const noticeLabel = document.getElementById( "plsr-notice-label" );
 				const authenticatedOptions = %s;

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -62,11 +62,10 @@ function plsr_get_authentication_labels(): array {
  * @since n.e.x.t
  * @access private
  *
- * @param string $field The field name to get description for.
- * @param bool   $strip_tags Whether to strip HTML tags from the description.
+ * @param 'mode'|'eagerness'|'authentication' $field The field name to get description for.
  * @return string The translated description string.
  */
-function plsr_get_field_description( string $field, bool $strip_tags = false ): string {
+function plsr_get_field_description( string $field ): string {
 	$descriptions = array(
 		'mode'           => __( 'Prerendering will lead to faster load times than prefetching. However, in case of interactive content, prefetching may be a safer choice.', 'speculation-rules' ),
 		'eagerness'      => __( 'The eagerness setting defines the heuristics based on which the loading is triggered. "Eager" will have the minimum delay to start speculative loads, "Conservative" increases the chance that only URLs the user actually navigates to are loaded.', 'speculation-rules' ),
@@ -76,9 +75,7 @@ function plsr_get_field_description( string $field, bool $strip_tags = false ): 
 			'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching'
 		),
 	);
-	$description  = $descriptions[ $field ] ?? '';
-
-	return $strip_tags ? wp_strip_all_tags( $description ) : $description;
+	return $descriptions[ $field ] ?? '';
 }
 
 /**
@@ -178,17 +175,17 @@ function plsr_register_setting(): void {
 					'type'                 => 'object',
 					'properties'           => array(
 						'mode'           => array(
-							'description' => plsr_get_field_description( 'mode', true ),
+							'description' => wp_strip_all_tags( plsr_get_field_description( 'mode' ) ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_mode_labels() ),
 						),
 						'eagerness'      => array(
-							'description' => plsr_get_field_description( 'eagerness', true ),
+							'description' => wp_strip_all_tags( plsr_get_field_description( 'eagerness' ) ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_eagerness_labels() ),
 						),
 						'authentication' => array(
-							'description' => plsr_get_field_description( 'authentication', true ),
+							'description' => wp_strip_all_tags( plsr_get_field_description( 'authentication' ) ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_authentication_labels() ),
 						),

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -307,24 +307,9 @@ function plsr_render_settings_field( array $args ): void {
 			</p>
 		<?php endforeach; ?>
 
-		<p class="description" style="max-width: 800px;">
-			<?php
-			echo wp_kses(
-				$args['description'],
-				array(
-					'a' => array(
-						'href'   => array(),
-						'target' => array(),
-					),
-				)
-			);
-			?>
-		</p>
-
 		<?php if ( $show_notice ) : ?>
 			<div id="plsr-auth-notice" class="notice <?php echo $show_warning ? 'notice-warning' : 'notice-info'; ?> inline">
 				<p>
-					<strong id="plsr-notice-label" <?php echo $show_warning ? '' : 'hidden'; ?>><?php esc_html_e( 'Warning: ', 'speculation-rules' ); ?></strong>
 					<?php
 					echo wp_kses(
 						sprintf(
@@ -343,6 +328,20 @@ function plsr_render_settings_field( array $args ): void {
 				</p>
 			</div>
 		<?php endif; ?>
+
+		<p class="description" style="max-width: 800px;">
+			<?php
+			echo wp_kses(
+				$args['description'],
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+				)
+			);
+			?>
+		</p>
 	</fieldset>
 
 	<?php
@@ -350,9 +349,8 @@ function plsr_render_settings_field( array $args ): void {
 		wp_print_inline_script_tag(
 			'const authRadios = document.querySelectorAll( "input[name=\'plsr_speculation_rules[authentication]\']" );
 			const noticeDiv = document.getElementById( "plsr-auth-notice" );
-			const noticeLabel = document.getElementById( "plsr-notice-label" );
 			
-			if ( authRadios.length && noticeDiv && noticeLabel ) {
+			if ( authRadios.length && noticeDiv ) {
 				authRadios.forEach( function ( radio, index ) {
 					radio.addEventListener( "change", function ( e ) {
 						// Index 0 is logged_out, any other index is authenticated option.
@@ -361,11 +359,9 @@ function plsr_render_settings_field( array $args ): void {
 						if ( isAuthOption ) {
 							noticeDiv.classList.remove( "notice-info" );
 							noticeDiv.classList.add( "notice-warning" );
-							noticeLabel.hidden = false;
 						} else {
 							noticeDiv.classList.remove( "notice-warning" );
 							noticeDiv.classList.add( "notice-info" );
-							noticeLabel.hidden = true;
 						}
 					} );
 				} );

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -284,9 +284,7 @@ function plsr_render_settings_field( array $args ): void {
 			return; // @codeCoverageIgnore
 	}
 
-	$value        = $option[ $args['field'] ];
-	$show_notice  = 'authentication' === $args['field'] && ! wp_using_ext_object_cache();
-	$show_warning = $show_notice && 'logged_out' !== $value;
+	$value = $option[ $args['field'] ];
 	?>
 	<fieldset id="<?php echo esc_attr( 'plsr-' . $args['field'] . '-setting' ); ?>">
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
@@ -304,8 +302,8 @@ function plsr_render_settings_field( array $args ): void {
 			</p>
 		<?php endforeach; ?>
 
-		<?php if ( $show_notice ) : ?>
-			<div id="plsr-auth-notice" class="notice <?php echo esc_attr( $show_warning ? 'notice-warning' : 'notice-info' ); ?> inline">
+		<?php if ( 'authentication' === $args['field'] && ! wp_using_ext_object_cache() ) : ?>
+			<div id="plsr-auth-notice" class="notice <?php echo esc_attr( 'logged_out' !== $value ? 'notice-warning' : 'notice-info' ); ?> inline">
 				<p>
 					<?php
 					echo wp_kses(
@@ -324,6 +322,26 @@ function plsr_render_settings_field( array $args ): void {
 					?>
 				</p>
 			</div>
+			<?php
+			// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed -- Part of the PCP ruleset. Appealed in <https://github.com/WordPress/plugin-check/issues/792#issuecomment-3214985527>.
+			$js = <<<'JS'
+				const authOptions = document.getElementById( 'plsr-authentication-setting' );
+				const noticeDiv = document.getElementById( 'plsr-auth-notice' );
+				if ( authOptions && noticeDiv ) {
+					authOptions.addEventListener( 'change', ( /** @type {Event} */ event ) => {
+						const target = event.target;
+						if ( ! ( target instanceof HTMLInputElement && 'radio' === target.type ) ) {
+							return;
+						}
+						const isLoggedOut = ( target.value === 'logged_out' );
+						noticeDiv.classList.toggle( 'notice-info', isLoggedOut );
+						noticeDiv.classList.toggle( 'notice-warning', ! isLoggedOut );
+					} );
+				}
+JS;
+			// 👆 This 'JS;' line can only be indented two tabs when minimum PHP version is increased to 7.3+.
+			wp_print_inline_script_tag( $js, array( 'type' => 'module' ) );
+			?>
 		<?php endif; ?>
 
 		<p class="description" style="max-width: 800px;">
@@ -341,28 +359,7 @@ function plsr_render_settings_field( array $args ): void {
 			?>
 		</p>
 	</fieldset>
-
 	<?php
-	if ( $show_notice ) {
-		// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed -- Part of the PCP ruleset. Appealed in <https://github.com/WordPress/plugin-check/issues/792#issuecomment-3214985527>.
-		$js = <<<'JS'
-			const authOptions = document.getElementById( 'plsr-authentication-setting' );
-			const noticeDiv = document.getElementById( 'plsr-auth-notice' );
-			if ( authOptions && noticeDiv ) {
-				authOptions.addEventListener( 'change', ( /** @type {Event} */ event ) => {
-					const target = event.target;
-					if ( ! ( target instanceof HTMLInputElement && 'radio' === target.type ) ) {
-						return;
-					}
-					const isLoggedOut = ( target.value === 'logged_out' );
-					noticeDiv.classList.toggle( 'notice-info', isLoggedOut );
-					noticeDiv.classList.toggle( 'notice-warning', ! isLoggedOut );
-				} );
-			}
-JS;
-		// 👆 This 'JS;' line can only be indented two tabs when minimum PHP version is increased to 7.3+.
-		wp_print_inline_script_tag( $js, array( 'type' => 'module' ) );
-	}
 }
 
 /**

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -163,7 +163,7 @@ function plsr_register_setting(): void {
 							'enum'        => array_keys( plsr_get_eagerness_labels() ),
 						),
 						'authentication' => array(
-							'description' => __( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
+							'description' => __( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. For optimal performance when enabling authenticated user support, ensure you have a persistent object cache configured. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
 							'type'        => 'string',
 							'enum'        => array_keys( plsr_get_authentication_labels() ),
 						),
@@ -211,7 +211,11 @@ function plsr_add_setting_ui(): void {
 		),
 		'authentication' => array(
 			'title'       => __( 'User Authentication Status', 'speculation-rules' ),
-			'description' => __( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
+			'description' => sprintf(
+				/* translators: %s: URL to persistent object cache documentation */
+				__( 'Only unauthenticated pages are typically served from cache. So in order to reduce load on the server, speculative loading is not enabled by default for logged-in users. If your server can handle the additional load, you can opt in to speculative loading for all logged-in users or just administrator users only. For optimal performance when enabling authenticated user support, ensure you have a <a href="%s" target="_blank">persistent object cache</a> configured. This only applies to pages on frontend; admin screens remain excluded.', 'speculation-rules' ),
+				'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching'
+			),
 		),
 	);
 	foreach ( $fields as $slug => $args ) {
@@ -262,14 +266,38 @@ function plsr_render_settings_field( array $args ): void {
 			return; // @codeCoverageIgnore
 	}
 
-	$value = $option[ $args['field'] ];
+	$value                 = $option[ $args['field'] ];
+	$has_object_cache      = wp_using_ext_object_cache();
+	$authenticated_options = array( 'logged_out_and_admins', 'any' );
+	$show_warning          = 'authentication' === $args['field'] && ! $has_object_cache && in_array( $value, $authenticated_options, true );
 	?>
+	
+	<?php if ( 'authentication' === $args['field'] && ! $has_object_cache ) : ?>
+		<div id="plsr-auth-warning" class="notice notice-warning inline" <?php echo $show_warning ? '' : 'hidden'; ?>>
+			<p>
+				<strong><?php esc_html_e( 'Warning:', 'speculation-rules' ); ?></strong>
+				<?php
+				printf(
+					/* translators: %s: URL to persistent object cache documentation */
+					esc_html__( 'Enabling speculative loading for authenticated users without a persistent object cache may significantly increase server load. Consider setting up a %s before enabling this feature for logged-in users.', 'speculation-rules' ),
+					sprintf(
+						'<a href="%s" target="_blank">%s</a>',
+						'https://developer.wordpress.org/advanced-administration/performance/optimization/#object-caching',
+						esc_html__( 'persistent object cache', 'speculation-rules' )
+					)
+				);
+				?>
+			</p>
+		</div>
+	<?php endif; ?>
+	
 	<fieldset>
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
 		<?php foreach ( $choices as $slug => $label ) : ?>
 			<p>
 				<label>
 					<input
+						class="plsr-auth-radio"
 						name="<?php echo esc_attr( "plsr_speculation_rules[{$args['field']}]" ); ?>"
 						type="radio"
 						value="<?php echo esc_attr( $slug ); ?>"
@@ -281,9 +309,39 @@ function plsr_render_settings_field( array $args ): void {
 		<?php endforeach; ?>
 
 		<p class="description" style="max-width: 800px;">
-			<?php echo esc_html( $args['description'] ); ?>
+			<?php
+			echo wp_kses(
+				$args['description'],
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+					),
+				)
+			);
+			?>
 		</p>
 	</fieldset>
+	
+	<?php if ( 'authentication' === $args['field'] && ! $has_object_cache ) : ?>
+		<script>
+		( function () {
+			const authRadios = document.querySelectorAll( '.plsr-auth-radio' );
+			const warningDiv = document.getElementById( 'plsr-auth-warning' );
+			const authenticatedOptions = <?php echo wp_json_encode( $authenticated_options ); ?>;
+			
+			if ( ! authRadios.length || ! warningDiv ) {
+				return;
+			}
+			
+			authRadios.forEach( function ( radio ) {
+				radio.addEventListener( 'change', function ( e ) {
+					warningDiv.hidden = ! authenticatedOptions.includes( e.target.value );
+				} );
+			} );
+		} )();
+		</script>
+	<?php endif; ?>
 	<?php
 }
 

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -287,9 +287,9 @@ function plsr_render_settings_field( array $args ): void {
 			return; // @codeCoverageIgnore
 	}
 
-	$value                 = $option[ $args['field'] ];
-	$show_notice           = 'authentication' === $args['field'] && ! wp_using_ext_object_cache();
-	$show_warning          = $show_notice && 'logged_out' !== $value;
+	$value        = $option[ $args['field'] ];
+	$show_notice  = 'authentication' === $args['field'] && ! wp_using_ext_object_cache();
+	$show_warning = $show_notice && 'logged_out' !== $value;
 	?>
 	<fieldset>
 		<legend class="screen-reader-text"><?php echo esc_html( $args['title'] ); ?></legend>
@@ -348,31 +348,28 @@ function plsr_render_settings_field( array $args ): void {
 	<?php
 	if ( $show_notice ) {
 		wp_print_inline_script_tag(
-			sprintf(
-				'const authRadios = document.querySelectorAll( "input[name=\'plsr_speculation_rules[authentication]\']" );
-				const noticeDiv = document.getElementById( "plsr-auth-notice" );
-				const noticeLabel = document.getElementById( "plsr-notice-label" );
-				const authenticatedOptions = %s;
-				
-				if ( authRadios.length && noticeDiv && noticeLabel ) {
-					authRadios.forEach( function ( radio ) {
-						radio.addEventListener( "change", function ( e ) {
-							const isAuthOption = authenticatedOptions.includes( e.target.value );
+			'const authRadios = document.querySelectorAll( "input[name=\'plsr_speculation_rules[authentication]\']" );
+			const noticeDiv = document.getElementById( "plsr-auth-notice" );
+			const noticeLabel = document.getElementById( "plsr-notice-label" );
+			
+			if ( authRadios.length && noticeDiv && noticeLabel ) {
+				authRadios.forEach( function ( radio, index ) {
+					radio.addEventListener( "change", function ( e ) {
+						// Index 0 is logged_out, any other index is authenticated option.
+						const isAuthOption = index > 0;
 
-							if ( isAuthOption ) {
-								noticeDiv.classList.remove( "notice-info" );
-								noticeDiv.classList.add( "notice-warning" );
-								noticeLabel.hidden = false;
-							} else {
-								noticeDiv.classList.remove( "notice-warning" );
-								noticeDiv.classList.add( "notice-info" );
-								noticeLabel.hidden = true;
-							}
-						} );
+						if ( isAuthOption ) {
+							noticeDiv.classList.remove( "notice-info" );
+							noticeDiv.classList.add( "notice-warning" );
+							noticeLabel.hidden = false;
+						} else {
+							noticeDiv.classList.remove( "notice-warning" );
+							noticeDiv.classList.add( "notice-info" );
+							noticeLabel.hidden = true;
+						}
 					} );
-				}',
-				wp_json_encode( $authenticated_options, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES )
-			),
+				} );
+			}',
 			array( 'type' => 'module' )
 		);
 	}

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -346,8 +346,7 @@ function plsr_render_settings_field( array $args ): void {
 
 	<?php
 	if ( $show_notice ) {
-		// TODO: Unsure why this is not allowed in PHPCS since not mentioned in WP coding standards and heredocs/nowdocs are use in core: <https://github.com/search?q=repo%3AWordPress%2Fwordpress-develop+%2F%3C%3C%3C%27%3F%5BA-Z%5D%2B%2F&type=code>.
-		// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
+		// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed -- Part of the PCP ruleset. Appealed in <https://github.com/WordPress/plugin-check/issues/792#issuecomment-3214985527>.
 		$js = <<<'JS'
 			const authRadios = /** @type {NodeListOf<HTMLInputElement>} */ ( document.querySelectorAll( "input[name='plsr_speculation_rules[authentication]']" ) );
 			const noticeDiv = document.getElementById( "plsr-auth-notice" );

--- a/plugins/speculation-rules/settings.php
+++ b/plugins/speculation-rules/settings.php
@@ -346,10 +346,12 @@ function plsr_render_settings_field( array $args ): void {
 
 	<?php
 	if ( $show_notice ) {
-		wp_print_inline_script_tag(
-			'const authRadios = document.querySelectorAll( "input[name=\'plsr_speculation_rules[authentication]\']" );
+		// TODO: Unsure why this is not allowed in PHPCS since not mentioned in WP coding standards and heredocs/nowdocs are use in core: <https://github.com/search?q=repo%3AWordPress%2Fwordpress-develop+%2F%3C%3C%3C%27%3F%5BA-Z%5D%2B%2F&type=code>.
+		// phpcs:ignore Squiz.PHP.Heredoc.NotAllowed
+		$js = <<<'JS'
+			const authRadios = document.querySelectorAll( "input[name='plsr_speculation_rules[authentication]']" );
 			const noticeDiv = document.getElementById( "plsr-auth-notice" );
-			
+
 			if ( authRadios.length && noticeDiv ) {
 				authRadios.forEach( function ( radio, index ) {
 					radio.addEventListener( "change", function ( e ) {
@@ -365,9 +367,10 @@ function plsr_render_settings_field( array $args ): void {
 						}
 					} );
 				} );
-			}',
-			array( 'type' => 'module' )
-		);
+			}
+JS;
+		// 👆 This can only be indented two tabs when minimum PHP version is increased to 7.3+.
+		wp_print_inline_script_tag( $js, array( 'type' => 'module' ) );
 	}
 }
 

--- a/plugins/speculation-rules/tests/test-speculation-rules-settings.php
+++ b/plugins/speculation-rules/tests/test-speculation-rules-settings.php
@@ -13,6 +13,7 @@ class Test_Speculation_Rules_Settings extends WP_UnitTestCase {
 	 * @covers ::plsr_get_eagerness_labels
 	 * @covers ::plsr_get_authentication_labels
 	 * @covers ::plsr_get_setting_default
+	 * @covers ::plsr_get_field_description
 	 */
 	public function test_plsr_register_setting(): void {
 		unregister_setting( 'reading', 'plsr_speculation_rules' );
@@ -22,6 +23,13 @@ class Test_Speculation_Rules_Settings extends WP_UnitTestCase {
 		plsr_register_setting();
 		$settings = get_registered_settings();
 		$this->assertArrayHasKey( 'plsr_speculation_rules', $settings );
+		foreach ( array( 'mode', 'eagerness', 'authentication' ) as $key ) {
+			$this->assertTrue( isset( $settings['plsr_speculation_rules']['show_in_rest']['schema']['properties'][ $key ]['description'] ) );
+			$description = $settings['plsr_speculation_rules']['show_in_rest']['schema']['properties'][ $key ]['description'];
+			$this->assertIsString( $description );
+			$this->assertGreaterThan( 0, strlen( $description ) );
+			$this->assertStringNotContainsString( '<', $description );
+		}
 
 		$settings = plsr_get_setting_default();
 		$this->assertArrayHasKey( 'mode', $settings );
@@ -31,6 +39,12 @@ class Test_Speculation_Rules_Settings extends WP_UnitTestCase {
 		// Test default settings applied correctly.
 		$default_settings = plsr_get_setting_default();
 		$this->assertEquals( $default_settings, get_option( 'plsr_speculation_rules' ) );
+
+		foreach ( array( 'mode', 'eagerness', 'authentication' ) as $key ) {
+			$description = plsr_get_field_description( $key );
+			$this->assertGreaterThan( 0, strlen( $description ) );
+		}
+		$this->assertSame( '', plsr_get_field_description( 'bogus' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2124 

## Relevant technical choices

<!-- Please describe your changes. -->
This PR adds a warning notice when users try to enable speculative loading for logged-in users without having a persistent object cache set up. The warning shows up right away when clicked on the "Administrators and logged-out visitors" or "Any user" options.

<!--
https://github.com/user-attachments/assets/ca471294-13fe-4978-b00e-3dbd6230add1
-->

https://github.com/user-attachments/assets/a53127da-0bee-48a8-82dc-ec9862534574



<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
