### PR TITLE
Pin GitHub actions to SHAs instead of versions

### DIFF
--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -16,7 +16,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.plugins }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Configure plugin matrix
         id: set-matrix
@@ -46,7 +46,7 @@ jobs:
         plugin: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Download WordPress.org readme
         run: |
@@ -84,7 +84,7 @@ jobs:
         run: cp "./plugins/$PLUGIN_SLUG/readme.txt" "$GITHUB_WORKSPACE/readme.txt"
 
       - name: Push to WordPress.org
-        uses: 10up/action-wordpress-plugin-asset-update@stable
+        uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # stable
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,12 +33,12 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@528ca598d956c91826bd742262cdfc5d02b77710 # v3
         with:
           languages: javascript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@528ca598d956c91826bd742262cdfc5d02b77710 # v3

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -26,7 +26,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.plugins }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Set matrix
         id: set-matrix
@@ -58,10 +58,10 @@ jobs:
         plugin: ${{ fromJSON(needs.pre-run.outputs.matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Setup Node.js (.nvmrc)
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -120,14 +120,14 @@ jobs:
 
       - name: Upload artifact
         if: steps.check-deployment.outputs.deploy == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.plugin }}
           path: ./build/dist
 
       - name: Start deployment
         if: steps.check-deployment.outputs.deploy == 'true'
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@18dcfe705d6892121d665b21ef9ff448791807f3 # v1
         id: wporg-deployment
         with:
           step: start
@@ -136,7 +136,7 @@ jobs:
 
       - name: Deploy Plugin - ${{ matrix.plugin }}
         if: steps.check-deployment.outputs.deploy == 'true'
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@2480306f6f693672726d08b5917ea114cb2825f7 # stable
         with:
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run || false }}
         env:
@@ -149,7 +149,7 @@ jobs:
 
       - name: Finish deployment
         if: ${{ steps.wporg-deployment.outputs.deployment_id && always() }}
-        uses: bobheadxi/deployments@v1
+        uses: bobheadxi/deployments@18dcfe705d6892121d665b21ef9ff448791807f3 # v1
         with:
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
     steps:
       - name: Check artifact existence
         id: artifact-existence
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const getArtifact = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts{?name}', {
@@ -191,14 +191,14 @@ jobs:
 
       - name: Download artifact
         if: steps.artifact-existence.outputs.exists == 'true'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: ${{ matrix.plugin }}
           path: ./build/dist
 
       - name: Upload release assets
         if: steps.artifact-existence.outputs.exists == 'true'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2
         with:
           files: |
             ./build/dist/${{ matrix.plugin }}.zip

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -33,10 +33,10 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
 
       - name: Setup Node.js (.nvmrc)
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.nvmrc'
           cache: npm

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
-      - uses: actions/checkout@v5
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Setup Node.js (via .nvmrc)
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.nvmrc'
           cache: npm

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -33,16 +33,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
-      - uses: actions/checkout@v5
-      - uses: shivammathur/setup-php@v2
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: shivammathur/setup-php@d64e82cc0fa7ec46f91dd4c73d6acc91adbd1937 # v2
         with:
           php-version: latest
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -57,10 +57,10 @@ jobs:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
       WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}
     steps:
-      - uses: styfle/cancel-workflow-action@0.12.1
-      - uses: actions/checkout@v5
+      - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa # 0.12.1
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Setup Node.js (.nvmrc)
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: '.nvmrc'
           cache: npm
@@ -121,7 +121,7 @@ jobs:
           fi
       - name: Upload single site coverage reports to Codecov
         if: ${{ matrix.coverage == true }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./single-site-reports
@@ -130,7 +130,7 @@ jobs:
           fail_ci_if_error: true
       - name: Upload multisite coverage reports to Codecov
         if: ${{ matrix.coverage == true }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./multisite-reports

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -71,10 +71,10 @@ jobs:
 
     steps:
       - name: Gather a list of contributors
-        uses: WordPress/props-bot-action@trunk
+        uses: WordPress/props-bot-action@e04f1e3b9824144892bfe3d278865f4b7c3e25a1 # trunk
 
       - name: Remove the props-bot label
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         if: ${{ github.event.action == 'labeled' && 'props-bot' == github.event.label.name }}
         with:
           retries: 2

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -7,8 +7,8 @@ jobs:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - name: Search for misspellings
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@85f62a8a84f939ae994ab3763f01a0296d61a7ee # master
         with:
           config: ./.github/typos.toml


### PR DESCRIPTION
See discussion with @thelovekesh at https://github.com/WordPress/performance/pull/1838#discussion_r2329659689:

> My recommendation would be to pin it to a specific SHA for better security.
> [...]
> Also, in core, it's very rare for maintainers to allow third-party actions, and when they do, they always pin to a specific SHA to mitigate potential security risks.
> [...]
> By default, pin to the SHA of a version that was published at least a week ago. This provides ample time to detect if the action has been compromised.

Note that [Gutenberg's workflows](https://github.com/WordPress/gutenberg/tree/trunk/.github/workflows) all have actions pinned to SHAs.

I used Gemini CLI to do this for me, using the prompt:

> I want to update the GitHub actions in .github use SHA pinning instead of just referencing the version. I want the version to be in a comment after the sha

