### PR TITLE
Follow-up: Skip stylesheets with empty href attributes in Site Health audit

### DIFF
--- a/plugins/performance-lab/includes/site-health/audit-enqueued-assets/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-enqueued-assets/helper.php
@@ -70,6 +70,8 @@ function perflab_aea_audit_blocking_assets(): array {
 
 		if ( 'SCRIPT' === $tag ) {
 			$src = $processor->get_attribute( 'src' );
+
+			// Skip scripts with empty or whitespace-only src attributes as they never load external scripts which block rendering.
 			if ( ! is_string( $src ) ) {
 				continue;
 			}
@@ -123,6 +125,8 @@ function perflab_aea_audit_blocking_assets(): array {
 			}
 
 			$href = $processor->get_attribute( 'href' );
+
+			// Skip stylesheets with empty or whitespace-only href attributes since they may be using a deferred loading technique.
 			if ( ! is_string( $href ) ) {
 				continue;
 			}

--- a/plugins/performance-lab/tests/includes/site-health/audit-enqueued-assets/test-audit-enqueued-assets.php
+++ b/plugins/performance-lab/tests/includes/site-health/audit-enqueued-assets/test-audit-enqueued-assets.php
@@ -149,7 +149,7 @@ class Test_Audit_Enqueued_Assets extends WP_UnitTestCase {
 		wp_enqueue_style( 'style-empty-href', 'https://style-empty-href.example.com', array(), null );
 		wp_enqueue_style( 'style-whitespace-href', 'https://style-whitespace-href.example.com', array(), null );
 
-		// Filter to remove href attribute from a specific style handle.
+		// Filter to manipulate style href attributes for testing various edge cases.
 		add_filter(
 			'style_loader_tag',
 			function ( $tag, $handle ) {
@@ -165,7 +165,7 @@ class Test_Audit_Enqueued_Assets extends WP_UnitTestCase {
 					$tag = $processor->get_updated_html();
 				} elseif ( 'style-boolean-href' === $handle ) {
 					$processor = $create_processor_state( $tag );
-					$processor->set_attribute( 'href', true );
+					$this->assertTrue( $processor->set_attribute( 'href', true ) );
 					$tag = $processor->get_updated_html();
 				} elseif ( 'style-empty-href' === $handle ) {
 					$processor = $create_processor_state( $tag );


### PR DESCRIPTION
## Summary


Follow-up to #2281.
See #2278.

## Use of AI Tools

This addresses these Copilot suggestions: https://github.com/WordPress/performance/pull/2281#pullrequestreview-3633008522

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.
-->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
