### PR TITLE
Add `--no-audit` to skip the security audit check for the PHP 8.2 PHPUnit

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           if [ "${{ matrix.php }}" == "8.2" ]; then
             # Version 2.1.0 of doctrine/instantiator started requiring PHP 8.4: <https://github.com/doctrine/instantiator/pull/148>.
-            composer require phpunit/phpunit:${{ matrix.phpunit }} "doctrine/instantiator:<2.1" --with-all-dependencies --ignore-platform-reqs
+            composer require phpunit/phpunit:${{ matrix.phpunit }} "doctrine/instantiator:<2.1" --with-all-dependencies --ignore-platform-reqs --no-audit
           else
             composer require --dev phpunit/phpunit:${{ matrix.phpunit }}
           fi

--- a/composer.json
+++ b/composer.json
@@ -44,11 +44,6 @@
 		},
 		"platform": {
 			"php": "7.2"
-		},
-		"audit": {
-			"ignore": [
-				"PKSA-z3gr-8qht-p93v"
-			]
 		}
 	},
 	"scripts": {

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,11 @@
 		},
 		"platform": {
 			"php": "7.2"
+		},
+		"audit": {
+			"ignore": [
+				"PKSA-z3gr-8qht-p93v"
+			]
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
## Summary

Fix issue https://github.com/WordPress/performance/actions/runs/21458842709/job/61828880918?pr=2365

## Relevant technical choices

<!-- Please describe your changes. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.
-->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
