### PR TITLE
Prevent fatal error in `webp_uploads_filter_wp_get_attachment_image()` when `wp_get_attachment_image_src()` returns false and during `rest_prepare_attachment` filtering

### DIFF
--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -595,8 +595,8 @@ function webp_uploads_filter_wp_get_attachment_image( $html, $attachment_id, $si
 		$html = '';
 	}
 	$attachment_id = (int) $attachment_id;
-	$icon          = (int) $icon;
-	if ( '' === $html || 0 === $attachment_id || true === (bool) $icon || ! webp_uploads_in_frontend_body() ) {
+	$icon          = (bool) $icon;
+	if ( '' === $html || 0 === $attachment_id || true === $icon || ! webp_uploads_in_frontend_body() ) {
 		return $html;
 	}
 

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -582,17 +582,21 @@ function webp_uploads_filter_image_tag( string $filtered_image, string $context,
  *
  * @since 2.7.0
  *
- * @param string                 $html          HTML img element or empty string on failure.
- * @param int                    $attachment_id Image attachment ID.
- * @param string|array{int, int} $size          Requested image size.
- * @param bool                   $icon          Whether the image should fall back to a mime type icon.
- * @param array<string, string>  $attr          Array of attribute values for the image markup, keyed by attribute name.
+ * @param string                   $html          HTML img element or empty string on failure.
+ * @param int                      $attachment_id Image attachment ID.
+ * @param string|array{int, int}   $size          Requested image size.
+ * @param bool                     $icon          Whether the image should fall back to a mime type icon.
+ * @param array<string, string>|'' $attr          Array of attribute values for the image markup, keyed by attribute name. An empty string if {@see wp_get_attachment_image_src()} did not return an image.
  * @phpstan-param int<1, max> $attachment_id
  * @return string The filtered HTML.
  */
-function webp_uploads_filter_wp_get_attachment_image( string $html, int $attachment_id, $size, bool $icon, array $attr ): string {
+function webp_uploads_filter_wp_get_attachment_image( string $html, int $attachment_id, $size, bool $icon, $attr ): string {
 	if ( '' === $html || 0 === $attachment_id || true === $icon || ! webp_uploads_in_frontend_body() ) {
 		return $html;
+	}
+
+	if ( '' === $attr ) {
+		$attr = array();
 	}
 
 	/**

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -585,7 +585,7 @@ function webp_uploads_filter_image_tag( string $filtered_image, string $context,
  * @param string|mixed             $html          HTML img element or empty string on failure.
  * @param int|numeric-string       $attachment_id Image attachment ID.
  * @param string|array{int, int}   $size          Requested image size.
- * @param mixed                    $icon          Unused.
+ * @param bool|mixed               $icon          Whether the image should fall back to a mime type icon.
  * @param array<string, string>|'' $attr          Array of attribute values for the image markup, keyed by attribute name. An empty string if {@see wp_get_attachment_image_src()} did not return an image.
  * @phpstan-param int<1, max> $attachment_id
  * @return string The filtered HTML.
@@ -595,7 +595,8 @@ function webp_uploads_filter_wp_get_attachment_image( $html, $attachment_id, $si
 		$html = '';
 	}
 	$attachment_id = (int) $attachment_id;
-	if ( '' === $html || 0 === $attachment_id || true === $icon || ! webp_uploads_in_frontend_body() ) {
+	$icon          = (int) $icon;
+	if ( '' === $html || 0 === $attachment_id || true === (bool) $icon || ! webp_uploads_in_frontend_body() ) {
 		return $html;
 	}
 

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -582,15 +582,18 @@ function webp_uploads_filter_image_tag( string $filtered_image, string $context,
  *
  * @since 2.7.0
  *
- * @param string                   $html          HTML img element or empty string on failure.
+ * @param string|mixed             $html          HTML img element or empty string on failure.
  * @param int|numeric-string       $attachment_id Image attachment ID.
  * @param string|array{int, int}   $size          Requested image size.
- * @param bool                     $icon          Whether the image should fall back to a mime type icon.
+ * @param mixed                    $icon          Unused.
  * @param array<string, string>|'' $attr          Array of attribute values for the image markup, keyed by attribute name. An empty string if {@see wp_get_attachment_image_src()} did not return an image.
  * @phpstan-param int<1, max> $attachment_id
  * @return string The filtered HTML.
  */
-function webp_uploads_filter_wp_get_attachment_image( string $html, $attachment_id, $size, bool $icon, $attr ): string {
+function webp_uploads_filter_wp_get_attachment_image( $html, $attachment_id, $size, $icon, $attr ): string {
+	if ( ! is_string( $html ) ) {
+		$html = '';
+	}
 	$attachment_id = (int) $attachment_id;
 	if ( '' === $html || 0 === $attachment_id || true === $icon || ! webp_uploads_in_frontend_body() ) {
 		return $html;

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -582,11 +582,15 @@ function webp_uploads_filter_image_tag( string $filtered_image, string $context,
  *
  * @since 2.7.0
  *
- * @param string|mixed             $html          HTML img element or empty string on failure.
- * @param int|numeric-string       $attachment_id Image attachment ID.
- * @param string|array{int, int}   $size          Requested image size.
- * @param bool|mixed               $icon          Whether the image should fall back to a mime type icon.
- * @param array<string, string>|'' $attr          Array of attribute values for the image markup, keyed by attribute name. An empty string if {@see wp_get_attachment_image_src()} did not return an image.
+ * @see wp_get_attachment_image()
+ *
+ * @param string|mixed                $html          HTML img element or empty string on failure.
+ * @param int|numeric-string          $attachment_id Image attachment ID.
+ * @param string|array{int, int}      $size          Requested image size.
+ * @param bool|mixed                  $icon          Whether the image should fall back to a mime type icon.
+ * @param array<string, mixed>|string $attr          Array of attribute values for the image markup, keyed by attribute name.
+ *                                                   May also be a query string which has not gone through {@see wp_parse_args()}
+ *                                                   if {@see wp_get_attachment_image_src()} returned false.
  * @phpstan-param int<1, max> $attachment_id
  * @return string The filtered HTML.
  */
@@ -600,7 +604,9 @@ function webp_uploads_filter_wp_get_attachment_image( $html, $attachment_id, $si
 		return $html;
 	}
 
-	if ( ! is_array( $attr ) ) {
+	if ( is_string( $attr ) ) {
+		$attr = wp_parse_args( $attr );
+	} elseif ( ! is_array( $attr ) ) {
 		$attr = array();
 	}
 

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -583,14 +583,15 @@ function webp_uploads_filter_image_tag( string $filtered_image, string $context,
  * @since 2.7.0
  *
  * @param string                   $html          HTML img element or empty string on failure.
- * @param int                      $attachment_id Image attachment ID.
+ * @param int|numeric-string       $attachment_id Image attachment ID.
  * @param string|array{int, int}   $size          Requested image size.
  * @param bool                     $icon          Whether the image should fall back to a mime type icon.
  * @param array<string, string>|'' $attr          Array of attribute values for the image markup, keyed by attribute name. An empty string if {@see wp_get_attachment_image_src()} did not return an image.
  * @phpstan-param int<1, max> $attachment_id
  * @return string The filtered HTML.
  */
-function webp_uploads_filter_wp_get_attachment_image( string $html, int $attachment_id, $size, bool $icon, $attr ): string {
+function webp_uploads_filter_wp_get_attachment_image( string $html, $attachment_id, $size, bool $icon, $attr ): string {
+	$attachment_id = (int) $attachment_id;
 	if ( '' === $html || 0 === $attachment_id || true === $icon || ! webp_uploads_in_frontend_body() ) {
 		return $html;
 	}

--- a/plugins/webp-uploads/hooks.php
+++ b/plugins/webp-uploads/hooks.php
@@ -595,7 +595,7 @@ function webp_uploads_filter_wp_get_attachment_image( string $html, int $attachm
 		return $html;
 	}
 
-	if ( '' === $attr ) {
+	if ( ! is_array( $attr ) ) {
 		$attr = array();
 	}
 

--- a/plugins/webp-uploads/rest-api.php
+++ b/plugins/webp-uploads/rest-api.php
@@ -66,7 +66,9 @@ function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Pos
 	) {
 		$full_url_basename = wp_basename( $full_src[0] );
 		foreach ( $data['media_details']['sources'] as $mime => &$mime_details ) {
-			$mime_details['source_url'] = str_replace( $full_url_basename, $mime_details['file'], $full_src[0] );
+			if ( is_array( $mime_details ) && isset( $mime_details['file'] ) && is_string( $mime_details['file'] ) ) {
+				$mime_details['source_url'] = str_replace( $full_url_basename, $mime_details['file'], $full_src[0] );
+			}
 		}
 		unset( $mime_details );
 

--- a/plugins/webp-uploads/rest-api.php
+++ b/plugins/webp-uploads/rest-api.php
@@ -26,19 +26,31 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function webp_uploads_update_rest_attachment( WP_REST_Response $response, WP_Post $post ): WP_REST_Response {
 	$data = $response->get_data();
-	if ( ! isset( $data['media_details'] ) || ! is_array( $data['media_details'] ) || ! isset( $data['media_details']['sizes'] ) || ! is_array( $data['media_details']['sizes'] ) ) {
+	if (
+		! is_array( $data ) ||
+		! isset( $data['media_details'] ) ||
+		! is_array( $data['media_details'] ) ||
+		! isset( $data['media_details']['sizes'] ) ||
+		! is_array( $data['media_details']['sizes'] ) ) {
 		return $response;
 	}
 
 	foreach ( $data['media_details']['sizes'] as $size => &$details ) {
 
-		if ( ! isset( $details['sources'] ) || ! is_array( $details['sources'] ) ) {
+		if (
+			! is_array( $details ) ||
+			! isset( $details['sources'], $details['source_url'] ) ||
+			! is_array( $details['sources'] ) ||
+			! is_string( $details['source_url'] )
+		) {
 			continue;
 		}
 
 		$image_url_basename = wp_basename( $details['source_url'] );
 		foreach ( $details['sources'] as $mime => &$mime_details ) {
-			$mime_details['source_url'] = str_replace( $image_url_basename, $mime_details['file'], $details['source_url'] );
+			if ( is_array( $mime_details ) && isset( $mime_details['file'] ) && is_string( $mime_details['file'] ) ) {
+				$mime_details['source_url'] = str_replace( $image_url_basename, $mime_details['file'], $details['source_url'] );
+			}
 		}
 		unset( $mime_details );
 	}

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1390,6 +1390,49 @@ class Test_WebP_Uploads_Load extends TestCase {
 	/**
 	 * @covers ::webp_uploads_filter_wp_get_attachment_image
 	 */
+	public function test_wp_get_attachment_image_when_passing_empty_string_as_attrs(): void {
+		$this->opt_in_to_jpeg_and_webp();
+		$this->mock_frontend_body_hooks();
+
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+		$size          = 'large';
+
+		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id, $size );
+
+		$html = sprintf(
+			'<img src="%s" width="%d" height="%d" alt="">',
+			esc_url( $src ),
+			(int) $width,
+			(int) $height
+		);
+
+		$filter_args = array();
+		add_filter(
+			'webp_uploads_filter_wp_get_attachment_image',
+			static function ( $should_filter, $attachment_id, $size, $attr ) use ( &$filter_args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- They are used in compact!
+				$filter_args[] = compact( 'should_filter', 'attachment_id', 'size', 'attr' );
+				return false;
+			},
+			10,
+			4
+		);
+
+		$this->assertSame( $html, webp_uploads_filter_wp_get_attachment_image( $html, $attachment_id, $size, false, '' ) );
+		$this->assertCount( 1, $filter_args );
+		$this->assertSame(
+			array(
+				'should_filter' => true,
+				'attachment_id' => $attachment_id,
+				'size'          => $size,
+				'attr'          => array(),
+			),
+			$filter_args[0]
+		);
+	}
+
+	/**
+	 * @covers ::webp_uploads_filter_wp_get_attachment_image
+	 */
 	public function test_wp_get_attachment_image_opt_out_filter_returns_original_html(): void {
 		$this->opt_in_to_jpeg_and_webp();
 		$this->mock_frontend_body_hooks();

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1388,9 +1388,40 @@ class Test_WebP_Uploads_Load extends TestCase {
 	}
 
 	/**
-	 * @covers ::webp_uploads_filter_wp_get_attachment_image
+	 * Data provider for testing how the `$attr` argument is normalized before being passed to the filter.
+	 *
+	 * @return array<string, array{ attr: string|array<string, mixed>|false, expected_attr: array<string, mixed> }>
 	 */
-	public function test_wp_get_attachment_image_when_passing_empty_string_as_attrs(): void {
+	public function data_provider_to_test_attr_normalization(): array {
+		return array(
+			'empty string'  => array(
+				'attr'          => '',
+				'expected_attr' => array(),
+			),
+			'query string'  => array(
+				'attr'          => 'loading=lazy',
+				'expected_attr' => array( 'loading' => 'lazy' ),
+			),
+			'array'         => array(
+				'attr'          => array( 'loading' => 'lazy' ),
+				'expected_attr' => array( 'loading' => 'lazy' ),
+			),
+			'invalid value' => array(
+				'attr'          => false,
+				'expected_attr' => array(),
+			),
+		);
+	}
+
+	/**
+	 * @covers ::webp_uploads_filter_wp_get_attachment_image
+	 *
+	 * @dataProvider data_provider_to_test_attr_normalization
+	 *
+	 * @param string|array<string, mixed>|false $attr          The attributes passed to the filter.
+	 * @param array<string, mixed>              $expected_attr The expected attributes passed to the inner filter.
+	 */
+	public function test_wp_get_attachment_image_attr_normalization( $attr, array $expected_attr ): void {
 		$this->opt_in_to_jpeg_and_webp();
 		$this->mock_frontend_body_hooks();
 
@@ -1417,14 +1448,14 @@ class Test_WebP_Uploads_Load extends TestCase {
 			4
 		);
 
-		$this->assertSame( $html, webp_uploads_filter_wp_get_attachment_image( $html, $attachment_id, $size, false, '' ) );
+		$this->assertSame( $html, webp_uploads_filter_wp_get_attachment_image( $html, $attachment_id, $size, false, $attr ) );
 		$this->assertCount( 1, $filter_args );
 		$this->assertSame(
 			array(
 				'should_filter' => true,
 				'attachment_id' => $attachment_id,
 				'size'          => $size,
-				'attr'          => array(),
+				'attr'          => $expected_attr,
 			),
 			$filter_args[0]
 		);

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1377,6 +1377,25 @@ class Test_WebP_Uploads_Load extends TestCase {
 	/**
 	 * @covers ::webp_uploads_filter_wp_get_attachment_image
 	 */
+	public function test_wp_get_attachment_image_is_rewritten_to_webp_without_attrs(): void {
+		$this->opt_in_to_jpeg_and_webp();
+		$this->mock_frontend_body_hooks();
+
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+
+		$html = wp_get_attachment_image( $attachment_id, 'large' );
+
+		$this->assertStringContainsString( '.webp', $html );
+		$this->assertStringNotContainsString( 'leaves.jpg', $html );
+
+		$processor = new WP_HTML_Tag_Processor( $html );
+		$this->assertTrue( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) );
+		$this->assertFalse( $processor->next_tag( array( 'tag_name' => 'IMG' ) ), 'Only one IMG tag should be present.' );
+	}
+
+	/**
+	 * @covers ::webp_uploads_filter_wp_get_attachment_image
+	 */
 	public function test_wp_get_attachment_image_opt_out_filter_returns_original_html(): void {
 		$this->opt_in_to_jpeg_and_webp();
 		$this->mock_frontend_body_hooks();

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1377,20 +1377,14 @@ class Test_WebP_Uploads_Load extends TestCase {
 	/**
 	 * @covers ::webp_uploads_filter_wp_get_attachment_image
 	 */
-	public function test_wp_get_attachment_image_is_rewritten_to_webp_without_attrs(): void {
+	public function test_wp_get_attachment_image_when_no_image_returned(): void {
 		$this->opt_in_to_jpeg_and_webp();
 		$this->mock_frontend_body_hooks();
+		add_filter( 'wp_get_attachment_image_src', '__return_false' );
 
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
 
-		$html = wp_get_attachment_image( $attachment_id, 'large' );
-
-		$this->assertStringContainsString( '.webp', $html );
-		$this->assertStringNotContainsString( 'leaves.jpg', $html );
-
-		$processor = new WP_HTML_Tag_Processor( $html );
-		$this->assertTrue( $processor->next_tag( array( 'tag_name' => 'IMG' ) ) );
-		$this->assertFalse( $processor->next_tag( array( 'tag_name' => 'IMG' ) ), 'Only one IMG tag should be present.' );
+		$this->assertSame( '', wp_get_attachment_image( $attachment_id, 'large' ) );
 	}
 
 	/**

--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1492,6 +1492,17 @@ class Test_WebP_Uploads_Load extends TestCase {
 	}
 
 	/**
+	 * @covers ::webp_uploads_filter_wp_get_attachment_image
+	 */
+	public function test_wp_get_attachment_image_bails_when_non_string_is_passed(): void {
+		$this->mock_frontend_body_hooks();
+		$this->assertSame(
+			'',
+			webp_uploads_filter_wp_get_attachment_image( false, 0, 'medium', true, array() )
+		);
+	}
+
+	/**
 	 * Check if AVIF encoding is supported.
 	 *
 	 * This is required due to false positive given by Imagick::queryFormats() for AVIF support,

--- a/plugins/webp-uploads/tests/test-rest-api.php
+++ b/plugins/webp-uploads/tests/test-rest-api.php
@@ -15,6 +15,8 @@ class Test_WebP_Uploads_REST_API extends WP_UnitTestCase {
 
 	/**
 	 * Checks whether the sources information is added to image sizes details of the REST response object.
+	 *
+	 * @covers ::webp_uploads_update_rest_attachment
 	 */
 	public function test_it_should_add_sources_to_rest_response(): void {
 		remove_all_filters( 'webp_uploads_upload_image_mime_transforms' );
@@ -70,6 +72,8 @@ class Test_WebP_Uploads_REST_API extends WP_UnitTestCase {
 
 	/**
 	 * Checks whether the media details information is added to the REST response object.
+	 *
+	 * @covers ::webp_uploads_update_rest_attachment
 	 */
 	public function test_it_should_check_media_details_in_rest_response(): void {
 		$file_location = TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg';
@@ -100,5 +104,156 @@ class Test_WebP_Uploads_REST_API extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'media_details', $data );
 		$this->assertIsNotArray( $data['media_details'] );
 		$this->assertIsObject( $data['media_details'] );
+	}
+
+	/**
+	 * Checks that an image size is skipped when its `source_url` is missing.
+	 *
+	 * @covers ::webp_uploads_update_rest_attachment
+	 */
+	public function test_it_should_skip_size_when_source_url_is_missing(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+		$post          = get_post( $attachment_id );
+		$this->assertInstanceOf( WP_Post::class, $post );
+
+		$response = new WP_REST_Response(
+			array(
+				'media_details' => array(
+					'sizes' => array(
+						'large' => array(
+							// Note: 'source_url' is intentionally omitted.
+							'sources' => array(
+								'image/webp' => array( 'file' => 'leaves-large.webp' ),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$data = webp_uploads_update_rest_attachment( $response, $post )->get_data();
+
+		// The size was skipped, so no `source_url` was written into the mime source.
+		$this->assertArrayNotHasKey( 'source_url', $data['media_details']['sizes']['large']['sources']['image/webp'] );
+	}
+
+	/**
+	 * Checks that an image size is skipped when its `source_url` is not a string.
+	 *
+	 * @covers ::webp_uploads_update_rest_attachment
+	 */
+	public function test_it_should_skip_size_when_source_url_is_not_a_string(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+		$post          = get_post( $attachment_id );
+		$this->assertInstanceOf( WP_Post::class, $post );
+
+		$response = new WP_REST_Response(
+			array(
+				'media_details' => array(
+					'sizes' => array(
+						'large' => array(
+							'source_url' => 12345, // Not a string.
+							'sources'    => array(
+								'image/webp' => array( 'file' => 'leaves-large.webp' ),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$data = webp_uploads_update_rest_attachment( $response, $post )->get_data();
+
+		// The size was skipped, so no `source_url` was written into the mime source.
+		$this->assertArrayNotHasKey( 'source_url', $data['media_details']['sizes']['large']['sources']['image/webp'] );
+	}
+
+	/**
+	 * Checks that a mime source is skipped when its `file` is missing or invalid, without affecting valid sources.
+	 *
+	 * @covers ::webp_uploads_update_rest_attachment
+	 */
+	public function test_it_should_skip_size_source_when_file_is_missing_or_invalid(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+		$post          = get_post( $attachment_id );
+		$this->assertInstanceOf( WP_Post::class, $post );
+
+		$response = new WP_REST_Response(
+			array(
+				'media_details' => array(
+					'sizes' => array(
+						'large' => array(
+							'source_url' => 'https://example.com/wp-content/uploads/leaves-large.jpg',
+							'sources'    => array(
+								'image/webp' => array( 'file' => 'leaves-large.webp' ), // Valid: rewritten.
+								'image/avif' => array(),                                 // Missing 'file': skipped.
+								'image/gif'  => 'not-an-array',                          // Not an array: skipped.
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$data    = webp_uploads_update_rest_attachment( $response, $post )->get_data();
+		$sources = $data['media_details']['sizes']['large']['sources'];
+
+		$this->assertSame( 'https://example.com/wp-content/uploads/leaves-large.webp', $sources['image/webp']['source_url'] );
+		$this->assertArrayNotHasKey( 'source_url', $sources['image/avif'] );
+		$this->assertSame( 'not-an-array', $sources['image/gif'] );
+	}
+
+	/**
+	 * Checks that a full-size mime source is skipped when its `file` is missing or invalid, without affecting valid sources.
+	 *
+	 * @covers ::webp_uploads_update_rest_attachment
+	 */
+	public function test_it_should_skip_full_source_when_file_is_missing_or_invalid(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+		$post          = get_post( $attachment_id );
+		$this->assertInstanceOf( WP_Post::class, $post );
+
+		$response = new WP_REST_Response(
+			array(
+				'media_details' => array(
+					'sizes'   => array(
+						'full' => array(),
+					),
+					'sources' => array(
+						'image/webp' => array( 'file' => 'leaves.webp' ), // Valid: rewritten.
+						'image/avif' => array(),                          // Missing 'file': skipped.
+						'image/gif'  => 'not-an-array',                   // Not an array: skipped.
+					),
+				),
+			)
+		);
+
+		$data = webp_uploads_update_rest_attachment( $response, $post )->get_data();
+
+		// The top-level `sources` are moved under the `full` size.
+		$this->assertArrayNotHasKey( 'sources', $data['media_details'] );
+		$full_sources = $data['media_details']['sizes']['full']['sources'];
+
+		$this->assertStringEndsWith( 'leaves.webp', $full_sources['image/webp']['source_url'] );
+		$this->assertArrayNotHasKey( 'source_url', $full_sources['image/avif'] );
+		$this->assertSame( 'not-an-array', $full_sources['image/gif'] );
+	}
+
+	/**
+	 * Checks that the response is returned unchanged when its data is not an array.
+	 *
+	 * @covers ::webp_uploads_update_rest_attachment
+	 */
+	public function test_it_should_return_response_when_data_is_not_an_array(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/leaves.jpg' );
+		$post          = get_post( $attachment_id );
+		$this->assertInstanceOf( WP_Post::class, $post );
+
+		$response = new WP_REST_Response( 'not-an-array' );
+
+		$filtered = webp_uploads_update_rest_attachment( $response, $post );
+
+		$this->assertSame( $response, $filtered );
+		$this->assertSame( 'not-an-array', $filtered->get_data() );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #2563

## Relevant technical choices

See https://github.com/WordPress/performance/issues/2563#issuecomment-4871212272

## Use of AI Tools

Claude Code with Claude Opus 4.8 used for code review and writing tests.