### PR TITLE
Add `prepare-release-notes` and `create-draft-release` scripts

### DIFF
--- a/bin/create-draft-release.sh
+++ b/bin/create-draft-release.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Create a draft GitHub release for the current release date using the combined per-plugin
+# changelogs (from `npm run prepare-release-notes`) as the release notes.
+#
+# The tag and release title are the release date, and the target is the release/<date> branch:
+#
+#   Tag:    $RELEASE_DATE
+#   Target: release/$RELEASE_DATE
+#   Title:  $RELEASE_DATE
+#
+# The RELEASE_DATE environment variable is used when set (as established at the start of the
+# release handbook via `RELEASE_DATE=$(date +%Y-%m-%d)`); otherwise it defaults to today.
+#
+# EXAMPLES:
+#   RELEASE_DATE=$(date +%Y-%m-%d) ./create-draft-release.sh
+#   RELEASE_DATE=2026-06-30 npm run create-draft-release
+#   npm run create-draft-release
+
+set -e
+
+for required_command in npm gh git; do
+	if ! command -v "$required_command" &> /dev/null; then
+		echo "Error: The $required_command command must be installed to use this script." >&2
+		exit 1
+	fi
+done
+
+RELEASE_DATE="${RELEASE_DATE:-$(date +%Y-%m-%d)}"
+tag="$RELEASE_DATE"
+target="release/$RELEASE_DATE"
+
+cd "$(git rev-parse --show-toplevel)"
+
+# The tag is created from the target branch when the release is published, so the target
+# branch must already exist on the remote; fail early with a clear message if it does not.
+if ! git ls-remote --exit-code --heads origin "$target" &> /dev/null; then
+	echo "Error: The target branch \"$target\" does not exist on the origin remote. Push it first." >&2
+	exit 1
+fi
+
+# Avoid clobbering an existing release/tag; drafts are cheap to delete and recreate.
+if gh release view "$tag" &> /dev/null; then
+	echo "Error: A release for tag \"$tag\" already exists. Delete it first with:" >&2
+	echo "       gh release delete \"$tag\"" >&2
+	exit 1
+fi
+
+notes_file="$(mktemp)"
+trap 'rm -f "$notes_file"' EXIT
+
+# Authenticate the milestone lookup with the gh token when available to avoid rate limiting.
+notes_args=()
+if github_token="$(gh auth token 2> /dev/null)" && [ -n "$github_token" ]; then
+	notes_args+=(--token "$github_token")
+fi
+
+echo "Generating release notes for $tag..." >&2
+npm run prepare-release-notes --silent -- "${notes_args[@]}" > "$notes_file"
+
+if [ ! -s "$notes_file" ]; then
+	echo "Error: No release notes were generated; aborting." >&2
+	exit 1
+fi
+
+echo "Creating draft release \"$tag\" targeting \"$target\"..." >&2
+gh release create "$tag" \
+	--draft \
+	--target "$target" \
+	--title "$tag" \
+	--notes-file "$notes_file"

--- a/bin/create-draft-release.sh
+++ b/bin/create-draft-release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Create a draft GitHub release for the current release date using the combined per-plugin
 # changelogs (from `npm run prepare-release-notes`) as the release notes.
 #

--- a/bin/create-draft-release.sh
+++ b/bin/create-draft-release.sh
@@ -38,10 +38,15 @@ if ! git ls-remote --exit-code --heads origin "$target" &> /dev/null; then
 	exit 1
 fi
 
-# Avoid clobbering an existing release/tag; drafts are cheap to delete and recreate.
-if gh release view "$tag" &> /dev/null; then
-	echo "Error: A release for tag \"$tag\" already exists. Delete it first with:" >&2
-	echo "       gh release delete \"$tag\"" >&2
+# Avoid clobbering an existing release. A draft is cheap to delete and recreate, but a
+# published release is immutable, so a new release date must be supplied instead.
+if is_draft="$(gh release view "$tag" --json isDraft --jq '.isDraft' 2> /dev/null)"; then
+	if [ "$is_draft" = 'true' ]; then
+		echo "Error: A draft release for tag \"$tag\" already exists. If it is no longer needed, delete it first with:" >&2
+		echo "       gh release delete \"$tag\"" >&2
+	else
+		echo "Error: A release for tag \"$tag\" has already been published and cannot be overridden. Supply a different RELEASE_DATE." >&2
+	fi
 	exit 1
 fi
 

