### PR TITLE
Fix `InvalidStateError` on bfcache navigations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,7 @@ const config = {
 			rules: {
 				'jsdoc/no-undefined-types': [
 					'error',
-					{ definedTypes: [ 'PageSwapEvent', 'PageRevealEvent' ] },
+					{ definedTypes: [ 'PageSwapEvent', 'PageRevealEvent', 'ViewTransition' ] },
 				],
 			},
 		},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,13 @@ const config = {
 			rules: {
 				'jsdoc/no-undefined-types': [
 					'error',
-					{ definedTypes: [ 'PageSwapEvent', 'PageRevealEvent', 'ViewTransition' ] },
+					{
+						definedTypes: [
+							'PageSwapEvent',
+							'PageRevealEvent',
+							'ViewTransition',
+						],
+					},
 				],
 			},
 		},

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -144,6 +144,11 @@ window.plvtInitViewTransitions = ( config ) => {
 		( /** @type {PageSwapEvent} */ event ) => {
 			if ( event.viewTransition ) {
 				const transitionType = 'default'; // Only 'default' is supported so far, but more to be added.
+				// Prevent unhandled promise rejections when the transition is already aborted (e.g. bfcache restoration).
+				const noop = () => {};
+				event.viewTransition.ready.catch( noop );
+				event.viewTransition.finished.catch( noop );
+
 				event.viewTransition.types.add( transitionType );
 
 				let viewTransitionEntries;
@@ -185,6 +190,11 @@ window.plvtInitViewTransitions = ( config ) => {
 		( /** @type {PageRevealEvent} */ event ) => {
 			if ( event.viewTransition ) {
 				const transitionType = 'default'; // Only 'default' is supported so far, but more to be added.
+				// Prevent unhandled promise rejections when the transition is already aborted (e.g. bfcache restoration).
+				const noop = () => {};
+				event.viewTransition.ready.catch( noop );
+				event.viewTransition.finished.catch( noop );
+
 				event.viewTransition.types.add( transitionType );
 
 				let viewTransitionEntries;

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -60,6 +60,23 @@ window.plvtInitViewTransitions = ( config ) => {
 	};
 
 	/**
+	 * Suppresses unhandled promise rejections on a ViewTransition.
+	 *
+	 * When a transition is already aborted (e.g. bfcache restoration), its ready
+	 * and finished promises reject. Without a rejection handler, these surface as
+	 * "Uncaught (in promise) InvalidStateError" errors.
+	 *
+	 * @since n.e.x.t
+	 *
+	 * @param {ViewTransition} viewTransition The view transition to suppress rejections for.
+	 */
+	const suppressViewTransitionRejections = ( viewTransition ) => {
+		const noop = () => {};
+		viewTransition.ready.catch( noop );
+		viewTransition.finished.catch( noop );
+	};
+
+	/**
 	 * Temporarily sets view transition names for the given entries until the view transition has been completed.
 	 *
 	 * @param {Array[]}       entries   View transition entries as received from `getViewTransitionEntries()`.
@@ -144,11 +161,7 @@ window.plvtInitViewTransitions = ( config ) => {
 		( /** @type {PageSwapEvent} */ event ) => {
 			if ( event.viewTransition ) {
 				const transitionType = 'default'; // Only 'default' is supported so far, but more to be added.
-				// Prevent unhandled promise rejections when the transition is already aborted (e.g. bfcache restoration).
-				const noop = () => {};
-				event.viewTransition.ready.catch( noop );
-				event.viewTransition.finished.catch( noop );
-
+				suppressViewTransitionRejections( event.viewTransition );
 				event.viewTransition.types.add( transitionType );
 
 				let viewTransitionEntries;
@@ -190,11 +203,7 @@ window.plvtInitViewTransitions = ( config ) => {
 		( /** @type {PageRevealEvent} */ event ) => {
 			if ( event.viewTransition ) {
 				const transitionType = 'default'; // Only 'default' is supported so far, but more to be added.
-				// Prevent unhandled promise rejections when the transition is already aborted (e.g. bfcache restoration).
-				const noop = () => {};
-				event.viewTransition.ready.catch( noop );
-				event.viewTransition.finished.catch( noop );
-
+				suppressViewTransitionRejections( event.viewTransition );
 				event.viewTransition.types.add( transitionType );
 
 				let viewTransitionEntries;


### PR DESCRIPTION
This addresses an issue reported in a [support topic](https://wordpress.org/support/topic/invalidstateerror-transition-was-aborted-because-of-invalid-state-wordpress/).

I was able to reproduce the issue when going back/forward in the browser. I'd see in the console:

> Uncaught (in promise) InvalidStateError: Transition was aborted because of invalid state

This goes away with the fix in this PR.

## Summary (via Claude Code)

Fixes `Uncaught (in promise) InvalidStateError: Transition was aborted because of invalid state` errors that occur on every back-forward cache (bfcache) navigation.

### Problem

When a user navigates back/forward and the page is restored from the bfcache, the browser still fires `pageswap` and `pagereveal` events with a `ViewTransition` object — however, the transition is immediately skipped because no old-page snapshot is available for a bfcache restoration. This causes the `ViewTransition.ready` and `ViewTransition.finished` promises to reject with an `InvalidStateError`. Since the plugin's event handlers never attached rejection handlers to these promises, the browser reports them as `Uncaught (in promise)` errors.

This was [reported](https://wordpress.org/support/topic/invalidstateerror-transition-was-aborted-because-of-invalid-state-wordpress/) as a significant uptick in Sentry errors, particularly on Chrome 146+ (mobile and desktop), affecting all pages on the site.

### Fix

In both the `pageswap` and `pagereveal` event handlers, no-op `.catch()` handlers are attached to `event.viewTransition.ready` and `event.viewTransition.finished` immediately — before any other interaction with the transition object. This marks the promises as handled, so when they reject due to an aborted transition (as happens with bfcache restorations), the browser no longer reports unhandled promise rejection errors.

The rest of the handler logic (calling `types.add()`, setting temporary view transition names) continues to work normally for regular navigations where the transition is valid.

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.

Moreover, see the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

I provided the support topic to Claude Code and it came up with the fix. No error now appears in the console for me.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
