### PR TITLE
Bump plugin-check to 1.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "yoast/phpunit-polyfills": "^4.0",
     "phpstan/php-8-stubs": "^0.4.0",
     "phpstan/phpstan-strict-rules": "^1.6",
-    "wpackagist-plugin/plugin-check": "^1.6"
+    "wpackagist-plugin/plugin-check": "^1.7"
   },
   "config": {
     "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e9179e1a7d56c38aded23a99fc15b8e",
+    "content-hash": "d8c77ba12203b33e7f3e7928a2b2a996",
     "packages": [],
     "packages-dev": [
         {
@@ -2703,15 +2703,15 @@
         },
         {
             "name": "wpackagist-plugin/plugin-check",
-            "version": "1.6.0",
+            "version": "1.7.0",
             "source": {
                 "type": "svn",
                 "url": "https://plugins.svn.wordpress.org/plugin-check/",
-                "reference": "tags/1.6.0"
+                "reference": "tags/1.7.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/plugin/plugin-check.1.6.0.zip"
+                "url": "https://downloads.wordpress.org/plugin/plugin-check.1.7.0.zip"
             },
             "require": {
                 "composer/installers": "^1.0 || ^2.0"


### PR DESCRIPTION
This updates plugin-check from 1.6 to 1.7. 

However, the update causes a failure:

```
> phpcs '--' './plugins/performance-lab' '--standard=./plugins/performance-lab/phpcs.xml.dist'
PHP Fatal error:  Uncaught Error: Class "PluginCheckCS\PluginCheck\Helpers\AbstractEscapingCheckSniff" not found in .../wp-content/plugins/performance/vendor/wpackagist-plugin/plugin-check/vendor/plugin-check/phpcs-sniffs/PluginCheck/Sniffs/Security/DirectDBSniff.php:20
Stack trace:
#0 .../wp-content/plugins/performance/vendor/squizlabs/php_codesniffer/autoload.php(173): include()
#1 .../wp-content/plugins/performance/vendor/squizlabs/php_codesniffer/src/Ruleset.php(1401): PHP_CodeSniffer\Autoload::loadFile('/Users/westonru...')
#2 .../wp-content/plugins/performance/vendor/squizlabs/php_codesniffer/src/Ruleset.php(249): PHP_CodeSniffer\Ruleset->registerSniffs(Array, Array, Array)
#3 .../wp-content/plugins/performance/vendor/squizlabs/php_codesniffer/src/Runner.php(348): PHP_CodeSniffer\Ruleset->__construct(Object(PHP_CodeSniffer\Config))
#4 .../wp-content/plugins/performance/vendor/squizlabs/php_codesniffer/src/Runner.php(76): PHP_CodeSniffer\Runner->init()
#5 .../wp-content/plugins/performance/vendor/squizlabs/php_codesniffer/bin/phpcs(14): PHP_CodeSniffer\Runner->runPHPCS()
#6 .../wp-content/plugins/performance/vendor/bin/phpcs(119): include('/Users/westonru...')
#7 {main}
  thrown in .../wp-content/plugins/performance/vendor/wpackagist-plugin/plugin-check/vendor/plugin-check/phpcs-sniffs/PluginCheck/Sniffs/Security/DirectDBSniff.php on line 20

Fatal error: Uncaught Error: Class "PluginCheckCS\PluginCheck\Helpers\AbstractEscapingCheckSniff" not found in .../wp-content/plugins/performance/vendor/wpackagist-plugin/plugin-check/vendor/plugin-check/phpcs-sniffs/PluginCheck/Sniffs/Security/DirectDBSniff.php on line 20

Error: Class "PluginCheckCS\PluginCheck\Helpers\AbstractEscapingCheckSniff" not found in .../wp-content/plugins/performance/vendor/wpackagist-plugin/plugin-check/vendor/plugin-check/phpcs-sniffs/PluginCheck/Sniffs/Security/DirectDBSniff.php on line 20
```

This needs to be investigated.