### PR TITLE
Add explanation notice for modern image format settings

### DIFF
--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -79,7 +79,7 @@ function webp_uploads_add_media_settings_fields(): void {
 	add_settings_section(
 		'perflab_modern_image_format_settings',
 		_x( 'Modern Image Formats', 'settings page section name', 'webp-uploads' ),
-		'__return_empty_string',
+		'webp_uploads_render_settings_section_info',
 		'media',
 		array(
 			'before_section' => '<div id="modern-image-formats">',
@@ -138,6 +138,33 @@ add_action( 'admin_init', 'webp_uploads_add_media_settings_fields' );
  * Renders the settings field for the 'perflab_modern_image_format' setting.
  *
  * @since 2.0.0
+ */
+/**
+ * Render informational notice for the Modern Image Formats settings section.
+ *
+ * Explains why modern format images may not always be generated after upload.
+ */
+function webp_uploads_render_settings_section_info(): void {
+	?>
+	<div class="notice notice-info inline" style="margin:0;padding:10px 14px;">
+		<p>
+			<?php
+			echo wp_kses(
+				__( 'Modern image formats (e.g. WebP, AVIF) are only generated when they result in a smaller file than the original. If a converted image would be larger, the original is kept instead. For more details, see the <a href="https://wordpress.org/plugins/webp-uploads/#faq">FAQ</a>.', 'webp-uploads' ),
+				array(
+					'a' => array(
+						'href' => array(),
+					),
+				)
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+
+/**
+ * Callback for rendering the AVIF/WebP output format setting.
  */
 function webp_uploads_generate_avif_webp_setting_callback(): void {
 

--- a/plugins/webp-uploads/tests/test-settings.php
+++ b/plugins/webp-uploads/tests/test-settings.php
@@ -8,6 +8,18 @@
 class Test_WebP_Uploads_Settings extends WP_UnitTestCase {
 
 	/**
+	 * @covers ::webp_uploads_render_settings_section_info
+	 */
+	public function test_webp_uploads_render_settings_section_info_contains_notice(): void {
+		$output = get_echo( 'webp_uploads_render_settings_section_info' );
+
+		$this->assertStringContainsString( 'notice notice-info inline', $output );
+		$this->assertStringContainsString( 'Modern image formats', $output );
+		$this->assertStringContainsString( 'https://wordpress.org/plugins/webp-uploads/#faq', $output );
+		$this->assertStringContainsString( 'smaller file than the original', $output );
+	}
+
+	/**
 	 * @covers ::webp_uploads_add_settings_action_link
 	 */
 	public function test_webp_uploads_add_settings_action_link(): void {


### PR DESCRIPTION
### Summary

Fixes #2442

Users frequently open support topics confused about why their uploads aren't generating AVIF/WebP files. The plugin discards converted files if they're larger than the original (`webp_uploads_discard_larger_generated_images` defaults to `true`), but there was no explanation in the admin dashboard.

### Changes

- Replaced `__return_empty_string` section callback with `webp_uploads_render_settings_section_info()` which renders an informational notice in the Modern Image Formats settings section
- The notice explains why modern format images may not always be generated
- Links to the existing plugin FAQ on wordpress.org for full details
- Follows the existing `notice notice-info inline` pattern used in other setting callbacks in this file

### Screenshots

The notice appears at the top of the Modern Image Formats settings section, before the output format dropdown:

> ℹ️ Modern image formats (e.g. WebP, AVIF) are only generated when they result in a smaller file than the original. If a converted image would be larger, the original is kept instead. For more details, see the [FAQ](https://wordpress.org/plugins/webp-uploads/#faq).

### Testing

- `php -l` — no syntax errors
- `phpcs --standard=WordPress-Core` — zero violations
- `phpstan analyse` — no errors

### AI Disclosure

AI tooling (Claude) was used to assist with code generation and analysis. The code was reviewed, tested, and validated manually.