### PR TITLE
Prepare 2026-07-03 release

### DIFF
--- a/plugins/webp-uploads/load.php
+++ b/plugins/webp-uploads/load.php
@@ -5,7 +5,7 @@
  * Description: Converts images to more modern formats such as WebP or AVIF during upload.
  * Requires at least: 6.9
  * Requires PHP: 7.4
- * Version: 2.7.0
+ * Version: 2.7.1
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  * License: GPLv2 or later
@@ -28,7 +28,7 @@ if ( defined( 'WEBP_UPLOADS_VERSION' ) ) {
 	return;
 }
 
-define( 'WEBP_UPLOADS_VERSION', '2.7.0' );
+define( 'WEBP_UPLOADS_VERSION', '2.7.1' );
 define( 'WEBP_UPLOADS_MAIN_FILE', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/helper.php';

--- a/plugins/webp-uploads/readme.txt
+++ b/plugins/webp-uploads/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors: wordpressdotorg
 Tested up to: 7.0
-Stable tag:   2.7.0
+Stable tag:   2.7.1
 License:      GPLv2 or later
 License URI:  https://www.gnu.org/licenses/gpl-2.0.html
 Tags:         performance, images, webp, avif, modern image formats
@@ -64,6 +64,12 @@ There are two primary reasons that a WebP image may not be generated:
 By default, the Modern Image Formats plugin will only generate WebP versions of the images that you upload. If you wish to have both WebP **and** JPEG versions generated, you can navigate to **Settings > Media** and enable the **Generate JPEG files in addition to WebP** option.
 
 == Changelog ==
+
+= 2.7.1 =
+
+**Bug Fixes**
+
+* Prevent fatal error in `webp_uploads_filter_wp_get_attachment_image()` when `wp_get_attachment_image_src()` returns false and during `rest_prepare_attachment` filtering. ([2565](https://github.com/WordPress/performance/pull/2565))
 
 = 2.7.0 =
 


### PR DESCRIPTION
Includes just https://github.com/WordPress/performance/pull/2565 which was already approved.