### PR TITLE
Add 1-week `cooldown` for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - "no milestone"
       - "[Type] Enhancement"
       - "github_actions"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: '/'
@@ -19,6 +21,8 @@ updates:
       - "no milestone"
       - "[Type] Enhancement"
       - "javascript"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: composer
     directory: '/'
@@ -29,3 +33,5 @@ updates:
       - "no milestone"
       - "[Type] Enhancement"
       - "php"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
While we already have a weekly interval in place for updates, adding a `cooldown` period will ensure that an update published shortly before Dependabot running won't suggest updating a package that may have been very recently exploited.

Read more:

 * [We should all be using dependency cooldowns](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns)
 * [Dependabot supports configuration of a minimum package age](https://github.blog/changelog/2025-07-01-dependabot-supports-configuration-of-a-minimum-package-age/)
 * [Cooldown Documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-)