### PR TITLE
Performance Lab: Show filesystem credentials modal on plugin install

### DIFF
--- a/plugins/performance-lab/includes/admin/load.php
+++ b/plugins/performance-lab/includes/admin/load.php
@@ -53,6 +53,31 @@ function perflab_load_features_page(): void {
 
 	// Handle style for settings page.
 	add_action( 'admin_head', 'perflab_print_features_page_style' );
+
+	// Print the filesystem credentials modal in the footer so the activation
+	// flow can surface it when FS_METHOD is not 'direct'.
+	add_action( 'admin_footer', 'perflab_print_filesystem_credentials_modal' );
+}
+
+/**
+ * Prints the filesystem credentials modal on the Performance Features screen.
+ *
+ * When `FS_METHOD` is anything other than 'direct' and FTP/SSH credentials
+ * have not been stored, `Plugin_Upgrader::install()` returns false without
+ * raising a WP_Error, so the REST activation endpoint falls through with a
+ * generic `plugin_not_found` response and the click appears to do nothing.
+ * Mirroring the markup that Plugins > Add Plugin already provides lets the
+ * activation JS fall back to `wp.updates.installPlugin()` to surface the
+ * standard "Connection Information" dialog.
+ *
+ * @since n.e.x.t
+ */
+function perflab_print_filesystem_credentials_modal(): void {
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+	require_once ABSPATH . 'wp-admin/includes/template.php';
+
+	wp_print_request_filesystem_credentials_modal();
+	wp_print_admin_notice_templates();
 }
 
 /**
@@ -401,6 +426,10 @@ function perflab_enqueue_features_page_scripts(): void {
 	wp_enqueue_style( 'thickbox' );
 	wp_enqueue_script( 'plugin-install' );
 
+	// Needed for the filesystem credentials modal fallback when FS_METHOD is
+	// not 'direct'. See perflab_print_filesystem_credentials_modal().
+	wp_enqueue_script( 'updates' );
+
 	// Enqueue plugin activate AJAX script and localize script data.
 	wp_enqueue_script(
 		'perflab-plugin-activate-ajax',
@@ -409,6 +438,46 @@ function perflab_enqueue_features_page_scripts(): void {
 		PERFLAB_VERSION,
 		true
 	);
+
+	wp_add_inline_script(
+		'perflab-plugin-activate-ajax',
+		sprintf(
+			'window.perflabPluginActivate = %s;',
+			wp_json_encode(
+				array(
+					'filesystemCredentialsRequired' => perflab_filesystem_credentials_required(),
+				)
+			)
+		),
+		'before'
+	);
+}
+
+/**
+ * Determines whether the current request needs filesystem credentials in
+ * order to install a plugin.
+ *
+ * Returns true when `get_filesystem_method()` is not 'direct' and FTP/SSH
+ * credentials have not yet been stored via {@see request_filesystem_credentials()}.
+ * The activation JS uses this flag to route through `wp.updates.installPlugin()`
+ * for the standard credentials prompt.
+ *
+ * @since n.e.x.t
+ *
+ * @return bool Whether filesystem credentials are required.
+ */
+function perflab_filesystem_credentials_required(): bool {
+	require_once ABSPATH . 'wp-admin/includes/file.php';
+
+	if ( 'direct' === get_filesystem_method() ) {
+		return false;
+	}
+
+	ob_start();
+	$stored = request_filesystem_credentials( self_admin_url() );
+	ob_end_clean();
+
+	return false === $stored;
 }
 
 /**

--- a/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
+++ b/plugins/performance-lab/includes/admin/plugin-activate-ajax.js
@@ -7,10 +7,88 @@
 	const { i18n, a11y, apiFetch } = wp;
 	const { __ } = i18n;
 
+	// Whether the current request needs FTP/SSH credentials before the
+	// plugin can be installed. Set from PHP via wp_add_inline_script().
+	const filesystemCredentialsRequired = Boolean(
+		// @ts-ignore
+		window.perflabPluginActivate?.filesystemCredentialsRequired
+	);
+
 	// Queue to hold pending activation requests.
 	/** @type {{target: HTMLElement, pluginSlug: string}[]} */
 	const activationQueue = [];
 	let isProcessingActivation = false;
