### PR TITLE
Blocking assets: treat non-cacheable and zero-size responses as error…

### DIFF
--- a/plugins/performance-lab/includes/site-health/audit-enqueued-assets/helper.php
+++ b/plugins/performance-lab/includes/site-health/audit-enqueued-assets/helper.php
@@ -522,9 +522,30 @@ function perflab_aea_get_asset_size( string $resource_url ) {
 		);
 	}
 
-	// TODO: A non-cacheable response should also be considered an error.
-	// TODO: A size of zero could be considered an error too.
-	return strlen( wp_remote_retrieve_body( $response ) );
+	$body = wp_remote_retrieve_body( $response );
+	if ( 0 === strlen( $body ) ) {
+		return new WP_Error(
+			'zero_size',
+			__( 'The asset returned an empty response (0 bytes).', 'performance-lab' )
+		);
+	}
+
+	$cache_control = wp_remote_retrieve_header( $response, 'Cache-Control' );
+	if ( is_string( $cache_control ) && ( false !== stripos( $cache_control, 'no-store' ) || false !== stripos( $cache_control, 'no-cache' ) ) ) {
+		return new WP_Error(
+			'non_cacheable',
+			wp_kses(
+				sprintf(
+					/* translators: %s is the Cache-Control header value */
+					__( 'The asset is not cacheable (<code>Cache-Control: %s</code>), which can harm performance.', 'performance-lab' ),
+					esc_html( $cache_control )
+				),
+				array( 'code' => array() )
+			)
+		);
+	}
+
+	return strlen( $body );
 }
 
 /**

--- a/plugins/performance-lab/tests/includes/site-health/audit-enqueued-assets/test-audit-enqueued-assets-helper.php
+++ b/plugins/performance-lab/tests/includes/site-health/audit-enqueued-assets/test-audit-enqueued-assets-helper.php
@@ -520,8 +520,43 @@ class Test_Audit_Enqueued_Assets_Helper extends WP_Ajax_UnitTestCase {
 
 		$this->assertWPError( perflab_aea_get_asset_size( 'https://example.com/script1.js' ) );
 		$this->assertWPError( perflab_aea_get_asset_size( 'https://example.com/script2.js' ) );
-		$this->assertEquals( 0, perflab_aea_get_asset_size( 'https://example.com/script3.js' ) );
+
+		$zero_size_result = perflab_aea_get_asset_size( 'https://example.com/script3.js' );
+		$this->assertWPError( $zero_size_result );
+		$this->assertSame( 'zero_size', $zero_size_result->get_error_code() );
+
 		$this->assertEquals( 1000, perflab_aea_get_asset_size( 'https://example.com/script4.js' ) );
+	}
+
+	/**
+	 * Tests perflab_aea_get_asset_size() returns error for non-cacheable Cache-Control header.
+	 *
+	 * @covers ::perflab_aea_get_asset_size
+	 */
+	public function test_perflab_aea_get_asset_size_non_cacheable(): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) {
+				if ( 'https://example.com/nocache.js' !== $url ) {
+					return $preempt;
+				}
+				return array(
+					'headers'  => new WpOrg\Requests\Utility\CaseInsensitiveDictionary( array( 'Cache-Control' => 'no-store' ) ),
+					'body'     => 'var x = 1;',
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		$result = perflab_aea_get_asset_size( 'https://example.com/nocache.js' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'non_cacheable', $result->get_error_code() );
+		$this->assertStringContainsString( 'no-store', $result->get_error_message() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Fixes #2417

This PR improves error handling for invalid and non-cacheable HTTP responses.

## Changes
- Return `WP_Error` when response body is empty (0 bytes)
- Return `WP_Error` when `Cache-Control` contains `no-store` or `no-cache`
- Add tests for:
  - zero_size response
  - non_cacheable response

## Technical Notes
- Added validation checks before processing response
- Scoped changes strictly to error handling
- Maintains backward compatibility