### PR TITLE
Include static page for posts for article transitions

### DIFF
--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -155,6 +155,7 @@ window.plvtInitViewTransitions = ( config ) => {
 					);
 				} else if (
 					document.body.classList.contains( 'home' ) ||
+					document.body.classList.contains( 'blog' ) ||
 					document.body.classList.contains( 'archive' )
 				) {
 					viewTransitionEntries = getViewTransitionEntries(


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2305

When a static page is used for posts:

<img width="489" height="245" alt="image" src="https://github.com/user-attachments/assets/f4f547de-e964-4bef-9ac8-da9d193784cf" />

The `BODY` element here is:

```html
<body class="blog wp-embed-responsive wp-theme-twentytwentyfive">
```

However, when showing the latest posts on the homepage, the `BODY` is:

```html
<body class="home blog wp-embed-responsive wp-theme-twentytwentyfive">
```

Currently only the `home` and `archive` class names are accounted for. The `blog` class name, which is the only one shown on a static page for posts, was not. This PR fixes that.