### PR TITLE
Exclude imagesrcset links from Link response header

### DIFF
--- a/plugins/optimization-detective/class-od-link-collection.php
+++ b/plugins/optimization-detective/class-od-link-collection.php
@@ -260,6 +260,7 @@ final class OD_Link_Collection implements Countable {
 	 * Constructs the Link HTTP response header.
 	 *
 	 * @since 0.4.0
+	 * @since n.e.x.t Excludes links with `imagesrcset` since responsive image preloads are sent via `<link>` tags in the HTML instead.
 	 *
 	 * @return non-empty-string|null Link HTTP response header, or null if there are none.
 	 */
@@ -267,32 +268,18 @@ final class OD_Link_Collection implements Countable {
 		$link_headers = array();
 
 		foreach ( $this->get_prepared_links() as $link ) {
-			if ( isset( $link['href'] ) ) {
-				$link['href'] = $this->encode_url_for_response_header( $link['href'] );
-			} else {
-				// The about:blank is present since a Link without a reference-uri is invalid so any imagesrcset would otherwise not get downloaded.
-				$link['href'] = 'about:blank';
-			}
-
-			// Encode the URLs in the srcset.
+			// Responsive image preloads are sent via <link> tags in the HTML (see get_html()) instead of the Link
+			// response header, since imagesrcset/imagesizes can make the header exceed common reverse-proxy header
+			// size limits. See <https://web.dev/articles/preload-responsive-images#imagesrcset-imagesizes>.
 			if ( isset( $link['imagesrcset'] ) ) {
-				$link['imagesrcset'] = join(
-					', ',
-					array_map(
-						function ( $image_candidate ) {
-							// Parse out the URL to separate it from the descriptor.
-							$image_candidate_parts = (array) preg_split( '/\s+/', (string) $image_candidate, 2 );
-
-							// Encode the URL.
-							$image_candidate_parts[0] = $this->encode_url_for_response_header( (string) $image_candidate_parts[0] );
-
-							// Re-join the URL with the descriptor.
-							return implode( ' ', $image_candidate_parts );
-						},
-						(array) preg_split( '/\s*,\s*/', $link['imagesrcset'] )
-					)
-				);
+				continue;
 			}
+
+			if ( ! isset( $link['href'] ) ) {
+				// Not reachable: imagesrcset-only links are skipped above, and add_link() requires either href or imagesrcset.
+				continue;
+			}
+			$link['href'] = $this->encode_url_for_response_header( $link['href'] );
 
 			$link_header = '<' . $link['href'] . '>';
 			unset( $link['href'] );

--- a/plugins/optimization-detective/tests/test-class-od-link-collection.php
+++ b/plugins/optimization-detective/tests/test-class-od-link-collection.php
@@ -37,7 +37,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_html'   => '
 					<link data-od-added-tag rel="preload" href="https://example.com/foo.jpg" imagesrcset="https://example.com/foo-400.jpg 400w, https://example.com/foo-800.jpg 800w" imagesizes="100vw" crossorigin="anonymous" fetchpriority="high" as="image" media="screen" integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC" referrerpolicy="origin" type="image/jpeg">
 				',
-				'expected_header' => 'Link: <https://example.com/foo.jpg>; rel="preload"; imagesrcset="https://example.com/foo-400.jpg 400w, https://example.com/foo-800.jpg 800w"; imagesizes="100vw"; crossorigin="anonymous"; fetchpriority="high"; as="image"; media="screen"; integrity="sha384-oqVuAfXRKap7fdgcCY5uykM6+R9GqQ8K/uxy9rx7HNQlGYl1kPzQho1wx4JwY8wC"; referrerpolicy="origin"; type="image/jpeg"',
+				'expected_header' => null,
 				'expected_count'  => 1,
 				'error'           => '',
 			),
@@ -56,8 +56,35 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_html'   => '
 					<link data-od-added-tag rel="preload" imagesrcset="https://example.com/foo-400.jpg 400w, https://example.com/foo-800.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" as="image" media="screen">
 				',
-				'expected_header' => 'Link: <about:blank>; rel="preload"; imagesrcset="https://example.com/foo-400.jpg 400w, https://example.com/foo-800.jpg 800w"; imagesizes="(max-width: 600px) 480px, 800px"; as="image"; media="screen"',
+				'expected_header' => null,
 				'expected_count'  => 1,
+				'error'           => '',
+			),
+			'preload_imagesrcset_excluded_from_header_when_mixed_with_plain_link' => array(
+				'links_args'      => array(
+					array(
+						array(
+							'rel'         => 'preload',
+							'href'        => 'https://example.com/foo.jpg',
+							'imagesrcset' => 'https://example.com/foo-400.jpg 400w, https://example.com/foo-800.jpg 800w',
+							'imagesizes'  => '100vw',
+							'as'          => 'image',
+						),
+					),
+					array(
+						array(
+							'rel'  => 'preload',
+							'href' => 'https://example.com/bar.jpg',
+							'as'   => 'image',
+						),
+					),
+				),
+				'expected_html'   => '
+					<link data-od-added-tag rel="preload" href="https://example.com/bar.jpg" as="image">
+					<link data-od-added-tag rel="preload" href="https://example.com/foo.jpg" imagesrcset="https://example.com/foo-400.jpg 400w, https://example.com/foo-800.jpg 800w" imagesizes="100vw" as="image">
+				',
+				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"',
+				'expected_count'  => 2,
 				'error'           => '',
 			),
 			'preload_with_min0_max_viewport_widths'      => array(
@@ -268,7 +295,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_html'   => '
 					<link data-od-added-tag rel="preload" href="https://example.com/bar.jpg" as="image" fetchpriority="high" imagesrcset="https://example.com/&quot;bar&quot;-480w.jpg 480w, https://example.com/&quot;bar&quot;-800w.jpg 800w" imagesizes="(max-width: 600px) 480px, 800px" crossorigin="anonymous">
 				',
-				'expected_header' => 'Link: <https://example.com/bar.jpg>; rel="preload"; as="image"; fetchpriority="high"; imagesrcset="https://example.com/%22bar%22-480w.jpg 480w, https://example.com/%22bar%22-800w.jpg 800w"; imagesizes="(max-width: 600px) 480px, 800px"; crossorigin="anonymous"',
+				'expected_header' => null,
 				'expected_count'  => 1,
 				'error'           => '',
 			),
@@ -469,7 +496,7 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 				'expected_html'   => '
 					<link data-od-added-tag href="https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp" rel="preload" as="image" imagesizes="(width &lt;= 480px) 316px, (480px &lt; width &lt;= 600px) 489px, (600px &lt; width &lt;= 782px) 644px, (782px &lt; width) 644px" imagesrcset="https://example.com/wp-content/uploads/2025/02/البيسون-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/البيسون-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/البيسون-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/البيسون-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/البيسون-2048x1336-jpg.webp 2048w">
 				',
-				'expected_header' => 'Link: <https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668-jpg.webp>; rel="preload"; as="image"; imagesizes="(width <= 480px) 316px, (480px < width <= 600px) 489px, (600px < width <= 782px) 644px, (782px < width) 644px"; imagesrcset="https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1024x668-jpg.webp 1024w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-300x196-jpg.webp 300w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-768x501-jpg.webp 768w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-1536x1002-jpg.webp 1536w, https://example.com/wp-content/uploads/2025/02/%D8%A7%D9%84%D8%A8%D9%8A%D8%B3%D9%88%D9%86-2048x1336-jpg.webp 2048w"',
+				'expected_header' => null,
 				'expected_count'  => 1,
 				'error'           => '',
 			),
