### PR TITLE
Build: Fail plugin ZIP build when untracked files would be included

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"versions": "./bin/plugin/cli.js versions",
 		"build": "wp-scripts build",
 		"build-plugins": "npm-run-all 'build:plugin:*'",
-		"build-plugins:zip": "npm-run-all 'build:plugin:* --env zip=true'",
+		"build-plugins:zip": "npm-run-all 'build:plugin:* --env zip=true {@}' --",
 		"build:plugin:performance-lab": "webpack --mode production --env plugin=performance-lab",
 		"build:plugin:auto-sizes": "webpack --mode production --env plugin=auto-sizes",
 		"build:plugin:dominant-color-images": "webpack --mode production --env plugin=dominant-color-images",

--- a/tools/webpack/utils.js
+++ b/tools/webpack/utils.js
@@ -176,6 +176,47 @@ const getZipContentFingerprint = ( zipPath ) => {
 };
 
 /**
+ * Get untracked files that would be included in a plugin's zip archive.
+ *
+ * Lists files under the plugin source directory that Git considers untracked
+ * (and are not ignored via .gitignore), then narrows the list to those that
+ * actually made it into the build output — i.e. files that were not excluded by
+ * the copy step's ignore patterns and would therefore end up in the archive.
+ *
+ * @param {string} slug     The plugin slug.
+ * @param {string} buildDir The path to the plugin's build output directory.
+ *
+ * @return {string[]} Repo-relative paths of untracked files that would be zipped.
+ */
+const getUntrackedIncludedFiles = ( slug, buildDir ) => {
+	const root = getPluginRootPath();
+	const sourceDir = path.join( 'plugins', slug );
+
+	const proc = spawnSync(
+		'git',
+		[ 'ls-files', '--others', '--exclude-standard', '--', sourceDir ],
+		{ cwd: root }
+	);
+
+	if ( 0 !== proc.status ) {
+		if ( proc.error ) {
+			throw proc.error;
+		} else {
+			throw new Error( proc.stderr.toString() || proc.stdout.toString() );
+		}
+	}
+
+	return proc.stdout
+		.toString()
+		.split( '\n' )
+		.filter( Boolean )
+		.filter( ( relPath ) => {
+			const relInsidePlugin = path.relative( sourceDir, relPath );
+			return fs.existsSync( path.join( buildDir, relInsidePlugin ) );
+		} );
+};
+
+/**
  * Create plugins zip file using `zip` command.
  *
  * The archive is built into a temporary file first and only replaces the
@@ -184,12 +225,36 @@ const getZipContentFingerprint = ( zipPath ) => {
  * output. Building fresh each time also ensures files removed from the plugin
  * do not linger in an updated-in-place archive.
  *
- * @param {string} pluginPath The path where the plugin build is located.
- * @param {string} pluginName The name of the plugin.
+ * The build fails if untracked files would be included in the archive, which
+ * usually indicates stray files were left in the plugin source directory by
+ * accident. Pass `force: true` (via `--env force=true`) to bypass this check.
+ *
+ * @param {string}  pluginPath      The path where the plugin build is located.
+ * @param {string}  pluginName      The name of the plugin.
+ * @param {Object}  [options]       Options.
+ * @param {boolean} [options.force] Whether to build even when untracked files
+ *                                  would be included in the archive.
  *
  * @return {void}
  */
-const createPluginZip = ( pluginPath, pluginName ) => {
+const createPluginZip = ( pluginPath, pluginName, { force = false } = {} ) => {
+	if ( ! force ) {
+		const untrackedFiles = getUntrackedIncludedFiles(
+			pluginName,
+			path.join( pluginPath, pluginName )
+		);
+
+		if ( untrackedFiles.length > 0 ) {
+			throw new Error(
+				`Refusing to build the "${ pluginName }" plugin zip because the following untracked files would be included:\n` +
+					untrackedFiles
+						.map( ( file ) => `  - ${ file }` )
+						.join( '\n' ) +
+					'\nCommit or remove these files, or pass `--env force=true` to override.'
+			);
+		}
+	}
+
 	chdir( pluginPath );
 
 	const zipFile = `${ pluginName }.zip`;
@@ -230,5 +295,6 @@ module.exports = {
 	assetDataTransformer,
 	cssMinifyTransformer,
 	getZipContentFingerprint,
+	getUntrackedIncludedFiles,
 	createPluginZip,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -398,7 +398,9 @@ const buildPlugin = ( env ) => {
 
 						// If zip flag is passed, create a zip file.
 						if ( env.zip ) {
-							createPluginZip( buildDir, env.plugin );
+							createPluginZip( buildDir, env.plugin, {
+								force: Boolean( env.force ),
+							} );
 						}
 					} );
 				},


### PR DESCRIPTION
## Summary

Make the plugin ZIP build fail when untracked files would be included in the archive, since stray files left in a plugin source directory otherwise get silently bundled into a release. The check can be overridden with `--env force=true`.

> [!NOTE]
> This is stacked on top of #2566 and targets that branch to keep the diff focused. GitHub will automatically retarget it to `trunk` once #2566 merges.

Personal note: This addresses another pain point I've had with creating ZIPs for testing. Often I find out extra files were accidentally included, and that just makes things messy. This prevents that from happening.

## Relevant technical choices

When zipping a plugin, files left in the plugin source directory get copied into the build output and bundled into the archive. It's easy to accidentally ship files that were never meant to be part of a release.

`createPluginZip()` now checks the plugin source directory before creating the archive:

1. Runs `git ls-files --others --exclude-standard` on `plugins/<slug>` to list files that Git considers **untracked and not gitignored**.
2. Narrows that list to files that actually made it into the build output (`build/<slug>/…`), so files excluded by the copy step's `ignore` patterns (e.g. `tests/`, `docs/`, `*.cache`) don't trigger a false positive.
3. If any remain, the build fails with a message listing the offending files.

Generated build artifacts (minified assets, `web-vitals.js`, `*.asset.php`, etc.) are unaffected because they're either committed to the repo or gitignored — neither shows up as untracked.

The check is bypassable with `--env force=true` for the rare case where including untracked files is intentional.

### Overriding the check

The `force` flag is a webpack `--env` value, so it must be passed **after `--`** — otherwise npm consumes the flag and never forwards it to the build:

```bash
# A single plugin:
npm run build:plugin:webp-uploads -- --env zip=true --env force=true

# The whole suite:
npm run build-plugins:zip -- --env force=true
```

The `--` after the script name is required by npm to forward arguments to the script; `npm run build-plugins:zip --env force=true` (without `--`) will not work.

The `build-plugins:zip` script also had to be updated to forward these arguments through `npm-run-all` to each `build:plugin:*` build (via the `{@}` argument placeholder). Without that change there was no way to pass `--env force=true` to the whole-suite build. `npm run build-plugins:zip` with no arguments continues to work unchanged.

Verified manually:

- Stray file in a plugin source root → build fails (non-zero exit) with the file listed.
- Same build with `--env force=true` → succeeds and includes the file.
- Stray file under an ignored path (`tests/`) → build succeeds (not included, not flagged).
- Clean source → build succeeds.
- `npm run build-plugins:zip -- --env force=true` → forwards `force` to all plugin builds and succeeds; `npm run build-plugins:zip` with no arguments still builds/zips as before.

## Use of AI Tools

This PR was authored with the assistance of Claude Code (Opus 4.8). The approach, implementation, and commit/PR text were AI-generated based on my direction, and I reviewed and verified the changes (including the manual build tests above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