--- a/bin/plugin/cli.js
+++ b/bin/plugin/cli.js
@@ -56,6 +56,10 @@ const {
 	handler: bumpVersionsHandler,
 	options: bumpVersionsOptions,
 } = require( './commands/bump-versions' );
+const {
+	handler: prepareReleaseNotesHandler,
+	options: prepareReleaseNotesOptions,
+} = require( './commands/prepare-release-notes' );
 
 withOptions( program.command( 'release-plugin-changelog' ), changelogOptions )
 	.alias( 'changelog' )
@@ -87,5 +91,14 @@ withOptions( program.command( 'bump-plugin-versions' ), bumpVersionsOptions )
 		'Bumps plugin versions based on open, dated release milestones (titled "$plugin_slug $version" without "n.e.x.t")'
 	)
 	.action( catchException( bumpVersionsHandler ) );
+
+withOptions(
+	program.command( 'prepare-release-notes' ),
+	prepareReleaseNotesOptions
+)
+	.description(
+		'Prints the combined per-plugin changelogs (release notes) for plugins with an open, dated release milestone; progress goes to STDERR so STDOUT can be piped'
+	)
+	.action( catchException( prepareReleaseNotesHandler ) );
 
 program.parse( process.argv );

--- a/bin/plugin/commands/prepare-release-notes.js
+++ b/bin/plugin/commands/prepare-release-notes.js
@@ -1,0 +1,162 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+const fs = require( 'fs' );
+
+/**
+ * Internal dependencies
+ */
+const { log, formats } = require( '../lib/logger' );
+const { getReleaseMilestones } = require( './bump-versions' );
+const { plugins } = require( '../../../plugins.json' );
+
+/**
+ * @typedef WPPrepareReleaseNotesCommandOptions
+ *
+ * @property {string=} plugin Optional plugin slug to limit the notes to a single plugin.
+ * @property {string=} token  Optional personal GitHub access token.
+ */
+
+exports.options = [
+	{
+		argname: '-p, --plugin <plugin>',
+		description:
+			'Plugin slug. Defaults to all plugins with an open, dated release milestone.',
+	},
+	{
+		argname: '-t, --token <token>',
+		description: 'GitHub token',
+	},
+];
+
+/**
+ * Command that assembles the release notes for the plugins currently being released,
+ * i.e. those with an open milestone that has a due date and whose title does not contain
+ * "n.e.x.t". The notes for each plugin are the changelog entry for its stable tag, read
+ * from the plugin's `readme.txt` (as populated by `npm run readme`).
+ *
+ * Progress and warnings are written to STDERR so that STDOUT (the Markdown release
+ * notes) can be piped to a file or the clipboard.
+ *
+ * @param {WPPrepareReleaseNotesCommandOptions} opt
+ */
+exports.handler = async ( opt ) => {
+	if ( opt.plugin && ! plugins.includes( opt.plugin ) ) {
+		throw new Error(
+			`The plugin "${ opt.plugin }" is not a valid plugin managed as part of this project.`
+		);
+	}
+
+	const milestones = await getReleaseMilestones( opt.token );
+
+	const selected = (
+		opt.plugin
+			? milestones.filter(
+					( milestone ) => milestone.slug === opt.plugin
+			  )
+			: milestones
+	).sort( ( a, b ) => a.slug.localeCompare( b.slug ) );
+
+	if ( selected.length === 0 ) {
+		process.stderr.write(
+			formats.warning(
+				opt.plugin
+					? `⚠ Skipping ${ opt.plugin }: no open release milestone with a due date (and without "n.e.x.t") was found.\n`
+					: '⚠ No plugins have an open release milestone with a due date (and without "n.e.x.t"); nothing to prepare.\n'
+			)
+		);
+		return;
+	}
+
+	const pluginRoot = path.resolve( __dirname, '../../../' );
+	const sections = [];
+
+	for ( const milestone of selected ) {
+		try {
+			const readmeFilePath = path.resolve(
+				pluginRoot,
+				'plugins',
+				milestone.slug,
+				'readme.txt'
+			);
+			const { version, changelog } =
+				getReadmeChangelogEntry( readmeFilePath );
+			sections.push(
+				`## \`${ milestone.slug }\` ${ version }\n\n${ changelog }`
+			);
+			process.stderr.write(
+				formats.success(
+					`✔ Prepared release notes for ${ milestone.slug } ${ version }.\n`
+				)
+			);
+		} catch ( error ) {
+			const message =
+				error instanceof Error ? error.message : 'Unknown error';
+			process.stderr.write(
+				formats.error(
+					`${ milestone.slug } failed to prepare: ${ message }\n`
+				)
+			);
+		}
+	}
+
+	if ( sections.length === 0 ) {
+		return;
+	}
+
+	log( sections.join( '\n\n' ) );
+};
+
+/**
+ * Reads the changelog entry for a plugin's stable tag from its `readme.txt`.
+ *
+ * @param {string} readmeFilePath Readme file path.
+ * @return {{version: string, changelog: string}} The stable tag version and its changelog body (without the version heading).
+ */
+function getReadmeChangelogEntry( readmeFilePath ) {
+	const fileContent = fs.readFileSync( readmeFilePath, 'utf-8' );
+
+	const stableTagMatches = fileContent.match(
+		/^Stable tag:\s*(\d+\.\d+\.\d+(?:-[\w.]+)?)$/m
+	);
+	if ( ! stableTagMatches ) {
+		throw new Error( `Unable to locate stable tag in ${ readmeFilePath }` );
+	}
+	const version = stableTagMatches[ 1 ];
+
+	const headingRegExp = new RegExp(
+		`^= ${ escapeRegExp( version ) } =$`,
+		'm'
+	);
+	const headingMatch = headingRegExp.exec( fileContent );
+	if ( ! headingMatch ) {
+		throw new Error(
+			`Unable to locate a "= ${ version } =" changelog entry in ${ readmeFilePath }`
+		);
+	}
+
+	const bodyStart = headingMatch.index + headingMatch[ 0 ].length;
+	const rest = fileContent.slice( bodyStart );
+	const nextHeadingMatch = /^= .+ =$/m.exec( rest );
+	const bodyEnd = nextHeadingMatch ? nextHeadingMatch.index : rest.length;
+	const changelog = rest.slice( 0, bodyEnd ).trim();
+
+	if ( changelog === '' ) {
+		throw new Error(
+			`The "= ${ version } =" changelog entry in ${ readmeFilePath } is empty; run "npm run readme" first.`
+		);
+	}
+
+	return { version, changelog };
+}
+
+/**
+ * Escapes a string for safe use inside a regular expression.
+ *
+ * @param {string} value String to escape.
+ * @return {string} Escaped string.
+ */
+function escapeRegExp( value ) {
+	return value.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"build:plugin:web-worker-offloading": "webpack --mode production --env plugin=web-worker-offloading",
 		"build:plugin:webp-uploads": "webpack --mode production --env plugin=webp-uploads",
 		"generate-pending-release-diffs": "bin/generate-pending-release-diffs.sh",
+		"create-draft-release": "bin/create-draft-release.sh",
 		"format-js": "wp-scripts format",
 		"lint-js": "wp-scripts lint-js",
 		"lint-json": "node bin/validate-json.js",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"bump-versions": "./bin/plugin/cli.js bump-versions",
 		"since": "./bin/plugin/cli.js since",
 		"readme": "./bin/plugin/cli.js readme",
+		"prepare-release-notes": "./bin/plugin/cli.js prepare-release-notes",
 		"versions": "./bin/plugin/cli.js versions",
 		"build": "wp-scripts build",
 		"build-plugins": "npm-run-all 'build:plugin:*'",


### PR DESCRIPTION
This introduces two new scripts that help automate the release process:

* `npm run gather-release-notes`
* `npm run create-draft-release`

The former is called automatically be the later. I've updated the handbook page to explain how they are used. I used them in the [most recent release](https://github.com/WordPress/performance/releases/tag/2026-06-30).

## Use of AI Tools

Changes were authored by Claude Opus 4.8 based on my prompts.

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.

Moreover, see the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
