### PR TITLE
Remove Web Worker Offloading from being featured by Performance Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ For WordPress and PHP version requirements, please refer to the [CONTRIBUTING.md
 
 The feature plugins which are currently highlighted by this plugin are:
 
-Plugin                          | Slug                      | Experimental | Links
---------------------------------|---------------------------|--------------|-------------
-[Embed Optimizer][5]            | `embed-optimizer`         | No           | [Source][13], [Issues][21], [PRs][29]
-[Enhanced Responsive Images][6] | `auto-sizes`              | No           | [Source][14], [Issues][22], [PRs][30]
-[Image Placeholders][1]         | `dominant-color-images`   | No           | [Source][9],  [Issues][17], [PRs][25]
-[Image Prioritizer][7]          | `image-prioritizer`       | No           | [Source][15], [Issues][23], [PRs][31]
-[Instant Back/Forward][41]      | `nocache-bfcache`         | No           | [Source][42], [Issues][43], [PRs][44]
-[Modern Image Formats][2]       | `webp-uploads`            | No           | [Source][10], [Issues][18], [PRs][26]
-[Optimization Detective][33]    | `optimization-detective`  | No           | [Source][34], [Issues][35], [PRs][36]
-[Performant Translations][3]    | `performant-translations` | No           | [Source][11], [Issues][19], [PRs][27]
-[Speculative Loading][4]        | `speculation-rules`       | No           | [Source][12], [Issues][20], [PRs][28]
-[View Transitions][37]          | `view-transitions`        | Yes          | [Source][38], [Issues][39], [PRs][40]
-[Web Worker Offloading][8]      | `web-worker-offloading`   | Yes          | [Source][16], [Issues][24], [PRs][32]
+Plugin                          | Slug                      | Experimental           | Links
+--------------------------------|---------------------------|------------------------|-------------
+[Embed Optimizer][5]            | `embed-optimizer`         | No                     | [Source][13], [Issues][21], [PRs][29]
+[Enhanced Responsive Images][6] | `auto-sizes`              | No                     | [Source][14], [Issues][22], [PRs][30]
+[Image Placeholders][1]         | `dominant-color-images`   | No                     | [Source][9],  [Issues][17], [PRs][25]
+[Image Prioritizer][7]          | `image-prioritizer`       | No                     | [Source][15], [Issues][23], [PRs][31]
+[Instant Back/Forward][41]      | `nocache-bfcache`         | No                     | [Source][42], [Issues][43], [PRs][44]
+[Modern Image Formats][2]       | `webp-uploads`            | No                     | [Source][10], [Issues][18], [PRs][26]
+[Optimization Detective][33]    | `optimization-detective`  | No                     | [Source][34], [Issues][35], [PRs][36]
+[Performant Translations][3]    | `performant-translations` | No                     | [Source][11], [Issues][19], [PRs][27]
+[Speculative Loading][4]        | `speculation-rules`       | No                     | [Source][12], [Issues][20], [PRs][28]
+[View Transitions][37]          | `view-transitions`        | Yes                    | [Source][38], [Issues][39], [PRs][40]
+[Web Worker Offloading][8]      | `web-worker-offloading`   | Yes ([sunsetting][45]) | [Source][16], [Issues][24], [PRs][32]
 
 [1]: https://wordpress.org/plugins/dominant-color-images/
 [2]: https://wordpress.org/plugins/webp-uploads/
@@ -72,5 +72,7 @@ Plugin                          | Slug                      | Experimental | Lin
 [36]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+Optimization%20Detective%22
 [40]: https://github.com/WordPress/performance/pulls?q=is%3Apr+is%3Aopen+label%3A%22%5BPlugin%5D+View%20Transitions%22
 [44]: https://github.com/westonruter/nocache-bfcache/pulls
+
+[45]: https://github.com/WordPress/performance/issues/2284
 
 Note that the plugin names sometimes diverge from the plugin slugs due to scope changes. For example, a plugin's purpose may change as some of its features are merged into WordPress core.

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -123,10 +123,6 @@ function perflab_get_standalone_plugin_data(): array {
 			'constant'     => 'VIEW_TRANSITIONS_VERSION',
 			'experimental' => true,
 		),
-		'web-worker-offloading'   => array(
-			'constant'     => 'WEB_WORKER_OFFLOADING_VERSION',
-			'experimental' => true,
-		),
 		'webp-uploads'            => array(
 			'constant' => 'WEBP_UPLOADS_VERSION',
 		),

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -25,7 +25,6 @@ The feature plugins which are currently featured by this plugin are:
 * [Performant Translations](https://wordpress.org/plugins/performant-translations/)
 * [Speculative Loading](https://wordpress.org/plugins/speculation-rules/)
 * [View Transitions](https://wordpress.org/plugins/view-transitions/) _(experimental)_
-* [Web Worker Offloading](https://wordpress.org/plugins/web-worker-offloading/) _(experimental)_
 
 These plugins can also be installed separately from installing Performance Lab, but having the Performance Lab plugin also active will ensure you find out about new performance features as they are developed.
 

--- a/plugins/web-worker-offloading/helper.php
+++ b/plugins/web-worker-offloading/helper.php
@@ -198,3 +198,33 @@ function plwwo_render_generator_meta_tag(): void {
 	// Use the plugin slug as it is immutable.
 	echo '<meta name="generator" content="web-worker-offloading ' . esc_attr( WEB_WORKER_OFFLOADING_VERSION ) . '">' . "\n";
 }
+
+/**
+ * Displays a sunset warning notice for the plugin in the plugin row meta.
+ *
+ * @since n.e.x.t
+ * @access private
+ *
+ * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+ */
+function plwwo_render_sunset_notice( string $plugin_file ): void {
+	if ( 'web-worker-offloading/load.php' !== $plugin_file ) {
+		return;
+	}
+
+	$message = sprintf(
+		/* translators: 1: GitHub issue URL. 2: Support forum URL. */
+		__( 'The Web Worker Offloading plugin is proposed for being sunset. Please refer to the <a href="%1$s" target="_blank" rel="noopener">GitHub issue</a> for more information. If you have metrics showing how this plugin specifically improved your Interaction to Next Paint (INP), please share them in the <a href="%2$s" target="_blank" rel="noopener">support forum</a> as this could provide a reason to keep the plugin.', 'web-worker-offloading' ),
+		esc_url( 'https://github.com/WordPress/performance/issues/2284' ),
+		esc_url( 'https://wordpress.org/support/plugin/web-worker-offloading/' )
+	);
+	?>
+	<div class="notice inline notice-warning notice-alt">
+		<p>
+			<?php
+			echo wp_kses_post( $message );
+			?>
+		</p>
+	</div>
+	<?php
+}

--- a/plugins/web-worker-offloading/hooks.php
+++ b/plugins/web-worker-offloading/hooks.php
@@ -15,4 +15,5 @@ add_filter( 'print_scripts_array', 'plwwo_filter_print_scripts_array', PHP_INT_M
 add_filter( 'script_loader_tag', 'plwwo_update_script_type', 10, 2 );
 add_filter( 'wp_inline_script_attributes', 'plwwo_filter_inline_script_attributes' );
 add_action( 'wp_head', 'plwwo_render_generator_meta_tag' );
+add_action( 'after_plugin_row_meta', 'plwwo_render_sunset_notice' );
 // @codeCoverageIgnoreEnd

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -396,4 +396,33 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		$this->assertFalse( function_exists( 'plwwo_rank_math_configure' ) );
 		$this->assertFalse( function_exists( 'plwwo_woocommerce_configure' ) );
 	}
+
+	/**
+	 * Test the sunset notice hook.
+	 *
+	 * @covers ::plwwo_render_sunset_notice
+	 */
+	public function test_plwwo_render_sunset_notice_hook(): void {
+		$this->assertEquals( 10, has_action( 'after_plugin_row_meta', 'plwwo_render_sunset_notice' ) );
+	}
+
+	/**
+	 * Test rendering the sunset notice.
+	 *
+	 * @covers ::plwwo_render_sunset_notice
+	 */
+	public function test_plwwo_render_sunset_notice_rendering(): void {
+		$plugin_file = 'web-worker-offloading/load.php';
+
+		$output = get_echo( 'plwwo_render_sunset_notice', array( $plugin_file ) );
+
+		$this->assertStringContainsString( 'notice-warning', $output );
+		$this->assertStringContainsString( 'The Web Worker Offloading plugin is proposed for being sunset.', $output );
+		$this->assertStringContainsString( 'Interaction to Next Paint (INP)', $output );
+		$this->assertStringContainsString( 'https://wordpress.org/support/plugin/web-worker-offloading/', $output );
+
+		// Test with different plugin file.
+		$output = get_echo( 'plwwo_render_sunset_notice', array( 'other-plugin/load.php' ) );
+		$this->assertEmpty( $output );
+	}
 }


### PR DESCRIPTION
## Summary

Per https://github.com/WordPress/performance/issues/2284 we are moving toward sunsetting the Web Worker Offloading plugin. As part of this, it doesn't make sense to list the plugin as a performance feature anymore on the Performance screen. So this removes it.

It also indicates it is being sunset in the main readme.

Before | After
--|--
<img width="1195" height="948" alt="image" src="https://github.com/user-attachments/assets/0d6badb9-f817-4bea-960d-4cfeb7df597c" /> | <img width="1195" height="911" alt="image" src="https://github.com/user-attachments/assets/25511d25-ab65-4b88-a8af-993a63dbafae" />


Inline admin notice added for the plugin:

<img width="1179" height="560" alt="image" src="https://github.com/user-attachments/assets/7b1d78b6-8d41-48ea-ad9c-700f7c307396" />


## Use of AI Tools

Gemini used to author the admin notice for the WWO plugin: ac38e3251e2d651994b5e268405f6401f56a8ef0.