### PR TITLE
Gallery block: Add `wide` align unit tests

### DIFF
--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -124,8 +124,10 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 				$size = array( 420, 420 );
 			}
 
-			// When the wide alignment for the gallery, the child image blocks should also use the
-			// wide alignment if chile image block didn't set the alignment.
+			/*
+			 * When the wide alignment for the gallery, the child image blocks should also use the
+			 * wide alignment if chile image block didn't set the alignment.
+			 */
 			$is_parent_gallery = $block->context['galleryId'] ?? false;
 			if ( $is_parent_gallery && '' === $alignment ) {
 				$alignment = $max_alignment;

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -128,7 +128,7 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 			 * When the wide alignment for the gallery, the child image blocks should also use the
 			 * wide alignment if chile image block didn't set the alignment.
 			 */
-			$is_parent_gallery = $block->context['galleryId'] ?? false;
+			$is_parent_gallery = $block->context['is_parent_aligned'] ?? false;
 			if ( $is_parent_gallery && '' === $alignment ) {
 				$alignment = $max_alignment;
 			}
@@ -320,7 +320,7 @@ function auto_sizes_filter_uses_context( array $uses_context, WP_Block_Type $blo
 	// Define block-specific context usage.
 	$block_specific_context = array(
 		'core/cover'               => array( 'max_alignment', 'container_relative_width' ),
-		'core/image'               => array( 'max_alignment', 'container_relative_width' ),
+		'core/image'               => array( 'max_alignment', 'container_relative_width', 'is_parent_aligned' ),
 		'core/post-featured-image' => array( 'max_alignment', 'container_relative_width' ),
 		'core/group'               => array( 'max_alignment' ),
 		'core/columns'             => array( 'max_alignment', 'column_count', 'container_relative_width' ),
@@ -384,6 +384,9 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 		} else {
 			$context['gallery_column_count'] = 3;
 		}
+
+		// If the gallery is aligned, we can assume that the child images are also aligned.
+		$context['is_parent_aligned'] = true;
 	}
 
 	// Special handling for images inside galleries, as they have a different layout calculation that depends on the number of columns.

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -385,7 +385,7 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 			$context['gallery_column_count'] = 3;
 		}
 
-		// If the gallery is wide or full aligned, treat child Image blocks as aligned too.
+		// If the gallery is wide aligned, treat child Image blocks as aligned too.
 		$gallery_alignment            = $block['attrs']['align'] ?? '';
 		$context['is_parent_aligned'] = 'wide' === $gallery_alignment;
 	}

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -125,11 +125,11 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 			}
 
 			/*
-			 * When the wide alignment for the gallery, the child image blocks should also use the
-			 * wide alignment if chile image block didn't set the alignment.
+			 * When a Gallery block has a wide or full alignment, child Image blocks inherit that
+			 * alignment unless the child block explicitly sets its own alignment.
 			 */
-			$is_parent_gallery = $block->context['is_parent_aligned'] ?? false;
-			if ( $is_parent_gallery && '' === $alignment ) {
+			$is_parent_gallery_aligned = (bool) ( $block->context['is_parent_aligned'] ?? false );
+			if ( $is_parent_gallery_aligned && '' === $alignment ) {
 				$alignment = $max_alignment;
 			}
 
@@ -385,8 +385,9 @@ function auto_sizes_filter_render_block_context( array $context, array $block, ?
 			$context['gallery_column_count'] = 3;
 		}
 
-		// If the gallery is aligned, we can assume that the child images are also aligned.
-		$context['is_parent_aligned'] = true;
+		// If the gallery is wide or full aligned, treat child Image blocks as aligned too.
+		$gallery_alignment            = $block['attrs']['align'] ?? '';
+		$context['is_parent_aligned'] = 'wide' === $gallery_alignment;
 	}
 
 	// Special handling for images inside galleries, as they have a different layout calculation that depends on the number of columns.

