### PR TITLE
Improve PHPCS compliance and add native type hints in auto-sizes and embed-optimizer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
-# See <https://github.com/github-linguist/linguist/blob/master/docs/overrides.md>.
+# Force LF for all text files
+* text=auto eol=lf
 
-# Improve highlighting for PHPStan stub files.
+# Improve highlighting for PHPStan stub files
 *.stub linguist-language=PHP
 
-# Hide diffs for Optimization Detective snapshots.
-plugins/*/tests/test-cases/*/expected.html linguist-generated=true
+# Hide diffs for Optimization Detective snapshots
+plugins/*/tests/test-cases/*/expected.html linguist-generated=trues

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -11,16 +11,16 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	/**
 	 * Attachment ID.
 	 *
-	 * @var int
+	 * @var int Attachment ID of the test image.
 	 */
-	public static $image_id;
+	public static int $image_id;
 
 	/**
 	 * Post ID.
 	 *
-	 * @var int
+	 * @var int ID of the test post.
 	 */
-	public static $post_id;
+	public static int $post_id;
 	/**
 	 * Set up the environment for the tests.
 	 */

--- a/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
+++ b/plugins/embed-optimizer/class-embed-optimizer-tag-visitor.php
@@ -25,9 +25,9 @@ final class Embed_Optimizer_Tag_Visitor {
 	/**
 	 * Whether the lazy-loading script was added to the body.
 	 *
-	 * @var bool
+	 * @var bool True when the script has already been injected.
 	 */
-	private $added_lazy_script = false;
+	private bool $added_lazy_script = false;
 
 	/**
 	 * Determines whether the processor is currently at a figure.wp-block-embed tag.

--- a/tools/phpcs/phpcs.ruleset.xml
+++ b/tools/phpcs/phpcs.ruleset.xml
@@ -114,7 +114,6 @@
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
 		<properties>
-			<property name="enableNativeTypeHint" value="true" /><!-- Only available in PHP 7.4+ -->
 			<property name="enableMixedTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableUnionTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableIntersectionTypeHint" value="false" /><!-- Only available in PHP 8.1+ -->

--- a/tools/phpcs/phpcs.ruleset.xml
+++ b/tools/phpcs/phpcs.ruleset.xml
@@ -3,7 +3,7 @@
 	<description>Sniffs for WordPress plugins</description>
 
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.2-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress-Extra" />

--- a/tools/phpcs/phpcs.ruleset.xml
+++ b/tools/phpcs/phpcs.ruleset.xml
@@ -114,7 +114,7 @@
 	</rule>
 	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
 		<properties>
-			<property name="enableNativeTypeHint" value="false" /><!-- Only available in PHP 7.4+ -->
+			<property name="enableNativeTypeHint" value="true" /><!-- Only available in PHP 7.4+ -->
 			<property name="enableMixedTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableUnionTypeHint" value="false" /><!-- Only available in PHP 8.0+ -->
 			<property name="enableIntersectionTypeHint" value="false" /><!-- Only available in PHP 8.1+ -->


### PR DESCRIPTION
Performance Lab now requires PHP 7.4+, so native property type hints can be enabled.

This updates phpcs.ruleset.xml:
- enableNativeTypeHint set to true
- aligns coding standards with PHP 7.4 minimum requirement

Fixes #2340
