### PR TITLE
Pin doctrine/instantiator <2.1 to fix PHP 8.2 tests

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -84,7 +84,8 @@ jobs:
       - name: Install PHPUnit
         run: |
           if [ "${{ matrix.php }}" == "8.2" ]; then
-            composer require phpunit/phpunit:${{ matrix.phpunit }} "doctrine/instantiator:<2.0" --with-all-dependencies --ignore-platform-reqs
+            # Version 2.1.0 of doctrine/instantiator started requiring PHP 8.4: <https://github.com/doctrine/instantiator/pull/148>.
+            composer require phpunit/phpunit:${{ matrix.phpunit }} "doctrine/instantiator:<2.1" --with-all-dependencies --ignore-platform-reqs
           else
             composer require --dev phpunit/phpunit:${{ matrix.phpunit }}
           fi

--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install PHPUnit
         run: |
           if [ "${{ matrix.php }}" == "8.2" ]; then
-            composer require phpunit/phpunit:${{ matrix.phpunit }} --with-all-dependencies --ignore-platform-reqs
+            composer require phpunit/phpunit:${{ matrix.phpunit }} "doctrine/instantiator:<2.0" --with-all-dependencies --ignore-platform-reqs
           else
             composer require --dev phpunit/phpunit:${{ matrix.phpunit }}
           fi


### PR DESCRIPTION
## Summary

Fix failing unit tests in PHP 8.2 due to doctrine/instantiator v2.1 now requiring PHP 8.4; because of this, it is now pinned to <2.1.

See https://github.com/WordPress/performance/pull/2325#issuecomment-3716535993

## Use of AI Tools

Authored with the support of Gemini CLI in https://github.com/WordPress/performance/pull/2325
