### PR TITLE
Build: Preserve plugin ZIP modified time when contents are unchanged

### DIFF
--- a/tools/webpack/utils.js
+++ b/tools/webpack/utils.js
@@ -133,7 +133,56 @@ const cssMinifyTransformer = ( content, absoluteFrom ) => {
 };
 
 /**
+ * Compute a content fingerprint for a zip archive, ignoring entry timestamps.
+ *
+ * Uses `unzip -v`, which lists each entry's uncompressed size, CRC-32 checksum,
+ * and name. The date and time columns are omitted so that two archives with
+ * identical contents produce the same fingerprint even when built at different
+ * times.
+ *
+ * @param {string} zipPath The path to the zip file.
+ *
+ * @return {string|null} The fingerprint, or null if the archive does not exist.
+ */
+const getZipContentFingerprint = ( zipPath ) => {
+	if ( ! fs.existsSync( zipPath ) ) {
+		return null;
+	}
+
+	const proc = spawnSync( 'unzip', [ '-v', zipPath ] );
+
+	if ( 0 !== proc.status ) {
+		if ( proc.error ) {
+			throw proc.error;
+		} else {
+			throw new Error( proc.stderr.toString() || proc.stdout.toString() );
+		}
+	}
+
+	const lineRegex =
+		/^\s*(\d+)\s+\S+\s+\d+\s+\S+\s+\d\d-\d\d-\d\d\d\d\s+\d\d:\d\d\s+([0-9a-f]{8})\s+(.*)$/;
+
+	return proc.stdout
+		.toString()
+		.split( '\n' )
+		.map( ( line ) => {
+			const match = lineRegex.exec( line );
+			return match
+				? `${ match[ 1 ] }:${ match[ 2 ] }:${ match[ 3 ] }`
+				: null;
+		} )
+		.filter( Boolean )
+		.join( '\n' );
+};
+
+/**
  * Create plugins zip file using `zip` command.
+ *
+ * The archive is built into a temporary file first and only replaces the
+ * existing zip when its contents actually change. This leaves the existing
+ * file (and its modified time) untouched when a rebuild produces identical
+ * output. Building fresh each time also ensures files removed from the plugin
+ * do not linger in an updated-in-place archive.
  *
  * @param {string} pluginPath The path where the plugin build is located.
  * @param {string} pluginName The name of the plugin.
@@ -143,19 +192,34 @@ const cssMinifyTransformer = ( content, absoluteFrom ) => {
 const createPluginZip = ( pluginPath, pluginName ) => {
 	chdir( pluginPath );
 
-	const proc = spawnSync( 'zip', [
-		'-r',
-		`${ pluginName }.zip`,
-		pluginName,
-	] );
+	const zipFile = `${ pluginName }.zip`;
+	const tempZipFile = `${ pluginName }.zip.tmp`;
+
+	deleteFileOrDirectory( tempZipFile );
+
+	const proc = spawnSync( 'zip', [ '-r', tempZipFile, pluginName ] );
 
 	if ( 0 !== proc.status ) {
+		deleteFileOrDirectory( tempZipFile );
 		if ( proc.error ) {
 			throw proc.error;
 		} else {
 			throw new Error( proc.stderr.toString() || proc.stdout.toString() );
 		}
 	}
+
+	// If the freshly built archive matches the existing one, discard it so the
+	// existing file is left untouched.
+	if (
+		fs.existsSync( zipFile ) &&
+		getZipContentFingerprint( zipFile ) ===
+			getZipContentFingerprint( tempZipFile )
+	) {
+		deleteFileOrDirectory( tempZipFile );
+		return;
+	}
+
+	fs.renameSync( tempZipFile, zipFile );
 };
 
 module.exports = {
@@ -165,5 +229,6 @@ module.exports = {
 	generateBuildManifest,
 	assetDataTransformer,
 	cssMinifyTransformer,
+	getZipContentFingerprint,
 	createPluginZip,
 };


### PR DESCRIPTION
## Summary

Make `build-plugins:zip` leave an existing plugin ZIP file — and its modified time — untouched when a rebuild produces identical contents. The modified time now only changes when the ZIP's contents actually change.

Personal note: This will help a lot with obtaining ZIP builds to share with others during pre-release testing. When sorting files in a directory by modified date, running `npm run build-plugins:zip` will always cause the actually modified plugins' ZIP files to appear at the top of the list. They can then be easily attached to a PR as a comment, for example in https://github.com/WordPress/performance/pull/2565#issuecomment-4878656697. 

## Relevant technical choices

`build-plugins:zip` rebuilds each plugin archive from a freshly re-copied build directory, so the `zip` command embeds new entry timestamps on every run. As a result the resulting archive bytes always differ even when the file contents are byte-for-byte identical, and every build bumped the ZIP's modified time regardless of whether anything actually changed. Comparing the raw archive bytes therefore can't detect "no change."

Instead, `createPluginZip()` now:

1. Builds the archive into a temporary file (`<plugin>.zip.tmp`) rather than directly over the existing ZIP.
2. Compares the new archive against the existing one via a new `getZipContentFingerprint()` helper, which runs `unzip -v` and keeps each entry's **uncompressed size + CRC-32 + name**, deliberately dropping the date/time columns — a timestamp-independent content fingerprint.
3. If the fingerprints match, discards the temporary file and leaves the existing ZIP (and its modified time) untouched. Otherwise it renames the temporary file over the existing one.

A side benefit: because each build now starts from a fresh temporary archive rather than updating the existing ZIP in place, files removed from a plugin no longer linger as stale entries (the previous `zip -r` over an existing archive only added/updated entries, never removed them).

Verified manually:

- Identical rebuild → modified time preserved, temporary file cleaned up.
- Source change → modified time updated to the new build.
- No leftover `.tmp` files; `zip` failures still throw (with temp cleanup).

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Opus 4.8). The approach, implementation, and commit/PR text were AI-generated based on my direction, and I reviewed and verified the changes (including the manual build tests above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
