### PR TITLE
Fix `Tests_Improve_Calculate_Sizes::test_no_image()`

### DIFF
--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -428,7 +428,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 
 		$result = apply_filters( 'the_content', $block_content );
 
-		$this->assertStringContainsString( '<p>No image here</p>', $result );
+		$this->assertStringContainsString( '<p class="wp-block-paragraph">No image here</p>', $result );
 	}
 
 	/**


### PR DESCRIPTION
This is a follow-up to cd0254b2259cc57f2f7e98fba5d5624f873ffb2a which I added to #2393 when I saw the tests failing on `trunk`, but Auto-Merge unexpectedly merged before the tests finished.