### PR TITLE
Use wp_template_enhancement_output_buffer hook when available.

### DIFF
--- a/plugins/optimization-detective/hooks.php
+++ b/plugins/optimization-detective/hooks.php
@@ -18,7 +18,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 // @codeCoverageIgnoreStart
 add_action( 'init', 'od_initialize_extensions', PHP_INT_MAX );
-add_filter( 'template_include', 'od_buffer_output', PHP_INT_MAX );
+
+// Backward compatibility with WP<6.9.
+if ( ! function_exists( 'wp_start_template_enhancement_output_buffer' ) ) {
+	add_filter( 'template_include', 'od_buffer_output', PHP_INT_MAX );
+}
+
 OD_URL_Metrics_Post_Type::add_hooks();
 OD_Storage_Lock::add_hooks();
 add_action( 'wp', 'od_maybe_add_template_output_buffer_filter' );

--- a/plugins/optimization-detective/optimization.php
+++ b/plugins/optimization-detective/optimization.php
@@ -106,7 +106,13 @@ function od_maybe_add_template_output_buffer_filter(): void {
 	) {
 		$callback = perflab_wrap_server_timing( $callback, 'optimization-detective', 'exist' );
 	}
-	add_filter( 'od_template_output_buffer', $callback );
+
+	// Backward compatibility with WP<6.9.
+	if ( function_exists( 'wp_start_template_enhancement_output_buffer' ) ) {
+		add_filter( 'wp_template_enhancement_output_buffer', $callback );
+	} else {
+		add_filter( 'od_template_output_buffer', $callback );
+	}
 }
 
 /**

--- a/plugins/optimization-detective/tests/test-hooks.php
+++ b/plugins/optimization-detective/tests/test-hooks.php
@@ -14,7 +14,13 @@ class Test_OD_Hooks extends WP_UnitTestCase {
 	 */
 	public function test_hooks_added(): void {
 		$this->assertEquals( PHP_INT_MAX, has_action( 'init', 'od_initialize_extensions' ) );
-		$this->assertEquals( PHP_INT_MAX, has_filter( 'template_include', 'od_buffer_output' ) );
+
+		// Backward compatibility with WP<6.9.
+		if ( version_compare( $GLOBALS['wp_version'], '6.9', '<' ) ) {
+			$this->assertEquals( PHP_INT_MAX, has_filter( 'template_include', 'od_buffer_output' ) );
+		} else {
+			$this->assertFalse( has_filter( 'template_include', 'od_buffer_output' ) );
+		}
 
 		$this->assertEquals( 10, has_filter( 'wp', 'od_maybe_add_template_output_buffer_filter' ) );
 		$this->assertEquals( 10, has_action( 'wp_head', 'od_render_generator_meta_tag' ) );

--- a/plugins/optimization-detective/tests/test-optimization.php
+++ b/plugins/optimization-detective/tests/test-optimization.php
@@ -240,7 +240,13 @@ class Test_OD_Optimization extends WP_UnitTestCase {
 		remove_all_filters( 'od_template_output_buffer' ); // In case go_to() caused them to be added.
 
 		od_maybe_add_template_output_buffer_filter();
-		$this->assertSame( $expected_has_filter, has_filter( 'od_template_output_buffer' ) );
+
+		// Backward compatibility with WP<6.9.
+		if ( version_compare( $GLOBALS['wp_version'], '6.9', '<' ) ) {
+			$this->assertSame( $expected_has_filter, has_filter( 'od_template_output_buffer' ) );
+		} else {
+			$this->assertSame( $expected_has_filter, has_filter( 'wp_template_enhancement_output_buffer' ) );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Fixes #2224

## Relevant technical choices

Let's use `wp_template_enhancement_output_buffer` hook when available and remove `od_buffer_output` callback for `template_include` hook (since WP6.9).
Follows issue requirements.

## Use of AI Tools

No AI on this one.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
