### PR TITLE
Update Blueprint to follow pattern in Gutenberg

### DIFF
--- a/plugins/performance-lab/.wordpress-org/blueprints/blueprint.json
+++ b/plugins/performance-lab/.wordpress-org/blueprints/blueprint.json
@@ -1,19 +1,20 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
 	"landingPage": "/wp-admin/admin.php?page=perflab-modules",
+	"plugins": [ "performance-lab" ],
+	"login": true,
+	"features": {
+		"networking": true
+	},
+	"preferredVersions": {
+		"php": "latest",
+		"wp": "latest"
+	},
 	"steps": [
 		{
-			"step": "login",
-			"username": "admin"
-		},
-		{
-			"step": "installPlugin",
-			"pluginData": {
-				"resource": "wordpress.org/plugins",
-				"slug": "performance-lab"
-			},
+			"step": "setSiteOptions",
 			"options": {
-				"activate": true
+				"blogname": "Testing Performance Lab"
 			}
 		}
 	]


### PR DESCRIPTION
This is another stab to fix https://github.com/WordPress/performance/issues/2279

Even after releasing https://github.com/WordPress/performance/pull/2325 it still didn't fix the issue.

The Gutenberg plugin's directory page has the "Live Preview" button as expected, so I looked at its `blueprint.json` and noticed some key differences in its [blueprint.json`](https://plugins.trac.wordpress.org/browser/gutenberg/assets/blueprints/blueprint.json):

1. The root `plugins` property.
2. The root `login` property.
3. The root `features` property.
4. The root `preferredVersions` property.
5. A step to blog name to indicate the plugin is being tested.

This also [works in Playground](https://playground.wordpress.net/#ewoJIiRzY2hlbWEiOiAiaHR0cHM6Ly9wbGF5Z3JvdW5kLndvcmRwcmVzcy5uZXQvYmx1ZXByaW50LXNjaGVtYS5qc29uIiwKCSJsYW5kaW5nUGFnZSI6ICIvd3AtYWRtaW4vYWRtaW4ucGhwP3BhZ2U9cGVyZmxhYi1tb2R1bGVzIiwKCSJwbHVnaW5zIjogWyAicGVyZm9ybWFuY2UtbGFiIiBdLAoJImxvZ2luIjogdHJ1ZSwKCSJmZWF0dXJlcyI6IHsKCQkibmV0d29ya2luZyI6IHRydWUKCX0sCgkicHJlZmVycmVkVmVyc2lvbnMiOiB7CgkJInBocCI6ICJsYXRlc3QiLAoJCSJ3cCI6ICJsYXRlc3QiCgl9LAoJInN0ZXBzIjogWwoJCXsKCQkJInN0ZXAiOiAic2V0U2l0ZU9wdGlvbnMiLAoJCQkib3B0aW9ucyI6IHsKCQkJCSJibG9nbmFtZSI6ICJUZXN0aW5nIFBlcmZvcm1hbmNlIExhYiIKCQkJfQoJCX0KCV0KfQo=).

I'm thinking the root `plugins` property is what the directory is looking at to decide whether to show the Live Preview button, making it conditional based on whether the slug is among the `plugins` property. It's confusing to me why there are these two different ways to install a plugin, however.