### PR TITLE
Gallery Block: Fix sizes issue for responsive screens

### DIFF
--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -362,10 +362,7 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 		// Store the total number of inner images in the gallery context for child blocks to access.
 		$context['gallery_total_images'] = $gallery_image_block_count;
 
-		if ( wp_is_mobile() ) {
-			// On mobile, the gallery is always 2 column.
-			$context['gallery_column_count'] = 2;
-		} elseif ( isset( $block['attrs']['columns'] ) && '' !== $block['attrs']['columns'] ) {
+		if ( isset( $block['attrs']['columns'] ) && '' !== $block['attrs']['columns'] ) {
 			$context['gallery_column_count'] = $block['attrs']['columns'] ?? '';
 		} elseif ( $gallery_image_block_count <= 3 ) {
 			/*


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Follow-up of https://github.com/WordPress/performance/pull/2534#discussion_r3437472824 discussion.

## Relevant technical choices

<!-- Please describe your changes. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.

Moreover, see the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
