### PR TITLE
Add links to WordPress AI Guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,8 @@ Fixes #
 You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.
 
 For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.
+
+Moreover, see the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
 -->
 
 <!--

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ You are free to use artificial intelligence (AI) tooling to contribute, but we a
 
 This repo includes an [`AGENTS.md`](./AGENTS.md) file which is a [README for agents](https://agents.md/). This can be used by tools like Cursor, Gemini CLI, GitHub Copilot coding agent, OpenAI Codex, and others. If your AI tool doesn't support `AGENTS.md` directly, you can simply create a symlink to it using the file name your tool is looking for.
 
+For more, please see see the [WordPress AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/).
+
 ## Reporting Security Issues
 
 Please see [SECURITY.md](/SECURITY.md).


### PR DESCRIPTION
This adds links to the new [AI Guidelines](https://make.wordpress.org/ai/handbook/ai-guidelines/). See [announcement post](https://make.wordpress.org/ai/2026/02/01/ai-guidelines-for-wordpress/).