### PR TITLE
Prevent fatal error in `od_get_current_url_metrics_etag()` when `$wp_query->posts` is `null`

### DIFF
--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -212,7 +212,11 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 						'post_modified_gmt' => $post->post_modified_gmt,
 					);
 				},
-				( $wp_query instanceof WP_Query && $wp_query->post_count > 0 ) ? $wp_query->posts : array()
+				(
+					$wp_query instanceof WP_Query &&
+					is_array( $wp_query->posts ) &&
+					count( $wp_query->posts ) > 0
+				) ? $wp_query->posts : array()
 			)
 		),
 		'active_theme'     => array(

--- a/plugins/optimization-detective/storage/data.php
+++ b/plugins/optimization-detective/storage/data.php
@@ -212,11 +212,7 @@ function od_get_current_url_metrics_etag( OD_Tag_Visitor_Registry $tag_visitor_r
 						'post_modified_gmt' => $post->post_modified_gmt,
 					);
 				},
-				(
-					$wp_query instanceof WP_Query &&
-					is_array( $wp_query->posts ) &&
-					count( $wp_query->posts ) > 0
-				) ? $wp_query->posts : array()
+				( $wp_query instanceof WP_Query && is_array( $wp_query->posts ) ) ? $wp_query->posts : array()
 			)
 		),
 		'active_theme'     => array(

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -506,6 +506,16 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 					};
 				},
 			),
+
+			'null_wp_query_posts'         => array(
+				'set_up' => function (): void {
+					$post = self::factory()->post->create_and_get();
+					$this->assertInstanceOf( WP_Post::class, $post );
+					$this->go_to( '/' );
+					global $wp_query;
+					unset( $wp_query->posts );
+				},
+			),
 		);
 	}
 

--- a/plugins/optimization-detective/tests/storage/test-data.php
+++ b/plugins/optimization-detective/tests/storage/test-data.php
@@ -290,7 +290,7 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 	/**
 	 * Data provider.
 	 *
-	 * @return array<string, mixed>
+	 * @return array<string, array{ set_up: Closure }>
 	 */
 	public function data_provider_test_od_get_current_url_metrics_etag(): array {
 		return array(
@@ -508,12 +508,16 @@ class Test_OD_Storage_Data extends WP_UnitTestCase {
 			),
 
 			'null_wp_query_posts'         => array(
-				'set_up' => function (): void {
+				'set_up' => function (): Closure {
 					$post = self::factory()->post->create_and_get();
 					$this->assertInstanceOf( WP_Post::class, $post );
 					$this->go_to( '/' );
 					global $wp_query;
 					unset( $wp_query->posts );
+
+					return function ( array $etag_data ): void {
+						$this->assertSame( array(), $etag_data['queried_posts'] );
+					};
 				},
 			),
 		);


### PR DESCRIPTION
## Summary

Fixes #2345

## Relevant technical choices

It turns out that `WP_Query::$posts` is defined as:

```php
	/**
	 * Array of post objects or post IDs.
	 *
	 * @since 1.5.0
	 * @var WP_Post[]|int[]|null
	 */
	public $posts;
```

Note: it can be `null`!

This ensures no error occurs in that case.