### PR TITLE
Add JSON Schemas to `tsconfig.json` and `package.json`

### DIFF
--- a/bin/validate-json-schema.js
+++ b/bin/validate-json-schema.js
@@ -16,9 +16,26 @@ const Ajv4 = require( 'ajv-draft-04' ).default;
 const addFormats = require( 'ajv-formats' ).default;
 const fg = require( 'fast-glob' );
 
+/**
+ * @typedef {import('ajv').default} Ajv
+ */
+
 const schemaCache = new Map();
 
+/**
+ * @template {Ajv} T
+ * @typedef {{ new (options: Object): T }} AjvConstructorType
+ */
+
+/**
+ * Creates an Ajv instance.
+ *
+ * @template {Ajv} T
+ * @param {AjvConstructorType<T>} AjvConstructor Ajv constructor.
+ * @return {T} Ajv instance.
+ */
 function createAjv( AjvConstructor ) {
+	/** @type {T & { removeKeyword: function(string): void; addKeyword: function(Object): void }} */
 	const ajv = new AjvConstructor( {
 		allErrors: true,
 		strict: false,
@@ -33,6 +50,10 @@ function createAjv( AjvConstructor ) {
 		validate: ( /** @type {string|boolean} */ deprecation ) =>
 			! deprecation,
 		error: {
+			/**
+			 * @param {Object}        cxt
+			 * @param {string|Object} [cxt.schema]
+			 */
 			message: ( cxt ) => {
 				return cxt.schema && typeof cxt.schema === 'string'
 					? `is deprecated: ${ cxt.schema }`
@@ -51,7 +72,7 @@ const ajv4 = createAjv( Ajv4 );
  * Fetches a JSON schema from a URL.
  *
  * @param {string} schemaUrl URL of the JSON schema.
- * @return {Promise<Object>} The JSON schema object.
+ * @return {Promise<any>} The JSON schema object.
  */
 async function fetchSchema( schemaUrl ) {
 	if ( schemaCache.has( schemaUrl ) ) {

--- a/bin/validate-json-schema.js
+++ b/bin/validate-json-schema.js
@@ -94,13 +94,13 @@ async function fetchSchema( schemaUrl ) {
  * Fetches a JSON schema and determines its draft version.
  *
  * @param {string} schemaUrl URL of the JSON schema.
- * @return {Promise<string>} The draft version (e.g., 'draft-04' or 'draft-07').
+ * @return {Promise<string>} The draft version ('draft-04' or 'default').
  */
 async function getSchemaDraft( schemaUrl ) {
 	const schema = await fetchSchema( schemaUrl );
 	const draft = typeof schema.$schema === 'string' ? schema.$schema : '';
-	// Default to draft-07 for other cases.
-	return draft.includes( 'draft-04' ) ? 'draft-04' : 'draft-07';
+	// Default to 'default' (modern Ajv) for other cases.
+	return draft.includes( 'draft-04' ) ? 'draft-04' : 'default';
 }
 
 /**

--- a/bin/validate-json-schema.js
+++ b/bin/validate-json-schema.js
@@ -11,37 +11,68 @@ const path = require( 'path' );
 /**
  * External dependencies
  */
-const Ajv = require( 'ajv' ).default;
+const Ajv7 = require( 'ajv' ).default;
+const Ajv4 = require( 'ajv-draft-04' );
 const addFormats = require( 'ajv-formats' ).default;
 const fg = require( 'fast-glob' );
 
-const ajv = new Ajv( {
-	allErrors: true,
-	strict: false,
-	loadSchema: async ( uri ) => {
-		const response = await fetch( uri );
-		if ( ! response.ok ) {
-			throw new Error(
-				`Failed to fetch schema from ${ uri }: ${ response.statusText }`
-			);
-		}
-		return await response.json();
-	},
-} );
-addFormats( ajv );
+function createAjv( AjvConstructor ) {
+	const ajv = new AjvConstructor( {
+		allErrors: true,
+		strict: false,
+		loadSchema: fetchSchema,
+	} );
 
-ajv.removeKeyword( 'deprecated' );
-ajv.addKeyword( {
-	keyword: 'deprecated',
-	validate: ( /** @type {string|boolean} */ deprecation ) => ! deprecation,
-	error: {
-		message: ( cxt ) => {
-			return cxt.schema && typeof cxt.schema === 'string'
-				? `is deprecated: ${ cxt.schema }`
-				: 'is deprecated';
+	addFormats( ajv );
+
+	ajv.removeKeyword( 'deprecated' );
+	ajv.addKeyword( {
+		keyword: 'deprecated',
+		validate: ( /** @type {string|boolean} */ deprecation ) =>
+			! deprecation,
+		error: {
+			message: ( cxt ) => {
+				return cxt.schema && typeof cxt.schema === 'string'
+					? `is deprecated: ${ cxt.schema }`
+					: 'is deprecated';
+			},
 		},
-	},
-} );
+	} );
+
+	return ajv;
+}
+
+const ajv7 = createAjv( Ajv7 );
+const ajv4 = createAjv( Ajv4 );
+
+/**
+ * Fetches a JSON schema from a URL.
+ *
+ * @param {string} schemaUrl URL of the JSON schema.
+ * @return {Promise<Object>} The JSON schema object.
+ */
+async function fetchSchema( schemaUrl ) {
+	const response = await fetch( schemaUrl );
+	if ( ! response.ok ) {
+		throw new Error(
+			`Failed to fetch schema from ${ schemaUrl }: ${ response.statusText }`
+		);
+	}
+	return await response.json();
+}
+
+/**
+ * Fetches a JSON schema and determines its draft version.
+ *
+ * @param {string} schemaUrl URL of the JSON schema.
+ * @return {Promise<string>} The draft version (e.g., 'draft-04' or 'draft-07').
+ */
+async function getSchemaDraft( schemaUrl ) {
+	const schema = await fetchSchema( schemaUrl );
+	const draft = typeof schema.$schema === 'string' ? schema.$schema : '';
+	// Default to draft-07 for other cases.
+	return draft.includes( 'draft-04' ) ? 'draft-04' : 'draft-07';
+}
 
 /**
  * Validates a JSON file against its schema.
@@ -74,7 +105,11 @@ async function validateFile( filePath ) {
 	console.log( `Validating ${ filePath } against schema: ${ data.$schema }` );
 
 	try {
-		const validate = await ajv.compileAsync( { $ref: data.$schema } );
+		const draft = await getSchemaDraft( data.$schema );
+		const ajvInstance = draft === 'draft-04' ? ajv4 : ajv7;
+		const validate = await ajvInstance.compileAsync( {
+			$ref: data.$schema,
+		} );
 		const valid = validate( data );
 
 		if ( ! valid ) {

--- a/bin/validate-json-schema.js
+++ b/bin/validate-json-schema.js
@@ -35,7 +35,6 @@ const schemaCache = new Map();
  * @return {T} Ajv instance.
  */
 function createAjv( AjvConstructor ) {
-	/** @type {T & { removeKeyword: function(string): void; addKeyword: function(Object): void }} */
 	const ajv = new AjvConstructor( {
 		allErrors: true,
 		strict: false,

--- a/bin/validate-json-schema.js
+++ b/bin/validate-json-schema.js
@@ -94,7 +94,7 @@ async function fetchSchema( schemaUrl ) {
  * Fetches a JSON schema and determines its draft version.
  *
  * @param {string} schemaUrl URL of the JSON schema.
- * @return {Promise<string>} The draft version ('draft-04' or 'default').
+ * @return {Promise<'draft-04'|'default'>} The draft version ('draft-04' or 'default').
  */
 async function getSchemaDraft( schemaUrl ) {
 	const schema = await fetchSchema( schemaUrl );

--- a/bin/validate-json-schema.js
+++ b/bin/validate-json-schema.js
@@ -12,7 +12,7 @@ const path = require( 'path' );
  * External dependencies
  */
 const Ajv7 = require( 'ajv' ).default;
-const Ajv4 = require( 'ajv-draft-04' );
+const Ajv4 = require( 'ajv-draft-04' ).default;
 const addFormats = require( 'ajv-formats' ).default;
 const fg = require( 'fast-glob' );
 

--- a/bin/validate-json-schema.js
+++ b/bin/validate-json-schema.js
@@ -16,6 +16,8 @@ const Ajv4 = require( 'ajv-draft-04' );
 const addFormats = require( 'ajv-formats' ).default;
 const fg = require( 'fast-glob' );
 
+const schemaCache = new Map();
+
 function createAjv( AjvConstructor ) {
 	const ajv = new AjvConstructor( {
 		allErrors: true,
@@ -52,13 +54,20 @@ const ajv4 = createAjv( Ajv4 );
  * @return {Promise<Object>} The JSON schema object.
  */
 async function fetchSchema( schemaUrl ) {
+	if ( schemaCache.has( schemaUrl ) ) {
+		return schemaCache.get( schemaUrl );
+	}
+
 	const response = await fetch( schemaUrl );
 	if ( ! response.ok ) {
 		throw new Error(
 			`Failed to fetch schema from ${ schemaUrl }: ${ response.statusText }`
 		);
 	}
-	return await response.json();
+	const schema = await response.json();
+	schemaCache.set( schemaUrl, schema );
+
+	return schema;
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@wordpress/prettier-config": "^4.37.0",
         "@wordpress/scripts": "^31.2.0",
         "ajv": "8.17.1",
+        "ajv-draft-04": "^1.0.0",
         "ajv-formats": "3.0.1",
         "commander": "14.0.2",
         "copy-webpack-plugin": "^13.0.1",
@@ -6685,6 +6686,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "dev": true,
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv-errors": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@wordpress/prettier-config": "^4.37.0",
     "@wordpress/scripts": "^31.2.0",
     "ajv": "8.17.1",
+    "ajv-draft-04": "^1.0.0",
     "ajv-formats": "3.0.1",
     "commander": "14.0.2",
     "copy-webpack-plugin": "^13.0.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://www.schemastore.org/package.json",
   "name": "performance",
   "license": "GPL-2.0-or-later",
   "repository": "git+https://github.com/WordPress/performance.git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://www.schemastore.org/tsconfig.json",
   "compilerOptions": {
     "checkJs": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2329

This PR adds JSON Schema references to `tsconfig.json` and `package.json` so that these files can be validated by the existing `validate-json-schema.js` script.

It also updates the validator to correctly handle schemas defined using different JSON Schema drafts. In particular, the `tsconfig.json` schema is defined using draft-04, whereas AJV defaults to draft-07.

## Relevant technical choices

- Introduced separate AJV instances for draft-07 and draft-04 schemas, since AJV cannot mix schema drafts within a single instance.
- Added `ajv-draft-04` as a dependency to support validation of schemas defined using JSON Schema draft-04 (e.g., the `tsconfig.json` schema).
- Detect the schema draft based on the referenced schema’s `$schema` value and route validation to the appropriate AJV instance.
- Added a small in-memory cache for fetched schemas to avoid repeated network requests during validation.
