### PR TITLE
webp-uploads: Link to FAQ from Modern Image Formats settings section

### DIFF
--- a/plugins/webp-uploads/settings.php
+++ b/plugins/webp-uploads/settings.php
@@ -71,6 +71,25 @@ function webp_uploads_register_media_settings_field(): void {
 add_action( 'init', 'webp_uploads_register_media_settings_field' );
 
 /**
+ * Renders the description for the Modern Image Formats settings section.
+ *
+ * @since n.e.x.t
+ */
+function webp_uploads_modern_image_formats_section_callback(): void {
+	printf(
+		'<p class="description">%s</p>',
+		wp_kses(
+			sprintf(
+				/* translators: %s: URL to the plugin FAQ. */
+				__( 'If converted images are not appearing as expected after upload, refer to the <a href="%s">FAQ</a> for common reasons why.', 'webp-uploads' ),
+				'https://wordpress.org/plugins/webp-uploads/#faq'
+			),
+			array( 'a' => array( 'href' => array() ) )
+		)
+	);
+}
+
+/**
  * Adds media settings field for the 'perflab_generate_webp_and_jpeg' setting.
  *
  * @since 1.0.0
@@ -79,7 +98,7 @@ function webp_uploads_add_media_settings_fields(): void {
 	add_settings_section(
 		'perflab_modern_image_format_settings',
 		_x( 'Modern Image Formats', 'settings page section name', 'webp-uploads' ),
-		'__return_empty_string',
+		'webp_uploads_modern_image_formats_section_callback',
 		'media',
 		array(
 			'before_section' => '<div id="modern-image-formats">',

--- a/plugins/webp-uploads/tests/test-settings.php
+++ b/plugins/webp-uploads/tests/test-settings.php
@@ -8,6 +8,18 @@
 class Test_WebP_Uploads_Settings extends WP_UnitTestCase {
 
 	/**
+	 * @covers ::webp_uploads_modern_image_formats_section_callback
+	 */
+	public function test_webp_uploads_modern_image_formats_section_callback(): void {
+		ob_start();
+		webp_uploads_modern_image_formats_section_callback();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'https://wordpress.org/plugins/webp-uploads/#faq', $output );
+		$this->assertStringContainsString( '<p class="description">', $output );
+	}
+
+	/**
 	 * @covers ::webp_uploads_add_settings_action_link
 	 */
 	public function test_webp_uploads_add_settings_action_link(): void {


### PR DESCRIPTION
## Summary

Fixes #2442.

Adds a description paragraph to the Modern Image Formats settings section that links to the FAQ on WordPress.org, so users can find an explanation for why converted images may not appear after upload without leaving the admin dashboard.

## Relevant technical choices

The FAQ in `readme.txt` already covers the two main reasons images aren't converted (converted file is larger than the original; image was not uploaded via the Media Library). Rather than duplicating that text, this links to it from the settings section.

`__return_empty_string` for the section callback is replaced with a named `webp_uploads_modern_image_formats_section_callback()` function (following the pattern used in `speculation-rules/settings.php`). A unit test is added to assert the output contains the FAQ URL and wrapper element.

## Use of AI Tools

This PR was authored with Claude Code (Anthropic). Claude wrote the code and opened the PR. I reviewed the diff, the issue discussion, the PR template, and the CONTRIBUTING.md requirements before approving.