### PR TITLE
Prepare 2026-06-30 release

### DIFF
--- a/bin/generate-pending-release-diffs.sh
+++ b/bin/generate-pending-release-diffs.sh
@@ -42,7 +42,10 @@ for plugin_slug in $( if [ $# -gt 0 ]; then echo "$@"; else jq '.plugins[]' -r p
 	remote_stable_tag=$( grep "Stable tag:" "$stable_dir/$plugin_slug/readme.txt" | awk '{print $3}' )
 	local_stable_tag=$( grep "Stable tag:" "build/$plugin_slug/readme.txt" | awk '{print $3}' )
 
-	rsync -avz --delete --exclude=".svn" "build/$plugin_slug/" "$stable_dir/$plugin_slug/" >&2
+	# Exclude minified assets: they are build artifacts derived from their sources, so
+	# diffing them just adds noise. Excluding them here also protects the stable copies
+	# from --delete, so svn status/diff below will not report them.
+	rsync -avz --delete --exclude=".svn" --exclude="*.min.js" --exclude="*.min.css" "build/$plugin_slug/" "$stable_dir/$plugin_slug/" >&2
 
 	cd "$stable_dir/$plugin_slug/"
 

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -72,7 +72,7 @@ withOptions( program.command( 'release-plugin-since' ), sinceOptions )
 withOptions( program.command( 'plugin-readme' ), readmeOptions )
 	.alias( 'readme' )
 	.description(
-		'Updates the changelog in the readme.txt file for the stable tag (requires milestones to be named "$plugin_slug $stable_tag")'
+		'Updates the changelog in the readme.txt file for the stable tag of plugins with an open, dated release milestone (use --all for every plugin); requires milestones to be named "$plugin_slug $stable_tag"'
 	)
 	.action( catchException( readmeHandler ) );
 

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -65,7 +65,7 @@ withOptions( program.command( 'release-plugin-changelog' ), changelogOptions )
 withOptions( program.command( 'release-plugin-since' ), sinceOptions )
 	.alias( 'since' )
 	.description(
-		'Updates "n.e.x.t" tags with the current release version in the "Stable tag" of readme.txt'
+		'Replaces "n.e.x.t" tags with the release version (the "Stable tag" of readme.txt) for plugins with an open, dated release milestone (use --all for every plugin)'
 	)
 	.action( catchException( sinceHandler ) );
 

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -52,6 +52,10 @@ const {
 	handler: versionsHandler,
 	options: versionsOptions,
 } = require( './commands/versions' );
+const {
+	handler: bumpVersionsHandler,
+	options: bumpVersionsOptions,
+} = require( './commands/bump-versions' );
 
 withOptions( program.command( 'release-plugin-changelog' ), changelogOptions )
 	.alias( 'changelog' )
@@ -76,5 +80,12 @@ withOptions( program.command( 'verify-version-consistency' ), versionsOptions )
 	.alias( 'versions' )
 	.description( 'Verifies consistency of versions in plugins' )
 	.action( catchException( versionsHandler ) );
+
+withOptions( program.command( 'bump-plugin-versions' ), bumpVersionsOptions )
+	.alias( 'bump-versions' )
+	.description(
+		'Bumps plugin versions based on open, dated release milestones (titled "$plugin_slug $version" without "n.e.x.t")'
+	)
+	.action( catchException( bumpVersionsHandler ) );
 
 program.parse( process.argv );

--- a/bin/plugin/commands/bump-versions.js
+++ b/bin/plugin/commands/bump-versions.js
@@ -1,0 +1,386 @@
+/**
+ * External dependencies
+ */
+const fs = require( 'fs' );
+const path = require( 'path' );
+const glob = require( 'fast-glob' );
+
+/**
+ * Internal dependencies
+ */
+const { log, formats } = require( '../lib/logger' );
+const { getMilestones } = require( '../lib/milestone' );
+const config = require( '../config' );
+const { plugins } = require( '../../../plugins.json' );
+
+/** @typedef {import('@octokit/rest').Octokit} GitHub */
+
+/**
+ * @typedef WPBumpVersionsCommandOptions
+ *
+ * @property {string=}  plugin Optional plugin slug to limit bumping to a single plugin.
+ * @property {string=}  token  Optional personal GitHub access token.
+ * @property {boolean=} dryRun Whether to only report what would change without writing.
+ */
+
+/**
+ * @typedef ReleaseMilestone
+ *
+ * @property {string} slug    Plugin slug.
+ * @property {string} version Target version parsed from the milestone title.
+ * @property {string} title   Full milestone title.
+ * @property {number} number  Milestone number.
+ * @property {number} open    Count of open issues/PRs in the milestone.
+ */
+
+const VERSION_PATTERN = '\\d+\\.\\d+\\.\\d+(?:-[\\w.]+)?';
+
+exports.options = [
+	{
+		argname: '-p, --plugin <plugin>',
+		description:
+			'The plugin slug to bump; if omitted, all plugins with a matching milestone are bumped',
+	},
+	{
+		argname: '-t, --token <token>',
+		description: 'GitHub token',
+	},
+	{
+		argname: '-n, --dry-run',
+		description: 'Report the version changes without writing any files',
+		defaults: false,
+	},
+];
+
+/**
+ * Command that bumps plugin versions based on their release milestones.
+ *
+ * A release milestone is an open milestone whose title is "<plugin-slug> <version>"
+ * (i.e. it does not contain "n.e.x.t") and which has a due date set. For each such
+ * milestone, the target version is applied to the plugin's bootstrap PHP file header,
+ * its PHP version constant, the "Stable tag" in readme.txt, and a new (empty) changelog
+ * entry is inserted so the readme is ready for `npm run readme`.
+ *
+ * @param {WPBumpVersionsCommandOptions} opt
+ */
+exports.handler = async ( opt ) => {
+	if ( opt.plugin && ! plugins.includes( opt.plugin ) ) {
+		throw new Error(
+			`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`
+		);
+	}
+
+	const milestones = await getReleaseMilestones( opt.token );
+
+	let selected = milestones;
+	if ( opt.plugin ) {
+		selected = milestones.filter( ( m ) => m.slug === opt.plugin );
+	}
+
+	if ( selected.length === 0 ) {
+		log(
+			formats.warning(
+				opt.plugin
+					? `⚠ No release milestone (open, dated, without "n.e.x.t") found for ${ opt.plugin }.`
+					: '⚠ No release milestones (open, dated, without "n.e.x.t") found.'
+			)
+		);
+		return;
+	}
+
+	// Guard against two dated milestones targeting the same plugin, which would be ambiguous.
+	const byPlugin = /** @type {Record<string, ReleaseMilestone[]>} */ ( {} );
+	for ( const milestone of selected ) {
+		( byPlugin[ milestone.slug ] ??= [] ).push( milestone );
+	}
+	const ambiguous = Object.entries( byPlugin ).filter(
+		( [ , list ] ) => list.length > 1
+	);
+	if ( ambiguous.length > 0 ) {
+		const details = ambiguous
+			.map(
+				( [ slug, list ] ) =>
+					`${ slug }: ${ list.map( ( m ) => m.title ).join( ', ' ) }`
+			)
+			.join( '; ' );
+		throw new Error(
+			`Multiple dated release milestones match the same plugin, so the target version is ambiguous: ${ details }`
+		);
+	}
+
+	const pluginRoot = path.resolve( __dirname, '../../../' );
+
+	for ( const milestone of selected.sort( ( a, b ) =>
+		a.slug.localeCompare( b.slug )
+	) ) {
+		if ( milestone.open > 0 ) {
+			log(
+				formats.warning(
+					`⚠ Milestone "${ milestone.title }" still has ${ milestone.open } open issue(s)/PR(s); the release should have none.`
+				)
+			);
+		}
+
+		try {
+			const pluginDirectory = path.resolve(
+				pluginRoot,
+				'plugins',
+				milestone.slug
+			);
+			const changes = await bumpPlugin(
+				pluginDirectory,
+				milestone.version,
+				opt.dryRun
+			);
+			const prefix = opt.dryRun ? '🔍 [dry-run] ' : '💃 ';
+			log(
+				formats.success(
+					`${ prefix }${ milestone.slug } → ${ milestone.version }:`
+				)
+			);
+			for ( const change of changes ) {
+				log( `    ${ change }` );
+			}
+		} catch ( error ) {
+			const message =
+				error instanceof Error ? error.message : 'Unknown error';
+			log( formats.error( `❌ ${ milestone.slug }: ${ message }` ) );
+		}
+	}
+};
+
+/**
+ * Fetches the release milestones: open milestones with a due date whose title is
+ * "<plugin-slug> <version>" (i.e. without "n.e.x.t").
+ *
+ * @param {string=} token Optional GitHub token.
+ * @return {Promise<ReleaseMilestone[]>} Release milestones.
+ */
+async function getReleaseMilestones( token ) {
+	const { Octokit } = await import( '@octokit/rest' );
+	const octokit = new Octokit( { auth: token } );
+
+	const milestones = await getMilestones(
+		octokit,
+		config.githubRepositoryOwner,
+		config.githubRepositoryName,
+		'open'
+	);
+
+	const titleRegExp = new RegExp(
+		`^(?<slug>[a-z0-9-]+)\\s+(?<version>${ VERSION_PATTERN })$`
+	);
+
+	/** @type {ReleaseMilestone[]} */
+	const releaseMilestones = [];
+
+	for ( const milestone of milestones ) {
+		// Skip milestones without a due date (e.g. backlog/planning milestones).
+		if ( ! milestone.due_on ) {
+			continue;
+		}
+
+		const matches = milestone.title.match( titleRegExp );
+		if ( ! matches || ! matches.groups ) {
+			continue;
+		}
+
+		const { slug, version } = matches.groups;
+		if ( ! plugins.includes( slug ) ) {
+			log(
+				formats.warning(
+					`⚠ Milestone "${ milestone.title }" does not correspond to a known plugin slug; skipping.`
+				)
+			);
+			continue;
+		}
+
+		releaseMilestones.push( {
+			slug,
+			version,
+			title: milestone.title,
+			number: milestone.number,
+			open: milestone.open_issues,
+		} );
+	}
+
+	return releaseMilestones;
+}
+
+/**
+ * Bumps the version everywhere it needs to be set for a single plugin.
+ *
+ * @param {string}   pluginDirectory Absolute path to the plugin directory.
+ * @param {string}   version         Target version.
+ * @param {boolean=} dryRun          Whether to avoid writing files.
+ * @return {Promise<string[]>} Human-readable descriptions of the changes made.
+ */
+async function bumpPlugin( pluginDirectory, version, dryRun ) {
+	const changes = [];
+
+	const bootstrapFile = await findBootstrapFile( pluginDirectory );
+	const bootstrapContents = fs.readFileSync( bootstrapFile, 'utf-8' );
+	const relativeBootstrap = path.basename( bootstrapFile );
+
+	// 1. Plugin header "Version:" metadata.
+	let updatedBootstrap = replaceOne(
+		bootstrapContents,
+		new RegExp( `^( \\* Version:\\s+)${ VERSION_PATTERN }$`, 'm' ),
+		( match, prefix ) => `${ prefix }${ version }`,
+		`Unable to locate the "Version" header in ${ relativeBootstrap }.`
+	);
+
+	// 2. PHP version constant literal (the first version-like single-quoted string).
+	updatedBootstrap = replaceOne(
+		updatedBootstrap,
+		new RegExp( `'${ VERSION_PATTERN }'` ),
+		() => `'${ version }'`,
+		`Unable to locate the PHP version constant in ${ relativeBootstrap }.`
+	);
+
+	if ( updatedBootstrap !== bootstrapContents ) {
+		if ( ! dryRun ) {
+			fs.writeFileSync( bootstrapFile, updatedBootstrap );
+		}
+		changes.push(
+			`${ relativeBootstrap }: updated "Version" header and PHP version constant`
+		);
+	} else {
+		changes.push( `${ relativeBootstrap }: already at ${ version }` );
+	}
+
+	// 3 & 4. readme.txt "Stable tag" and a new changelog entry.
+	const readmeFile = path.resolve( pluginDirectory, 'readme.txt' );
+	const readmeContents = fs.readFileSync( readmeFile, 'utf-8' );
+
+	const stableTagUpdated = replaceOne(
+		readmeContents,
+		new RegExp( `^(Stable tag:\\s*)${ VERSION_PATTERN }$`, 'm' ),
+		( match, prefix ) => `${ prefix }${ version }`,
+		`Unable to locate "Stable tag" in ${ readmeFile }.`
+	);
+
+	const { contents: updatedReadme, status } = ensureChangelogEntry(
+		stableTagUpdated,
+		version
+	);
+
+	const readmeChanges = [];
+	if ( stableTagUpdated !== readmeContents ) {
+		readmeChanges.push( 'updated "Stable tag"' );
+	}
+	if ( status === 'inserted' ) {
+		readmeChanges.push( `inserted "= ${ version } =" changelog entry` );
+	} else if ( status === 'relabeled' ) {
+		readmeChanges.push(
+			`relabeled "= n.e.x.t =" changelog entry to "= ${ version } ="`
+		);
+	}
+
+	if ( updatedReadme !== readmeContents ) {
+		if ( ! dryRun ) {
+			fs.writeFileSync( readmeFile, updatedReadme );
+		}
+		changes.push( `readme.txt: ${ readmeChanges.join( ' and ' ) }` );
+	} else {
+		changes.push( `readme.txt: already at ${ version }` );
+	}
+
+	return changes;
+}
+
+/**
+ * Locates the plugin bootstrap PHP file (the one declaring the plugin header).
+ *
+ * @param {string} pluginDirectory Absolute path to the plugin directory.
+ * @return {Promise<string>} Absolute path to the bootstrap file.
+ */
+async function findBootstrapFile( pluginDirectory ) {
+	for ( const phpFile of await glob(
+		path.resolve( pluginDirectory, '*.php' )
+	) ) {
+		const phpFileContents = fs.readFileSync( phpFile, 'utf-8' );
+		if ( /^<\?php\n\/\*\*\n \* Plugin Name:/.test( phpFileContents ) ) {
+			return phpFile;
+		}
+	}
+	throw new Error(
+		`Unable to locate the PHP bootstrap file in ${ pluginDirectory }.`
+	);
+}
+
+/**
+ * Ensures the changelog has a single "= <version> =" entry at the top.
+ *
+ * This keeps the readme version-consistent (the latest changelog entry must match the
+ * stable tag) and primes the section for `npm run readme`. There are three cases:
+ *
+ * - An entry for the version already exists: nothing to do (idempotent).
+ * - A "= n.e.x.t =" placeholder entry exists (where contributors accrued notes during
+ *   development): relabel it to "= <version> =". This avoids producing a duplicate
+ *   entry once `npm run since` rewrites any remaining "n.e.x.t" headings.
+ * - Otherwise: insert a new empty "= <version> =" entry as the first entry.
+ *
+ * @param {string} readmeContents Readme contents.
+ * @param {string} version        Target version.
+ * @return {{contents: string, status: 'present'|'relabeled'|'inserted'}} Updated contents and what was done.
+ */
+function ensureChangelogEntry( readmeContents, version ) {
+	// Already has an entry for this version anywhere in the changelog; nothing to do.
+	const versionHeadingRegExp = new RegExp(
+		`^= ${ escapeRegExp( version ) } =$`,
+		'm'
+	);
+	if ( versionHeadingRegExp.test( readmeContents ) ) {
+		return { contents: readmeContents, status: 'present' };
+	}
+
+	// Relabel an existing "= n.e.x.t =" placeholder heading (the first one, which is in
+	// the Changelog section rather than a later Upgrade Notice section).
+	const nextHeadingRegExp = /^= n\.e\.x\.t =$/m;
+	if ( nextHeadingRegExp.test( readmeContents ) ) {
+		return {
+			contents: readmeContents.replace(
+				nextHeadingRegExp,
+				`= ${ version } =`
+			),
+			status: 'relabeled',
+		};
+	}
+
+	// Otherwise insert a new empty entry at the top of the changelog.
+	const contents = replaceOne(
+		readmeContents,
+		/^(== Changelog ==\n+)/m,
+		( match, heading ) => `${ heading }= ${ version } =\n\n`,
+		'Unable to locate the "== Changelog ==" section in readme.txt.'
+	);
+
+	return { contents, status: 'inserted' };
+}
+
+/**
+ * Replaces exactly one match of a regular expression, throwing if there is no match.
+ *
+ * @param {string}                     contents     Input string.
+ * @param {RegExp}                     regexp       Regular expression (must not be global).
+ * @param {function(...string):string} replacer     Replacement callback.
+ * @param {string}                     errorMessage Error message thrown when there is no match.
+ * @return {string} The string with the replacement applied.
+ */
+function replaceOne( contents, regexp, replacer, errorMessage ) {
+	if ( ! regexp.test( contents ) ) {
+		throw new Error( errorMessage );
+	}
+	return contents.replace( regexp, replacer );
+}
+
+/**
+ * Escapes a string for safe use inside a regular expression.
+ *
+ * @param {string} value String to escape.
+ * @return {string} Escaped string.
+ */
+function escapeRegExp( value ) {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+}

--- a/bin/plugin/commands/bump-versions.js
+++ b/bin/plugin/commands/bump-versions.js
@@ -207,6 +207,10 @@ async function getReleaseMilestones( token ) {
 	return releaseMilestones;
 }
 
+// Export getReleaseMilestones so other release commands (e.g. `since`) can target the
+// same set of plugins.
+exports.getReleaseMilestones = getReleaseMilestones;
+
 /**
  * Bumps the version everywhere it needs to be set for a single plugin.
  *

--- a/bin/plugin/commands/bump-versions.js
+++ b/bin/plugin/commands/bump-versions.js
@@ -233,7 +233,7 @@ async function bumpPlugin( pluginDirectory, version, dryRun ) {
 	let updatedBootstrap = replaceOne(
 		bootstrapContents,
 		new RegExp( `^( \\* Version:\\s+)${ VERSION_PATTERN }$`, 'm' ),
-		( match, prefix ) => `${ prefix }${ version }`,
+		( _match, prefix ) => `${ prefix }${ version }`,
 		`Unable to locate the "Version" header in ${ relativeBootstrap }.`
 	);
 
@@ -263,7 +263,7 @@ async function bumpPlugin( pluginDirectory, version, dryRun ) {
 	const stableTagUpdated = replaceOne(
 		readmeContents,
 		new RegExp( `^(Stable tag:\\s*)${ VERSION_PATTERN }$`, 'm' ),
-		( match, prefix ) => `${ prefix }${ version }`,
+		( _match, prefix ) => `${ prefix }${ version }`,
 		`Unable to locate "Stable tag" in ${ readmeFile }.`
 	);
 
@@ -359,7 +359,7 @@ function ensureChangelogEntry( readmeContents, version ) {
 	const contents = replaceOne(
 		readmeContents,
 		/^(== Changelog ==\n+)/m,
-		( match, heading ) => `${ heading }= ${ version } =\n\n`,
+		( _match, heading ) => `${ heading }= ${ version } =\n\n`,
 		'Unable to locate the "== Changelog ==" section in readme.txt.'
 	);
 

--- a/bin/plugin/commands/bump-versions.js
+++ b/bin/plugin/commands/bump-versions.js
@@ -57,9 +57,12 @@ exports.options = [
  *
  * A release milestone is an open milestone whose title is "<plugin-slug> <version>"
  * (i.e. it does not contain "n.e.x.t") and which has a due date set. For each such
- * milestone, the target version is applied to the plugin's bootstrap PHP file header,
- * its PHP version constant, the "Stable tag" in readme.txt, and a new (empty) changelog
- * entry is inserted so the readme is ready for `npm run readme`.
+ * milestone, the target version is applied to:
+ *
+ *  - the plugin's bootstrap PHP file header,
+ *  - its PHP version constant,
+ *  - the "Stable tag" in readme.txt, and
+ *  - a new (empty) changelog entry is inserted so the readme is ready for `npm run readme`.
  *
  * @param {WPBumpVersionsCommandOptions} opt
  */

--- a/bin/plugin/commands/bump-versions.js
+++ b/bin/plugin/commands/bump-versions.js
@@ -91,7 +91,10 @@ exports.handler = async ( opt ) => {
 	// Guard against two dated milestones targeting the same plugin, which would be ambiguous.
 	const byPlugin = /** @type {Record<string, ReleaseMilestone[]>} */ ( {} );
 	for ( const milestone of selected ) {
-		( byPlugin[ milestone.slug ] ??= [] ).push( milestone );
+		if ( ! byPlugin[ milestone.slug ] ) {
+			byPlugin[ milestone.slug ] = [];
+		}
+		byPlugin[ milestone.slug ].push( milestone );
 	}
 	const ambiguous = Object.entries( byPlugin ).filter(
 		( [ , list ] ) => list.length > 1

--- a/bin/plugin/commands/changelog.js
+++ b/bin/plugin/commands/changelog.js
@@ -141,12 +141,11 @@ function getIssueType( issue ) {
 /**
  * Formats the changelog string for a given list of pull requests.
  *
- * @param {string}                          milestone    Milestone title.
  * @param {IssuesListForRepoResponseItem[]} pullRequests List of pull requests.
  *
  * @return {string} The formatted changelog string (without the heading).
  */
-function formatChangelog( milestone, pullRequests ) {
+function formatChangelog( pullRequests ) {
 	let changelog = '';
 
 	// Group PRs by type.
@@ -243,7 +242,7 @@ async function getChangelog( settings ) {
 		);
 	}
 
-	return formatChangelog( settings.milestone, nonSkippedPullRequests );
+	return formatChangelog( nonSkippedPullRequests );
 }
 
 /**

--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -47,7 +47,7 @@ exports.handler = async ( opt ) => {
  * Updates the `readme.txt` file with the given changelog.
  *
  * @param {string} readmeFile Readme file path.
- * @param {string} changelog  Changelog in markdown.
+ * @param {string} changelog  Changelog in Markdown format.
  * @return {string} Success status message.
  */
 function updateReadmeChangelog( readmeFile, changelog ) {

--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -10,24 +10,32 @@ const fs = require( 'fs' );
 const { log, formats } = require( '../lib/logger' );
 const config = require( '../config' );
 const { getChangelog } = require( './changelog' );
+const { getReleaseMilestones } = require( './bump-versions' );
 const { plugins } = require( '../../../plugins.json' );
 
 /**
  * @typedef WPReadmeCommandOptions
  *
- * @property {string=} plugin Optional plugin slug to update one a single plugin's readme. If omitted, all plugins are updated.
- * @property {string=} token  Optional personal GitHub access token.
+ * @property {string=}  plugin Optional plugin slug to update a single plugin's readme. Defaults to all plugins with an open, dated release milestone.
+ * @property {string=}  token  Optional personal GitHub access token.
+ * @property {boolean=} all    Update every plugin, ignoring release milestones (legacy behavior).
  */
 
 exports.options = [
 	{
 		argname: '-p, --plugin <plugin>',
 		description:
-			'The plugin slug to update; if omitted, all plugins are updated',
+			'Plugin slug. Defaults to all plugins with an open, dated release milestone.',
 	},
 	{
 		argname: '-t, --token <token>',
 		description: 'GitHub token',
+	},
+	{
+		argname: '-a, --all',
+		description:
+			'Update all plugins, ignoring release milestones (legacy behavior). When combined with --plugin, that plugin is updated without checking for a milestone.',
+		defaults: false,
 	},
 ];
 
@@ -37,14 +45,50 @@ exports.options = [
  * @param {WPReadmeCommandOptions} opt
  */
 exports.handler = async ( opt ) => {
+	if ( opt.plugin && ! plugins.includes( opt.plugin ) ) {
+		throw new Error(
+			`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`
+		);
+	}
+
+	let pluginSlugs;
+	if ( opt.all ) {
+		// Legacy behavior: update every plugin (or the given one), ignoring milestones.
+		pluginSlugs = opt.plugin ? [ opt.plugin ] : plugins;
+	} else {
+		// Default: only update plugins that are being released, i.e. those with an open
+		// milestone that has a due date and whose title does not contain "n.e.x.t".
+		const releaseSlugs = ( await getReleaseMilestones( opt.token ) ).map(
+			( milestone ) => milestone.slug
+		);
+		pluginSlugs = opt.plugin
+			? releaseSlugs.filter( ( slug ) => slug === opt.plugin )
+			: releaseSlugs;
+
+		if ( pluginSlugs.length === 0 ) {
+			log(
+				formats.warning(
+					opt.plugin
+						? `⚠ Skipping ${ opt.plugin }: no open release milestone with a due date (and without "n.e.x.t") was found. Pass --all to update it anyway.`
+						: '⚠ No plugins have an open release milestone with a due date (and without "n.e.x.t"); nothing to update. Pass --all to update every plugin.'
+				)
+			);
+			return;
+		}
+	}
+
 	await updateReadme( {
-		plugin: opt.plugin,
+		pluginSlugs,
 		token: opt.token,
 	} );
 };
 
 /**
  * Updates the `readme.txt` file with the given changelog.
+ *
+ * If the changelog already has an entry for the stable tag, the newly generated
+ * entries are merged into it, skipping any pull requests that are already listed
+ * (so the command is idempotent and never duplicates entries into an "Other" section).
  *
  * @param {string} readmeFile Readme file path.
  * @param {string} changelog  Changelog in Markdown format.
@@ -53,53 +97,179 @@ exports.handler = async ( opt ) => {
 function updateReadmeChangelog( readmeFile, changelog ) {
 	const fileContent = fs.readFileSync( readmeFile, 'utf-8' );
 
-	const stableTagVersionMatches = fileContent.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w.]+)?)$/m
-	);
-	if ( ! stableTagVersionMatches ) {
-		throw new Error( `Unable to locate stable tag in ${ readmeFile }` );
-	}
-	const stableTagVersion = stableTagVersionMatches[ 1 ];
+	const stableTagVersion = getStableTag( readmeFile );
 
-	const regex = new RegExp(
-		`(== Changelog ==\n+)(= ${ stableTagVersion } =\n+)([^=]+)`
-	);
-
-	const versionHeading = `= ${ stableTagVersion } =\n\n`;
 	const normalizedChangelog = changelog.trimEnd() + '\n';
 
-	let status = '';
-
-	// Try to merge the new changelog with the existing changelog.
-	let newContent = fileContent.replace(
-		regex,
-		( _match, changelogHeading, _versionHeading, existingChangelog ) => {
-			const newChangelog = `${ changelogHeading }${ _versionHeading.trimEnd() }\n\n${ normalizedChangelog }`;
-			if ( existingChangelog.trim() !== '' ) {
-				status =
-					'Merged existing changelog with the new changelog in an Other section.';
-				return `${ newChangelog }\n**Other**\n\n${ existingChangelog }`;
-			}
-			status = 'Populated empty changelog section.';
-			return `${ newChangelog }${ existingChangelog }`;
-		}
+	const versionHeadingRegExp = new RegExp(
+		`^= ${ escapeRegExp( stableTagVersion ) } =$`,
+		'm'
 	);
+	const headingMatch = versionHeadingRegExp.exec( fileContent );
 
-	// No replacement was done, so we need to insert a new section.
-	if ( newContent === fileContent ) {
-		newContent = fileContent.replace( /(== Changelog ==\n+)/, ( match ) => {
-			status = 'Added new changelog section.';
-			return `${ match }${ versionHeading }${ normalizedChangelog }\n`;
-		} );
+	// No existing entry for this version: insert a fresh section at the top of the changelog.
+	if ( ! headingMatch ) {
+		const versionHeading = `= ${ stableTagVersion } =\n\n`;
+		const newContent = fileContent.replace(
+			/(== Changelog ==\n+)/,
+			( match ) =>
+				`${ match }${ versionHeading }${ normalizedChangelog }\n`
+		);
+		if ( newContent === fileContent ) {
+			throw new Error( 'Failed to insert changelog into readme.' );
+		}
+		fs.writeFileSync( readmeFile, newContent );
+		return 'Added new changelog section.';
 	}
 
-	if ( newContent === fileContent ) {
-		throw new Error( 'Failed to insert changelog into readme.' );
+	// Isolate the body between this version heading and the next version heading (or EOF).
+	const bodyStart = headingMatch.index + headingMatch[ 0 ].length;
+	const before = fileContent.slice( 0, bodyStart );
+	const rest = fileContent.slice( bodyStart );
+	const nextHeadingMatch = /^= .+ =$/m.exec( rest );
+	const bodyEnd = nextHeadingMatch ? nextHeadingMatch.index : rest.length;
+	const existingBody = rest
+		.slice( 0, bodyEnd )
+		.replace( /^\n+/, '' )
+		.replace( /\s+$/, '' );
+	const after = rest.slice( bodyEnd );
+
+	let newBody;
+	let status;
+	if ( existingBody === '' ) {
+		newBody = changelog.trimEnd();
+		status = 'Populated empty changelog section.';
+	} else {
+		const { merged, addedCount } = mergeChangelog(
+			existingBody,
+			changelog
+		);
+		newBody = merged;
+		status =
+			addedCount === 0
+				? 'Existing changelog already up to date; no new entries added.'
+				: `Merged ${ addedCount } new ${
+						addedCount === 1 ? 'entry' : 'entries'
+				  } into the existing changelog.`;
+	}
+
+	let newContent = `${ before }\n\n${ newBody }\n`;
+	if ( after !== '' ) {
+		newContent += `\n${ after }`;
 	}
 
 	fs.writeFileSync( readmeFile, newContent );
 
 	return status;
+}
+
+/**
+ * Merges newly generated changelog entries into an existing changelog body.
+ *
+ * The existing body is preserved verbatim; only entries for pull requests that are
+ * not already listed are appended, each under its corresponding section heading (a
+ * new section is created when necessary). This makes re-running the command safe:
+ * previously added entries are never duplicated.
+ *
+ * @param {string} existingBody Existing changelog body for the version (without the version heading).
+ * @param {string} incomingBody Newly generated changelog body (without the version heading).
+ * @return {{merged: string, addedCount: number}} The merged body and the number of entries added.
+ */
+function mergeChangelog( existingBody, incomingBody ) {
+	const existingPullRequests = new Set(
+		[ ...existingBody.matchAll( /\(\[(\d+)]/g ) ].map(
+			( matches ) => matches[ 1 ]
+		)
+	);
+
+	const incomingSections = parseChangelogSections( incomingBody );
+
+	let merged = existingBody.replace( /\s+$/, '' );
+	let addedCount = 0;
+
+	for ( const [ section, entries ] of incomingSections ) {
+		const newEntries = entries.filter( ( entry ) => {
+			const matches = entry.match( /\(\[(\d+)]/ );
+			return ! ( matches && existingPullRequests.has( matches[ 1 ] ) );
+		} );
+		if ( newEntries.length === 0 ) {
+			continue;
+		}
+		addedCount += newEntries.length;
+		merged = insertEntriesIntoSection( merged, section, newEntries );
+	}
+
+	return { merged, addedCount };
+}
+
+/**
+ * Parses a changelog body into an ordered map of section headings to entry lines.
+ *
+ * @param {string} body Changelog body (without the version heading).
+ * @return {Map<string, string[]>} Map of section heading text (without the `**` markers) to entry lines.
+ */
+function parseChangelogSections( body ) {
+	/** @type {Map<string, string[]>} */
+	const sections = new Map();
+	let currentSection = null;
+	for ( const rawLine of body.split( '\n' ) ) {
+		const line = rawLine.trim();
+		const headingMatch = line.match( /^\*\*(.+)\*\*$/ );
+		if ( headingMatch ) {
+			currentSection = headingMatch[ 1 ];
+			if ( ! sections.has( currentSection ) ) {
+				sections.set( currentSection, [] );
+			}
+			continue;
+		}
+		if ( currentSection && line.startsWith( '* ' ) ) {
+			const entries = sections.get( currentSection );
+			if ( entries ) {
+				entries.push( line );
+			}
+		}
+	}
+	return sections;
+}
+
+/**
+ * Inserts entry lines under the given section heading within a changelog body,
+ * appending a new section when the heading is not already present.
+ *
+ * @param {string}   body    Changelog body.
+ * @param {string}   section Section heading text (without the `**` markers).
+ * @param {string[]} entries Entry lines to insert.
+ * @return {string} Updated changelog body.
+ */
+function insertEntriesIntoSection( body, section, entries ) {
+	const headingLine = `**${ section }**`;
+	const lines = body.split( '\n' );
+	const headingIndex = lines.findIndex(
+		( line ) => line.trim() === headingLine
+	);
+
+	// Section not present: append it at the end of the body.
+	if ( headingIndex === -1 ) {
+		return `${ body.replace(
+			/\s+$/,
+			''
+		) }\n\n${ headingLine }\n\n${ entries.join( '\n' ) }`;
+	}
+
+	// Insert after the last bullet belonging to this section (before the next heading).
+	let insertIndex = headingIndex;
+	for ( let i = headingIndex + 1; i < lines.length; i++ ) {
+		const trimmed = lines[ i ].trim();
+		if ( trimmed.startsWith( '**' ) && trimmed.endsWith( '**' ) ) {
+			break;
+		}
+		if ( trimmed.startsWith( '* ' ) ) {
+			insertIndex = i;
+		}
+	}
+
+	lines.splice( insertIndex + 1, 0, ...entries );
+	return lines.join( '\n' );
 }
 
 /**
@@ -121,26 +291,24 @@ function getStableTag( readmeFilePath ) {
 }
 
 /**
+ * Escapes a string for safe use inside a regular expression.
+ *
+ * @param {string} value String to escape.
+ * @return {string} Escaped string.
+ */
+function escapeRegExp( value ) {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+}
+
+/**
  * Updates the `readme.txt` file with a specific release changelog.
  *
- * @param {WPReadmeCommandOptions} settings
+ * @param {{pluginSlugs: string[], token?: string}} settings
  */
 async function updateReadme( settings ) {
 	const pluginRoot = path.resolve( __dirname, '../../../' );
 
-	if ( settings.plugin && ! plugins.includes( settings.plugin ) ) {
-		throw new Error( `Unrecognized plugin: ${ settings.plugin }` );
-	}
-
-	const pluginSlugs = [];
-
-	if ( settings.plugin ) {
-		pluginSlugs.push( settings.plugin );
-	} else {
-		pluginSlugs.push( ...plugins );
-	}
-
-	for ( const pluginSlug of pluginSlugs ) {
+	for ( const pluginSlug of settings.pluginSlugs ) {
 		try {
 			const pluginDirectory = path.resolve(
 				pluginRoot,

--- a/bin/plugin/commands/readme.js
+++ b/bin/plugin/commands/readme.js
@@ -54,7 +54,7 @@ function updateReadmeChangelog( readmeFile, changelog ) {
 	const fileContent = fs.readFileSync( readmeFile, 'utf-8' );
 
 	const stableTagVersionMatches = fileContent.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w.]+)?)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
 		throw new Error( `Unable to locate stable tag in ${ readmeFile }` );
@@ -73,7 +73,7 @@ function updateReadmeChangelog( readmeFile, changelog ) {
 	// Try to merge the new changelog with the existing changelog.
 	let newContent = fileContent.replace(
 		regex,
-		( match, changelogHeading, _versionHeading, existingChangelog ) => {
+		( _match, changelogHeading, _versionHeading, existingChangelog ) => {
 			const newChangelog = `${ changelogHeading }${ _versionHeading.trimEnd() }\n\n${ normalizedChangelog }`;
 			if ( existingChangelog.trim() !== '' ) {
 				status =
@@ -112,7 +112,7 @@ function getStableTag( readmeFilePath ) {
 	const readmeContents = fs.readFileSync( readmeFilePath, 'utf-8' );
 
 	const stableTagVersionMatches = readmeContents.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w.]+)?)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
 		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -90,7 +90,7 @@ exports.handler = async ( opt ) => {
 		const readmeFile = path.resolve( pluginDirectory, 'readme.txt' );
 		const readmeContent = fs.readFileSync( readmeFile, 'utf-8' );
 		const readmeContentMatches = readmeContent.match(
-			/^Stable tag:\s+(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
+			/^Stable tag:\s+(\d+\.\d+\.\d+(?:-[\w.]+)?)$/m
 		);
 		if ( ! readmeContentMatches ) {
 			throw new Error(
@@ -118,7 +118,7 @@ exports.handler = async ( opt ) => {
 				if ( regexp.test( content ) ) {
 					fs.writeFileSync(
 						file,
-						content.replace( regexp, function ( matches, tag ) {
+						content.replace( regexp, function ( _matches, tag ) {
 							replacementCount++;
 							return tag + version;
 						} )
@@ -130,7 +130,7 @@ exports.handler = async ( opt ) => {
 		// Update versions in Changelog and Upgrade Notices.
 		const readmeContentUpdated = readmeContent.replace(
 			/(^= )(n\.e\.x\.t)( =$)/gm,
-			function ( matches, before, next, after ) {
+			function ( _matches, before, _next, after ) {
 				replacementCount++;
 				return before + version + after;
 			}

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -10,17 +10,31 @@ const { log, formats } = require( '../lib/logger' );
  * Internal dependencies
  */
 const { plugins } = require( '../../../plugins.json' );
+const { getReleaseMilestones } = require( './bump-versions' );
 
 /**
  * @typedef WPSinceCommandOptions
  *
- * @property {string=} plugin Plugin slug.
+ * @property {string=}  plugin Plugin slug.
+ * @property {string=}  token  Optional personal GitHub access token.
+ * @property {boolean=} all    Update every plugin, ignoring release milestones (legacy behavior).
  */
 
 exports.options = [
 	{
 		argname: '-p, --plugin <plugin>',
-		description: 'Plugin slug. Defaults to update all.',
+		description:
+			'Plugin slug. Defaults to all plugins with an open, dated release milestone.',
+	},
+	{
+		argname: '-t, --token <token>',
+		description: 'GitHub token',
+	},
+	{
+		argname: '-a, --all',
+		description:
+			'Update all plugins, ignoring release milestones (legacy behavior). When combined with --plugin, that plugin is updated without checking for a milestone.',
+		defaults: false,
 	},
 ];
 
@@ -36,20 +50,36 @@ exports.handler = async ( opt ) => {
 		);
 	}
 
-	const pluginDirectories = [];
-	const pluginRoot = path.resolve( __dirname, '../../../' );
-
-	if ( opt.plugin ) {
-		pluginDirectories.push(
-			path.resolve( pluginRoot, 'plugins', opt.plugin )
-		);
+	let targetSlugs;
+	if ( opt.all ) {
+		// Legacy behavior: update every plugin (or the given one), ignoring milestones.
+		targetSlugs = opt.plugin ? [ opt.plugin ] : plugins;
 	} else {
-		for ( const pluginSlug of plugins ) {
-			pluginDirectories.push(
-				path.resolve( pluginRoot, 'plugins', pluginSlug )
+		// Default: only update plugins that are being released, i.e. those with an open
+		// milestone that has a due date and whose title does not contain "n.e.x.t".
+		const releaseSlugs = ( await getReleaseMilestones( opt.token ) ).map(
+			( milestone ) => milestone.slug
+		);
+		targetSlugs = opt.plugin
+			? releaseSlugs.filter( ( slug ) => slug === opt.plugin )
+			: releaseSlugs;
+
+		if ( targetSlugs.length === 0 ) {
+			log(
+				formats.warning(
+					opt.plugin
+						? `⚠ Skipping ${ opt.plugin }: no open release milestone with a due date (and without "n.e.x.t") was found. Pass --all to update it anyway.`
+						: '⚠ No plugins have an open release milestone with a due date (and without "n.e.x.t"); nothing to update. Pass --all to update every plugin.'
+				)
 			);
+			return;
 		}
 	}
+
+	const pluginRoot = path.resolve( __dirname, '../../../' );
+	const pluginDirectories = targetSlugs.map( ( pluginSlug ) =>
+		path.resolve( pluginRoot, 'plugins', pluginSlug )
+	);
 
 	for ( const pluginDirectory of pluginDirectories ) {
 		const patterns = [];

--- a/bin/plugin/commands/since.js
+++ b/bin/plugin/commands/since.js
@@ -39,7 +39,8 @@ exports.options = [
 ];
 
 /**
- * Replaces "@since n.e.x.t" tags in the code with the current release version.
+ * Replaces "n.e.x.t" version placeholders (in "@since"/"@deprecated" tags, single-quoted
+ * version literals, and readme changelog/upgrade-notice headings) with the release version.
  *
  * @param {WPSinceCommandOptions} opt Command options.
  */
@@ -106,7 +107,7 @@ exports.handler = async ( opt ) => {
 		} );
 
 		const regexps = [
-			/(@since\s+)n\.e\.x\.t/g,
+			/(@(?:since|deprecated)\s+)n\.e\.x\.t/g,
 			/('[^']*?)n\.e\.x\.t(?=')/g,
 		];
 
@@ -117,13 +118,10 @@ exports.handler = async ( opt ) => {
 				if ( regexp.test( content ) ) {
 					fs.writeFileSync(
 						file,
-						content.replace(
-							regexp,
-							function ( matches, sinceTag ) {
-								replacementCount++;
-								return sinceTag + version;
-							}
-						)
+						content.replace( regexp, function ( matches, tag ) {
+							replacementCount++;
+							return tag + version;
+						} )
 					);
 				}
 			}

--- a/bin/plugin/commands/versions.js
+++ b/bin/plugin/commands/versions.js
@@ -38,7 +38,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const readmeContents = fs.readFileSync( readmeFilePath, 'utf-8' );
 
 	const stableTagVersionMatches = readmeContents.match(
-		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w.]+)?)$/m
 	);
 	if ( ! stableTagVersionMatches ) {
 		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );
@@ -46,7 +46,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const stableTagVersion = stableTagVersionMatches[ 1 ];
 
 	const latestChangelogMatches = readmeContents.match(
-		/^== Changelog ==\n+= (\d+\.\d+\.\d+(?:-[\w\.]+)?) =$/m
+		/^== Changelog ==\n+= (\d+\.\d+\.\d+(?:-[\w.]+)?) =$/m
 	);
 	if ( ! latestChangelogMatches ) {
 		throw new Error(
@@ -71,7 +71,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	}
 
 	const headerVersionMatches = phpBootstrapFileContents.match(
-		/^ \* Version:\s+(\d+\.\d+\.\d+(?:-[\w\.]+)?)$/m
+		/^ \* Version:\s+(\d+\.\d+\.\d+(?:-[\w.]+)?)$/m
 	);
 	if ( ! headerVersionMatches ) {
 		throw new Error(
@@ -81,7 +81,7 @@ async function checkPluginDirectory( pluginDirectory ) {
 	const headerVersion = headerVersionMatches[ 1 ];
 
 	const phpLiteralVersionMatches = phpBootstrapFileContents.match(
-		/'(\d+\.\d+\.\d+(?:-[\w\.]+)?)'/
+		/'(\d+\.\d+\.\d+(?:-[\w.]+)?)'/
 	);
 	if ( ! phpLiteralVersionMatches ) {
 		throw new Error( 'Unable to locate the PHP literal version.' );

--- a/bin/plugin/lib/milestone.js
+++ b/bin/plugin/lib/milestone.js
@@ -36,6 +36,32 @@ async function getMilestoneByTitle( octokit, owner, repo, title ) {
 }
 
 /**
+ * Returns a promise resolving to all milestones in a repository.
+ *
+ * @param {GitHub}     octokit Initialized Octokit REST client.
+ * @param {string}     owner   Repository owner.
+ * @param {string}     repo    Repository name.
+ * @param {IssueState} [state] Optional milestone state. Defaults to "open".
+ *
+ * @return {Promise<import('@octokit/rest').RestEndpointMethodTypes['issues']['listMilestones']['response']['data']>} Promise resolving to milestones.
+ */
+async function getMilestones( octokit, owner, repo, state = 'open' ) {
+	const options = octokit.issues.listMilestones.endpoint.merge( {
+		owner,
+		repo,
+		state,
+	} );
+
+	const milestones = [];
+
+	for await ( const response of octokit.paginate.iterator( options ) ) {
+		milestones.push( ...response.data );
+	}
+
+	return milestones;
+}
+
+/**
  * Returns a promise resolving to pull requests by a given milestone ID.
  *
  * @param {GitHub}     octokit       Initialized Octokit REST client.
@@ -89,5 +115,6 @@ async function getIssuesByMilestone(
 
 module.exports = {
 	getMilestoneByTitle,
+	getMilestones,
 	getIssuesByMilestone,
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
 	},
 	"scripts": {
 		"changelog": "./bin/plugin/cli.js changelog",
+		"bump-versions": "./bin/plugin/cli.js bump-versions",
 		"since": "./bin/plugin/cli.js since",
 		"readme": "./bin/plugin/cli.js readme",
 		"versions": "./bin/plugin/cli.js versions",

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -263,7 +263,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * This method will soon be equivalent to calling {@see self::next_tag()} without passing any `$query`.
 	 *
 	 * @since 0.4.0
-	 * @deprecated n.e.x.t Use {@see self::next_tag()} instead.
+	 * @deprecated 1.0.0 Use {@see self::next_tag()} instead.
 	 *
 	 * @return bool Whether a tag was matched.
 	 */

--- a/plugins/performance-lab/hooks.php
+++ b/plugins/performance-lab/hooks.php
@@ -3,7 +3,7 @@
  * Hook callbacks used for Performance Lab.
  *
  * @package performance-lab
- * @since n.e.x.t
+ * @since 4.2.0
  */
 
 declare( strict_types = 1 );

--- a/plugins/performance-lab/includes/server-timing/class-perflab-server-timing-metric.php
+++ b/plugins/performance-lab/includes/server-timing/class-perflab-server-timing-metric.php
@@ -42,7 +42,7 @@ class Perflab_Server_Timing_Metric {
 	/**
 	 * The metric description.
 	 *
-	 * @since n.e.x.t
+	 * @since 4.2.0
 	 * @var non-empty-string|null
 	 */
 	private ?string $description = null;
@@ -159,7 +159,7 @@ class Perflab_Server_Timing_Metric {
 	 * An empty string is treated as no description, in which case the metric is
 	 * emitted without a `desc` parameter.
 	 *
-	 * @since n.e.x.t
+	 * @since 4.2.0
 	 *
 	 * @param string $description The metric description. Pass an empty string to unset it.
 	 */
@@ -180,7 +180,7 @@ class Perflab_Server_Timing_Metric {
 	/**
 	 * Gets the metric description.
 	 *
-	 * @since n.e.x.t
+	 * @since 4.2.0
 	 *
 	 * @return non-empty-string|null The metric description, or null if none set.
 	 */

--- a/plugins/performance-lab/load.php
+++ b/plugins/performance-lab/load.php
@@ -5,7 +5,7 @@
  * Description: Performance plugin from the WordPress Performance Team, which is a collection of standalone performance features.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 4.1.0
+ * Version: 4.2.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 // @codeCoverageIgnoreEnd
 
-define( 'PERFLAB_VERSION', '4.1.0' );
+define( 'PERFLAB_VERSION', '4.2.0' );
 define( 'PERFLAB_MAIN_FILE', __FILE__ );
 define( 'PERFLAB_PLUGIN_DIR_PATH', plugin_dir_path( PERFLAB_MAIN_FILE ) );
 define( 'PERFLAB_SCREEN', 'performance-lab' );

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 7.0
-Stable tag:   4.1.0
+Stable tag:   4.2.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, site health, measurement, optimization, diagnostics
@@ -72,6 +72,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 4.2.0 =
 
 = 4.1.0 =
 

--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -75,6 +75,13 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 4.2.0 =
 
+**Enhancements**
+
+* Add `declare( strict_types = 1 )` to all PHP files. ([2424](https://github.com/WordPress/performance/pull/2424))
+* Bump minimum PHP requirement from 7.2 to 7.4. ([2469](https://github.com/WordPress/performance/pull/2469))
+* Enqueued Assets audit: treat zero-size and no-store responses as errors. ([2481](https://github.com/WordPress/performance/pull/2481))
+* Server Timing - Allow description and make duration optional. ([2379](https://github.com/WordPress/performance/pull/2379))
+
 = 4.1.0 =
 
 **Bug Fixes**

--- a/plugins/view-transitions/js/view-transitions.js
+++ b/plugins/view-transitions/js/view-transitions.js
@@ -66,7 +66,7 @@ window.plvtInitViewTransitions = ( config ) => {
 	 * and finished promises reject. Without a rejection handler, these surface as
 	 * "Uncaught (in promise) InvalidStateError" errors.
 	 *
-	 * @since n.e.x.t
+	 * @since 1.2.1
 	 *
 	 * @param {ViewTransition} viewTransition The view transition to suppress rejections for.
 	 */

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -58,6 +58,10 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 
 = 1.2.1 =
 
+**Bug Fixes**
+
+* Fix `InvalidStateError` on bfcache navigations. ([2438](https://github.com/WordPress/performance/pull/2438))
+
 = 1.2.0 =
 
 **Enhancements**

--- a/plugins/view-transitions/readme.txt
+++ b/plugins/view-transitions/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 7.0
-Stable tag:   1.2.0
+Stable tag:   1.2.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, view transitions, smooth transitions, animations
@@ -55,6 +55,8 @@ To report a security issue, please visit the [WordPress HackerOne](https://hacke
 Contributions are always welcome! Learn more about how to get involved in the [Core Performance Team Handbook](https://make.wordpress.org/performance/handbook/get-involved/).
 
 == Changelog ==
+
+= 1.2.1 =
 
 = 1.2.0 =
 

--- a/plugins/view-transitions/view-transitions.php
+++ b/plugins/view-transitions/view-transitions.php
@@ -5,7 +5,7 @@
  * Description: Adds smooth transitions between navigations to your WordPress site.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 1.2.0
+ * Version: 1.2.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -27,7 +27,7 @@ if ( defined( 'VIEW_TRANSITIONS_VERSION' ) ) {
 	return;
 }
 
-define( 'VIEW_TRANSITIONS_VERSION', '1.2.0' );
+define( 'VIEW_TRANSITIONS_VERSION', '1.2.1' );
 define( 'VIEW_TRANSITIONS_MAIN_FILE', __FILE__ );
 
 require_once __DIR__ . '/includes/admin.php';

--- a/plugins/webp-uploads/deprecated.php
+++ b/plugins/webp-uploads/deprecated.php
@@ -76,7 +76,7 @@ function webp_uploads_media_setting_style(): void {
  * Updates the references of the featured image to the new image format if available.
  *
  * @since 1.0.0
- * @deprecated n.e.x.t Featured images are now rewritten through the `wp_get_attachment_image`
+ * @deprecated 2.7.0 Featured images are now rewritten through the `wp_get_attachment_image`
  *                     filter; see webp_uploads_filter_wp_get_attachment_image().
  *
  * @param string $html          The current HTML markup of the featured image.
@@ -85,7 +85,7 @@ function webp_uploads_media_setting_style(): void {
  * @return string The updated HTML markup.
  */
 function webp_uploads_update_featured_image( string $html, int $post_id, int $attachment_id ): string {
-	_deprecated_function( __FUNCTION__, 'Modern Image Formats n.e.x.t', 'webp_uploads_filter_wp_get_attachment_image()' );
+	_deprecated_function( __FUNCTION__, 'Modern Image Formats 2.7.0', 'webp_uploads_filter_wp_get_attachment_image()' );
 
 	if ( webp_uploads_is_picture_element_enabled() ) {
 		return webp_uploads_wrap_image_in_picture( $html, 'post_thumbnail_html', $attachment_id );

--- a/plugins/webp-uploads/helper.php
+++ b/plugins/webp-uploads/helper.php
@@ -347,7 +347,7 @@ function webp_uploads_should_discard_additional_image_file( array $original, arr
  * Includes special handling for false positives on AVIF support.
  *
  * @since 2.0.0
- * @since n.e.x.t AVIF is now only reported as supported when the server can also encode transparent AVIF images.
+ * @since 2.7.0 AVIF is now only reported as supported when the server can also encode transparent AVIF images.
  *
  * @param string $mime_type The mime type to check.
  * @return bool Whether the server supports a given mime type.
@@ -368,7 +368,7 @@ function webp_uploads_mime_type_supported( string $mime_type ): bool {
 /**
  * Checks if the server supports AVIF image format.
  *
- * @since n.e.x.t
+ * @since 2.7.0
  *
  * @return bool True if the server supports AVIF, false otherwise.
  */
@@ -386,7 +386,7 @@ function webp_uploads_avif_supported(): bool {
 /**
  * Checks if the server supports transparent AVIF images.
  *
- * @since n.e.x.t
+ * @since 2.7.0
  *
  * @return bool True if the server supports transparent AVIF images, false otherwise.
  */
@@ -405,7 +405,7 @@ function webp_uploads_avif_transparency_supported(): bool {
 /**
  * Checks if Imagick supports AVIF format on the server.
  *
- * @since n.e.x.t
+ * @since 2.7.0
  *
  * @param string $editor The image editor class name.
  * @return bool True if Imagick supports AVIF, false otherwise.
@@ -572,7 +572,7 @@ function webp_uploads_get_attachment_file_mime_type( int $attachment_id, string 
  * transparent images converted to AVIF on those versions silently lose their transparency.
  * Support for AVIF transparency was added in 6.9.12-68, so this gates on that minimum version.
  *
- * @since n.e.x.t
+ * @since 2.7.0
  *
  * @link https://github.com/WordPress/performance/issues/2237
  *
@@ -600,7 +600,7 @@ function webp_uploads_imagick_avif_transparency_supported( ?string $version = nu
 	/**
 	 * Filters whether Imagick has AVIF transparency support.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.7.0
 	 *
 	 * @param bool $supported Whether AVIF transparency is supported.
 	 */

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -580,7 +580,7 @@ function webp_uploads_filter_image_tag( string $filtered_image, string $context,
  * their return values feed non-HTML contexts (OG tags, RSS, JSON) where
  * silently substituting a modern format is unsafe.
  *
- * @since n.e.x.t
+ * @since 2.7.0
  *
  * @param string                 $html          HTML img element or empty string on failure.
  * @param int                    $attachment_id Image attachment ID.
@@ -601,7 +601,7 @@ function webp_uploads_filter_wp_get_attachment_image( string $html, int $attachm
 	 * Returning false short-circuits the rewrite and preserves the original HTML. This gives
 	 * integrators a surgical per-call opt-out in addition to `remove_filter()`.
 	 *
-	 * @since n.e.x.t
+	 * @since 2.7.0
 	 *
 	 * @param bool                   $should_filter Whether to apply modern-format rewriting. Default true.
 	 * @param int<1, max>            $attachment_id Image attachment ID.

--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 2.6.1
+ * Version: 2.7.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -28,7 +28,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.6.1' );
+define( 'WEBP_UPLOADS_VERSION', '2.7.0' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 7.0
-Stable tag:   2.6.1
+Stable tag:   2.7.0
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -64,6 +64,8 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.7.0 =
 
 = 2.6.1 =
 

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -67,6 +67,16 @@ By default, the Modern Image Formats plugin will only generate WebP versions of 
 
 = 2.7.0 =
 
+**Enhancements**
+
+* Add explanation for discarded modern image outputs. ([2518](https://github.com/WordPress/performance/pull/2518))
+* Link to FAQ from settings section. ([2480](https://github.com/WordPress/performance/pull/2480))
+* Rewrite `img` tags output by `wp_get_attachment_image()`. ([2451](https://github.com/WordPress/performance/pull/2451))
+
+**Bug Fixes**
+
+* Disable AVIF when ImageMagick does not support AVIF transparency. ([2540](https://github.com/WordPress/performance/pull/2540))
+
 = 2.6.1 =
 
 **Bug Fixes**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 	"compilerOptions": {
 		"checkJs": true,
 		"noEmit": true,
+		"noUnusedParameters": true,
 		"allowJs": true,
 		"target": "es2020",
 		"moduleResolution": "nodenext",


### PR DESCRIPTION
- **Add bump-versions command to automate release version bumping**
- **Limit `since` to plugins with a release milestone**
- **Replace "n.e.x.t" in @deprecated tags too in `since`**
- **Replace `??=` in bump-versions with an explicit guard for readability**
- **Resolve static-analysis warnings in release CLI commands**
- **Enable noUnusedParameters in tsconfig**
- **Break up description into a list**
- **Use Markdown as proper noun**
- **Bump versions via npm run bump-versions**
- **Supply version in Optimization Detective deprecated tag which was missed in 1.0.0-beta3**
- **Run npm run since**
- **Gate `npm run readme` by release milestones and make it idempotent**
- **Populate changelogs**
- **Exclude minified assets from pending release diffs**
