### PR TITLE
Prepare 2026-01-08 release

### DIFF
--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -5,7 +5,7 @@
  * Description: Optimizes the performance of embeds through lazy-loading, preconnecting, and reserving space to reduce layout shifts.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.0.0-beta2
+ * Version: 1.0.0-beta3
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'embed_optimizer_pending_plugin',
-	'1.0.0-beta2',
+	'1.0.0-beta3',
 	static function ( string $version ): void {
 		if ( defined( 'EMBED_OPTIMIZER_VERSION' ) ) {
 			return;

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.9
-Stable tag:   1.0.0-beta2
+Stable tag:   1.0.0-beta3
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, embeds, optimization-detective
@@ -66,6 +66,13 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 1.0.0-beta3 =
+
+**Enhancements**
+
+* Add URL Metric mutation helpers to extension initialization API. ([1951](https://github.com/WordPress/performance/pull/1951))
+* Improve construction of inline scripts with `sourceURL`, hardened JSON encoding, and exporting JSON in separate script. ([2169](https://github.com/WordPress/performance/pull/2169))
 
 = 1.0.0-beta2 =
 

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -6,7 +6,7 @@
  * Requires at least: 6.6
  * Requires PHP: 7.2
  * Requires Plugins: optimization-detective
- * Version: 1.0.0-beta2
+ * Version: 1.0.0-beta3
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -72,7 +72,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'image_prioritizer_pending_plugin',
-	'1.0.0-beta2',
+	'1.0.0-beta3',
 	static function ( string $version ): void {
 		if ( defined( 'IMAGE_PRIORITIZER_VERSION' ) ) {
 			return;

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.9
-Stable tag:   1.0.0-beta2
+Stable tag:   1.0.0-beta3
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, optimization, image, optimization-detective
@@ -71,6 +71,8 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 1.0.0-beta3 =
 
 = 1.0.0-beta2 =
 

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -74,6 +74,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 1.0.0-beta3 =
 
+**Bug Fixes**
+
+* Allow background image URLs for file types the web server doesn't know about, e.g. when AVIF is sent as `application/octet-stream`. ([1956](https://github.com/WordPress/performance/pull/1956))
+* Remove responsive image sizes computation. ([2109](https://github.com/WordPress/performance/pull/2109))
+
 = 1.0.0-beta2 =
 
 **Enhancements**

--- a/plugins/image-prioritizer/readme.txt
+++ b/plugins/image-prioritizer/readme.txt
@@ -74,6 +74,11 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 1.0.0-beta3 =
 
+**Enhancements**
+
+* Add URL Metric mutation helpers to extension initialization API. ([1951](https://github.com/WordPress/performance/pull/1951))
+* Improve construction of inline scripts with `sourceURL`, hardened JSON encoding, and exporting JSON in separate script. ([2169](https://github.com/WordPress/performance/pull/2169))
+
 **Bug Fixes**
 
 * Allow background image URLs for file types the web server doesn't know about, e.g. when AVIF is sent as `application/octet-stream`. ([1956](https://github.com/WordPress/performance/pull/1956))

--- a/plugins/optimization-detective/class-od-url-metric-group.php
+++ b/plugins/optimization-detective/class-od-url-metric-group.php
@@ -274,7 +274,7 @@ final class OD_URL_Metric_Group implements IteratorAggregate, Countable, JsonSer
 	 *
 	 * @since 0.1.0
 	 * @since 0.9.0 If the current environment's generated ETag does not match the URL Metric's ETag, the URL Metric is considered stale.
-	 * @since n.e.x.t Negative freshness TTL values now disable timestamp-based freshness checks.
+	 * @since 1.0.0 Negative freshness TTL values now disable timestamp-based freshness checks.
 	 *
 	 * @return bool Whether complete.
 	 */

--- a/plugins/optimization-detective/detection.php
+++ b/plugins/optimization-detective/detection.php
@@ -109,7 +109,7 @@ function od_get_detection_scripts( string $slug, OD_URL_Metric_Group_Collection 
 	/**
 	 * Filters whether URL Metric JSON data should be compressed with gzip when being submitted to the `/url-metrics:store` REST API endpoint.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 * @link https://github.com/WordPress/performance/blob/trunk/plugins/optimization-detective/docs/hooks.md#:~:text=Filter%3A%20od_gzip_url_metric_store_request_payloads
 	 *
 	 * @param bool $gzip_url_metric_store_request_payloads Whether to use gzip to compress URL Metric JSON.
@@ -206,7 +206,7 @@ function od_register_rest_url_metric_store_endpoint(): void {
 /**
  * Decompresses the REST API request body for the URL Metrics endpoint.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  *
  * @phpstan-param WP_REST_Request<array<string, mixed>> $request

--- a/plugins/optimization-detective/helper.php
+++ b/plugins/optimization-detective/helper.php
@@ -63,7 +63,7 @@ function od_generate_media_query( ?int $minimum_viewport_width, ?int $maximum_vi
 /**
  * Gets the reasons why Optimization Detective is disabled for the current response.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  *
  * @return array{
@@ -130,7 +130,7 @@ function od_get_disabled_reasons(): array {
 	 * Filters whether the current response can be optimized.
 	 *
 	 * @since 0.1.0
-	 * @since n.e.x.t Added $disabled_flags parameter
+	 * @since 1.0.0 Added $disabled_flags parameter
 	 * @link https://github.com/WordPress/performance/blob/trunk/plugins/optimization-detective/docs/hooks.md#:~:text=Filter%3A%20od_can_optimize_response
 	 *
 	 * @param bool $can_optimize Whether response can be optimized.
@@ -203,7 +203,7 @@ function od_render_generator_meta_tag(): void {
  * This link directs users to the plugin directory to discover extensions that
  * provide optimization functionality using the Optimization Detective plugin.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  *
  * @param string[]|mixed $plugin_meta The plugin's metadata.
@@ -232,7 +232,7 @@ function od_render_extensions_meta_link( $plugin_meta, string $plugin_file ): ar
 /**
  * Checks for active extension plugins for Optimization Detective.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  *
  * @return string[] List of active extension plugin files.
@@ -266,7 +266,7 @@ function od_get_active_extensions(): array {
 /**
  * Renders an inline admin notice prompting the user to install or activate extensions for Optimization Detective.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  */
 function od_maybe_render_installed_extensions_admin_notice(): void {
@@ -333,7 +333,7 @@ function od_maybe_render_installed_extensions_admin_notice(): void {
 /**
  * Renders a paragraph of links to the plugin's documentation on GitHub.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  */
 function od_render_documentation_links(): void {
@@ -355,7 +355,7 @@ function od_render_documentation_links(): void {
 /**
  * Displays an inline admin notice on the plugin row if no extensions are installed and active.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  *
  * @param non-empty-string $plugin_file Plugin file.

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -65,7 +65,7 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 * Bump web-vitals from 5.0.3 to 5.1.0. ([2116](https://github.com/WordPress/performance/pull/2116))
 * Change default garbage collection TTL of `od_url_metrics` posts from 1 month to 3 months and add the filter to customize expiration. ([1950](https://github.com/WordPress/performance/pull/1950))
 * Enhance Optimization Detective meta generator tag with all disabled reasons. ([1979](https://github.com/WordPress/performance/pull/1979))
-* Enhancement: Amend URL metrics to the generator meta tag content. ([1954](https://github.com/WordPress/performance/pull/1954))
+* Amend URL metrics to the generator meta tag content. ([1954](https://github.com/WordPress/performance/pull/1954))
 * Improve construction of inline scripts with `sourceURL`, hardened JSON encoding, and exporting JSON in separate script. ([2169](https://github.com/WordPress/performance/pull/2169))
 * Improve discoverability and user guidance for Optimization Detective extensions. ([2261](https://github.com/WordPress/performance/pull/2261))
 * Remove deprecated `url_metrics_group_collection` and class aliases and bump required OD version in Image Prioritizer. ([1943](https://github.com/WordPress/performance/pull/1943))

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -57,6 +57,26 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 = 1.0.0-beta4 =
 
+**Enhancements**
+
+* Add URL Metric mutation helpers to extension initialization API. ([1951](https://github.com/WordPress/performance/pull/1951))
+* Add gzip compression for URL metrics using Compression Streams API. ([1959](https://github.com/WordPress/performance/pull/1959))
+* Allow disabling timestamp-based freshness checks by using negative TTL values. ([1940](https://github.com/WordPress/performance/pull/1940))
+* Bump web-vitals from 5.0.3 to 5.1.0. ([2116](https://github.com/WordPress/performance/pull/2116))
+* Change default garbage collection TTL of `od_url_metrics` posts from 1 month to 3 months and add the filter to customize expiration. ([1950](https://github.com/WordPress/performance/pull/1950))
+* Enhance Optimization Detective meta generator tag with all disabled reasons. ([1979](https://github.com/WordPress/performance/pull/1979))
+* Enhancement: Amend URL metrics to the generator meta tag content. ([1954](https://github.com/WordPress/performance/pull/1954))
+* Improve construction of inline scripts with `sourceURL`, hardened JSON encoding, and exporting JSON in separate script. ([2169](https://github.com/WordPress/performance/pull/2169))
+* Improve discoverability and user guidance for Optimization Detective extensions. ([2261](https://github.com/WordPress/performance/pull/2261))
+* Remove deprecated `url_metrics_group_collection` and class aliases and bump required OD version in Image Prioritizer. ([1943](https://github.com/WordPress/performance/pull/1943))
+
+**Bug Fixes**
+
+* Avoid possible error when reading groups in debug mode. ([2108](https://github.com/WordPress/performance/pull/2108))
+* Delay loading detect module until page is loaded and idle. ([2017](https://github.com/WordPress/performance/pull/2017))
+* Ensure URL Metric is initially constructed with all elements prior to initializing extensions. ([1968](https://github.com/WordPress/performance/pull/1968))
+* Short-circuit detection when page is opened in background tab since web-vitals.js will not report LCP. ([1927](https://github.com/WordPress/performance/pull/1927))
+
 = 1.0.0-beta3 =
 
 **Enhancements**

--- a/plugins/optimization-detective/readme.txt
+++ b/plugins/optimization-detective/readme.txt
@@ -55,6 +55,8 @@ The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plu
 
 == Changelog ==
 
+= 1.0.0-beta4 =
+
 = 1.0.0-beta3 =
 
 **Enhancements**

--- a/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
+++ b/plugins/optimization-detective/storage/class-od-url-metrics-post-type.php
@@ -300,7 +300,7 @@ class OD_URL_Metrics_Post_Type {
 		/**
 		 * Filters the expiration time (TTL) after which a since-unmodified od_url_metrics post will be garbage collected.
 		 *
-		 * @since n.e.x.t
+		 * @since 1.0.0
 		 * @link https://github.com/WordPress/performance/blob/trunk/plugins/optimization-detective/docs/hooks.md#:~:text=Filter%3A%20od_url_metric_garbage_collection_ttl
 		 *
 		 * @return int TTL for garbage collection in seconds. Defaults to 3 months.

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -27,7 +27,7 @@ function od_get_url_metric_freshness_ttl(): int {
 	 * Filters age (TTL) for which a URL Metric can be considered fresh.
 	 *
 	 * @since 0.1.0
-	 * @since n.e.x.t Negative values disable timestamp-based freshness checks.
+	 * @since 1.0.0 Negative values disable timestamp-based freshness checks.
 	 * @link https://github.com/WordPress/performance/blob/trunk/plugins/optimization-detective/docs/hooks.md#:~:text=Filter%3A%20od_url_metric_freshness_ttl
 	 *
 	 * @param int $ttl Expiration TTL in seconds. Defaults to 1 week.
@@ -443,7 +443,7 @@ function od_get_url_metrics_breakpoint_sample_size(): int {
 /**
  * Gets the maximum allowed size in bytes for a URL Metric serialized to JSON.
  *
- * @since n.e.x.t
+ * @since 1.0.0
  * @access private
  *
  * @return positive-int Maximum allowed byte size.
@@ -452,7 +452,7 @@ function od_get_maximum_url_metric_size(): int {
 	/**
 	 * Filters the maximum allowed size in bytes for a URL Metric serialized to JSON.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.0.0
 	 * @link https://github.com/WordPress/performance/blob/trunk/plugins/optimization-detective/docs/hooks.md#:~:text=Filter%3A%20od_maximum_url_metric_size
 	 *
 	 * @param int $max_size Maximum allowed byte size.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 4.0.0
+ * Version: 4.1.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 // @codeCoverageIgnoreEnd
 
-define( 'PERFLAB_VERSION', '4.0.0' );
+define( 'PERFLAB_VERSION', '4.1.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 4.1.0
+ * Version: 4.0.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 // @codeCoverageIgnoreEnd
 
-define( 'PERFLAB_VERSION', '4.1.0' );
+define( 'PERFLAB_VERSION', '4.0.1' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -11,7 +11,7 @@ Performance plugin from the WordPress Performance Team, which is a collection of
 
 == Description ==
 
-The Performance Lab plugin is a collection of features focused on enhancing performance of your site, most of which should eventually be merged into WordPress core. The plugin facilitates the discovery and activation of the individual performance feature plugins which the performance team is developing. In this way you can test the features to get their benefits before they become available in WordPress core. You can also play an important role by providing feedback to further improve the solutions.
+The Performance Lab plugin is a collection of features focused on enhancing the performance of your site, most of which should eventually be merged into WordPress core. The plugin facilitates the discovery and activation of the individual performance feature plugins which the performance team is developing. In this way you can test the features to get their benefits before they become available in WordPress core. You can also play an important role by providing feedback to further improve the solutions.
 
 The feature plugins which are currently featured by this plugin are:
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -76,6 +76,17 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 4.1.0 =
 
+**Enhancements**
+
+* Add JSON Schema validation for JSON files with a $schema property. ([2325](https://github.com/WordPress/performance/pull/2325))
+
+**Bug Fixes**
+
+* Add notices and improved type checking for `$wpdb->queries` when attempting to compute server-timing for database queries. ([2159](https://github.com/WordPress/performance/pull/2159))
+* Fix: Use proper escape function. ([2246](https://github.com/WordPress/performance/pull/2246))
+* Follow-up: Skip stylesheets with empty href attributes in Site Health audit. ([2328](https://github.com/WordPress/performance/pull/2328))
+* Skip stylesheets with empty href attributes in Site Health audit. ([2281](https://github.com/WordPress/performance/pull/2281))
+
 = 4.0.0 =
 
 **Enhancements**

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.9
-Stable tag:   4.1.0
+Stable tag:   4.0.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -74,18 +74,13 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 == Changelog ==
 
-= 4.1.0 =
-
-**Enhancements**
-
-* Add JSON Schema validation for JSON files with a $schema property. ([2325](https://github.com/WordPress/performance/pull/2325))
+= 4.0.1 =
 
 **Bug Fixes**
 
 * Add notices and improved type checking for `$wpdb->queries` when attempting to compute server-timing for database queries. ([2159](https://github.com/WordPress/performance/pull/2159))
-* Fix: Use proper escape function. ([2246](https://github.com/WordPress/performance/pull/2246))
-* Follow-up: Skip stylesheets with empty href attributes in Site Health audit. ([2328](https://github.com/WordPress/performance/pull/2328))
-* Skip stylesheets with empty href attributes in Site Health audit. ([2281](https://github.com/WordPress/performance/pull/2281))
+* Skip stylesheets with empty `href` attributes in Site Health audit. ([2281](https://github.com/WordPress/performance/pull/2281), [2328](https://github.com/WordPress/performance/pull/2328))
+* Use proper escape function. ([2246](https://github.com/WordPress/performance/pull/2246))
 
 = 4.0.0 =
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.9
-Stable tag:   4.0.0
+Stable tag:   4.1.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -11,7 +11,7 @@ Performance plugin from the WordPress Performance Team, which is a collection of
 
 == Description ==
 
-The Performance Lab plugin is a collection of features focused on enhancing performance of your site, most of which should eventually be merged into WordPress core. The plugin facilitates the discovery and activation of the individual performance feature plugins which the performance team is developing. In this way you can test the features to get their benefits before they become available in WordPress core. You can also play an important role by providing feedback to further improve the solutions. 
+The Performance Lab plugin is a collection of features focused on enhancing performance of your site, most of which should eventually be merged into WordPress core. The plugin facilitates the discovery and activation of the individual performance feature plugins which the performance team is developing. In this way you can test the features to get their benefits before they become available in WordPress core. You can also play an important role by providing feedback to further improve the solutions.
 
 The feature plugins which are currently featured by this plugin are:
 
@@ -73,6 +73,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 4.1.0 =
 
 = 4.0.0 =
 

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.9
-Stable tag:   1.1.1
+Stable tag:   1.1.2
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, view transitions, smooth transitions, animations
@@ -55,6 +55,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.1.2 =
 
 = 1.1.1 =
 

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -58,6 +58,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.1.2 =
 
+**Bug Fixes**
+
+* Include static page for posts for article transitions. ([2306](https://github.com/WordPress/performance/pull/2306))
+
 = 1.1.1 =
 
 **Bug Fixes**

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -5,7 +5,7 @@
  * Description: Adds smooth transitions between navigations to your WordPress site.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.1.1
+ * Version: 1.1.2
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -25,7 +25,7 @@ if ( defined( 'VIEW_TRANSITIONS_VERSION' ) ) {
 	return;
 }
 
-define( 'VIEW_TRANSITIONS_VERSION', '1.1.1' );
+define( 'VIEW_TRANSITIONS_VERSION', '1.1.2' );
 define( 'VIEW_TRANSITIONS_MAIN_FILE', __FILE__ );
 
 require_once __DIR__ . '/includes/admin.php';

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 2.6.0
+ * Version: 2.6.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -26,7 +26,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.6.0' );
+define( 'WEBP_UPLOADS_VERSION', '2.6.1' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -69,8 +69,8 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 **Bug Fixes**
 
-* Add a simple php version check around a deprecated function. ([2285](https://github.com/WordPress/performance/pull/2285))
-* Fix missing `PICTURE` element support for post thumbnail and add missing Modern Image Formats support for Widget Block. ([2179](https://github.com/WordPress/performance/pull/2179))
+* Add a simple PHP version check around a deprecated function. ([2285](https://github.com/WordPress/performance/pull/2285))
+* Fix missing `PICTURE` element support for post thumbnail and add missing Modern Image Formats support for Widget block. ([2179](https://github.com/WordPress/performance/pull/2179))
 
 = 2.6.0 =
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.9
-Stable tag:   2.6.0
+Stable tag:   2.6.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -64,6 +64,8 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.6.1 =
 
 = 2.6.0 =
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -67,6 +67,11 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.6.1 =
 
+**Bug Fixes**
+
+* Add a simple php version check around a deprecated function. ([2285](https://github.com/WordPress/performance/pull/2285))
+* Fix missing `PICTURE` element support for post thumbnail and add missing Modern Image Formats support for Widget Block. ([2179](https://github.com/WordPress/performance/pull/2179))
+
 = 2.6.0 =
 
 **Bug Fixes**


### PR DESCRIPTION
- **Bump versions**
- **Update since versions**
- **Add changelogs to readme**
- **Update embed-optimizer for release and add missing image-prioritizer changelog entries**

The following plugins are part of this release:

1. embed-optimizer (1.0.0-beta3)
1. image-prioritizer (1.0.0-beta3)
1. optimization-detective (1.0.0-beta4)
1. performance-lab (4.0.1)
1. view-transitions (1.1.2)
1. webp-uploads (2.6.1)

Note that Embed Optimizer doesn't have any milestoned issues/PRs directly, but changes were made as part of a PR milestoned for Optimization Detective.