### PR TITLE
Remove obsolete temporary View Transitions code from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,13 +22,6 @@ const {
  */
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
-/*
- * Temporary workaround because 'view-transitions' should not be added to `plugins.json` just yet, since it is not
- * ready to be released.
- * TODO: Remove this workaround once the plugin is added to `plugins.json`.
- */
-standalonePlugins.push( 'view-transitions' );
-
 const defaultBuildConfig = {
 	entry: {},
 	output: {


### PR DESCRIPTION
Something that was missed as part of https://github.com/WordPress/performance/pull/2027

Props to Gemini for pointing this out.