### PR TITLE
Fix static type error in REST API endpoint and add Generic.PHP.RequireStrictTypes to PHPCS ruleset

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -24,7 +24,7 @@
 				"FS_METHOD": "direct"
 			},
 			"mappings": {
-				"/wp-content/plugins/performance": "."
+				"wp-content/plugins/performance": "."
 			}
 		}
 	}

--- a/composer.json
+++ b/composer.json
@@ -96,9 +96,9 @@
 		"lint:web-worker-offloading": "@lint -- ./plugins/web-worker-offloading --standard=./plugins/web-worker-offloading/phpcs.xml.dist",
 		"lint:webp-uploads": "@lint -- ./plugins/webp-uploads --standard=./plugins/webp-uploads/phpcs.xml.dist",
 		"phpstan": "phpstan analyse --memory-limit=2048M",
-		"test": "phpunit --strict-coverage",
+		"test": "php vendor/bin/phpunit --strict-coverage",
 		"test-multisite": [
-			"WP_MULTISITE=1 phpunit --exclude-group=ms-excluded"
+			"WP_MULTISITE=1 php vendor/bin/phpunit --exclude-group=ms-excluded"
 		],
 		"test-multisite:plugins": [
 			"@test-multisite:auto-sizes",

--- a/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
+++ b/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
@@ -89,12 +89,15 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 				'required'          => true,
 				'pattern'           => '^[0-9a-f]+\z',
 				'validate_callback' => static function ( string $hmac, WP_REST_Request $request ) use ( $cache_purge_post_id_schema ) {
-					// Obtain the validated and sanitized cache_purge_post_id.
-					$cache_purge_post_id_validity = rest_validate_value_from_schema( $request['cache_purge_post_id'], $cache_purge_post_id_schema, 'cache_purge_post_id' );
-					if ( is_wp_error( $cache_purge_post_id_validity ) ) {
-						return $cache_purge_post_id_validity;
+					// Obtain the validated and sanitized cache_purge_post_id since the param is not yet sanitized at this point.
+					$cache_purge_post_id = $request['cache_purge_post_id'];
+					if ( null !== $cache_purge_post_id ) {
+						$cache_purge_post_id_validity = rest_validate_value_from_schema( $cache_purge_post_id, $cache_purge_post_id_schema, 'cache_purge_post_id' );
+						if ( is_wp_error( $cache_purge_post_id_validity ) ) {
+							return $cache_purge_post_id_validity;
+						}
+						$cache_purge_post_id = rest_sanitize_value_from_schema( $cache_purge_post_id, $cache_purge_post_id_schema, 'cache_purge_post_id' );
 					}
-					$cache_purge_post_id = rest_sanitize_value_from_schema( $request['cache_purge_post_id'], $cache_purge_post_id_schema, 'cache_purge_post_id' );
 
 					if ( '' === $hmac || ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $cache_purge_post_id ) ) {
 						return new WP_Error( 'invalid_hmac', __( 'URL Metrics HMAC verification failure.', 'optimization-detective' ) );

--- a/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
+++ b/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
@@ -163,7 +163,7 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 			);
 		}
 
-		// This validation is done here as opposed to the a validate_callback for the arg since here the params have all been validated and sanitized.
+		// This validation is done here as opposed to a validate_callback for the arg since here the params have all been validated and sanitized.
 		if ( ! od_verify_url_metrics_storage_hmac( $request['hmac'], $request['slug'], $request['current_etag'], $request['url'], $request['cache_purge_post_id'] ) ) {
 			return new WP_Error(
 				'rest_invalid_param',

--- a/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
+++ b/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
@@ -56,13 +56,6 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 	 * }
 	 */
 	public function get_registration_args(): array {
-		$cache_purge_post_id_schema = array(
-			'type'        => 'integer',
-			'description' => __( 'Cache purge post ID.', 'optimization-detective' ),
-			'required'    => false,
-			'minimum'     => 1,
-		);
-
 		// The slug and cache_purge_post_id args are further validated via the validate_callback for the 'hmac' parameter,
 		// they are provided as input with the 'url' argument to create the HMAC by the server.
 		$args = array(
@@ -82,30 +75,36 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 				'minLength'   => 32,
 				'maxLength'   => 32,
 			),
-			'cache_purge_post_id' => $cache_purge_post_id_schema,
+			'cache_purge_post_id' => array(
+				'type'        => 'integer',
+				'description' => __( 'Cache purge post ID.', 'optimization-detective' ),
+				'required'    => false,
+				'minimum'     => 1,
+			),
 			'hmac'                => array(
-				'type'              => 'string',
-				'description'       => __( 'HMAC originally computed by server required to authorize the request.', 'optimization-detective' ),
-				'required'          => true,
-				'pattern'           => '^[0-9a-f]+\z',
-				'validate_callback' => static function ( string $hmac, WP_REST_Request $request ) use ( $cache_purge_post_id_schema ) {
-					// Obtain the validated and sanitized cache_purge_post_id since the param is not yet sanitized at this point.
-					$cache_purge_post_id = $request['cache_purge_post_id'];
-					if ( null !== $cache_purge_post_id ) {
-						$cache_purge_post_id_validity = rest_validate_value_from_schema( $cache_purge_post_id, $cache_purge_post_id_schema, 'cache_purge_post_id' );
-						if ( is_wp_error( $cache_purge_post_id_validity ) ) {
-							return $cache_purge_post_id_validity;
-						}
-						$cache_purge_post_id = rest_sanitize_value_from_schema( $cache_purge_post_id, $cache_purge_post_id_schema, 'cache_purge_post_id' );
-					}
-
-					if ( '' === $hmac || ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $cache_purge_post_id ) ) {
-						return new WP_Error( 'invalid_hmac', __( 'URL Metrics HMAC verification failure.', 'optimization-detective' ) );
-					}
-					return true;
-				},
+				'type'        => 'string',
+				'description' => __( 'HMAC originally computed by server required to authorize the request.', 'optimization-detective' ),
+				'required'    => true,
+				'pattern'     => '^[0-9a-f]+\z',
 			),
 		);
+
+		$args['hmac']['validate_callback'] = static function ( string $hmac, WP_REST_Request $request ) use ( $args ) {
+			// Obtain the validated and sanitized cache_purge_post_id since the param is not yet sanitized at this point.
+			$cache_purge_post_id = $request['cache_purge_post_id'];
+			if ( null !== $cache_purge_post_id ) {
+				$cache_purge_post_id_validity = rest_validate_value_from_schema( $cache_purge_post_id, $args['cache_purge_post_id'], 'cache_purge_post_id' );
+				if ( is_wp_error( $cache_purge_post_id_validity ) ) {
+					return $cache_purge_post_id_validity;
+				}
+				$cache_purge_post_id = rest_sanitize_value_from_schema( $cache_purge_post_id, $args['cache_purge_post_id'], 'cache_purge_post_id' );
+			}
+
+			if ( '' === $hmac || ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $cache_purge_post_id ) ) {
+				return new WP_Error( 'invalid_hmac', __( 'URL Metrics HMAC verification failure.', 'optimization-detective' ) );
+			}
+			return true;
+		};
 
 		return array(
 			'methods'             => 'POST',

--- a/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
+++ b/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
@@ -56,6 +56,13 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 	 * }
 	 */
 	public function get_registration_args(): array {
+		$cache_purge_post_id_schema = array(
+			'type'        => 'integer',
+			'description' => __( 'Cache purge post ID.', 'optimization-detective' ),
+			'required'    => false,
+			'minimum'     => 1,
+		);
+
 		// The slug and cache_purge_post_id args are further validated via the validate_callback for the 'hmac' parameter,
 		// they are provided as input with the 'url' argument to create the HMAC by the server.
 		$args = array(
@@ -75,19 +82,21 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 				'minLength'   => 32,
 				'maxLength'   => 32,
 			),
-			'cache_purge_post_id' => array(
-				'type'        => 'integer',
-				'description' => __( 'Cache purge post ID.', 'optimization-detective' ),
-				'required'    => false,
-				'minimum'     => 1,
-			),
+			'cache_purge_post_id' => $cache_purge_post_id_schema,
 			'hmac'                => array(
 				'type'              => 'string',
 				'description'       => __( 'HMAC originally computed by server required to authorize the request.', 'optimization-detective' ),
 				'required'          => true,
 				'pattern'           => '^[0-9a-f]+\z',
-				'validate_callback' => static function ( string $hmac, WP_REST_Request $request ) {
-					if ( '' === $hmac || ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $request['cache_purge_post_id'] ?? null ) ) {
+				'validate_callback' => static function ( string $hmac, WP_REST_Request $request ) use ( $cache_purge_post_id_schema ) {
+					// Obtain the validated and sanitized cache_purge_post_id.
+					$cache_purge_post_id_validity = rest_validate_value_from_schema( $request['cache_purge_post_id'], $cache_purge_post_id_schema, 'cache_purge_post_id' );
+					if ( is_wp_error( $cache_purge_post_id_validity ) ) {
+						return $cache_purge_post_id_validity;
+					}
+					$cache_purge_post_id = rest_sanitize_value_from_schema( $request['cache_purge_post_id'], $cache_purge_post_id_schema, 'cache_purge_post_id' );
+
+					if ( '' === $hmac || ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $cache_purge_post_id ) ) {
 						return new WP_Error( 'invalid_hmac', __( 'URL Metrics HMAC verification failure.', 'optimization-detective' ) );
 					}
 					return true;

--- a/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
+++ b/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php
@@ -56,8 +56,8 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 	 * }
 	 */
 	public function get_registration_args(): array {
-		// The slug and cache_purge_post_id args are further validated via the validate_callback for the 'hmac' parameter,
-		// they are provided as input with the 'url' argument to create the HMAC by the server.
+		// The slug and cache_purge_post_id args are further validated in the callback by checking against the 'hmac'
+		// parameter. They are provided as input with the 'url' argument to create the HMAC by the server.
 		$args = array(
 			'slug'                => array(
 				'type'        => 'string',
@@ -88,23 +88,6 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 				'pattern'     => '^[0-9a-f]+\z',
 			),
 		);
-
-		$args['hmac']['validate_callback'] = static function ( string $hmac, WP_REST_Request $request ) use ( $args ) {
-			// Obtain the validated and sanitized cache_purge_post_id since the param is not yet sanitized at this point.
-			$cache_purge_post_id = $request['cache_purge_post_id'];
-			if ( null !== $cache_purge_post_id ) {
-				$cache_purge_post_id_validity = rest_validate_value_from_schema( $cache_purge_post_id, $args['cache_purge_post_id'], 'cache_purge_post_id' );
-				if ( is_wp_error( $cache_purge_post_id_validity ) ) {
-					return $cache_purge_post_id_validity;
-				}
-				$cache_purge_post_id = rest_sanitize_value_from_schema( $cache_purge_post_id, $args['cache_purge_post_id'], 'cache_purge_post_id' );
-			}
-
-			if ( '' === $hmac || ! od_verify_url_metrics_storage_hmac( $hmac, $request['slug'], $request['current_etag'], $request['url'], $cache_purge_post_id ) ) {
-				return new WP_Error( 'invalid_hmac', __( 'URL Metrics HMAC verification failure.', 'optimization-detective' ) );
-			}
-			return true;
-		};
 
 		return array(
 			'methods'             => 'POST',
@@ -177,6 +160,15 @@ final class OD_REST_URL_Metrics_Store_Endpoint {
 				'rest_cross_origin_forbidden',
 				__( 'Cross-origin requests are not allowed for this endpoint.', 'optimization-detective' ),
 				array( 'status' => 403 )
+			);
+		}
+
+		// This validation is done here as opposed to the a validate_callback for the arg since here the params have all been validated and sanitized.
+		if ( ! od_verify_url_metrics_storage_hmac( $request['hmac'], $request['slug'], $request['current_etag'], $request['url'], $request['cache_purge_post_id'] ) ) {
+			return new WP_Error(
+				'rest_invalid_param',
+				__( 'URL Metrics HMAC verification failure.', 'optimization-detective' ),
+				array( 'status' => 400 )
 			);
 		}
 

--- a/plugins/optimization-detective/tests/storage/test-class-od-rest-url-metrics-store-endpoint.php
+++ b/plugins/optimization-detective/tests/storage/test-class-od-rest-url-metrics-store-endpoint.php
@@ -308,6 +308,36 @@ class Test_OD_REST_URL_Metrics_Store_Endpoint extends WP_UnitTestCase {
 				'expected_status' => 400,
 				'expected_code'   => 'rest_invalid_param',
 			),
+			'negative_cache_purge_post_id'             => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'cache_purge_post_id' => -1,
+					)
+				),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'zero_cache_purge_post_id'                 => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'cache_purge_post_id' => 0,
+					)
+				),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
+			'non_numeric_cache_purge_post_id'          => array(
+				'params'          => array_merge(
+					$valid_params,
+					array(
+						'cache_purge_post_id' => 'evil',
+					)
+				),
+				'expected_status' => 400,
+				'expected_code'   => 'rest_invalid_param',
+			),
 			'invalid_viewport_type'                    => array(
 				'params'          => array_merge(
 					$valid_params,
@@ -1117,7 +1147,10 @@ class Test_OD_REST_URL_Metrics_Store_Endpoint extends WP_UnitTestCase {
 		 */
 		$request = new WP_REST_Request( 'POST', $this->get_route() );
 		$request->set_header( 'Content-Type', 'application/json' );
-		$request->set_query_params( wp_array_slice_assoc( $params, array( 'hmac', 'current_etag', 'slug', 'cache_purge_post_id' ) ) );
+		// Cast all query params to strings to simulate real HTTP requests where all parameter values are strings.
+		$query_params = wp_array_slice_assoc( $params, array( 'hmac', 'current_etag', 'slug', 'cache_purge_post_id' ) );
+		$query_params = array_map( 'strval', $query_params );
+		$request->set_query_params( $query_params );
 		$request->set_header( 'Origin', home_url() );
 		unset( $params['hmac'], $params['slug'], $params['current_etag'], $params['cache_purge_post_id'] );
 

--- a/tools/phpcs/phpcs.ruleset.xml
+++ b/tools/phpcs/phpcs.ruleset.xml
@@ -8,6 +8,7 @@
 	<rule ref="WordPress-Docs"/>
 	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress.WP.I18n"/>
+	<rule ref="Generic.PHP.RequireStrictTypes"/>
 
 	<arg value="ps"/>
 	<arg name="extensions" value="php"/>
@@ -137,6 +138,10 @@
 	<rule ref="WordPress.Security.ValidatedSanitizedInput.InputNotSanitized">
 		<exclude-pattern>./plugins/*/tests/**</exclude-pattern>
 		<exclude-pattern>./tools/phpunit/bootstrap.php</exclude-pattern>
+	</rule>
+	<rule ref="Generic.PHP.RequireStrictTypes.MissingDeclaration">
+		<exclude-pattern>./plugins/*/tests/**</exclude-pattern>
+		<exclude-pattern>./tools/**</exclude-pattern>
 	</rule>
 
 	<!-- Exclude built plugins and built assets in plugins. -->


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
See #2348.

This is a follow-up to https://github.com/WordPress/performance/pull/2424.

This PR ensures that new PHP files (aside from tests) will fail PHPCS if `declare( strict_types = 1 );` is absent.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->


This also fixes an error I encountered when attempting to store a new URL Metric via the REST API:

```
PHP Fatal error:  Uncaught TypeError: od_verify_url_metrics_storage_hmac(): Argument #5 ($cache_purge_post_id) must be of type ?int, string given, called in /var/www/src/wp-content/plugins/performance/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php on line 91 and defined in /var/www/src/wp-content/plugins/performance/plugins/optimization-detective/storage/data.php:295
Stack trace:
#0 /var/www/src/wp-content/plugins/performance/plugins/optimization-detective/storage/class-od-rest-url-metrics-store-endpoint.php(91): od_verify_url_metrics_storage_hmac('74b5101d6b3d321...', '6c9843f1487a1bb...', 'd6d7c1f27cb4884...', 'http://localhos...', '442')
#1 /var/www/src/wp-includes/rest-api/class-wp-rest-request.php(930): OD_REST_URL_Metrics_Store_Endpoint::{closure}('74b5101d6b3d321...', Object(WP_REST_Request), 'hmac')
#2 /var/www/src/wp-includes/rest-api/class-wp-rest-server.php(1109): WP_REST_Request->has_valid_params()
#3 /var/www/src/wp-includes/rest-api/class-wp-rest-server.php(435): WP_REST_Server->dispatch(Object(WP_REST_Request))
#4 /var/www/src/wp-includes/rest-api.php(478): WP_REST_Server->serve_request('/optimization-d...')
#5 /var/www/src/wp-includes/class-wp-hook.php(341): rest_api_loaded(Object(WP))
#6 /var/www/src/wp-includes/class-wp-hook.php(365): WP_Hook->apply_filters('', Array)
#7 /var/www/src/wp-includes/plugin.php(570): WP_Hook->do_action(Array)
#8 /var/www/src/wp-includes/class-wp.php(418): do_action_ref_array('parse_request', Array)
#9 /var/www/src/wp-includes/class-wp.php(821): WP->parse_request('')
#10 /var/www/src/wp-includes/functions.php(1343): WP->main('')
#11 /var/www/src/wp-blog-header.php(16): wp()
#12 /var/www/src/_index.php(17): require('/var/www/src/wp...')
#13 /var/www/src/index.php(19): require_once('/var/www/src/_i...')
#14 {main}
  thrown in /var/www/src/wp-content/plugins/performance/plugins/optimization-detective/storage/data.php on line 295
```

This is fixed in 563764d. The issue is that when a `validate_callback` obtains the REST API params, no validation or sanitization is applied. So the string value is passed through. But it needs to be enforced as `int<1, max>|null`. So this is now fixed.


# AI Use

I prompted Claude to help me debug issues with `wp-env`, PHPUnit, and tests.