+
+	/**
+	 * Installs a plugin via wp.updates.installPlugin() so the standard
+	 * "Connection Information" modal handles the FTP/SSH credentials flow.
+	 *
+	 * Resolves with a status describing the outcome:
+	 *   - 'installed': the plugin was written to disk.
+	 *   - 'canceled': the user closed the credentials modal.
+	 * Rejects only on a genuine install failure (e.g. download error or
+	 * wp.updates not being available on the page).
+	 *
+	 * @param {string} slug Plugin slug.
+	 * @return {Promise<'installed' | 'canceled'>} Outcome of the install.
+	 */
+	function installPluginViaWpUpdates( slug ) {
+		return new Promise( ( resolve, reject ) => {
+			// @ts-ignore
+			const updates = window.wp?.updates;
+			// @ts-ignore
+			const $ = window.jQuery;
+			if ( ! updates?.installPlugin || ! $ ) {
+				reject(
+					new Error( 'wp.updates.installPlugin is not available.' )
+				);
+				return;
+			}
+
+			const cleanup = () => {
+				$( document ).off( 'wp-plugin-install-success', onSuccess );
+				$( document ).off( 'wp-plugin-install-error', onError );
+				$( document ).off( 'credential-modal-cancel', onCancel );
+			};
+
+			/**
+			 * @param {unknown}        _event
+			 * @param {{slug: string}} response
+			 */
+			const onSuccess = ( _event, response ) => {
+				if ( response.slug !== slug ) {
+					return;
+				}
+				cleanup();
+				resolve( 'installed' );
+			};
+
+			/**
+			 * @param {unknown}                               _event
+			 * @param {{slug: string, errorMessage?: string}} response
+			 */
+			const onError = ( _event, response ) => {
+				if ( response.slug !== slug ) {
+					return;
+				}
+				cleanup();
+				reject(
+					new Error( response.errorMessage || 'Install failed.' )
+				);
+			};
+
+			const onCancel = () => {
+				cleanup();
+				resolve( 'canceled' );
+			};
+
+			$( document ).on( 'wp-plugin-install-success', onSuccess );
+			$( document ).on( 'wp-plugin-install-error', onError );
+			$( document ).on( 'credential-modal-cancel', onCancel );
+
+			updates.installPlugin( { slug } );
+		} );
+	}
 
 	/**
 	 * Enqueues plugin activation requests and starts processing if not already in progress.
@@ -63,6 +141,21 @@
 		a11y.speak( __( 'Activating…', 'performance-lab' ) );
 
 		try {
+			// When the filesystem method is not 'direct' and credentials
+			// have not been stored, the REST endpoint silently fails to
+			// install the plugin. Route the install through wp.updates so
+			// the standard "Connection Information" modal handles credential
+			// entry, then let the REST endpoint perform the activation step
+			// (which no longer needs filesystem access).
+			if ( filesystemCredentialsRequired ) {
+				const outcome = await installPluginViaWpUpdates( pluginSlug );
+				if ( 'canceled' === outcome ) {
+					target.classList.remove( 'updating-message' );
+					target.textContent = __( 'Activate', 'performance-lab' );
+					return;
+				}
+			}
+
 			// Activate the plugin/feature via the REST API.
 			await apiFetch( {
 				path: `/performance-lab/v1/features/${ pluginSlug }:activate`,

--- a/plugins/performance-lab/tests/includes/admin/test-load.php
+++ b/plugins/performance-lab/tests/includes/admin/test-load.php
@@ -280,4 +280,133 @@ class Test_Admin_Load extends WP_UnitTestCase {
 	public function test_perflab_sanitize_plugin_slug( $slug, ?string $expected ): void {
 		$this->assertSame( $expected, perflab_sanitize_plugin_slug( $slug ) );
 	}
+
+	/**
+	 * @covers ::perflab_load_features_page
+	 */
+	public function test_perflab_load_features_page_registers_filesystem_credentials_modal(): void {
+		remove_all_actions( 'admin_footer' );
+
+		perflab_load_features_page();
+
+		$this->assertSame(
+			10,
+			has_action( 'admin_footer', 'perflab_print_filesystem_credentials_modal' )
+		);
+		$this->assertSame(
+			10,
+			has_action( 'admin_enqueue_scripts', 'perflab_enqueue_features_page_scripts' )
+		);
+	}
+
+	/**
+	 * @covers ::perflab_enqueue_features_page_scripts
+	 */
+	public function test_perflab_enqueue_features_page_scripts_enqueues_updates_and_inline_data(): void {
+		// Ensure get_filesystem_method() is 'direct' so the inline data is deterministic.
+		add_filter(
+			'filesystem_method',
+			static function (): string {
+				return 'direct';
+			}
+		);
+
+		set_current_screen( 'options-general' );
+
+		perflab_enqueue_features_page_scripts();
+
+		$this->assertTrue( wp_script_is( 'updates', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'perflab-plugin-activate-ajax', 'enqueued' ) );
+
+		$inline = wp_scripts()->get_inline_script_data( 'perflab-plugin-activate-ajax', 'before' );
+		$this->assertStringContainsString( 'window.perflabPluginActivate', $inline );
+		$this->assertStringContainsString( '"filesystemCredentialsRequired":false', $inline );
+	}
+
+	/**
+	 * @covers ::perflab_filesystem_credentials_required
+	 */
+	public function test_perflab_filesystem_credentials_required_is_false_for_direct_method(): void {
+		add_filter(
+			'filesystem_method',
+			static function (): string {
+				return 'direct';
+			}
+		);
+
+		$this->assertFalse( perflab_filesystem_credentials_required() );
+	}
+
+	/**
+	 * @covers ::perflab_filesystem_credentials_required
+	 */
+	public function test_perflab_filesystem_credentials_required_is_true_when_credentials_missing(): void {
+		add_filter(
+			'filesystem_method',
+			static function (): string {
+				return 'ftpext';
+			}
+		);
+
+		// No FTP constants/credentials are available, so request_filesystem_credentials() returns false.
+		$this->assertTrue( perflab_filesystem_credentials_required() );
+	}
+
+	/**
+	 * @covers ::perflab_filesystem_credentials_required
+	 */
+	public function test_perflab_filesystem_credentials_required_is_false_when_credentials_stored(): void {
+		add_filter(
+			'filesystem_method',
+			static function (): string {
+				return 'ftpext';
+			}
+		);
+
+		// Simulate stored/available credentials by short-circuiting request_filesystem_credentials().
+		add_filter(
+			'request_filesystem_credentials',
+			static function () {
+				return array(
+					'hostname' => 'example.com',
+					'username' => 'user',
+					'password' => 'pass',
+				);
+			}
+		);
+
+		$this->assertFalse( perflab_filesystem_credentials_required() );
+	}
+
+	/**
+	 * @covers ::perflab_print_filesystem_credentials_modal
+	 */
+	public function test_perflab_print_filesystem_credentials_modal_prints_nothing_for_direct_method(): void {
+		add_filter(
+			'filesystem_method',
+			static function (): string {
+				return 'direct';
+			}
+		);
+
+		$output = get_echo( 'perflab_print_filesystem_credentials_modal' );
+
+		$this->assertStringNotContainsString( 'id="request-filesystem-credentials-dialog"', $output );
+	}
+
+	/**
+	 * @covers ::perflab_print_filesystem_credentials_modal
+	 */
+	public function test_perflab_print_filesystem_credentials_modal_prints_dialog_when_credentials_required(): void {
+		add_filter(
+			'filesystem_method',
+			static function (): string {
+				return 'ftpext';
+			}
+		);
+
+		$output = get_echo( 'perflab_print_filesystem_credentials_modal' );
+
+		$this->assertStringContainsString( 'id="request-filesystem-credentials-dialog"', $output );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the Performance Features install/activate flow when `FS_METHOD` is not `direct` — for example, `ftpext` / `ftpsockets`.

To reproduce on `trunk`: with `define( 'FS_METHOD', 'ftpsockets' );` in `wp-config.php`, visit Settings → Performance and click **Activate** on a not-yet-installed feature plugin (e.g. Performant Translations). The click appears to do nothing — the button briefly says "Activating…" and then reverts. Under the hood `POST /wp-json/performance-lab/v1/features/{slug}:activate` returns 404 `plugin_not_found`. The chain of failures is silent:

1. `Plugin_Upgrader::install()` calls `WP_Upgrader::fs_connect()`, which calls `request_filesystem_credentials( false, … )` — that returns `false` when credentials aren't available.
2. `fs_connect()` then returns `false` without populating `$skin->errors`, so `Plugin_Upgrader::install()` returns `false` (not a `WP_Error`).
3. `perflab_install_and_activate_plugin()` falls through all of its `is_wp_error` / `$skin->get_errors()->has_errors()` checks, then hits the `get_plugins( '/' . $plugin_slug )` empty check and returns the misleading `plugin_not_found` error.

Plugins > Add Plugin handles the same case by displaying the standard "Connection Information" modal. This PR mirrors that flow on the Performance Features screen.

This is the Performance Lab adaptation of the same fix made for the Connectors screen in Gutenberg in [WordPress/gutenberg#78367](https://github.com/WordPress/gutenberg/pull/78367) (for Core-65223).

## Changes

- **`plugins/performance-lab/includes/admin/load.php`**
  - `perflab_load_features_page()` registers an `admin_footer` action to print the standard filesystem credentials modal.
  - `perflab_enqueue_features_page_scripts()` enqueues the `updates` script and uses `wp_add_inline_script` (printed `'before'` the activation handler) to expose `window.perflabPluginActivate.filesystemCredentialsRequired`.
  - New `perflab_filesystem_credentials_required()` helper returns true when `get_filesystem_method() !== 'direct'` and `request_filesystem_credentials( self_admin_url() )` is `false`.

- **`plugins/performance-lab/includes/admin/plugin-activate-ajax.js`**
  - When `filesystemCredentialsRequired` is true, the install is routed through a new `installPluginViaWpUpdates()` helper that wraps `wp.updates.installPlugin()` and resolves with `'installed' | 'canceled'`. Cancellation is a normal control-flow outcome of the promise — not an error message string — so the caller branches on the discriminated return value, not on `error.message`.
  - Real install failures (download error, missing `wp.updates`, etc.) still reject and flow through the existing `} catch {` path unchanged.
  - After the install succeeds, the existing REST `:activate` call performs the activation step (which no longer needs filesystem access).

The `plugin-activate-ajax.min.js` is generated by `npm run build:plugin:performance-lab` and is gitignored, so it isn't part of the diff.

## Test plan

- [ ] In `wp-config.php`, set `define( 'FS_METHOD', 'ftpsockets' );` (or `'ftpext'`). See [Trac comment](https://core.trac.wordpress.org/ticket/65223#comment:4) for how to set this up.
- [ ] Have an FTP/SSH server reachable with credentials you know.
- [ ] Make sure `performant-translations` is not installed, then visit Settings → Performance.
- [ ] Click **Activate** on Performant Translations. Confirm the standard **Connection Information** modal opens (matching Plugins > Add Plugin).
- [ ] Enter valid FTP credentials and click **Proceed**. Confirm the plugin installs, activates, and the button flips to **Active**.
- [ ] Re-test with invalid credentials — the modal shows the standard error and stays open.
- [ ] Re-test by **cancelling** the modal — the button reverts to **Activate** with no error snackbar.
- [ ] Re-test on a `direct` filesystem environment — the install proceeds via REST as before, no modal.
- [ ] Re-test activating an already-installed feature plugin — the FS modal is skipped (no install needed) and the existing REST activate runs as before.

## How AI was used

This fix was implemented with Claude Code as an adaptation of the Connectors-screen fix made for Gutenberg in https://github.com/WordPress/gutenberg/pull/78367.

The Performance Lab work was kicked off with this prompt:

> ok, excellent. Now, let's shift gears and implement the same fix for the Performance Lab plugin. You can reproduce this by going to <http://localhost:8000/wp-admin/options-general.php?page=performance-lab> in Chrome and attempting to install the "Performant Translations" plugin. You'll see that upon clicking "Activate" (which normally installs behind the scenes) actually results in nothing happening, while the REST API responses have errors behind the scenes. The repo you'll be working with here is at src/wp-content/plugins/performance

Summary of the conversation that followed:

1. **Investigation.** Traced `plugin-activate-ajax.js` → `POST /performance-lab/v1/features/{slug}:activate` → `perflab_install_and_activate_plugin()` → `Plugin_Upgrader::install()`. Confirmed via `WP_Upgrader::fs_connect()` that the upgrader silently returns `false` when filesystem credentials are missing, with no error set on the skin — which is why the helper falls through to the `plugin_not_found` branch.
2. **Reproduction.** Clicked Activate on Performant Translations under `FS_METHOD=ftpsockets` and captured the `POST … 404 {"code":"plugin_not_found",…}` response confirming the silent failure mode.
3. **Implementation.** Mirrored the Gutenberg/Connectors approach: enqueue `wp.updates` and print the standard credentials modal on the Performance Features page; pass a `filesystemCredentialsRequired` flag from PHP via `wp_add_inline_script`; have the activation JS route through `wp.updates.installPlugin()` first when that flag is set, then continue to the existing REST `:activate` call.
4. **Design feedback round.** Initial draft signaled "user cancelled" by rejecting with `new Error( 'Filesystem credentials request canceled.' )` and matching the message string at the call site. Reviewer flagged this as brittle. Redesigned `installPluginViaWpUpdates()` to resolve with the discriminated string `'installed' | 'canceled'` instead — cancel is a normal resolved value, real errors still reject. Documented the return type via JSDoc.
5. **Static analysis fixes.** PHPStan flagged `empty( $stored )` (forbidden by the project's rule level); replaced with `false === $stored`. ESLint required JSDoc alignment fixes, auto-applied. PHPCS and TypeScript checks clean.
6. **Verification.** Rebuilt the min.js with `npm run build:plugin:performance-lab`. (First in-browser test ran the old cached JS; a hard reload picked up the new build.) Clicked Activate, FTP modal opened, entered valid credentials, plugin installed via FTP and activated, button flipped to **Active**. Verified `wp plugin status performant-translations` returned `Status: Active`. Cleaned up by deleting the test install and the `ftp_credentials` option.

### Relationship to the Gutenberg PR's review feedback

This PR is a sibling of [WordPress/gutenberg#78367](https://github.com/WordPress/gutenberg/pull/78367), which received Copilot review feedback after this implementation was written. Because the Performance Lab work post-dated (and learned from) that review, the corrected patterns were applied here from the start — no follow-up changes are needed:

- **`.on()` not `.one()` for the install handlers** — `installPluginViaWpUpdates()` registers `wp-plugin-install-success`/`-error`/`credential-modal-cancel` with `.on()` + an explicit slug-filtered `cleanup()`, so a concurrent install of a different plugin can't consume a one-shot handler and strand the promise. (Gutenberg fix: [discussion_r3250956734](https://github.com/WordPress/gutenberg/pull/78367#discussion_r3250956734).)
- **Cancel as a discriminated outcome, not an error-message string** — resolves `'installed' | 'canceled'` rather than throwing/matching a hard-coded message. (Gutenberg fix: [discussion_r3250956865](https://github.com/WordPress/gutenberg/pull/78367#discussion_r3250956865).)
- **No `empty()`** — uses `false === $stored` to satisfy this repo's PHPStan rule level.
- The Gutenberg `pluginBasename` activation note ([discussion_r3250928328](https://github.com/WordPress/gutenberg/pull/78367#discussion_r3250928328)) does not apply here: Performance Lab activates via its own slug-based `POST /performance-lab/v1/features/{slug}:activate` endpoint, not the core `/wp/v2/plugins` path.
