### PR TITLE
Incorporate port of `CSS.escape()` to support funky ID attributes

### DIFF
--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -5,7 +5,7 @@
  * Description: Optimizes the performance of embeds through lazy-loading, preconnecting, and reserving space to reduce layout shifts.
  * Requires at least: 6.6
  * Requires PHP: 7.2
- * Version: 1.0.0-beta3
+ * Version: 1.0.0-beta4
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -71,7 +71,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	}
 )(
 	'embed_optimizer_pending_plugin',
-	'1.0.0-beta3',
+	'1.0.0-beta4',
 	static function ( string $version ): void {
 		if ( defined( 'EMBED_OPTIMIZER_VERSION' ) ) {
 			return;

--- a/plugins/embed-optimizer/readme.txt
+++ b/plugins/embed-optimizer/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 6.9
-Stable tag:   1.0.0-beta3
+Stable tag:   1.0.0-beta4
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, embeds, optimization-detective
@@ -66,6 +66,12 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 The [plugin source code](https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer) is located in the [WordPress/performance](https://github.com/WordPress/performance) repo on GitHub.
 
 == Changelog ==
+
+= 1.0.0-beta4 =
+
+**Security**
+
+* Add escaping for ID selector in styles added to reduce layout shifts. This fixes an XSS security vulnerability which required an authenticated user with at least a contributor role. Props to [duc193](https://github.com/nduc193) for [responsible disclosure](https://github.com/WordPress/performance/blob/trunk/SECURITY.md). ([2397](https://github.com/WordPress/performance/pull/2397))
 
 = 1.0.0-beta3 =
 

--- a/plugins/embed-optimizer/tests/test-cases/figures-with-fancy-ids/buffer.html
+++ b/plugins/embed-optimizer/tests/test-cases/figures-with-fancy-ids/buffer.html
@@ -1,0 +1,44 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+		<meta name="generator" content="embed-optimizer 0.0.0">
+	</head>
+	<body>
+		<div class="wp-site-blocks">
+			<figure
+				id="foo[bar][baz]"
+				class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+				<div class="wp-block-embed__wrapper">
+					<iframe title="Introduction to WordPress Playground landing page" width="500" height="281"
+							src="https://www.youtube.com/embed/fVj1sze2kAY?feature=oembed" frameborder="0"
+							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+							referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+				</div>
+			</figure>
+
+			<figure
+				id="a.b.c"
+				class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+				<div class="wp-block-embed__wrapper">
+					<iframe title="Previewing GitHub branches with WordPress Playground" width="500" height="281"
+							src="https://www.youtube.com/embed/2VQkCPYyabQ?feature=oembed" frameborder="0"
+							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+							referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+				</div>
+			</figure>
+
+			<figure
+				id="hover:text-blue-500"
+				class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+				<div class="wp-block-embed__wrapper">
+					<iframe title="Using WordPress Playground to work with AI agents" width="500" height="281"
+							src="https://www.youtube.com/embed/r9eXlgUPCV4?feature=oembed" frameborder="0"
+							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+							referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+				</div>
+			</figure>
+		</div>
+	</body>
+</html>

--- a/plugins/embed-optimizer/tests/test-cases/figures-with-fancy-ids/expected.html
+++ b/plugins/embed-optimizer/tests/test-cases/figures-with-fancy-ids/expected.html
@@ -1,0 +1,83 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:complete, 480:complete, 600:complete, 782:complete}">
+		<meta name="generator" content="embed-optimizer 0.0.0">
+	<style>
+@media (width <= 480px) { #foo\[bar\]\[baz\] { min-height: 500px; } }
+@media (480px < width <= 600px) { #foo\[bar\]\[baz\] { min-height: 500px; } }
+@media (600px < width <= 782px) { #foo\[bar\]\[baz\] { min-height: 500px; } }
+@media (782px < width) { #foo\[bar\]\[baz\] { min-height: 500px; } }
+/*# sourceURL=embed-optimizer-reduce-layout-shifts */
+</style>
+<style>
+@media (width <= 480px) { #a\.b\.c { min-height: 500px; } }
+@media (480px < width <= 600px) { #a\.b\.c { min-height: 500px; } }
+@media (600px < width <= 782px) { #a\.b\.c { min-height: 500px; } }
+@media (782px < width) { #a\.b\.c { min-height: 500px; } }
+/*# sourceURL=embed-optimizer-reduce-layout-shifts */
+</style>
+<style>
+@media (width <= 480px) { #hover\:text-blue-500 { min-height: 500px; } }
+@media (480px < width <= 600px) { #hover\:text-blue-500 { min-height: 500px; } }
+@media (600px < width <= 782px) { #hover\:text-blue-500 { min-height: 500px; } }
+@media (782px < width) { #hover\:text-blue-500 { min-height: 500px; } }
+/*# sourceURL=embed-optimizer-reduce-layout-shifts */
+</style>
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(width &lt;= 480px)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(width &lt;= 480px)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(width &lt;= 600px)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(480px &lt; width &lt;= 600px)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(480px &lt; width &lt;= 782px)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(600px &lt; width &lt;= 782px)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(600px &lt; width)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(782px &lt; width)">
+<link data-od-added-tag rel="preconnect" href="https://i.ytimg.com" media="(782px &lt; width)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(width &lt;= 480px)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(width &lt;= 480px)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(width &lt;= 600px)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(480px &lt; width &lt;= 600px)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(480px &lt; width &lt;= 782px)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(600px &lt; width &lt;= 782px)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(600px &lt; width)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(782px &lt; width)">
+<link data-od-added-tag rel="preconnect" href="https://www.youtube.com" media="(782px &lt; width)">
+</head>
+	<body>
+		<div class="wp-site-blocks">
+			<figure
+				id="foo[bar][baz]"
+				class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+				<div class="wp-block-embed__wrapper">
+					<iframe title="Introduction to WordPress Playground landing page" width="500" height="281"
+							src="https://www.youtube.com/embed/fVj1sze2kAY?feature=oembed" frameborder="0"
+							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+							referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+				</div>
+			</figure>
+
+			<figure
+				id="a.b.c"
+				class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+				<div class="wp-block-embed__wrapper">
+					<iframe title="Previewing GitHub branches with WordPress Playground" width="500" height="281"
+							src="https://www.youtube.com/embed/2VQkCPYyabQ?feature=oembed" frameborder="0"
+							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+							referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+				</div>
+			</figure>
+
+			<figure
+				id="hover:text-blue-500"
+				class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+				<div class="wp-block-embed__wrapper">
+					<iframe title="Using WordPress Playground to work with AI agents" width="500" height="281"
+							src="https://www.youtube.com/embed/r9eXlgUPCV4?feature=oembed" frameborder="0"
+							allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+							referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+				</div>
+			</figure>
+		</div>
+	</body>
+</html>

--- a/plugins/embed-optimizer/tests/test-cases/figures-with-fancy-ids/set-up.php
+++ b/plugins/embed-optimizer/tests/test-cases/figures-with-fancy-ids/set-up.php
@@ -1,0 +1,25 @@
+<?php
+return static function ( Test_Embed_Optimizer_Optimization_Detective $test_case ): void {
+	$test_case->populate_url_metrics(
+		array(
+			array(
+				'xpath'                     => '/HTML/BODY/DIV[@class=\'wp-site-blocks\']/*[1][self::FIGURE]/*[1][self::DIV]',
+				'isLCP'                     => true,
+				'intersectionRatio'         => 1,
+				'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
+			),
+			array(
+				'xpath'                     => '/HTML/BODY/DIV[@class=\'wp-site-blocks\']/*[2][self::FIGURE]/*[1][self::DIV]',
+				'isLCP'                     => true,
+				'intersectionRatio'         => 1,
+				'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
+			),
+			array(
+				'xpath'                     => '/HTML/BODY/DIV[@class=\'wp-site-blocks\']/*[3][self::FIGURE]/*[1][self::DIV]',
+				'isLCP'                     => true,
+				'intersectionRatio'         => 1,
+				'resizedBoundingClientRect' => array_merge( $test_case->get_sample_dom_rect(), array( 'height' => 500 ) ),
+			),
+		)
+	);
+};

--- a/plugins/embed-optimizer/tests/test-class-embed-optimizer-tag-visitor-escape-css.php
+++ b/plugins/embed-optimizer/tests/test-class-embed-optimizer-tag-visitor-escape-css.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Tests for Embed_Optimizer_Tag_Visitor.
+ *
+ * @package embed-optimizer
+ *
+ * @coversDefaultClass Embed_Optimizer_Tag_Visitor
+ */
+class Test_Embed_Optimizer_Tag_Visitor_Escape_CSS extends WP_UnitTestCase {
+
+	/**
+	 * Runs the routine before each test is executed.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		require_once dirname( __DIR__ ) . '/class-embed-optimizer-tag-visitor.php';
+	}
+
+	/**
+	 * Tests escape_css().
+	 *
+	 * @covers ::escape_css
+	 *
+	 * @dataProvider data_escape_css
+	 *
+	 * @param string $ident    Identifier to escape.
+	 * @param string $expected Expected escaped identifier.
+	 */
+	public function test_escape_css( string $ident, string $expected ): void {
+		$visitor = new Embed_Optimizer_Tag_Visitor();
+		$method  = new ReflectionMethod( $visitor, 'escape_css' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invoke( $visitor, $ident ) );
+	}
+
+	/**
+	 * Data provider for test_escape_css.
+	 *
+	 * @return array<string, array{string, string}> Test cases.
+	 */
+	public function data_escape_css(): array {
+		return array(
+			'empty'             => array( '', '' ),
+			'simple'            => array( 'foo', 'foo' ),
+			'brackets'          => array( 'foo[bar][baz]', 'foo\[bar\]\[baz\]' ),
+			'hyphen'            => array( '-', '\-' ),
+			'unicode'           => array( '🌈', '🌈' ),
+			'double-hyphen'     => array( '--', '--' ),
+			'hyphen-digit'      => array( '-1', '-\31 ' ),
+			'digit'             => array( '1', '\31 ' ),
+			'digit-alpha'       => array( '1a', '\31 a' ),
+			'dot'               => array( '.foo', '\.foo' ),
+			'hash'              => array( '#bar', '\#bar' ),
+			'space'             => array( ' ', '\ ' ),
+			'null'              => array( "\0", "\xEF\xBF\xBD" ), // U+FFFD is EF BF BD in UTF-8.
+			'control'           => array( "\x1F", '\1f ' ),
+			'delete'            => array( "\x7F", '\7f ' ),
+			'backslash'         => array( '\\', '\\\\' ),
+			'underscore'        => array( '_', '_' ),
+			'mixed'             => array( 'foo-bar_baz', 'foo-bar_baz' ),
+			'unicode-multibyte' => array( 'é', 'é' ),
+			'complex'           => array( '1.2#3-4_5', '\31 \.2\#3-4_5' ),
+		);
+	}
+}


### PR DESCRIPTION
## Summary

This fixes handling of Embeds which have `FIGURE` elements that have an `id` attribute containing characters which need escaping to form a valid ID selector in CSS. For example, an HTML ID like `a.b.c` needs escaping to be a CSS selector as `#a\.b\.c`.

> [!IMPORTANT]
> This fixes an XSS security vulnerability which required an authenticated user with at least a contributor role. Props to @duc193 for [responsible disclosure](https://github.com/WordPress/performance/blob/trunk/SECURITY.md).

## Use of AI Tools

Gemini CLI was used to port Mathias Bynens's [`CSS.escape()`](https://drafts.csswg.org/cssom/#the-css.escape()-method) [polyfill](https://github.com/mathiasbynens/CSS.escape) from JS to PHP.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