--- a/plugins/auto-sizes/includes/improve-calculate-sizes.php
+++ b/plugins/auto-sizes/includes/improve-calculate-sizes.php
@@ -124,6 +124,13 @@ function auto_sizes_filter_image_tag( $content, array $parsed_block, WP_Block $b
 				$size = array( 420, 420 );
 			}
 
+			// When the wide alignment for the gallery, the child image blocks should also use the
+			// wide alignment if chile image block didn't set the alignment.
+			$is_parent_gallery = $block->context['galleryId'] ?? false;
+			if ( $is_parent_gallery && '' === $alignment ) {
+				$alignment = $max_alignment;
+			}
+
 			$better_sizes = auto_sizes_calculate_better_sizes( $id, $size, $alignment, $width, $max_alignment, $container_relative_width );
 
 			// If better sizes can't be calculated, use the default sizes.

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -1515,11 +1515,23 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				1,
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 1 image (1 column)' => array(
+				'wide',
+				'',
+				1,
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 2 images (2 columns)' => array(
 				'',
 				'',
 				2,
 				'sizes="(max-width: 310px) 100vw, 310px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 2 images (2 columns)' => array(
+				'wide',
+				'',
+				2,
+				'sizes="(max-width: 640px) 100vw, 640px" ',
 			),
 			'Default alignment, 3 images (3 columns)' => array(
 				'',
@@ -1527,17 +1539,35 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				3,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 3 images (3 columns)' => array(
+				'wide',
+				'',
+				3,
+				'sizes="(max-width: 426px) 100vw, 426px" ',
+			),
 			'Default alignment, 6 images (maxes out column constraints)' => array(
 				'',
 				'',
 				6,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 6 images (6 columns)' => array(
+				'wide',
+				'',
+				6,
+				'sizes="(max-width: 426px) 100vw, 426px" ',
+			),
 			'Default alignment, 9 images (maxes out column constraints)' => array(
 				'',
 				'',
 				9,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 9 images (9 columns)' => array(
+				'wide',
+				'',
+				9,
+				'sizes="(max-width: 426px) 100vw, 426px" ',
 			),
 		);
 	}
