### PR TITLE
Add Dependabot groups for WordPress and PHPStan packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
       - "javascript"
     cooldown:
       default-days: 7
+    groups:
+      wordpress-packages:
+        patterns:
+          - '@wordpress/*'
 
   - package-ecosystem: composer
     directory: '/'
@@ -35,3 +39,7 @@ updates:
       - "php"
     cooldown:
       default-days: 7
+    groups:
+      phpstan-packages:
+        patterns:
+          - 'phpstan/*'


### PR DESCRIPTION
This will reduce some of the noise for Dependabot updates by grouping them.