@@ -576,11 +603,11 @@ class Test_OD_Link_Collection extends WP_UnitTestCase {
 	 *
 	 * @param array<string, mixed> $links_args      Links args.
 	 * @param string               $expected_html   Expected HTML.
-	 * @param string               $expected_header Expected Link header.
+	 * @param string|null          $expected_header Expected Link header.
 	 * @param int                  $expected_count  Expected count of links.
 	 * @param string               $error           Error.
 	 */
-	public function test_add_link( array $links_args, string $expected_html, string $expected_header, int $expected_count, string $error = '' ): void {
+	public function test_add_link( array $links_args, string $expected_html, ?string $expected_header, int $expected_count, string $error = '' ): void {
 		if ( '' !== $error ) {
 			$this->expectException( InvalidArgumentException::class );
 			$this->expectExceptionMessage( $error );


### PR DESCRIPTION
## Summary

Fixes #2304

## Relevant technical choices

- `OD_Link_Collection::get_response_header()` now excludes any link with `imagesrcset` set (responsive image preloads) from the `Link:` HTTP response header. These links already get an HTML `<link rel="preload" imagesrcset="..." ...>` tag unconditionally via `get_html()`, so no functionality is lost — the responsive preload just moves to HTML-only delivery.
- Non-responsive preload links (plain `href`, e.g. video posters, background images) are unaffected and still go into both the header and the HTML.
- No changes needed in Image Prioritizer or any other extension plugin: they only call `$context->link_collection->add_link()` with attributes; the header/HTML emission choice is made entirely in this one method in Optimization Detective.
- Root cause: responsive image preloads with long/non-ASCII filenames and multiple `srcset` variants can push the combined response header size past common reverse-proxy limits (Nginx/Apache default buffers), causing intermittent 502 Bad Gateway errors — worse for logged-in users where cookies add to the header total.
- Per the maintainer's guidance on the issue, citing [web.dev's preload responsive images guidance](https://web.dev/articles/preload-responsive-images#imagesrcset-imagesizes): responsive image preloads should use `<link rel="preload">` elements rather than `Link:` response headers.
- Scope: intentionally limited to this header/HTML behavior. A separate idea from the issue thread (repositioning preload `<link>` tags to right after `<meta charset>`/`<title>` in `<head>`) is left as a possible follow-up, not included here.

### How to test

1. Enable Image Prioritizer + Optimization Detective on a page with a large responsive image (`srcset`/`sizes`, ideally long/non-ASCII filename) detected as the LCP element.
2. Visit the page uncached (e.g. logged in as admin).
3. Inspect response headers — confirm no `Link: ...imagesrcset=...` entry.
4. View page source — confirm the `<link rel="preload" imagesrcset="..." ...>` tag is still present in `<head>` and the image still loads with priority.

### Testing already done

- `npm run phpstan` — clean
- `composer lint:optimization-detective` (phpcs) — clean
- `coderabbit review --agent` — 0 findings on changed files
- Updated/added PHPUnit cases in `test-class-od-link-collection.php` covering the excluded-from-header behavior

## Use of AI Tools

Confirmed I've used Claude AI to generate this PR. Claude Code was used for the full workflow: investigating the issue and root cause across `optimization-detective` and `image-prioritizer`, drafting and implementing the fix, updating tests, and running lint/static analysis. I reviewed the diff, the reasoning, and the test changes, and take responsibility for the change as submitted.