### PR TITLE
Add JSHint configuration scoped to the repo to avoid ancestor-config false positives

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,6 @@
+build/
+dist/
+node_modules/
+vendor/
+artifacts/
+**/*.min.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,23 @@
+{
+	"boss": true,
+	"curly": true,
+	"eqeqeq": true,
+	"eqnull": true,
+	"esversion": 11,
+	"expr": true,
+	"immed": true,
+	"laxbreak": true,
+	"loopfunc": true,
+	"noarg": true,
+	"nonbsp": true,
+	"quotmark": "single",
+	"undef": true,
+	"unused": true,
+
+	"node": true,
+
+	"globals": {
+		"fetch": false,
+		"AbortController": false
+	}
+}

--- a/plugins/.jshintrc
+++ b/plugins/.jshintrc
@@ -1,0 +1,30 @@
+{
+	"boss": true,
+	"curly": true,
+	"eqeqeq": true,
+	"eqnull": true,
+	"esversion": 11,
+	"expr": true,
+	"immed": true,
+	"laxbreak": true,
+	"noarg": true,
+	"nonbsp": true,
+	"quotmark": "single",
+	"undef": true,
+	"unused": true,
+
+	"browser": true,
+	"devel": true,
+
+	"globals": {
+		"wp": false,
+		"jQuery": false,
+		"ResizeObserver": false,
+		"requestIdleCallback": false,
+		"cancelIdleCallback": false,
+		"structuredClone": false,
+		"CompressionStream": false,
+		"crypto": false,
+		"name": true
+	}
+}

--- a/plugins/auto-sizes/tests/e2e/specs/improve-calculate-sizes.spec.js
+++ b/plugins/auto-sizes/tests/e2e/specs/improve-calculate-sizes.spec.js
@@ -1,3 +1,7 @@
+/* jshint node: true */
+// ^ This Playwright spec runs in Node (CommonJS), not the browser like the
+// sibling plugin scripts that the `plugins/.jshintrc` browser config targets.
+
 /**
  * External dependencies
  */


### PR DESCRIPTION
## Summary

When this repo is checked out **inside** a `wordpress-develop` checkout (a common local setup), the IDE's JSHint inspection has no `.jshintrc` in this repo to anchor on, so it walks up the directory tree and falls through to wordpress-develop's ancestor `.jshintrc`. That ancestor config assumes a **browser** environment, an older ECMAScript version, and WP-core's operator-at-line-end style — none of which match this repo's Prettier-formatted, modern, mixed Node/browser JavaScript. The result is a stream of false-positive JSHint warnings across the repo's JS files.

This PR adds a JSHint configuration scoped to this repo that shadows the ancestor and silences those false positives, while still doing real linting (genuinely undefined globals and unused vars are still flagged).

This is purely IDE/tooling configuration — this repo uses ESLint (`@wordpress/scripts`) for its actual JS linting and does not run JSHint in CI. The configuration simply mirrors, in JSHint terms, the Node-vs-browser split that `eslint.config.js` already encodes.

## What's included

- **`.jshintrc` (root)** — Node environment for the root config files, `bin/`, and `tools/` tooling. Enables `laxbreak` (Prettier puts `?`/`:` at line starts), `loopfunc`, and the `fetch`/`AbortController` globals Node 18+ provides but JSHint's stale `node` set omits.
- **`plugins/.jshintrc`** — Browser environment for the shipped client scripts. Adds `devel` (console) plus the modern globals the stale `browser` set omits: `ResizeObserver`, `requestIdleCallback`/`cancelIdleCallback`, `structuredClone`, `CompressionStream`, `crypto` — and `name`, so the ES-module `export const name` stops tripping the read-only-global redefinition warning.
- **`.jshintignore`** — Skips generated/minified output (`build/`, `dist/`, `**/*.min.js`) and vendored/installed dependencies.
- **`plugins/auto-sizes/tests/e2e/specs/improve-calculate-sizes.spec.js`** — Gets an inline `/* jshint node: true */` directive because it's a Node CommonJS Playwright test living under the browser-oriented `plugins/` tree, so it needs the Node globals layered on top of the browser config.

## Testing

Ran JSHint (via the wordpress-develop checkout's `node_modules/.bin/jshint`, auto-discovering these configs) across all tracked, non-generated JS files in the repo: **0 warnings**. A probe confirmed the new configs are the ones being applied — JSHint recognizes the added globals (e.g. `ResizeObserver`) yet still flags genuinely undefined identifiers and unused variables, so linting integrity is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
