### PR TITLE
Omit admin View Transitions functionality when present in core

### DIFF
--- a/plugins/view-transitions/includes/admin.php
+++ b/plugins/view-transitions/includes/admin.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.1.0
  */
 function plvt_print_view_transitions_admin_style(): void {
-	// Short-circuit if feature is already present in core. See <https://core.trac.wordpress.org/ticket/64470>.
+	// Short circuit if the feature is already present in core. See <https://core.trac.wordpress.org/ticket/64470>.
 	if ( function_exists( 'wp_enqueue_view_transitions_admin_css' ) ) {
 		return;
 	}

--- a/plugins/view-transitions/includes/admin.php
+++ b/plugins/view-transitions/includes/admin.php
@@ -23,6 +23,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.1.0
  */
 function plvt_print_view_transitions_admin_style(): void {
+	// Short-circuit if feature is already present in core. See <https://core.trac.wordpress.org/ticket/64470>.
+	if ( function_exists( 'wp_enqueue_view_transitions_admin_css' ) ) {
+		return;
+	}
+
 	$options = plvt_get_stored_setting_value();
 	if ( ! isset( $options['enable_admin_transitions'] ) || true !== $options['enable_admin_transitions'] ) {
 		return;

--- a/plugins/view-transitions/includes/settings.php
+++ b/plugins/view-transitions/includes/settings.php
@@ -296,22 +296,25 @@ function plvt_add_setting_ui(): void {
 		)
 	);
 
-	add_settings_section(
-		'plvt_admin_view_transitions',
-		_x( 'Admin View Transitions', 'Settings section', 'view-transitions' ),
-		static function (): void {
-			?>
-			<p class="description">
-				<?php esc_html_e( 'This section allows you to control view transitions usage in the WordPress admin area.', 'view-transitions' ); ?>
-			</p>
-			<?php
-		},
-		'reading',
-		array(
-			'before_section' => '<div id="admin-view-transitions">',
-			'after_section'  => '</div>',
-		)
-	);
+	// Only show setting if feature is not present in core. See <https://core.trac.wordpress.org/ticket/64470>.
+	if ( ! function_exists( 'wp_enqueue_view_transitions_admin_css' ) ) {
+		add_settings_section(
+			'plvt_admin_view_transitions',
+			_x( 'Admin View Transitions', 'Settings section', 'view-transitions' ),
+			static function (): void {
+				?>
+				<p class="description">
+					<?php esc_html_e( 'This section allows you to control view transitions usage in the WordPress admin area.', 'view-transitions' ); ?>
+				</p>
+				<?php
+			},
+			'reading',
+			array(
+				'before_section' => '<div id="admin-view-transitions">',
+				'after_section'  => '</div>',
+			)
+		);
+	}
 
 	$fields = array(
 		'override_theme_config'                 => array(

--- a/plugins/view-transitions/includes/settings.php
+++ b/plugins/view-transitions/includes/settings.php
@@ -296,7 +296,7 @@ function plvt_add_setting_ui(): void {
 		)
 	);
 
-	// Only show setting if feature is not present in core. See <https://core.trac.wordpress.org/ticket/64470>.
+	// Only show the setting if the feature is not already present in core. See <https://core.trac.wordpress.org/ticket/64470>.
 	if ( ! function_exists( 'wp_enqueue_view_transitions_admin_css' ) ) {
 		add_settings_section(
 			'plvt_admin_view_transitions',


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-develop/pull/10699

Without 7.0-alpha | With 7.0-alpha
--|--
<img width="713" height="64" alt="image" src="https://github.com/user-attachments/assets/ddcd6c05-f240-4941-ae7c-23d50e7e643e" /> | <img width="503" height="167" alt="image" src="https://github.com/user-attachments/assets/11213788-0387-4a32-8312-1c0eed0a3e0b" />
<img width="880" height="875" alt="image" src="https://github.com/user-attachments/assets/7b8ee77b-c677-4dc8-a0c8-69c2a853128d" />  | <img width="883" height="746" alt="image" src="https://github.com/user-attachments/assets/024571d7-4fa4-4c98-8f46-3c08e64726df" />
