### PR TITLE
Add notices and improved type checking for `$wpdb->queries` when attempting to compute server-timing for database queries

### DIFF
--- a/plugins/performance-lab/includes/server-timing/defaults.php
+++ b/plugins/performance-lab/includes/server-timing/defaults.php
@@ -49,6 +49,17 @@ function perflab_register_default_server_timing_before_template_metrics(): void 
 					'measure_callback' => static function ( $metric ) use ( $current_function ): void {
 						// This should never happen, but some odd database implementations may be doing it wrong.
 						if ( ! isset( $GLOBALS['wpdb']->queries ) || ! is_array( $GLOBALS['wpdb']->queries ) ) {
+							wp_trigger_error(
+								$current_function,
+								esc_html(
+									sprintf(
+										/* translators: 1: before-template-db-queries, 2: $wpdb->queries */
+										__( 'Unable to compute server timing for "%1$s" because %2$s is not an array.', 'performance-lab' ),
+										'before-template-db-queries',
+										'$wpdb->queries'
+									)
+								)
+							);
 							return;
 						}
 

--- a/plugins/performance-lab/includes/server-timing/defaults.php
+++ b/plugins/performance-lab/includes/server-timing/defaults.php
@@ -25,7 +25,9 @@ if ( defined( 'PERFLAB_DISABLE_SERVER_TIMING' ) && PERFLAB_DISABLE_SERVER_TIMING
  * @since 1.8.0
  */
 function perflab_register_default_server_timing_before_template_metrics(): void {
-	$calculate_before_template_metrics = static function (): void {
+	$current_function = __FUNCTION__;
+
+	$calculate_before_template_metrics = static function () use ( $current_function ): void {
 		// WordPress execution prior to serving the template.
 		perflab_server_timing_register_metric(
 			'before-template',
@@ -44,17 +46,41 @@ function perflab_register_default_server_timing_before_template_metrics(): void 
 			perflab_server_timing_register_metric(
 				'before-template-db-queries',
 				array(
-					'measure_callback' => static function ( $metric ): void {
+					'measure_callback' => static function ( $metric ) use ( $current_function ): void {
 						// This should never happen, but some odd database implementations may be doing it wrong.
 						if ( ! isset( $GLOBALS['wpdb']->queries ) || ! is_array( $GLOBALS['wpdb']->queries ) ) {
 							return;
 						}
 
+						/**
+						 * Query times.
+						 *
+						 * @var float[] $query_times
+						 */
+						$query_times = array();
+						foreach ( $GLOBALS['wpdb']->queries as $query ) {
+							if ( ! is_array( $query ) || ! isset( $query[1] ) || ! is_float( $query[1] ) ) {
+								wp_trigger_error(
+									$current_function,
+									esc_html(
+										sprintf(
+											/* translators: 1: before-template-db-queries, 2: $wpdb->queries */
+											__( 'Unable to compute server timing for "%1$s" because a saved query in %2$s lacks the elapsed time as the second array value.', 'performance-lab' ),
+											'before-template-db-queries',
+											'$wpdb->queries'
+										)
+									)
+								);
+								return;
+							}
+							$query_times[] = $query[1];
+						}
+
 						// Store this value in a global to later subtract it from total query time after template.
 						$GLOBALS['perflab_query_time_before_template'] = array_reduce(
-							$GLOBALS['wpdb']->queries,
-							static function ( $acc, $query ) {
-								return $acc + $query[1];
+							$query_times,
+							static function ( float $acc, float $query_time ): float {
+								return $acc + $query_time;
 							},
 							0.0
 						);

--- a/plugins/performance-lab/includes/server-timing/defaults.php
+++ b/plugins/performance-lab/includes/server-timing/defaults.php
@@ -192,19 +192,35 @@ function perflab_register_default_server_timing_template_metrics(): void {
 					array(
 						'measure_callback' => static function ( $metric ): void {
 							// This global should typically be set when this is called, but check just in case.
-							if ( ! isset( $GLOBALS['perflab_query_time_before_template'] ) ) {
+							if ( ! isset( $GLOBALS['perflab_query_time_before_template'] ) || ! is_float( $GLOBALS['perflab_query_time_before_template'] ) ) {
 								return;
 							}
 
 							// This should never happen, but some odd database implementations may be doing it wrong.
 							if ( ! isset( $GLOBALS['wpdb']->queries ) || ! is_array( $GLOBALS['wpdb']->queries ) ) {
+								// A notice is already emitted above, but if $perflab_query_time_before_template was not
+								// set, then this condition wouldn't be checked in the first place.
 								return;
 							}
 
+							/**
+							 * Query times.
+							 *
+							 * @var float[] $query_times
+							 */
+							$query_times = array();
+							foreach ( $GLOBALS['wpdb']->queries as $query ) {
+								if ( ! is_array( $query ) || ! isset( $query[1] ) || ! is_float( $query[1] ) ) {
+									// A notice is already emitted above.
+									return;
+								}
+								$query_times[] = $query[1];
+							}
+
 							$total_query_time = array_reduce(
-								$GLOBALS['wpdb']->queries,
-								static function ( $acc, $query ) {
-									return $acc + $query[1];
+								$query_times,
+								static function ( float $acc, float $query_time ): float {
+									return $acc + $query_time;
 								},
 								0.0
 							);


### PR DESCRIPTION
Fixes #2158

This addresses issues which may arise when using a database implementation which doesn't construct `$wpdb->queries` in the same way as core does, namely when a logged query is not an indexed array or it it doesn't have a float at index 1. This can happen when using a custom `save_query_callback` in HyperDB, for example. This essentially builds upon the existing type checking for odd database implementations which don't define `$wpdb->queries`. In both cases, notices are now emitted before aborting.

If `$wpdb->queries` is absent or not an array, this notice is emitted:

> perflab_register_default_server_timing_before_template_metrics(): Unable to compute server timing for "before-template-db-queries" because $wpdb->queries is not an array.	

If a saved query array doesn't have the expected elapsed time as the second argument, then this notice is emitted:

> perflab_register_default_server_timing_before_template_metrics(): Unable to compute server timing for "before-template-db-queries" because a saved query in $wpdb->queries lacks the elapsed time as the second array value.	

Otherwise, if all is good, then the `before-template-db-queries` server timing entry is sent:

<img width="581" height="126" alt="Screenshot 2025-09-04 at 18 02 07" src="https://github.com/user-attachments/assets/77c437ef-d564-40ba-886d-e5851bed99ea" />
