### PR TITLE
Recover image dimensions when base metadata is incomplete (1x1 WebP)

### DIFF
--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -89,7 +89,7 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 	 *
 	 * See https://github.com/WordPress/performance/issues/2468.
 	 */
-	if ( empty( $metadata['width'] ) || empty( $metadata['height'] ) ) {
+	if ( ! isset( $metadata['width'], $metadata['height'] ) || (int) $metadata['width'] < 1 || (int) $metadata['height'] < 1 ) {
 		$image_size = wp_getimagesize( $file );
 		if ( ! is_array( $image_size ) ) {
 			return $metadata;

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -74,6 +74,30 @@ function webp_uploads_create_sources_property( array $metadata, int $attachment_
 		return $metadata;
 	}
 
+	/*
+	 * If the base image metadata is missing its dimensions, the core sub-size
+	 * generation failed at upload time. This happens when wp_create_image_subsizes()
+	 * bails early because wp_getimagesize() could not read the file -- typically an
+	 * intermittent race where the upload is read before it has finished being written
+	 * to disk. The result is metadata without `width`/`height`/`sizes`, which renders
+	 * the attachment at 1x1 pixels both in the Media Library and on the front end.
+	 *
+	 * The file is readable by the time this filter runs, so attempt to recover the
+	 * original dimensions from it. If they can be recovered, the full-size image will
+	 * display correctly again (responsive sub-sizes still require regeneration). If the
+	 * file still cannot be read, bail without decorating or persisting a partial record.
+	 *
+	 * See https://github.com/WordPress/performance/issues/2468.
+	 */
+	if ( empty( $metadata['width'] ) || empty( $metadata['height'] ) ) {
+		$image_size = wp_getimagesize( $file );
+		if ( ! is_array( $image_size ) ) {
+			return $metadata;
+		}
+		$metadata['width']  = $image_size[0];
+		$metadata['height'] = $image_size[1];
+	}
+
 	// Make sure the top level `sources` key is a valid array.
 	if ( ! isset( $metadata['sources'] ) || ! is_array( $metadata['sources'] ) ) {
 		$metadata['sources'] = array();

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -124,6 +124,67 @@ class Test_WebP_Uploads_Load extends TestCase {
 	}
 
 	/**
+	 * Recover the original image dimensions when the base metadata is incomplete.
+	 *
+	 * When core's wp_create_image_subsizes() cannot read the uploaded file (an
+	 * intermittent race at upload time) it returns metadata without width/height/sizes,
+	 * which makes the attachment render at 1x1 pixels. The filter should recover the
+	 * dimensions from the now-readable file instead of decorating a 1x1 record.
+	 *
+	 * @link https://github.com/WordPress/performance/issues/2468
+	 *
+	 * @covers ::webp_uploads_create_sources_property
+	 */
+	public function test_it_should_recover_dimensions_when_base_metadata_is_incomplete(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+
+		// The metadata generated during upload holds the real dimensions.
+		$generated = wp_get_attachment_metadata( $attachment_id );
+		$this->assertArrayHasKey( 'width', $generated );
+		$this->assertArrayHasKey( 'height', $generated );
+		$this->assertGreaterThan( 1, $generated['width'] );
+		$this->assertGreaterThan( 1, $generated['height'] );
+
+		// Simulate the core failure: base metadata without dimensions or sizes.
+		$result = webp_uploads_create_sources_property( array(), $attachment_id );
+
+		// The dimensions should be recovered from the readable file, not left empty.
+		$this->assertArrayHasKey( 'width', $result );
+		$this->assertArrayHasKey( 'height', $result );
+		$this->assertSame( $generated['width'], $result['width'] );
+		$this->assertSame( $generated['height'], $result['height'] );
+
+		// Sources are attached to the now-valid record rather than to a 1x1 placeholder.
+		$this->assertArrayHasKey( 'sources', $result );
+	}
+
+	/**
+	 * Do not decorate or persist metadata when the file cannot be read.
+	 *
+	 * If the dimensions still cannot be recovered (the file is genuinely unreadable),
+	 * the filter must bail without inventing dimensions or adding a sources property.
+	 *
+	 * @link https://github.com/WordPress/performance/issues/2468
+	 *
+	 * @covers ::webp_uploads_create_sources_property
+	 */
+	public function test_it_should_not_decorate_metadata_when_file_is_missing(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+
+		// Remove the underlying file so it can no longer be read.
+		$file = get_attached_file( $attachment_id );
+		$this->assertIsString( $file );
+		wp_delete_file( $file );
+
+		$result = webp_uploads_create_sources_property( array(), $attachment_id );
+
+		// No dimensions invented and no sources attached to the empty record.
+		$this->assertArrayNotHasKey( 'width', $result );
+		$this->assertArrayNotHasKey( 'height', $result );
+		$this->assertArrayNotHasKey( 'sources', $result );
+	}
+
+	/**
 	 * Create JPEG and output format for JPEG images, if perflab_generate_webp_and_jpeg option set.
 	 *
 	 * @covers ::wp_get_attachment_metadata


### PR DESCRIPTION
## Summary

Addresses the intermittent "1×1 px WebP" bug reported in #2468.

### Root cause

The reporter's stored metadata for a broken attachment contained only the keys *added by the performance plugins* and none of the base metadata that core normally produces:

```php
array(
  'dominant_color'   => '757863',
  'has_transparency' => false,
  'sources'          => array( 'image/webp' => array( ... ) ),
)
```

No `width`, `height`, `file`, or `sizes`. That happens when core's `wp_create_image_subsizes()` bails early:

```php
$imagesize = wp_getimagesize( $file );
if ( empty( $imagesize ) ) {
    return array(); // no width/height/sizes
}
```

`wp_getimagesize()` can fail intermittently at upload time (e.g. the file is read before it has finished being written to disk). Core then returns an empty array, the `wp_generate_attachment_metadata` filters decorate it, and the incomplete record is persisted. With `width`/`height` missing, core's `wp_constrain_dimensions()` clamps the dimensions to `max( 1, 0 ) = 1`, which is why the image renders at **1×1** in the Media Library grid and in the front-end HTML, even though the file itself opens fine. This also explains the "random / works on re-upload" behavior: re-uploading creates a fresh attachment that usually processes cleanly.

### The change

By the time `webp_uploads_create_sources_property()` runs, the file is readable again (the `sources` and `dominant_color` keys prove the file was read successfully a moment later). So when the base metadata is missing its dimensions, the filter now recovers `width`/`height` from the file before attaching the `sources` property. If the file still can't be read, it bails without inventing dimensions or persisting a partial record.

This restores correct display of the **full-size** image. Responsive sub-sizes (`sizes`) are still absent in this failure case and require regenerating the attachment (`wp media regenerate <id>`).

### Why only the webp-uploads plugin

`dominant-color-images` is intentionally designed to extract the dominant color independently of base metadata (see `test-dominant-color.php`, which asserts the color is added even when the incoming metadata is `array()`). The `dominant_color` key in the corrupted record is a *witness*, not a cause, so that plugin is left unchanged.

## Testing

- `test_it_should_recover_dimensions_when_base_metadata_is_incomplete` — passes incomplete metadata and asserts the real dimensions are recovered and `sources` attached.
- `test_it_should_not_decorate_metadata_when_file_is_missing` — asserts no dimensions are invented and no `sources` added when the file can't be read.

## Open questions / follow-ups

- This is a mitigation at the plugin layer. The underlying trigger is core returning empty metadata on an intermittent `wp_getimagesize()` failure; a more complete fix (retry, or regenerating sub-sizes) may warrant a core Trac ticket.
- Draft pending a green CI run of the new tests.

Refs #2468