### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -8,10 +8,16 @@ on:
         description: 'Plugin slug (leave empty for all plugins)'
         required: false
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   prepare-matrix:
     name: Prepare plugins matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     outputs:
       matrix: ${{ steps.set-matrix.outputs.plugins }}
     steps:
@@ -39,6 +45,8 @@ jobs:
     name: Update "Tested up to" value for ${{ matrix.plugin }}
     needs: prepare-matrix
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     env:
       PLUGIN_SLUG: ${{ matrix.plugin }}
     strategy:

--- a/.github/workflows/bump-wordpress-tested-up-to.yml
+++ b/.github/workflows/bump-wordpress-tested-up-to.yml
@@ -16,6 +16,7 @@ jobs:
   prepare-matrix:
     name: Prepare plugins matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read # Required to clone the repo.
     outputs:
@@ -45,6 +46,7 @@ jobs:
     name: Update "Tested up to" value for ${{ matrix.plugin }}
     needs: prepare-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read # Required to clone the repo.
     env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      contents: read # Required for actions/checkout to read the repository.
       security-events: write # Required to upload CodeQL results.
     steps:
       - name: Checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,7 +30,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
+      security-events: write # Required to upload CodeQL results.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,6 +29,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       security-events: write # Required to upload CodeQL results.
     steps:

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -55,7 +55,7 @@ jobs:
     name: 'Deploy Plugin: ${{ matrix.plugin }}'
     needs: pre-run
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read # Required to clone the repo.
       deployments: write # Required by bobheadxi/deployments to create and update deployments.

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -57,6 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
+      contents: read # Required to clone the repo.
       deployments: write # Required by bobheadxi/deployments to create and update deployments.
     strategy:
       matrix:

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -24,6 +24,7 @@ jobs:
   pre-run:
     name: Pre-run
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read # Required to clone the repo.
     outputs:
@@ -54,6 +55,7 @@ jobs:
     name: 'Deploy Plugin: ${{ matrix.plugin }}'
     needs: pre-run
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       deployments: write # Required by bobheadxi/deployments to create and update deployments.
     strategy:
@@ -165,6 +167,7 @@ jobs:
     name: Add release assets
     needs: [pre-run, deploy]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       actions: read   # Required to look up workflow run artifacts via the GitHub API.
       contents: write # Required by softprops/action-gh-release to upload release assets.

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -16,12 +16,16 @@ on:
         description: 'Debug mode (run without publishing).'
         default: false
 
+# Disable permissions for all available scopes.
+# Enable permissions for specific scopes as needed on job level.
 permissions: {}
 
 jobs:
   pre-run:
     name: Pre-run
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     outputs:
       matrix: ${{ steps.set-matrix.outputs.plugins }}
     steps:
@@ -51,8 +55,7 @@ jobs:
     needs: pre-run
     runs-on: ubuntu-latest
     permissions:
-      actions: write
-      deployments: write
+      deployments: write # Required by bobheadxi/deployments to create and update deployments.
     strategy:
       matrix:
         plugin: ${{ fromJSON(needs.pre-run.outputs.matrix) }}
@@ -163,8 +166,8 @@ jobs:
     needs: [pre-run, deploy]
     runs-on: ubuntu-latest
     permissions:
-      actions: read
-      contents: write
+      actions: read   # Required to look up workflow run artifacts via the GitHub API.
+      contents: write # Required by softprops/action-gh-release to upload release assets.
     if: github.event_name == 'release'
     strategy:
       matrix:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,11 +26,17 @@ on:
       - reopened
       - synchronize
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   e2e-test:
     name: E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -31,11 +31,18 @@ on:
       - reopened
       - synchronize
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   js-lint:
     name: JS Lint
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
+      actions: write # Required by styfle/cancel-workflow-action to cancel prior runs.
     steps:
       - uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -27,11 +27,18 @@ on:
       - reopened
       - synchronize
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   php-lint:
     name: PHP
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
+      actions: write # Required by styfle/cancel-workflow-action to cancel prior runs.
     steps:
       - uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -31,11 +31,18 @@ on:
       - reopened
       - synchronize
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   php-test-plugins:
     name: 'PHP ${{ matrix.php }} / WP ${{ matrix.wp }}'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
+      actions: write # Required by styfle/cancel-workflow-action to cancel prior runs.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -143,8 +143,7 @@ jobs:
     if: needs.prepare-matrix.result == 'success' && needs.prepare-matrix.outputs.plugins != '[]'
     name: Check ${{ matrix.plugin }}
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read # Required for actions/download-artifact to download workflow artifacts.
+    permissions: {}
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -27,6 +27,7 @@ jobs:
   detect-changes:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    timeout-minutes: 20
     permissions:
       contents: read       # Required to clone the repo.
       pull-requests: read  # Required by dorny/paths-filter to read PR file changes.
@@ -74,6 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     # Always run this job, even if detect-changes was skipped
     if: always() && (needs.detect-changes.result == 'success' || needs.detect-changes.result == 'skipped')
+    timeout-minutes: 20
     permissions:
       contents: read # Required to clone the repo.
     outputs:
@@ -142,7 +144,7 @@ jobs:
     name: Check ${{ matrix.plugin }}
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      contents: read # Required for actions/download-artifact to download workflow artifacts.
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -28,8 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read       # Required to clone the repo.
+      pull-requests: read  # Required by dorny/paths-filter to read PR file changes.
     outputs:
       changed-plugins: ${{ steps.filter-plugins.outputs.changed-plugins }}
     steps:
@@ -75,7 +75,7 @@ jobs:
     # Always run this job, even if detect-changes was skipped
     if: always() && (needs.detect-changes.result == 'success' || needs.detect-changes.result == 'skipped')
     permissions:
-      contents: read
+      contents: read # Required to clone the repo.
     outputs:
       plugins: ${{ steps.set-matrix.outputs.plugins }}
     steps:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,16 +19,22 @@ on:
 env:
   LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   check-type-label:
     name: Check [Type] Label
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - if: contains( env.LABELS, '[Type]' ) == false
         run: exit 1
   check-milestone:
     name: Check Milestone
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no milestone' ) == false
         run: exit 1

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -27,6 +27,7 @@ jobs:
   check-type-label:
     name: Check [Type] Label
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}
     steps:
       - if: contains( env.LABELS, '[Type]' ) == false
@@ -34,6 +35,7 @@ jobs:
   check-milestone:
     name: Check Milestone
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions: {}
     steps:
       - if: github.event.pull_request.milestone == null && contains( env.LABELS, 'no milestone' ) == false

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -50,9 +50,8 @@ jobs:
     name: Generate a list of props
     runs-on: ubuntu-latest
     permissions:
-      # The action needs permission `write` permission for PRs in order to add a comment.
-      pull-requests: write
-      contents: read
+      pull-requests: write # Required by WordPress/props-bot-action to post the props comment on the PR.
+      contents: read       # Required to clone the repo.
     timeout-minutes: 20
     # The job will run when pull requests are open, ready for review and:
     #

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -10,6 +10,7 @@ jobs:
   spell-checker:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read # Required to clone the repo.
     steps:

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -2,10 +2,16 @@ name: Spell Check
 
 on: [pull_request]
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   spell-checker:
     name: Spell Check with Typos
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Search for misspellings


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/performance/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Claude Code was used to create the initial changes. All permissions and timeouts changes were reviewed and adjusted by me where necessary.
