### PR TITLE
Dominant Color: Tidy Up and Add GD tests

### DIFF
--- a/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
@@ -21,11 +21,11 @@ declare( strict_types = 1 );
 class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 
 	/**
-	 * Get dominant color from a file as raw RGB values.
+	 * Get dominant color from a file.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array{r: int, g: int, b: int}|WP_Error RGB values (0-255), or WP_Error on failure.
+	 * @return string|WP_Error Dominant hex color string, or an error on failure.
 	 */
 	public function get_dominant_color() {
 
@@ -49,12 +49,15 @@ class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 		if ( false === $rgb ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
+		$r   = ( $rgb >> 16 ) & 0xFF;
+		$g   = ( $rgb >> 8 ) & 0xFF;
+		$b   = $rgb & 0xFF;
+		$hex = dominant_color_rgb_to_hex( $r, $g, $b );
+		if ( null === $hex ) {
+			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
+		}
 
-		return array(
-			'r' => ( $rgb >> 16 ) & 0xFF,
-			'g' => ( $rgb >> 8 ) & 0xFF,
-			'b' => $rgb & 0xFF,
-		);
+		return $hex;
 	}
 
 	/**

--- a/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-gd.php
@@ -21,11 +21,11 @@ declare( strict_types = 1 );
 class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 
 	/**
-	 * Get dominant color from a file.
+	 * Get dominant color from a file as raw RGB values.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string|WP_Error Dominant hex color string, or an error on failure.
+	 * @return array{r: int, g: int, b: int}|WP_Error RGB values (0-255), or WP_Error on failure.
 	 */
 	public function get_dominant_color() {
 
@@ -49,15 +49,12 @@ class Dominant_Color_Image_Editor_GD extends WP_Image_Editor_GD {
 		if ( false === $rgb ) {
 			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
 		}
-		$r   = ( $rgb >> 16 ) & 0xFF;
-		$g   = ( $rgb >> 8 ) & 0xFF;
-		$b   = $rgb & 0xFF;
-		$hex = dominant_color_rgb_to_hex( $r, $g, $b );
-		if ( null === $hex ) {
-			return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
-		}
 
-		return $hex;
+		return array(
+			'r' => ( $rgb >> 16 ) & 0xFF,
+			'g' => ( $rgb >> 8 ) & 0xFF,
+			'b' => $rgb & 0xFF,
+		);
 	}
 
 	/**

--- a/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
@@ -21,11 +21,11 @@ declare( strict_types = 1 );
 class Dominant_Color_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 
 	/**
-	 * Get dominant color from a file.
+	 * Get dominant color from a file as raw RGB values.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return string|WP_Error Dominant hex color string, or an error on failure.
+	 * @return array{r: int, g: int, b: int}|WP_Error RGB values (0-255), or WP_Error on failure.
 	 */
 	public function get_dominant_color() {
 
@@ -38,12 +38,12 @@ class Dominant_Color_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 			$this->image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
 			$pixel = $this->image->getImagePixelColor( 0, 0 );
 			$color = $pixel->getColor();
-			$hex   = dominant_color_rgb_to_hex( $color['r'], $color['g'], $color['b'] );
-			if ( null === $hex ) {
-				return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
-			}
 
-			return $hex;
+			return array(
+				'r' => $color['r'],
+				'g' => $color['g'],
+				'b' => $color['b'],
+			);
 		} catch ( Exception $e ) {
 			/* translators: %s is the error message. */
 			return new WP_Error( 'image_editor_dominant_color_error', sprintf( __( 'Dominant color detection failed: %s', 'dominant-color-images' ), $e->getMessage() ) );

--- a/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
@@ -21,11 +21,11 @@ declare( strict_types = 1 );
 class Dominant_Color_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 
 	/**
-	 * Get dominant color from a file as raw RGB values.
+	 * Get dominant color from a file.
 	 *
 	 * @since 1.0.0
 	 *
-	 * @return array{r: int, g: int, b: int}|WP_Error RGB values (0-255), or WP_Error on failure.
+	 * @return string|WP_Error Dominant hex color string, or an error on failure.
 	 */
 	public function get_dominant_color() {
 
@@ -38,15 +38,15 @@ class Dominant_Color_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 			$this->image->resizeImage( 1, 1, Imagick::FILTER_LANCZOS, 1 );
 			$pixel = $this->image->getImagePixelColor( 0, 0 );
 			$color = $pixel->getColor();
-
 			// Cast to int: ImagickPixel::getColor() may return floats depending on
 			// ImageMagick/Imagick configuration, which would break the int contract
-			// of this method under strict_types.
-			return array(
-				'r' => (int) $color['r'],
-				'g' => (int) $color['g'],
-				'b' => (int) $color['b'],
-			);
+			// of dominant_color_rgb_to_hex() under strict_types.
+			$hex = dominant_color_rgb_to_hex( (int) $color['r'], (int) $color['g'], (int) $color['b'] );
+			if ( null === $hex ) {
+				return new WP_Error( 'image_editor_dominant_color_error', __( 'Dominant color detection failed.', 'dominant-color-images' ) );
+			}
+
+			return $hex;
 		} catch ( Exception $e ) {
 			/* translators: %s is the error message. */
 			return new WP_Error( 'image_editor_dominant_color_error', sprintf( __( 'Dominant color detection failed: %s', 'dominant-color-images' ), $e->getMessage() ) );

--- a/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/class-dominant-color-image-editor-imagick.php
@@ -39,10 +39,13 @@ class Dominant_Color_Image_Editor_Imagick extends WP_Image_Editor_Imagick {
 			$pixel = $this->image->getImagePixelColor( 0, 0 );
 			$color = $pixel->getColor();
 
+			// Cast to int: ImagickPixel::getColor() may return floats depending on
+			// ImageMagick/Imagick configuration, which would break the int contract
+			// of this method under strict_types.
 			return array(
-				'r' => $color['r'],
-				'g' => $color['g'],
-				'b' => $color['b'],
+				'r' => (int) $color['r'],
+				'g' => (int) $color['g'],
+				'b' => (int) $color['b'],
 			);
 		} catch ( Exception $e ) {
 			/* translators: %s is the error message. */

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -130,7 +130,16 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 	if ( is_wp_error( $dominant_color ) ) {
 		return $dominant_color;
 	}
-	$dominant_color_data['dominant_color'] = $dominant_color;
+
+	$hex = dominant_color_rgb_to_hex( $dominant_color['r'], $dominant_color['g'], $dominant_color['b'] );
+	if ( null === $hex ) {
+		return new WP_Error(
+			'image_editor_dominant_color_error',
+			__( 'Dominant color detection failed.', 'dominant-color-images' )
+		);
+	}
+	$dominant_color_data['dominant_color'] = $hex;
+
 
 	return $dominant_color_data;
 }

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -140,7 +140,6 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 	}
 	$dominant_color_data['dominant_color'] = $hex;
 
-
 	return $dominant_color_data;
 }
 
@@ -150,9 +149,9 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
  * @since 1.0.0
  *
  * @param int $attachment_id Attachment ID.
- * @return array|null Attachment metadata array or null if not an image or metadata unavailable.
+ * @return array<string, mixed>|null Attachment metadata array, or null if not an image or metadata unavailable.
  */
-function dominant_color_get_attachment_metadata( int $attachment_id ) {
+function dominant_color_get_attachment_metadata( int $attachment_id ): ?array {
 
 	if ( ! wp_attachment_is_image( $attachment_id ) ) {
 		return null;

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -55,7 +55,7 @@ function dominant_color_set_image_editors( array $editors ): array {
  *
  * @since n.e.x.t
  *
- * @param mixed $editors List of image editor class names, or mixed value from previous filter.
+ * @param string[]|mixed $editors List of image editor class names, or mixed value from previous filter.
  * @return string[] Filtered list of image editor class names.
  */
 function dominant_color_filter_image_editors( $editors ): array {
@@ -69,10 +69,10 @@ function dominant_color_filter_image_editors( $editors ): array {
 	 */
 
 	if ( ! class_exists( 'WP_Image_Editor_GD' ) ) {
-		require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';// @codeCoverageIgnore
+		require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php'; // @codeCoverageIgnore
 	}
 	if ( ! class_exists( 'WP_Image_Editor_Imagick' ) ) {
-		require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';// @codeCoverageIgnore
+		require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php'; // @codeCoverageIgnore
 	}
 
 	return dominant_color_set_image_editors( $editors );

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -47,6 +47,38 @@ function dominant_color_set_image_editors( array $editors ): array {
 }
 
 /**
+ * Filters the list of image editors to include the dominant color editors.
+ *
+ * Ensures core editor classes are loaded before delegating to
+ * {@see dominant_color_set_image_editors()}, since the `wp_image_editors`
+ * filter can run early (e.g. during `wp_image_editor_supports()`).
+ *
+ * @since n.e.x.t
+ *
+ * @param mixed $editors List of image editor class names, or mixed value from previous filter.
+ * @return string[] Filtered list of image editor class names.
+ */
+function dominant_color_filter_image_editors( $editors ): array {
+	if ( ! is_array( $editors ) ) {
+		$editors = array();
+	}
+	/**
+	 * Because plugins do bad things.
+	 *
+	 * @var string[] $editors
+	 */
+
+	if ( ! class_exists( 'WP_Image_Editor_GD' ) ) {
+		require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';// @codeCoverageIgnore
+	}
+	if ( ! class_exists( 'WP_Image_Editor_Imagick' ) ) {
+		require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';// @codeCoverageIgnore
+	}
+
+	return dominant_color_set_image_editors( $editors );
+}
+
+/**
  * Computes the dominant color of the given attachment image and whether it has transparency.
  *
  * The image types jpeg, png, gif, webp, and avif are supported for determining the dominant color.
@@ -188,12 +220,12 @@ function dominant_color_get_attachment_file_path( int $attachment_id, string $si
  * @since 1.0.0
  *
  * @param int $attachment_id Attachment ID for image.
- * @return string|null Hex value of dominant color or null if not set.
+ * @return non-empty-string|null Hex value of dominant color or null if not set.
  */
 function dominant_color_get_dominant_color( int $attachment_id ): ?string {
 	$image_meta = dominant_color_get_attachment_metadata( $attachment_id );
 
-	if ( ! isset( $image_meta['dominant_color'] ) ) {
+	if ( ! isset( $image_meta['dominant_color'] ) || ! is_string( $image_meta['dominant_color'] ) || '' === $image_meta['dominant_color'] ) {
 		return null;
 	}
 
@@ -215,7 +247,7 @@ function dominant_color_has_transparency( int $attachment_id ): ?bool {
 		return null;
 	}
 
-	return $image_meta['has_transparency'];
+	return (bool) $image_meta['has_transparency'];
 }
 
 /**

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -136,6 +136,28 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 }
 
 /**
+ * Retrieves attachment metadata for an image attachment.
+ *
+ * @since 1.0.0
+ *
+ * @param int $attachment_id Attachment ID.
+ * @return array|null Attachment metadata array or null if not an image or metadata unavailable.
+ */
+function dominant_color_get_attachment_metadata( int $attachment_id ) {
+
+	if ( ! wp_attachment_is_image( $attachment_id ) ) {
+		return null;
+	}
+
+	$image_meta = wp_get_attachment_metadata( $attachment_id );
+	if ( ! is_array( $image_meta ) ) {
+		return null;
+	}
+
+	return $image_meta;
+}
+
+/**
  * Gets file path of image based on size.
  *
  * @since 1.0.0
@@ -145,18 +167,16 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
  * @return false|string Path to an image or false if not found.
  */
 function dominant_color_get_attachment_file_path( int $attachment_id, string $size = 'medium' ) {
-	$imagedata = wp_get_attachment_metadata( $attachment_id );
-	if ( ! is_array( $imagedata ) ) {
-		return false;
-	}
 
 	$filepath = get_attached_file( $attachment_id );
 	if ( false === $filepath ) {
 		return false;
 	}
 
-	if ( isset( $imagedata['sizes'][ $size ] ) ) {
-		$filepath = str_replace( wp_basename( $filepath ), $imagedata['sizes'][ $size ]['file'], $filepath );
+	$image_meta = dominant_color_get_attachment_metadata( $attachment_id );
+
+	if ( isset( $image_meta['sizes'][ $size ] ) ) {
+		$filepath = str_replace( wp_basename( $filepath ), $image_meta['sizes'][ $size ]['file'], $filepath );
 	}
 
 	return $filepath;
@@ -171,13 +191,7 @@ function dominant_color_get_attachment_file_path( int $attachment_id, string $si
  * @return string|null Hex value of dominant color or null if not set.
  */
 function dominant_color_get_dominant_color( int $attachment_id ): ?string {
-	if ( ! wp_attachment_is_image( $attachment_id ) ) {
-		return null;
-	}
-	$image_meta = wp_get_attachment_metadata( $attachment_id );
-	if ( ! is_array( $image_meta ) ) {
-		return null;
-	}
+	$image_meta = dominant_color_get_attachment_metadata( $attachment_id );
 
 	if ( ! isset( $image_meta['dominant_color'] ) ) {
 		return null;
@@ -195,10 +209,7 @@ function dominant_color_get_dominant_color( int $attachment_id ): ?string {
  * @return bool|null Whether the image has transparency, or null if not set.
  */
 function dominant_color_has_transparency( int $attachment_id ): ?bool {
-	$image_meta = wp_get_attachment_metadata( $attachment_id );
-	if ( ! is_array( $image_meta ) ) {
-		return null;
-	}
+	$image_meta = dominant_color_get_attachment_metadata( $attachment_id );
 
 	if ( ! isset( $image_meta['has_transparency'] ) ) {
 		return null;
@@ -206,7 +217,6 @@ function dominant_color_has_transparency( int $attachment_id ): ?bool {
 
 	return $image_meta['has_transparency'];
 }
-
 
 /**
  * Gets hex color from RGB.

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -146,7 +146,7 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 /**
  * Retrieves attachment metadata for an image attachment.
  *
- * @since 1.0.0
+ * @since n.e.x.t
  *
  * @param int $attachment_id Attachment ID.
  * @return array<string, mixed>|null Attachment metadata array, or null if not an image or metadata unavailable.

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -130,15 +130,7 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 	if ( is_wp_error( $dominant_color ) ) {
 		return $dominant_color;
 	}
-
-	$hex = dominant_color_rgb_to_hex( $dominant_color['r'], $dominant_color['g'], $dominant_color['b'] );
-	if ( null === $hex ) {
-		return new WP_Error(
-			'image_editor_dominant_color_error',
-			__( 'Dominant color detection failed.', 'dominant-color-images' )
-		);
-	}
-	$dominant_color_data['dominant_color'] = $hex;
+	$dominant_color_data['dominant_color'] = $dominant_color;
 
 	return $dominant_color_data;
 }

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -155,16 +155,14 @@ function dominant_color_get_attachment_file_path( int $attachment_id, string $si
 		return false;
 	}
 
-	if ( ! isset( $imagedata['sizes'][ $size ] ) ) {
+	$filepath = get_attached_file( $attachment_id );
+	if ( false === $filepath ) {
 		return false;
 	}
 
-	$file = get_attached_file( $attachment_id );
-	if ( false === $file ) {
-		return false;
+	if ( isset( $imagedata['sizes'][ $size ] ) ) {
+		$filepath = str_replace( wp_basename( $filepath ), $imagedata['sizes'][ $size ]['file'], $filepath );
 	}
-
-	$filepath = str_replace( wp_basename( $file ), $imagedata['sizes'][ $size ]['file'], $file );
 
 	return $filepath;
 }

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -91,9 +91,6 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 
 	$file = dominant_color_get_attachment_file_path( $attachment_id );
 	if ( false === $file ) {
-		$file = get_attached_file( $attachment_id );
-	}
-	if ( false === $file ) {
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'dominant-color-images' ) );
 	}
 

--- a/plugins/dominant-color-images/helper.php
+++ b/plugins/dominant-color-images/helper.php
@@ -96,7 +96,6 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 	if ( false === $file ) {
 		return new WP_Error( 'no_image_found', __( 'Unable to load image.', 'dominant-color-images' ) );
 	}
-	add_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
 
 	/**
 	 * Editor.
@@ -113,7 +112,6 @@ function dominant_color_get_dominant_color_data( int $attachment_id ) {
 			),
 		)
 	);
-	remove_filter( 'wp_image_editors', 'dominant_color_set_image_editors' );
 
 	if ( is_wp_error( $editor ) ) {
 		return $editor;

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -33,21 +33,5 @@ define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.3.0' );
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';
 
-add_filter(
-	'wp_image_editors',
-	static function ( array $editors ): array {
-		// Ensure core editor classes are loaded before delegating, since this
-		// filter can run early (e.g. during wp_image_editor_supports()).
-		if ( ! class_exists( 'WP_Image_Editor_GD' ) ) {
-			require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';
-		}
-		if ( ! class_exists( 'WP_Image_Editor_Imagick' ) ) {
-			require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
-		}
-
-		return dominant_color_set_image_editors( $editors );
-	},
-	999,
-	1
-);
+add_filter( 'wp_image_editors', 'dominant_color_filter_image_editors', 999, 1 );
 // @codeCoverageIgnoreEnd

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -33,5 +33,21 @@ define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.3.0' );
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';
 
-add_filter( 'wp_image_editors', 'dominant_color_set_image_editors', 999, 1 );
+add_filter(
+	'wp_image_editors',
+	static function ( array $editors ): array {
+		// Ensure core editor classes are loaded before delegating, since this
+		// filter can run early (e.g. during wp_image_editor_supports()).
+		if ( ! class_exists( 'WP_Image_Editor_GD' ) ) {
+			require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';
+		}
+		if ( ! class_exists( 'WP_Image_Editor_Imagick' ) ) {
+			require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
+		}
+
+		return dominant_color_set_image_editors( $editors );
+	},
+	999,
+	1
+);
 // @codeCoverageIgnoreEnd

--- a/plugins/dominant-color-images/load.php
+++ b/plugins/dominant-color-images/load.php
@@ -32,4 +32,6 @@ define( 'DOMINANT_COLOR_IMAGES_VERSION', '1.3.0' );
 
 require_once __DIR__ . '/helper.php';
 require_once __DIR__ . '/hooks.php';
+
+add_filter( 'wp_image_editors', 'dominant_color_set_image_editors', 999, 1 );
 // @codeCoverageIgnoreEnd

--- a/plugins/dominant-color-images/tests/data/class-testcase.php
+++ b/plugins/dominant-color-images/tests/data/class-testcase.php
@@ -182,7 +182,6 @@ abstract class TestCase extends WP_UnitTestCase {
 		}
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
@@ -209,7 +208,6 @@ abstract class TestCase extends WP_UnitTestCase {
 			$this->markTestSkipped( "Mime type $mime_type is not supported." );
 		}
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
@@ -227,7 +225,6 @@ abstract class TestCase extends WP_UnitTestCase {
 		$image_path = TESTS_PLUGIN_DIR . '/tests/data/images/red.jpg';
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
@@ -245,7 +242,6 @@ abstract class TestCase extends WP_UnitTestCase {
 	 */
 	public function test_get_dominant_color_none_images( string $image_path ): void {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 

--- a/plugins/dominant-color-images/tests/data/class-testcase.php
+++ b/plugins/dominant-color-images/tests/data/class-testcase.php
@@ -157,10 +157,10 @@ abstract class TestCase extends WP_UnitTestCase {
 	public function provider_get_dominant_color_none_images(): array {
 		return array(
 			'pdf' => array(
-				'files_path' => TESTS_PLUGIN_DIR . '/tests/data/images/wordpress-gsoc-flyer.pdf',
+				'image_path' => TESTS_PLUGIN_DIR . '/tests/data/images/wordpress-gsoc-flyer.pdf',
 			),
 			'mp4' => array(
-				'files_path' => TESTS_PLUGIN_DIR . '/tests/data/images/small-video.mp4',
+				'image_path' => TESTS_PLUGIN_DIR . '/tests/data/images/small-video.mp4',
 			),
 		);
 	}
@@ -207,33 +207,41 @@ abstract class TestCase extends WP_UnitTestCase {
 		if ( ! wp_image_editor_supports( array( 'mime_type' => $mime_type ) ) ) {
 			$this->markTestSkipped( "Mime type $mime_type is not supported." );
 		}
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create(
+			array(
+				'post_mime_type' => $mime_type,
+			)
+		);
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
-		$this->assertStringContainsString( 'unsupported_attachment_type', $dominant_color_data->get_error_code() );
+		$this->assertSame( 'unsupported_attachment_type', $dominant_color_data->get_error_code() );
 	}
 
 	/**
-	 * Test the function returns a WP_Error object for unsupported mime types.
+	 * Tests dominant_color_get_dominant_color_data() returns a WP_Error when the
+	 * dominant_color_supported_mime_types filter returns an empty array.
 	 *
 	 * @covers dominant_color_get_dominant_color_data
 	 */
 	public function test_get_dominant_color_data_unsupported_mime_type(): void {
 		add_filter( 'dominant_color_supported_mime_types', '__return_empty_array' );
-		$image_path = TESTS_PLUGIN_DIR . '/tests/data/images/red.jpg';
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id = self::factory()->attachment->create(
+			array(
+				'post_mime_type' => 'image/jpeg',
+			)
+		);
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
-		$this->assertStringContainsString( 'unsupported_attachment_type', $dominant_color_data->get_error_code() );
+		$this->assertSame( 'unsupported_attachment_type', $dominant_color_data->get_error_code() );
 	}
 
 	/**
-	 * Test if the function returns the correct color.
+	 * Tests dominant_color_get_dominant_color_data() returns a WP_Error for non-image file types.
 	 *
 	 * @covers Dominant_Color_Image_Editor_GD::get_dominant_color
 	 * @covers Dominant_Color_Image_Editor_Imagick::get_dominant_color
@@ -241,10 +249,20 @@ abstract class TestCase extends WP_UnitTestCase {
 	 * @dataProvider provider_get_dominant_color_none_images
 	 */
 	public function test_get_dominant_color_none_images( string $image_path ): void {
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$mime_type = wp_check_filetype( $image_path )['type'];
+		if ( false === $mime_type ) {
+			$this->markTestSkipped( 'Mime type is not supported.' );
+		}
+
+		$attachment_id = self::factory()->attachment->create(
+			array(
+				'post_mime_type' => $mime_type,
+			)
+		);
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
 		$this->assertWPError( $dominant_color_data );
+		$this->assertSame( 'unsupported_attachment_type', $dominant_color_data->get_error_code() );
 	}
 }

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
@@ -3,10 +3,14 @@
  * Tests for Image Placeholders plugin.
  *
  * @package dominant-color-images
+ * @noinspection PhpComposerExtensionStubsInspection
  */
 
 use Dominant_Color_Images\Tests\TestCase;
 
+/**
+ * @coversDefaultClass Dominant_Color_Image_Editor_GD
+ */
 class Test_Dominant_Color_Image_Editor_GD extends TestCase {
 
 	/**
@@ -35,5 +39,95 @@ class Test_Dominant_Color_Image_Editor_GD extends TestCase {
 				);
 			}
 		);
+	}
+
+	/**
+	 * @covers ::get_dominant_color
+	 */
+	public function test_invalid_image_type(): void {
+		$editor = new Dominant_Color_Image_Editor_GD( '/invalid/type' );
+		$result = $editor->get_dominant_color();
+		$this->assertWPError( $result );
+		$this->assertSame( 'image_editor_dominant_color_error_no_image', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_dominant_color
+	 */
+	public function test_get_dominant_color_no_image(): void {
+		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$result = $editor->get_dominant_color();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'image_editor_dominant_color_error_no_image', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::has_transparency
+	 */
+	public function test_has_transparency_no_image(): void {
+		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$result = $editor->has_transparency();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'image_editor_has_transparency_error_no_image', $result->get_error_code() );
+	}
+
+	/**
+	 * @covers ::get_dominant_color
+	 */
+	public function test_get_dominant_color_success(): void {
+		$im = imagecreatetruecolor( 1, 1 );
+		$red = imagecolorallocate( $im, 255, 0, 0 );
+		imagefill( $im, 0, 0, $red );
+
+		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$reflection = new ReflectionClass( $editor );
+		$property = $reflection->getProperty( 'image' );
+		$property->setAccessible( true );
+		$property->setValue( $editor, $im );
+
+		$result = $editor->get_dominant_color();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( array( 'r' => 255, 'g' => 0, 'b' => 0 ), $result );
+	}
+
+	/**
+	 * @covers ::has_transparency
+	 */
+	public function test_has_no_transparency(): void {
+		$im = imagecreatetruecolor( 1, 1 );
+		$red = imagecolorallocate( $im, 255, 0, 0 );
+		imagefill( $im, 0, 0, $red );
+
+		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$reflection = new ReflectionClass( $editor );
+		$property = $reflection->getProperty( 'image' );
+		$property->setAccessible( true );
+		$property->setValue( $editor, $im );
+
+		$result = $editor->has_transparency();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * @covers ::has_transparency
+	 */
+	public function test_has_transparency_with_transparency(): void {
+		$im = imagecreatetruecolor( 1, 1 );
+		$alpha_color = imagecolorallocatealpha( $im, 255, 0, 0, 64 );
+		imagefill( $im, 0, 0, $alpha_color );
+
+		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$reflection = new ReflectionClass( $editor );
+		$property = $reflection->getProperty( 'image' );
+		$property->setAccessible( true );
+		$property->setValue( $editor, $im );
+
+		$result = $editor->has_transparency();
+
+		$this->assertTrue( $result );
 	}
 }

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
@@ -77,33 +77,40 @@ class Test_Dominant_Color_Image_Editor_GD extends TestCase {
 	 * @covers ::get_dominant_color
 	 */
 	public function test_get_dominant_color_success(): void {
-		$im = imagecreatetruecolor( 1, 1 );
+		$im  = imagecreatetruecolor( 1, 1 );
 		$red = imagecolorallocate( $im, 255, 0, 0 );
 		imagefill( $im, 0, 0, $red );
 
-		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$editor     = new Dominant_Color_Image_Editor_GD( null );
 		$reflection = new ReflectionClass( $editor );
-		$property = $reflection->getProperty( 'image' );
+		$property   = $reflection->getProperty( 'image' );
 		$property->setAccessible( true );
 		$property->setValue( $editor, $im );
 
 		$result = $editor->get_dominant_color();
 
 		$this->assertIsArray( $result );
-		$this->assertSame( array( 'r' => 255, 'g' => 0, 'b' => 0 ), $result );
+		$this->assertSame(
+			array(
+				'r' => 255,
+				'g' => 0,
+				'b' => 0,
+			),
+			$result
+		);
 	}
 
 	/**
 	 * @covers ::has_transparency
 	 */
 	public function test_has_no_transparency(): void {
-		$im = imagecreatetruecolor( 1, 1 );
+		$im  = imagecreatetruecolor( 1, 1 );
 		$red = imagecolorallocate( $im, 255, 0, 0 );
 		imagefill( $im, 0, 0, $red );
 
-		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$editor     = new Dominant_Color_Image_Editor_GD( null );
 		$reflection = new ReflectionClass( $editor );
-		$property = $reflection->getProperty( 'image' );
+		$property   = $reflection->getProperty( 'image' );
 		$property->setAccessible( true );
 		$property->setValue( $editor, $im );
 
@@ -116,13 +123,13 @@ class Test_Dominant_Color_Image_Editor_GD extends TestCase {
 	 * @covers ::has_transparency
 	 */
 	public function test_has_transparency_with_transparency(): void {
-		$im = imagecreatetruecolor( 1, 1 );
+		$im          = imagecreatetruecolor( 1, 1 );
 		$alpha_color = imagecolorallocatealpha( $im, 255, 0, 0, 64 );
 		imagefill( $im, 0, 0, $alpha_color );
 
-		$editor = new Dominant_Color_Image_Editor_GD( null );
+		$editor     = new Dominant_Color_Image_Editor_GD( null );
 		$reflection = new ReflectionClass( $editor );
-		$property = $reflection->getProperty( 'image' );
+		$property   = $reflection->getProperty( 'image' );
 		$property->setAccessible( true );
 		$property->setValue( $editor, $im );
 

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
@@ -23,7 +23,7 @@ class Test_Dominant_Color_Image_Editor_GD extends TestCase {
 			$this->markTestSkipped( 'The GD PHP extension is not loaded.' );
 		}
 
-		// ensure the GD editor is registered. Doesnt seem to be by the time this runs.
+		// Ensure the GD editor is registered. It doesn't seem to be by the time this runs.
 		require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
 		require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';
 		require_once __DIR__ . '/../class-dominant-color-image-editor-gd.php';

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
@@ -19,6 +19,11 @@ class Test_Dominant_Color_Image_Editor_GD extends TestCase {
 			$this->markTestSkipped( 'The GD PHP extension is not loaded.' );
 		}
 
+		// ensure the GD editor is registered. Doesnt seem to be by the time this runs.
+		require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
+		require_once ABSPATH . WPINC . '/class-wp-image-editor-gd.php';
+		require_once __DIR__ . '/../class-dominant-color-image-editor-gd.php';
+
 		add_filter(
 			'wp_image_editors',
 			static function ( array $editors ): array {

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-gd.php
@@ -89,15 +89,7 @@ class Test_Dominant_Color_Image_Editor_GD extends TestCase {
 
 		$result = $editor->get_dominant_color();
 
-		$this->assertIsArray( $result );
-		$this->assertSame(
-			array(
-				'r' => 255,
-				'g' => 0,
-				'b' => 0,
-			),
-			$result
-		);
+		$this->assertSame( 'ff0000', $result );
 	}
 
 	/**

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
@@ -26,7 +26,7 @@ class Test_Dominant_Color_Image_Editor_Imagick extends TestCase {
 			$this->markTestSkipped( 'The Imagick PHP extension is not loaded.' );
 		}
 
-		// ensure the Imagick editor is registered, even though it seems to be by the time this runs.
+		// Ensure the Imagick editor is registered, even though it seems to be by the time this runs.
 		require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
 		require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
 		require_once __DIR__ . '/../class-dominant-color-image-editor-imagick.php';

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
@@ -152,7 +152,14 @@ class Test_Dominant_Color_Image_Editor_Imagick extends TestCase {
 
 		$result = $editor->get_dominant_color();
 
-		$this->assertEquals( array( 'r' => 255, 'g' => 0, 'b' => 0 ), $result );
+		$this->assertEquals(
+			array(
+				'r' => 255,
+				'g' => 0,
+				'b' => 0,
+			),
+			$result
+		);
 	}
 
 	/**

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
@@ -152,14 +152,7 @@ class Test_Dominant_Color_Image_Editor_Imagick extends TestCase {
 
 		$result = $editor->get_dominant_color();
 
-		$this->assertEquals(
-			array(
-				'r' => 255,
-				'g' => 0,
-				'b' => 0,
-			),
-			$result
-		);
+		$this->assertSame( 'ff0000', $result );
 	}
 
 	/**

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
@@ -152,7 +152,7 @@ class Test_Dominant_Color_Image_Editor_Imagick extends TestCase {
 
 		$result = $editor->get_dominant_color();
 
-		$this->assertEquals( 'ff0000', $result );
+		$this->assertEquals( array( 'r' => 255, 'g' => 0, 'b' => 0 ), $result );
 	}
 
 	/**

--- a/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color-image-editor-imagick.php
@@ -26,6 +26,11 @@ class Test_Dominant_Color_Image_Editor_Imagick extends TestCase {
 			$this->markTestSkipped( 'The Imagick PHP extension is not loaded.' );
 		}
 
+		// ensure the Imagick editor is registered, even though it seems to be by the time this runs.
+		require_once ABSPATH . WPINC . '/class-wp-image-editor.php';
+		require_once ABSPATH . WPINC . '/class-wp-image-editor-imagick.php';
+		require_once __DIR__ . '/../class-dominant-color-image-editor-imagick.php';
+
 		add_filter(
 			'wp_image_editors',
 			static function ( array $editors ): array {

--- a/plugins/dominant-color-images/tests/test-dominant-color.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color.php
@@ -409,26 +409,6 @@ class Test_Dominant_Color extends TestCase {
 	}
 
 	/**
-	 * @covers Dominant_Color_Image_Editor_GD::get_dominant_color
-	 */
-	public function test_invalid_image_type(): void {
-		$editor = new Dominant_Color_Image_Editor_GD( '/invalid/type' );
-		$result = $editor->get_dominant_color();
-		$this->assertWPError( $result );
-		$this->assertEquals( 'image_editor_dominant_color_error_no_image', $result->get_error_code() );
-	}
-
-	/**
-	 * @covers Dominant_Color_Image_Editor_GD::get_dominant_color
-	 */
-	public function test_corrupted_image_file(): void {
-		$editor = new Dominant_Color_Image_Editor_GD( 'path/to/corrupted/file.jpg' );
-		$result = $editor->get_dominant_color();
-		$this->assertWPError( $result );
-		$this->assertEquals( 'image_editor_dominant_color_error_no_image', $result->get_error_code() );
-	}
-
-	/**
 	 * @covers ::dominant_color_add_inline_style
 	 */
 	public function test_dominant_color_add_inline_style(): void {

--- a/plugins/dominant-color-images/tests/test-dominant-color.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color.php
@@ -26,7 +26,7 @@ class Test_Dominant_Color extends TestCase {
 		$this->assertEmpty( $dominant_color_metadata );
 
 		// Creating attachment.
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id           = self::factory()->attachment->create_upload_object( $image_path );
 		$dominant_color_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'dominant_color', $dominant_color_metadata );
 		$this->assertNotEmpty( $dominant_color_metadata['dominant_color'] );
@@ -76,7 +76,7 @@ class Test_Dominant_Color extends TestCase {
 		$transparency_metadata = dominant_color_metadata( array(), 1 );
 		$this->assertEmpty( $transparency_metadata );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id         = self::factory()->attachment->create_upload_object( $image_path );
 		$transparency_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'has_transparency', $transparency_metadata );
 		$this->assertSame( $expected_transparency, $transparency_metadata['has_transparency'] );

--- a/plugins/dominant-color-images/tests/test-dominant-color.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color.php
@@ -27,7 +27,6 @@ class Test_Dominant_Color extends TestCase {
 
 		// Creating attachment.
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$dominant_color_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'dominant_color', $dominant_color_metadata );
 		$this->assertNotEmpty( $dominant_color_metadata['dominant_color'] );
@@ -78,7 +77,6 @@ class Test_Dominant_Color extends TestCase {
 		$this->assertEmpty( $transparency_metadata );
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$transparency_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'has_transparency', $transparency_metadata );
 		$this->assertSame( $expected_transparency, $transparency_metadata['has_transparency'] );
@@ -130,7 +128,6 @@ class Test_Dominant_Color extends TestCase {
 		$this->skip_if_mime_type_unsupported( $image_path );
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );
 		// Testing tag_add_adjust() with image being lazy load.
@@ -167,7 +164,6 @@ class Test_Dominant_Color extends TestCase {
 	 */
 	public function test_dominant_color_img_tag_add_dominant_color_requires_proper_quotes( string $image, bool $expected ): void {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/red.jpg' );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$image_url = wp_get_attachment_image_url( $attachment_id );
 		$image     = sprintf( $image, $image_url );
@@ -211,7 +207,6 @@ class Test_Dominant_Color extends TestCase {
 	 */
 	public function test_dominant_color_img_tag_add_dominant_color_should_add_dominant_color_inline_style( string $filtered_image, string $expected ): void {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/red.jpg' );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );
 


### PR DESCRIPTION
## Summary

Fixes #2524 
Depends on #2523 (I cant be bothered to rebase back to trunk, and then back on top when that gets merged)

## Relevant technical choices

I noticed some strange/redundant code in the dominant-color-images plugin so took it as an opportunity to do a bit of tidying up as well as implement tests for GD. 

The commits are self-describing. Let me know if it is necessary to split this into a few PRs... 

## Use of AI Tools

I used Deepseek V4 via VS Code Github Copilot Chat to assist me. I reviewed and refactored its output.

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
