### PR TITLE
Bump minimum required WordPress version to 6.9

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -57,7 +57,7 @@ jobs:
         coverage: [false]
         include:
           - php: '7.4'
-            wp: '6.7'
+            wp: '6.9'
           - php: '8.3'
             wp: 'trunk'
           - php: '8.4'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the Performance Lab plugin! Compl
 
 In general, all code must follow the [WordPress Coding Standards and best practices](https://developer.wordpress.org/coding-standards/). All code in the Performance Lab plugin must follow these requirements:
 
-- **WordPress**: As of Performance Lab v3.3.0, released July 15, 2024, the plugin's minimum WordPress version requirement is 6.5.
+- **WordPress**: Always match the latest WordPress version (minus one). The minimum required version right now is 6.9.
 - **PHP**: Always match the latest WordPress version. The minimum required version right now is 7.4.
 
 ## Guidelines

--- a/plugins/auto-sizes/auto-sizes.php
+++ b/plugins/auto-sizes/auto-sizes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Enhanced Responsive Images
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/auto-sizes
  * Description: Improves responsive images with better sizes calculations and auto-sizes for lazy-loaded images.
- * Requires at least: 6.8
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 1.7.0
  * Author: WordPress Performance Team

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -824,11 +824,6 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 * @param string $expected                 Expected output.
 	 */
 	public function test_image_block_with_two_equal_column_block( string $ancestor_block_alignment, string $image_block_alignment, string $expected ): void {
-		// Skip test for WordPress versions below 6.8.
-		if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 6.8 or higher.' );
-		}
-
 		$block_content = $this->get_columns_block_markup(
 			$this->get_image_block_markup( self::$image_id, 'large', $image_block_alignment ),
 			array(
@@ -960,11 +955,6 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 * @param string $expected                 Expected output.
 	 */
 	public function test_image_block_with_two_different_width_column_block( string $ancestor_block_alignment, string $image_block_alignment, string $expected ): void {
-		// Skip test for WordPress versions below 6.8.
-		if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 6.8 or higher.' );
-		}
-
 		$block_content = $this->get_columns_block_markup(
 			$this->get_image_block_markup( self::$image_id, 'large', $image_block_alignment ),
 			array(
@@ -1097,11 +1087,6 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 * @param string $expected                Expected output.
 	 */
 	public function test_image_block_with_parent_columns_and_its_parent_group_block( string $group_block_alignment, string $columns_block_alignment, string $image_block_alignment, string $expected ): void {
-		// Skip test for WordPress versions below 6.8.
-		if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 6.8 or higher.' );
-		}
-
 		$block_content = $this->get_group_block_markup(
 			$this->get_columns_block_markup(
 				$this->get_image_block_markup( self::$image_id, 'large', $image_block_alignment ),
@@ -1307,11 +1292,6 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 * @cover ::auto_sizes_filter_render_block_context
 	 */
 	public function test_image_block_in_two_column_layout_renders_correct_sizes_attribute(): void {
-		// Skip test for WordPress versions below 6.8.
-		if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 6.8 or higher.' );
-		}
-
 		$block_content = '<!-- wp:columns -->
 			<div class="wp-block-columns"><!-- wp:column -->
 			<div class="wp-block-column">
@@ -1335,11 +1315,6 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 	 * @cover ::auto_sizes_filter_render_block_context
 	 */
 	public function test_image_block_in_three_column_layout_renders_correct_sizes_attribute(): void {
-		// Skip test for WordPress versions below 6.8.
-		if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
-			$this->markTestSkipped( 'This test requires WordPress 6.8 or higher.' );
-		}
-
 		$block_content = '<!-- wp:columns -->
 			<div class="wp-block-columns"><!-- wp:column -->
 			<div class="wp-block-column">

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Image Placeholders
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/dominant-color-images
  * Description: Displays placeholders based on an image's dominant color while the image is loading.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 1.2.1
  * Author: WordPress Performance Team

--- a/plugins/embed-optimizer/load.php
+++ b/plugins/embed-optimizer/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Embed Optimizer
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/embed-optimizer
  * Description: Optimizes the performance of embeds through lazy-loading, adding dns-prefetch links, and reserving space to reduce layout shifts.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 1.0.0-beta5
  * Author: WordPress Performance Team

--- a/plugins/image-prioritizer/load.php
+++ b/plugins/image-prioritizer/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Image Prioritizer
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/image-prioritizer
  * Description: Prioritizes the loading of images and videos based on how visible they are to actual visitors; adds <code>fetchpriority</code> and applies lazy-loading.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Requires Plugins: optimization-detective
  * Version: 1.0.0-beta3

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/buffer.html
@@ -7,7 +7,7 @@
 	</head>
 	<body>
 		<div id="page">
-			<div style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==); width:100%; height: 200px;">This is so background!</div>
+			<div style="background-image:url('data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%221%22%20height=%221%22%3E%3Crect%20width=%221%22%20height=%221%22%20fill=%22red%22/%3E%3C/svg%3E'); width:100%; height: 200px;">This is so background!</div>
 		</div>
 	</body>
 </html>

--- a/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/no-url-metrics-with-data-url-background-image/expected.html
@@ -7,7 +7,7 @@
 	</head>
 	<body>
 		<div id="page">
-			<div style="background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQAAAAA3bvkkAAAACklEQVR4AWNgAAAAAgABc3UBGAAAAABJRU5ErkJggg==); width:100%; height: 200px;">This is so background!</div>
+			<div style="background-image:url('data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20width=%221%22%20height=%221%22%3E%3Crect%20width=%221%22%20height=%221%22%20fill=%22red%22/%3E%3C/svg%3E'); width:100%; height: 200px;">This is so background!</div>
 		</div>
 	<script type="application/json" id="optimization-detective-detect-args">[]</script>
 <script type="module">/* detect loader */</script>

--- a/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint/buffer.html
+++ b/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint/buffer.html
@@ -4,12 +4,10 @@
 		<title>...</title>
 		<!--</head>-->
 	</head>
-	<!--</head>-->
 	<body>
 		<div id="page">
 			<img src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800">
 			<!--</body>-->
 		</div>
 	</body>
-	<!--</body>-->
 </html>

--- a/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint/expected.html
+++ b/plugins/image-prioritizer/tests/test-cases/url-metric-only-captured-for-one-breakpoint/expected.html
@@ -5,7 +5,6 @@
 		<!--</head>-->
 	<link data-od-added-tag rel="preload" fetchpriority="high" as="image" href="https://example.com/foo.jpg" media="screen and (width &lt;= 480px)">
 </head>
-	<!--</head>-->
 	<body>
 		<div id="page">
 			<img data-od-xpath="/HTML/BODY/DIV[@id=&apos;page&apos;]/*[1][self::IMG]" src="https://example.com/foo.jpg" alt="Foo" width="1200" height="800">
@@ -14,5 +13,4 @@
 	<script type="application/json" id="optimization-detective-detect-args">[]</script>
 <script type="module">/* detect loader */</script>
 </body>
-	<!--</body>-->
 </html>

--- a/plugins/image-prioritizer/tests/test-helper.php
+++ b/plugins/image-prioritizer/tests/test-helper.php
@@ -203,9 +203,10 @@ class Test_Image_Prioritizer_Helper extends WP_UnitTestCase {
 		$buffer = preg_replace( '#.+?<body[^>]*><div[^>]*>#s', '', $buffer );
 		$buffer = preg_replace( '#</div></body>.*$#s', '', $buffer );
 
-		$this->assertEquals(
-			$this->remove_initial_tabs( $expected ),
-			$this->remove_initial_tabs( $buffer ),
+		$this->assertEqualHTML(
+			$expected,
+			$buffer,
+			'<body>',
 			"Buffer snapshot:\n$buffer"
 		);
 	}

--- a/plugins/optimization-detective/load.php
+++ b/plugins/optimization-detective/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Optimization Detective
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/optimization-detective
  * Description: Provides a framework for leveraging real user metrics to detect optimizations for improving page performance.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 1.0.0-beta5
  * Author: WordPress Performance Team

--- a/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
+++ b/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
@@ -278,11 +278,6 @@ trait Optimization_Detective_Test_Helpers {
 
 		$buffer = od_optimize_template_output_buffer( $buffer );
 
-		// When testing WP versions prior to 6.9, ensure the output buffer accounts for the change to entity encoding in <https://core.trac.wordpress.org/changeset/60919>.
-		if ( ! is_wp_version_compatible( '6.9' ) ) {
-			$buffer = str_replace( '&#039;', '&apos;', $buffer );
-		}
-
 		$home_url_needles = array( home_url( '/', 'http' ), home_url( '/', 'https' ) );
 
 		// Normalize script module content so changes do not impact snapshots.

--- a/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
+++ b/plugins/optimization-detective/tests/class-optimization-detective-test-helpers.php
@@ -8,6 +8,8 @@
  * @noinspection PhpUnhandledExceptionInspection
  */
 
+use PHPUnit\Framework\ExpectationFailedException;
+
 /**
  * @phpstan-type ElementDataSubset array{
  *     xpath: string,
@@ -191,16 +193,6 @@ trait Optimization_Detective_Test_Helpers {
 	}
 
 	/**
-	 * Removes initial tabs from the lines in the input.
-	 *
-	 * @param string $input Input.
-	 * @return string Output.
-	 */
-	public function remove_initial_tabs( string $input ): string {
-		return (string) preg_replace( '/^\t+/m', '', $input );
-	}
-
-	/**
 	 * Gets JSON-serializable data from an array of JsonSerializable objects.
 	 *
 	 * @param JsonSerializable[] $items Items.
@@ -316,7 +308,6 @@ trait Optimization_Detective_Test_Helpers {
 		$buffer = $processor->get_updated_html();
 
 		// Normalize detect-args JSON script content so detect payloads do not impact snapshots.
-		// TODO: This should use assertEqualHTML() once 6.9 is the minimum supported version.
 		$processor = new WP_HTML_Tag_Processor( $buffer );
 		while ( $processor->next_tag( array( 'tag_name' => 'SCRIPT' ) ) ) {
 			if (
@@ -339,12 +330,7 @@ trait Optimization_Detective_Test_Helpers {
 
 			$processor->set_modifiable_text( $text );
 		}
-		// WP_HTML_Tag_Processor preserves source attribute order; normalize to match snapshots (type before id).
-		$buffer = str_replace(
-			'<script id="optimization-detective-detect-args" type="application/json">',
-			'<script type="application/json" id="optimization-detective-detect-args">',
-			$processor->get_updated_html()
-		);
+		$buffer = $processor->get_updated_html();
 
 		// Normalize style content so changes do not impact snapshots.
 		$processor = new WP_HTML_Tag_Processor( $buffer );
@@ -374,27 +360,25 @@ trait Optimization_Detective_Test_Helpers {
 			$snapshot = str_replace( array_values( $replacements ), array_keys( $replacements ), $snapshot );
 		}
 
-		$buffer = $this->remove_initial_tabs( $buffer );
-		if ( is_string( $expected ) ) {
-			$expected = $this->remove_initial_tabs( $expected );
-		}
-
-		if ( $buffer !== $expected ) {
-			file_put_contents( $actual_file, $snapshot ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-		}
-
 		$rel_actual_file   = str_replace( trailingslashit( getcwd() ), '', $actual_file );
 		$rel_expected_file = str_replace( trailingslashit( getcwd() ), '', $expected_file );
 		$rel_buffer_file   = str_replace( trailingslashit( getcwd() ), '', $buffer_file );
 
 		if ( null === $expected ) {
+			file_put_contents( $actual_file, $snapshot ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 			$this->markTestIncomplete( "Examine $actual_file to see if it is expected and if so rename to $expected_file." );
 		} else {
-			$this->assertEquals(
-				$expected,
-				$buffer,
-				"Examine $rel_actual_file for differences with $rel_buffer_file and if acceptable move to $rel_expected_file"
-			);
+			try {
+				$this->assertEqualHTML(
+					$expected,
+					$buffer,
+					null,
+					"Examine $rel_actual_file for differences with $rel_buffer_file and if acceptable move to $rel_expected_file"
+				);
+			} catch ( ExpectationFailedException $e ) {
+				file_put_contents( $actual_file, $snapshot ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+				throw $e;
+			}
 		}
 	}
 }

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Performance Lab
  * Plugin URI: https://github.com/WordPress/performance
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 4.1.0
  * Author: WordPress Performance Team

--- a/plugins/speculation-rules/load.php
+++ b/plugins/speculation-rules/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Speculative Loading
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/speculation-rules
  * Description: Enables browsers to speculatively prerender or prefetch pages to achieve near-instant loads based on user interaction.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 1.6.0
  * Author: WordPress Performance Team

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -3,7 +3,7 @@
  * Plugin Name: View Transitions
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/view-transitions
  * Description: Adds smooth transitions between navigations to your WordPress site.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 1.2.0
  * Author: WordPress Performance Team

--- a/plugins/web-worker-offloading/load.php
+++ b/plugins/web-worker-offloading/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Web Worker Offloading
  * Plugin URI: https://github.com/WordPress/performance/issues/176
  * Description: Offloads select JavaScript execution to a Web Worker to reduce work on the main thread and improve the Interaction to Next Paint (INP) metric.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 0.2.1
  * Author: WordPress Performance Team

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -207,19 +207,16 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		$set_up();
 
 		$normalize = static function ( $html ) {
-			// See <https://core.trac.wordpress.org/ticket/63887>.
-			if ( method_exists( 'WP_HTML_Tag_Processor', 'set_modifiable_text' ) ) { // @phpstan-ignore function.alreadyNarrowedType
-				// This normalization logic is only relevant to WP>=6.9-alpha anyway.
-				$p = new WP_HTML_Tag_Processor( $html );
-				while ( $p->next_tag( array( 'tag_name' => 'SCRIPT' ) ) ) {
-					$text = $p->get_modifiable_text();
-					$text = preg_replace( ':\n//# sourceURL=.+$:', '', $text );
-					$p->set_modifiable_text( $text );
-				}
-				$html = $p->get_updated_html();
+			// Strip the sourceURL comment that core appends to inline script text. See <https://core.trac.wordpress.org/ticket/63887>.
+			$p = new WP_HTML_Tag_Processor( $html );
+			while ( $p->next_tag( array( 'tag_name' => 'SCRIPT' ) ) ) {
+				$text = $p->get_modifiable_text();
+				$text = preg_replace( ':\n//# sourceURL=.+$:', '', $text );
+				$p->set_modifiable_text( $text );
 			}
+			$html = $p->get_updated_html();
 
-			// This is admittedly EXTREMELY naïve. We should be using the assertEqualHTML method instead as of WP 6.9, but in the meantime, since WWO is proposed for deprecation, this is quick and dirty.
+			// This is admittedly EXTREMELY naïve, but since WWO is proposed for deprecation, this is quick and dirty.
 			$html = preg_replace_callback(
 				'/<script ([^>]+)>/',
 				static function ( array $matches ): string {

--- a/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
+++ b/plugins/web-worker-offloading/tests/test-web-worker-offloading.php
@@ -71,10 +71,6 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		$before_data      = wp_scripts()->get_inline_script_data( 'web-worker-offloading', 'before' );
 		$after_data       = wp_scripts()->get_inline_script_data( 'web-worker-offloading', 'after' );
 
-		// See <https://core.trac.wordpress.org/ticket/63887>.
-		$before_data = preg_replace( ':\n//# sourceURL=.+$:', '', $before_data );
-		$after_data  = preg_replace( ':\n//# sourceURL=.+$:', '', $after_data );
-
 		$this->assertTrue( wp_script_is( 'web-worker-offloading', 'registered' ) );
 		$this->assertNotEmpty( $before_data );
 		$this->assertNotEmpty( $after_data );
@@ -86,7 +82,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 			wp_json_encode( $partytown_config, JSON_HEX_TAG | JSON_UNESCAPED_SLASHES ),
 			$before_data
 		);
-		$this->assertEquals( file_get_contents( $partytown_lib . 'partytown.js' ), $after_data );
+		$this->assertEquals( file_get_contents( $partytown_lib . 'partytown.js' ) . "\n//# sourceURL=web-worker-offloading-js-after", $after_data );
 		$this->assertTrue( wp_script_is( 'web-worker-offloading', 'registered' ) );
 	}
 
@@ -110,7 +106,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_enqueue_script( 'foo' );
 				},
-				'expected' => '<script id="foo-js-before">console.log("Hello, Before World!");</script><script id="foo-js-after">console.log("Hello, After World!");</script>',
+				'expected' => '<script id="foo-js-before">console.log("Hello, Before World!");//# sourceURL=foo-js-before</script><script id="foo-js-after">console.log("Hello, After World!");//# sourceURL=foo-js-after</script>',
 			),
 			'add-script-for-web-worker-offloading'       => array(
 				'set_up'   => static function (): void {
@@ -139,7 +135,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 					wp_add_inline_script( 'foo', 'console.log("Hello, Before World!");', 'before' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script>',
+				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");//# sourceURL=foo-js-before</script><script id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script>',
 			),
 			'add-script-for-web-worker-offloading-with-after-data' => array(
 				'set_up'   => static function (): void {
@@ -147,7 +143,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
+				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");//# sourceURL=foo-js-after</script>',
 			),
 			'add-script-for-web-worker-offloading-with-before-and-after-data' => array(
 				'set_up'   => static function (): void {
@@ -156,7 +152,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
+				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");//# sourceURL=foo-js-before</script><script id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");//# sourceURL=foo-js-after</script>',
 			),
 			'add-async-script-for-web-worker-offloading-with-before-and-after-data' => array(
 				'set_up'   => static function (): void {
@@ -165,7 +161,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script data-wp-strategy="async" id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
+				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");//# sourceURL=foo-js-before</script><script data-wp-strategy="async" id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");//# sourceURL=foo-js-after</script>',
 			),
 			'add-defer-script-for-web-worker-offloading-with-before-and-after-data' => array(
 				'set_up'   => static function (): void {
@@ -174,7 +170,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 					wp_add_inline_script( 'foo', 'console.log("Hello, After World!");', 'after' );
 					wp_script_add_data( 'foo', 'worker', true );
 				},
-				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script data-wp-strategy="defer" id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
+				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");//# sourceURL=foo-js-before</script><script data-wp-strategy="defer" id="foo-js" src="https://example.com/foo.js?ver=1.0.0" type="text/partytown"></script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");//# sourceURL=foo-js-after</script>',
 			),
 			'add-inline-script-offloaded-to-web-worker'  => array(
 				'set_up'   => static function (): void {
@@ -184,7 +180,7 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 					wp_script_add_data( 'foo', 'worker', true );
 					wp_enqueue_script( 'foo' );
 				},
-				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");</script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");</script>',
+				'expected' => '{{ plwwo_config }}{{ plwwo_inline_script }}<script id="foo-js-before" type="text/partytown">console.log("Hello, Before World!");//# sourceURL=foo-js-before</script><script id="foo-js-after" type="text/partytown">console.log("Hello, After World!");//# sourceURL=foo-js-after</script>',
 			),
 		);
 	}
@@ -207,15 +203,6 @@ class Test_Web_Worker_Offloading extends WP_UnitTestCase {
 		$set_up();
 
 		$normalize = static function ( $html ) {
-			// Strip the sourceURL comment that core appends to inline script text. See <https://core.trac.wordpress.org/ticket/63887>.
-			$p = new WP_HTML_Tag_Processor( $html );
-			while ( $p->next_tag( array( 'tag_name' => 'SCRIPT' ) ) ) {
-				$text = $p->get_modifiable_text();
-				$text = preg_replace( ':\n//# sourceURL=.+$:', '', $text );
-				$p->set_modifiable_text( $text );
-			}
-			$html = $p->get_updated_html();
-
 			// This is admittedly EXTREMELY naïve, but since WWO is proposed for deprecation, this is quick and dirty.
 			$html = preg_replace_callback(
 				'/<script ([^>]+)>/',

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: Modern Image Formats
  * Plugin URI: https://github.com/WordPress/performance/tree/trunk/plugins/webp-uploads
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
- * Requires at least: 6.6
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 2.6.1
  * Author: WordPress Performance Team


### PR DESCRIPTION
## Summary

Bumps the minimum supported WordPress version to **6.9** across all plugins and cleans up the technical debt this unblocks.

This builds on top of #2511 (which set the CI floor to 6.7 and converted the OD test helper to `set_modifiable_text()`), extending it to the full 6.9 bump that the issue calls for.

### Version bump
- `Requires at least: 6.9` in all plugin headers (9 were `6.6`, auto-sizes was `6.8`).
- CI minimum-version matrix leg: `WP 6.7` → `WP 6.9`.
- `CONTRIBUTING.md` minimum-version note updated to 6.9.

### Cleanup enabled by the bump
- Removed the dead `is_wp_version_compatible( '6.9' )` entity-encoding workaround in the OD snapshot test helper.
- Removed the `version_compare( …, '6.8', '<' )` `markTestSkipped()` guards in the Auto Sizes tests.
- Removed the now-always-true `method_exists( …, 'set_modifiable_text' )` guard in the Web Worker Offloading test.

### Switch snapshot assertions to `assertEqualHTML()`
Now that `assertEqualHTML()` (added in 6.9) is available, the shared OD snapshot assertion and the Image Prioritizer auto-sizes test use it instead of byte-exact `assertEquals()`. Because it normalizes attribute order and insignificant whitespace, this lets us drop the detect-args attribute-order canonicalization and the `remove_initial_tabs()` normalization (the helper is now unused and removed).

Two Image Prioritizer snapshots use markup that core's HTML API cannot normalize, so the fixtures were adjusted rather than adding a fallback:
- The data-URL background image was switched from a base64 PNG to a semicolon-free inline SVG. `build_visual_html_tree()` splits `style` values on `;` without respecting `url()`, so any `;` in the value (e.g. `;base64`) makes it throw.
- The decoy end-tag comments placed *outside* of `<head>`/`<body>` were dropped (full-document parsing rejects content after `</body>`). The decoy comments *inside* `<head>`/`<body>` are retained, preserving the coverage that injection targets the real boundaries.

## Testing
All affected PHPUnit suites pass: Optimization Detective (356), Image Prioritizer (91), Embed Optimizer (66), Web Worker Offloading (27), Auto Sizes (169). PHPStan (level 8) and PHPCS are clean.

Fixes #2354.
