### PR TITLE
Generate picture source elements when wp_calculate_image_srcset disable.

### DIFF
--- a/plugins/webp-uploads/picture-element.php
+++ b/plugins/webp-uploads/picture-element.php
@@ -148,6 +148,16 @@ function webp_uploads_wrap_image_in_picture( string $image, string $context, int
 					esc_attr( $image_srcset ),
 					is_string( $sizes ) ? sprintf( ' sizes="%s"', esc_attr( $sizes ) ) : ''
 				);
+			} else {
+				// Fallback when wp_calculate_image_srcset returns false - generate simple source without srcset.
+				$image_url = webp_uploads_get_mime_type_image( $attachment_id, $src, $image_mime_type );
+				if ( is_string( $image_url ) ) {
+					$picture_sources .= sprintf(
+						'<source type="%s" srcset="%s">',
+						esc_attr( $image_mime_type ),
+						esc_attr( $image_url )
+					);
+				}
 			}
 		}
 	} else {

--- a/plugins/webp-uploads/tests/test-picture-element.php
+++ b/plugins/webp-uploads/tests/test-picture-element.php
@@ -436,10 +436,15 @@ class Test_WebP_Uploads_Picture_Element extends TestCase {
 		$this->assertStringEndsWith( '.jpg', $picture_processor->get_attribute( 'src' ), 'Make sure the fallback IMG should return JPEG src.' );
 
 		$picture_processor = new WP_HTML_Tag_Processor( $picture_markup );
+		$source_count      = 0;
 		while ( $picture_processor->next_tag( array( 'tag_name' => 'source' ) ) ) {
+			++$source_count;
 			$this->assertSame( self::$mime_type, $picture_processor->get_attribute( 'type' ), 'Make sure the Picture source should not return JPEG as source.' );
 			$this->assertStringContainsString( '.webp', $picture_processor->get_attribute( 'srcset' ), 'Make sure the Picture source srcset should return WEBP images.' );
 		}
+
+		// Ensure at least one source element was created (addresses GitHub issue with wp_calculate_image_srcset disabled).
+		$this->assertGreaterThan( 0, $source_count, 'At least one source element should be created even when responsive images are disabled.' );
 	}
 
 	/**


### PR DESCRIPTION
Fix: https://github.com/WordPress/performance/issues/2191 

### Problem

When users disable responsive image srcset generation via `add_filter('wp_calculate_image_srcset', '__return_false')`, the picture element functionality was broken - no `<source>` elements were being generated for modern image formats like AVIF and WebP.

This resulted in the picture element only containing the fallback `<img>` tag, defeating the purpose of serving modern image formats.

### Root Cause

The picture element generation logic only had two paths:
1. **With srcset**: Generate responsive `<source>` elements with full srcset attributes
2. **Without srcset/sizes**: Generate simple `<source>` elements using `webp_uploads_get_mime_type_image()`

However, there was a gap when the IMG tag had `srcset` and `sizes` attributes, but `wp_calculate_image_srcset()` returned `false`. In this case, the code attempted the first path but failed silently when srcset generation was disabled.

