### PR TITLE
Added inline script to cleanup dominant color CSS variable on image load

### DIFF
--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -180,6 +180,35 @@ function dominant_color_add_inline_style(): void {
 add_action( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
 
 /**
+ * Add inline script to cleanup dominant color CSS variable on image load.
+ *
+ * This script removes the --dominant-color CSS variable from images after they load,
+ * preventing issues with dynamically loaded or lazily-loaded images.
+ *
+ * @since 1.2.1
+ */
+function dominant_color_add_cleanup_script(): void {
+	$script = <<<'JS'
+document.addEventListener(
+  "load",
+  (event) => {
+    if (
+      event.target instanceof HTMLImageElement &&
+      event.target.hasAttribute("data-dominant-color")
+    ) {
+      event.target.style.removeProperty("--dominant-color");
+    }
+  },
+  { capture: true },
+);
+JS;
+	wp_register_script( 'dominant-color-cleanup', false );
+	wp_enqueue_script( 'dominant-color-cleanup' );
+	wp_add_inline_script( 'dominant-color-cleanup', $script );
+}
+add_action( 'wp_enqueue_scripts', 'dominant_color_add_cleanup_script' );
+
+/**
  * Displays the HTML generator tag for the Image Placeholders plugin.
  *
  * See {@see 'wp_head'}.

--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -202,7 +202,7 @@ document.addEventListener(
   { capture: true },
 );
 JS;
-	wp_register_script( 'dominant-color-cleanup', false, array(), DOMINANT_COLOR_IMAGES_VERSION, true );
+	wp_register_script( 'dominant-color-cleanup', false, array(), null, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_script( 'dominant-color-cleanup' );
 	wp_add_inline_script( 'dominant-color-cleanup', $script );
 }

--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -202,7 +202,7 @@ document.addEventListener(
   { capture: true },
 );
 JS;
-	wp_register_script( 'dominant-color-cleanup', false );
+	wp_register_script( 'dominant-color-cleanup', false, array(), DOMINANT_COLOR_IMAGES_VERSION, true );
 	wp_enqueue_script( 'dominant-color-cleanup' );
 	wp_add_inline_script( 'dominant-color-cleanup', $script );
 }

--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -185,7 +185,7 @@ add_action( 'wp_enqueue_scripts', 'dominant_color_add_inline_style' );
  * This script removes the --dominant-color CSS variable from images after they load,
  * preventing issues with dynamically loaded or lazily-loaded images.
  *
- * @since 1.2.1
+ * @since n.e.x.t
  */
 function dominant_color_add_cleanup_script(): void {
 	$script = <<<'JS'

--- a/plugins/dominant-color-images/hooks.php
+++ b/plugins/dominant-color-images/hooks.php
@@ -202,7 +202,7 @@ document.addEventListener(
   { capture: true },
 );
 JS;
-	wp_register_script( 'dominant-color-cleanup', false, array(), null, true ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+	wp_register_script( 'dominant-color-cleanup', false, array(), null, array( 'in_footer' => true ) ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 	wp_enqueue_script( 'dominant-color-cleanup' );
 	wp_add_inline_script( 'dominant-color-cleanup', $script );
 }


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Fixes #2432 

## Changes
Added inline script to cleanup dominant color CSS variable on image load.
This script removes the --dominant-color CSS variable from images after they load,
 preventing issues with dynamically loaded or lazily-loaded images.
 
<!-- Please describe your changes. -->

## Use of AI Tools
Clude code
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.

Moreover, see the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
