### PR TITLE
Infrastructure: Replace styfle/cancel-workflow-action with native concurrency

### DIFF
--- a/.github/workflows/js-lint.yml
+++ b/.github/workflows/js-lint.yml
@@ -31,6 +31,13 @@ on:
       - reopened
       - synchronize
 
+# Cancel previous workflow run groups that have not completed.
+concurrency:
+  # Group workflow runs by workflow name, along with the head branch ref of the pull request
+  # or otherwise the branch or tag ref.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
@@ -42,9 +49,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read # Required to clone the repo.
-      actions: write # Required by styfle/cancel-workflow-action to cancel prior runs.
     steps:
-      - uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js (via .nvmrc)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/php-lint.yml
+++ b/.github/workflows/php-lint.yml
@@ -27,6 +27,13 @@ on:
       - reopened
       - synchronize
 
+# Cancel previous workflow run groups that have not completed.
+concurrency:
+  # Group workflow runs by workflow name, along with the head branch ref of the pull request
+  # or otherwise the branch or tag ref.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
@@ -38,9 +45,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read # Required to clone the repo.
-      actions: write # Required by styfle/cancel-workflow-action to cancel prior runs.
     steps:
-      - uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:

--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -31,6 +31,13 @@ on:
       - reopened
       - synchronize
 
+# Cancel previous workflow run groups that have not completed.
+concurrency:
+  # Group workflow runs by workflow name, along with the head branch ref of the pull request
+  # or otherwise the branch or tag ref.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
@@ -42,7 +49,6 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read # Required to clone the repo.
-      actions: write # Required by styfle/cancel-workflow-action to cancel prior runs.
     strategy:
       fail-fast: false
       matrix:
@@ -66,7 +72,6 @@ jobs:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
       WP_ENV_CORE: ${{ matrix.wp == 'trunk' && 'WordPress/WordPress' || format( 'https://wordpress.org/wordpress-{0}.zip', matrix.wp ) }}
     steps:
-      - uses: styfle/cancel-workflow-action@d07a454dad7609a92316b57b23c9ccfd4f59af66 # 0.13.1
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node.js (.nvmrc)
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
## Summary

- Replaces `styfle/cancel-workflow-action` with GitHub Actions' built-in `concurrency` feature in `php-lint.yml`, `php-test-plugins.yml`, and `js-lint.yml`.
- Drops the `actions: write` permission those jobs needed only for the third-party action.
- Concurrency group pattern matches the existing one in `.github/workflows/codeql-analysis.yml`.

Follows up on @thelovekesh's review feedback in https://github.com/WordPress/performance/pull/2471#discussion_r3235042781.

## Test plan

- [ ] Push a follow-up commit to this PR and verify the prior in-progress workflow run is cancelled (visible in the Actions tab).
- [ ] Confirm the three workflows still complete successfully on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)