### PR TITLE
Add .npmrc to harden npm install against supply-chain risk

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# Block lifecycle scripts (preinstall/install/postinstall/prepare) from
+# dependencies. Mitigates supply-chain attacks that rely on install scripts.
+# Note: this also skips this project's own `prepare` script, so the husky
+# git hooks must be installed manually (see CONTRIBUTING.md).
+ignore-scripts = true
+
+# Refuse to install package versions younger than this many days. Mitigates
+# fast-pulled malicious releases. Requires npm >= 11; uncomment once the
+# project's minimum npm version (and/or .nvmrc Node version) is raised to
+# ship npm 11+ by default.
+# See https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
+# min-release-age = 7
+
+# Pin exact versions when installing new packages instead of using ^/~ ranges.
+save-exact = true
+
+# WordPress ecosystem defaults (matching wordpress-develop and Gutenberg).
+engine-strict = true
+legacy-peer-deps = true
+lockfile-version = 3
+prefer-dedupe = true

--- a/.npmrc
+++ b/.npmrc
@@ -20,6 +20,7 @@ save-exact = true
 # enabling this breaks on lint-staged@17, which requires Node >= 22.22.1.
 # engine-strict = true
 
-# WordPress ecosystem defaults (matching wordpress-develop and Gutenberg).
+# WordPress ecosystem defaults (matching wordpress-develop and Gutenberg),
+# except for the unnecessary `legacy-peer-deps = true`.
 lockfile-version = 3
 prefer-dedupe = true

--- a/.npmrc
+++ b/.npmrc
@@ -21,6 +21,5 @@ save-exact = true
 # engine-strict = true
 
 # WordPress ecosystem defaults (matching wordpress-develop and Gutenberg).
-legacy-peer-deps = true
 lockfile-version = 3
 prefer-dedupe = true

--- a/.npmrc
+++ b/.npmrc
@@ -14,8 +14,13 @@ ignore-scripts = true
 # Pin exact versions when installing new packages instead of using ^/~ ranges.
 save-exact = true
 
+# Hard-enforce the `engines` field in package.json so contributors and CI
+# fail fast on too-old Node/npm. Uncomment once the project's minimum Node
+# version is raised; with the current floor (`engines.node >= 20.19.0`),
+# enabling this breaks on lint-staged@17, which requires Node >= 22.22.1.
+# engine-strict = true
+
 # WordPress ecosystem defaults (matching wordpress-develop and Gutenberg).
-engine-strict = true
 legacy-peer-deps = true
 lockfile-version = 3
 prefer-dedupe = true


### PR DESCRIPTION
## Summary

<!-- No specific issue; opening as a hardening change. -->

Adds an `.npmrc` to the Performance repo to harden `npm install` against supply-chain attacks and to align with the rest of the WordPress ecosystem.

Sister PRs in adjacent WordPress projects:

- WordPress/gutenberg#78191 — adds `min-release-age = 1` to Gutenberg's `.npmrc`.
- WordPress/ai#535 — adds an `.npmrc` to the WordPress AI repo, bumps Node to 24 / npm to 11, and sets `min-release-age` for the same reason.

## Relevant technical choices

### Supply-chain hardening (new to the WordPress ecosystem in this repo)

- **`ignore-scripts = true`** — blocks `preinstall` / `install` / `postinstall` lifecycle scripts in dependencies. This is the main entry point exploited by recent npm supply-chain attacks (malicious package executes arbitrary code at install time). Neither `wordpress-develop` nor `gutenberg` set this today; this repo goes one step further.
  - Side effect: it also disables this repo's *own* `prepare` script (which sets up husky). Contributors must now run `npm run prepare` once after `npm install` to wire up the git hooks. This is documented in the Performance Lab section of the WordPress Performance Team Handbook.
- **`min-release-age = 7`** — commented out for now. Refuses to install packages released within the last 7 days, mitigating fast-pulled malicious releases (similar to the Gutenberg change in WordPress/gutenberg#78191, but at 7 days vs. Gutenberg's 1 day). Requires npm ≥ 11; left commented until the project's minimum npm version is raised (the WordPress/ai sister PR raised Node to 24 / npm to 11 for this same reason — we can follow when ready).

### Alignment with `wordpress-develop` and `gutenberg`

Adds the standard set already present in both [`wordpress-develop/.npmrc`](https://github.com/WordPress/wordpress-develop/blob/trunk/.npmrc) and [`gutenberg/.npmrc`](https://github.com/WordPress/gutenberg/blob/trunk/.npmrc):

- ~**`engine-strict = true`** — enforces the existing `engines` field in `package.json` (Node ≥ 20.19.0, npm ≥ 10.2.3). Without this, npm only emits a warning, which contributors routinely miss. Also a prerequisite for cleanly enabling `min-release-age` later. (Originally introduced in Gutenberg in WordPress/gutenberg#23600.)~ Commented out per 3484824.
- **`lockfile-version = 3`** — pins the lockfile format so contributors on differing npm versions don't accidentally regenerate it in an older format. Likely a no-op for current contributors on npm 10+, but worth locking in. (Introduced in Gutenberg in WordPress/gutenberg#65923.)
- **`prefer-dedupe = true`** — tells `npm install` to deduplicate rather than nest when adding new deps. Smaller `node_modules`, marginally more reproducible installs. (Introduced in Gutenberg in WordPress/gutenberg#61630.)
- **`legacy-peer-deps = true`** — restores npm 6-style peer-dep behavior. The `@wordpress/*` peer-dep graph clashes with npm 7+ strict resolution; both `wordpress-develop` and `gutenberg` use this setting. Adding it preemptively for consistency.
- **`save-exact = true`** — pins exact versions when contributors run `npm install <pkg>`. Existing `^`/`~` ranges in `package.json` aren't rewritten — they'll converge over time as deps are added/updated by contributors. (Dependabot preserves whatever prefix is already on each line, so this doesn't retroactively pin existing entries; the `package-lock.json` is what actually enforces reproducibility at install time.)

### Why the existing `package-lock.json` isn't enough

The lockfile already pins the full transitive tree at install time, so most of these settings (`save-exact`, `prefer-dedupe`, `lockfile-version`) are defense-in-depth / hygiene rather than primary defenses. The two settings that meaningfully change the security posture are `ignore-scripts` (blocks the install-script attack vector) and the future `min-release-age` (blocks freshly-published malicious releases before they're pulled). The rest aligns this repo with the rest of WordPress.

## Use of AI Tools

Wrote the `.npmrc` and this PR description in collaboration with Claude Code (Opus 4.7). All technical choices were reviewed and decided by me; the diff is small and I verified each setting against npm docs and the upstream `.npmrc` files in `wordpress-develop` and `gutenberg`.