@@ -1596,12 +1626,26 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				1,
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 1 image (1 column)' => array(
+				'wide',
+				'',
+				1,
+				1,
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 2 images (2 columns)' => array(
 				'',
 				'',
 				2,
 				2,
 				'sizes="(max-width: 310px) 100vw, 310px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 2 images (2 columns)' => array(
+				'wide',
+				'',
+				2,
+				2,
+				'sizes="(max-width: 640px) 100vw, 640px" ',
 			),
 			'Default alignment, 3 images (3 columns)' => array(
 				'',
@@ -1610,12 +1654,26 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				3,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 3 images (3 columns)' => array(
+				'wide',
+				'',
+				3,
+				3,
+				'sizes="(max-width: 426px) 100vw, 426px" ',
+			),
 			'Default alignment, 4 images (4 columns)' => array(
 				'',
 				'',
 				4,
 				4,
 				'sizes="(max-width: 155px) 100vw, 155px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 4 images (4 columns)' => array(
+				'wide',
+				'',
+				4,
+				4,
+				'sizes="(max-width: 320px) 100vw, 320px" ',
 			),
 			'Default alignment, 5 images (5 columns)' => array(
 				'',
@@ -1624,12 +1682,26 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				5,
 				'sizes="(max-width: 124px) 100vw, 124px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 5 images (5 columns)' => array(
+				'wide',
+				'',
+				5,
+				5,
+				'sizes="(max-width: 256px) 100vw, 256px" ',
+			),
 			'Default alignment, 6 images (6 columns)' => array(
 				'',
 				'',
 				6,
 				6,
 				'sizes="(max-width: 103px) 100vw, 103px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 6 images (6 columns)' => array(
+				'wide',
+				'',
+				6,
+				6,
+				'sizes="(max-width: 213px) 100vw, 213px" ',
 			),
 			'Default alignment, 7 images (7 columns)' => array(
 				'',
@@ -1638,12 +1710,26 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				7,
 				'sizes="(max-width: 88px) 100vw, 88px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 7 images (7 columns)' => array(
+				'wide',
+				'',
+				7,
+				7,
+				'sizes="(max-width: 182px) 100vw, 182px" ',
+			),
 			'Default alignment, 8 images (8 columns)' => array(
 				'',
 				'',
 				8,
 				8,
 				'sizes="(max-width: 77px) 100vw, 77px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 8 images (8 columns)' => array(
+				'wide',
+				'',
+				8,
+				8,
+				'sizes="(max-width: 160px) 100vw, 160px" ',
 			),
 
 			// Different combination of image and columns.
@@ -1654,6 +1740,13 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				1,
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 2 images (1 column)' => array(
+				'wide',
+				'',
+				2,
+				1,
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 3 image (2 columns)'  => array(
 				'',
 				'',
@@ -1662,13 +1755,27 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 310px) 100vw, 310px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 3 images (2 columns)' => array(
+				'wide',
+				'',
+				3,
+				2,
+				'sizes="(max-width: 640px) 100vw, 640px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 4 image (2 columns)'  => array(
 				'',
 				'',
 				4,
 				2,
 				'sizes="(max-width: 310px) 100vw, 310px" ',
-				'sizes="(max-width: 310px) 100vw, 310px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 4 images (2 columns)' => array(
+				'wide',
+				'',
+				4,
+				2,
+				'sizes="(max-width: 640px) 100vw, 640px" ',
 			),
 			'Default alignment, 5 image (2 columns)'  => array(
 				'',
@@ -1678,6 +1785,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 310px) 100vw, 310px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 5 images (2 columns)' => array(
+				'wide',
+				'',
+				5,
+				2,
+				'sizes="(max-width: 640px) 100vw, 640px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 4 image (3 columns)'  => array(
 				'',
 				'',
@@ -1685,6 +1800,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				3,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 4 images (3 columns)' => array(
+				'wide',
+				'',
+				4,
+				3,
+				'sizes="(max-width: 426px) 100vw, 426px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
 			),
 			'Default alignment, 5 image (3 columns)'  => array(
 				'',
@@ -1694,12 +1817,27 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 				'sizes="(max-width: 310px) 100vw, 310px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 5 image (3 columns)' => array(
+				'wide',
+				'',
+				5,
+				3,
+				'sizes="(max-width: 426px) 100vw, 426px" ',
+				'sizes="(max-width: 640px) 100vw, 640px" ',
+			),
 			'Default alignment, 6 image (3 columns)'  => array(
 				'',
 				'',
 				6,
 				3,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 6 image (3 columns)' => array(
+				'wide',
+				'',
+				6,
+				3,
+				'sizes="(max-width: 426px) 100vw, 426px" ',
 			),
 			'Default alignment, 5 image (4 columns)'  => array(
 				'',
@@ -1709,6 +1847,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 155px) 100vw, 155px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 5 image (4 columns)' => array(
+				'wide',
+				'',
+				5,
+				4,
+				'sizes="(max-width: 320px) 100vw, 320px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 6 image (4 columns)'  => array(
 				'',
 				'',
@@ -1716,6 +1862,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				4,
 				'sizes="(max-width: 155px) 100vw, 155px" ',
 				'sizes="(max-width: 310px) 100vw, 310px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 6 image (4 columns)' => array(
+				'wide',
+				'',
+				6,
+				4,
+				'sizes="(max-width: 320px) 100vw, 320px" ',
+				'sizes="(max-width: 640px) 100vw, 640px" ',
 			),
 			'Default alignment, 7 image (4 columns)'  => array(
 				'',
@@ -1725,6 +1879,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 155px) 100vw, 155px" ',
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 7 image (4 columns)' => array(
+				'wide',
+				'',
+				7,
+				4,
+				'sizes="(max-width: 320px) 100vw, 320px" ',
+				'sizes="(max-width: 426px) 100vw, 426px" ',
+			),
 			'Default alignment, 6 image (5 columns)'  => array(
 				'',
 				'',
@@ -1732,6 +1894,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				5,
 				'sizes="(max-width: 124px) 100vw, 124px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 6 image (5 columns)' => array(
+				'wide',
+				'',
+				6,
+				5,
+				'sizes="(max-width: 256px) 100vw, 256px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
 			),
 			'Default alignment, 7 image (5 columns)'  => array(
 				'',
@@ -1741,6 +1911,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 124px) 100vw, 124px" ',
 				'sizes="(max-width: 310px) 100vw, 310px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 7 image (5 columns)' => array(
+				'wide',
+				'',
+				7,
+				5,
+				'sizes="(max-width: 256px) 100vw, 256px" ',
+				'sizes="(max-width: 640px) 100vw, 640px" ',
+			),
 			'Default alignment, 8 image (5 columns)'  => array(
 				'',
 				'',
@@ -1748,6 +1926,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				5,
 				'sizes="(max-width: 124px) 100vw, 124px" ',
 				'sizes="(max-width: 206px) 100vw, 206px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 8 image (5 columns)' => array(
+				'wide',
+				'',
+				8,
+				5,
+				'sizes="(max-width: 256px) 100vw, 256px" ',
+				'sizes="(max-width: 426px) 100vw, 426px" ',
 			),
 			'Default alignment, 7 image (6 columns)'  => array(
 				'',
@@ -1757,6 +1943,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 103px) 100vw, 103px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 7 image (6 columns)' => array(
+				'wide',
+				'',
+				7,
+				6,
+				'sizes="(max-width: 213px) 100vw, 213px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 8 image (6 columns)'  => array(
 				'',
 				'',
@@ -1764,6 +1958,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				6,
 				'sizes="(max-width: 103px) 100vw, 103px" ',
 				'sizes="(max-width: 310px) 100vw, 310px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 8 image (6 columns)' => array(
+				'wide',
+				'',
+				8,
+				6,
+				'sizes="(max-width: 213px) 100vw, 213px" ',
+				'sizes="(max-width: 640px) 100vw, 640px" ',
 			),
 			'Default alignment, 9 image (6 columns)'  => array(
 				'',
@@ -1773,6 +1975,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 103px) 100vw, 103px" ',
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 9 image (6 columns)' => array(
+				'wide',
+				'',
+				9,
+				6,
+				'sizes="(max-width: 213px) 100vw, 213px" ',
+				'sizes="(max-width: 426px) 100vw, 426px" ',
+			),
 			'Default alignment, 8 image (7 columns)'  => array(
 				'',
 				'',
@@ -1780,6 +1990,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				7,
 				'sizes="(max-width: 88px) 100vw, 88px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 8 image (7 columns)' => array(
+				'wide',
+				'',
+				8,
+				7,
+				'sizes="(max-width: 182px) 100vw, 182px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
 			),
 			'Default alignment, 9 image (7 columns)'  => array(
 				'',
@@ -1789,6 +2007,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 88px) 100vw, 88px" ',
 				'sizes="(max-width: 310px) 100vw, 310px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 9 image (7 columns)' => array(
+				'wide',
+				'',
+				9,
+				7,
+				'sizes="(max-width: 182px) 100vw, 182px" ',
+				'sizes="(max-width: 640px) 100vw, 640px" ',
+			),
 			'Default alignment, 10 image (7 columns)' => array(
 				'',
 				'',
@@ -1796,6 +2022,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				7,
 				'sizes="(max-width: 88px) 100vw, 88px" ',
 				'sizes="(max-width: 206px) 100vw, 206px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 10 image (7 columns)' => array(
+				'wide',
+				'',
+				10,
+				7,
+				'sizes="(max-width: 182px) 100vw, 182px" ',
+				'sizes="(max-width: 426px) 100vw, 426px" ',
 			),
 			'Default alignment, 9 image (8 columns)'  => array(
 				'',
@@ -1805,6 +2039,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 77px) 100vw, 77px" ',
 				'sizes="(max-width: 620px) 100vw, 620px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 9 image (8 columns)' => array(
+				'wide',
+				'',
+				9,
+				8,
+				'sizes="(max-width: 160px) 100vw, 160px" ',
+				'sizes="(max-width: 1280px) 100vw, 1280px" ',
+			),
 			'Default alignment, 10 image (8 columns)' => array(
 				'',
 				'',
@@ -1813,6 +2055,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				'sizes="(max-width: 77px) 100vw, 77px" ',
 				'sizes="(max-width: 310px) 100vw, 310px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 10 image (8 columns)' => array(
+				'wide',
+				'',
+				10,
+				8,
+				'sizes="(max-width: 160px) 100vw, 160px" ',
+				'sizes="(max-width: 640px) 100vw, 640px" ',
+			),
 			'Default alignment, 11 image (8 columns)' => array(
 				'',
 				'',
@@ -1820,6 +2070,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				8,
 				'sizes="(max-width: 77px) 100vw, 77px" ',
 				'sizes="(max-width: 206px) 100vw, 206px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 11 image (8 columns)' => array(
+				'wide',
+				'',
+				11,
+				8,
+				'sizes="(max-width: 160px) 100vw, 160px" ',
+				'sizes="(max-width: 426px) 100vw, 426px" ',
 			),
 
 			// Random image columns setup.
@@ -1830,6 +2088,13 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				5,
 				'sizes="(max-width: 124px) 100vw, 124px" ',
 			),
+			'Wide gallery alignment, Default image alignment, 15 image (5 columns)' => array(
+				'wide',
+				'',
+				15,
+				5,
+				'sizes="(max-width: 256px) 100vw, 256px" ',
+			),
 			'Default alignment, 15 image (6 columns)' => array(
 				'',
 				'',
@@ -1837,6 +2102,14 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				6,
 				'sizes="(max-width: 103px) 100vw, 103px" ',
 				'sizes="(max-width: 206px) 100vw, 206px" ',
+			),
+			'Wide gallery alignment, Default image alignment, 15 image (6 columns)' => array(
+				'wide',
+				'',
+				15,
+				6,
+				'sizes="(max-width: 213px) 100vw, 213px" ',
+				'sizes="(max-width: 426px) 100vw, 426px" ',
 			),
 		);
 	}

--- a/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
+++ b/plugins/auto-sizes/tests/test-improve-calculate-sizes.php
@@ -1551,7 +1551,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				6,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 			),
-			'Wide gallery alignment, Default image alignment, 6 images (6 columns)' => array(
+			'Wide gallery alignment, Default image alignment, 6 images (maxes out column constraints)' => array(
 				'wide',
 				'',
 				6,
@@ -1563,7 +1563,7 @@ class Tests_Improve_Calculate_Sizes extends WP_UnitTestCase {
 				9,
 				'sizes="(max-width: 206px) 100vw, 206px" ',
 			),
-			'Wide gallery alignment, Default image alignment, 9 images (9 columns)' => array(
+			'Wide gallery alignment, Default image alignment, 9 images (maxes out column constraints)' => array(
 				'wide',
 				'',
 				9,


### PR DESCRIPTION
## Summary

<!-- Please reference the issue this PR fixes. If this PR does not fix the entire issue, change this to Addresses #... instead. -->
Part of https://github.com/WordPress/performance/issues/2449

This PR add unit test for `wide` alignment for gallery block.

## Use of AI Tools
N/A
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.

Moreover, see the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
