### PR TITLE
Fix: Prevent header errors in Perflab_Server_Timing::send_header 

### DIFF
--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -140,14 +140,10 @@ class Perflab_Server_Timing {
 	 *
 	 * @since 1.8.0
 	 */
-	public function send_header(): void {
+	public function send_header(): bool {
+		// Return early if headers have already been sent to avoid PHP warnings/errors.
 		if ( headers_sent() ) {
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'The method must be called before headers have been sent.', 'performance-lab' ),
-				''
-			);
-			return;
+			return false;
 		}
 
 		/**
@@ -161,10 +157,11 @@ class Perflab_Server_Timing {
 
 		$header_value = $this->get_header();
 		if ( '' === $header_value ) {
-			return;
+			return false;
 		}
 
 		header( sprintf( 'Server-Timing: %s', $header_value ), false );
+		return true;
 	}
 
 	/**

--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing.php
@@ -140,10 +140,15 @@ class Perflab_Server_Timing {
 	 *
 	 * @since 1.8.0
 	 */
-	public function send_header(): bool {
+	public function send_header(): void {
 		// Return early if headers have already been sent to avoid PHP warnings/errors.
 		if ( headers_sent() ) {
-			return false;
+			_doing_it_wrong(
+				__METHOD__,
+				esc_html__( 'Cannot send Server-Timing header: headers already sent.', 'performance-lab' ),
+				''
+			);
+			return;
 		}
 
 		/**
@@ -157,11 +162,10 @@ class Perflab_Server_Timing {
 
 		$header_value = $this->get_header();
 		if ( '' === $header_value ) {
-			return false;
+			return;
 		}
 
 		header( sprintf( 'Server-Timing: %s', $header_value ), false );
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2063: Prevent header errors in Perflab_Server_Timing::send_header when headers have already been sent.

## Relevant technical choices

<!-- Please describe your changes. -->

Updated the send_header method in Perflab_Server_Timing to return false if headers have already been sent, instead of triggering a PHP warning.
Changed the method signature to return a boolean, making it safer for use in different contexts.
Cleaned up the test config file to follow coding standards.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
