### PR TITLE
Deduplicate per-plugin coverage commands

### DIFF
--- a/.github/workflows/php-test-plugins.yml
+++ b/.github/workflows/php-test-plugins.yml
@@ -105,32 +105,18 @@ jobs:
       - name: Running single site unit tests
         run: |
           if [ "${{ matrix.coverage }}" == "true" ]; then
-            npm run test-php:performance-lab -- -- -- --coverage-clover=./single-site-reports/coverage-performance-lab.xml
-            npm run test-php:auto-sizes -- -- -- --coverage-clover=./single-site-reports/coverage-auto-sizes.xml
-            npm run test-php:dominant-color-images -- -- -- --coverage-clover=./single-site-reports/coverage-dominant-color-images.xml
-            npm run test-php:embed-optimizer -- -- -- --coverage-clover=./single-site-reports/coverage-embed-optimizer.xml
-            npm run test-php:image-prioritizer -- -- -- --coverage-clover=./single-site-reports/coverage-image-prioritizer.xml
-            npm run test-php:optimization-detective -- -- -- --coverage-clover=./single-site-reports/coverage-optimization-detective.xml
-            npm run test-php:speculation-rules -- -- -- --coverage-clover=./single-site-reports/coverage-speculation-rules.xml
-            npm run test-php:view-transitions -- -- -- --coverage-clover=./single-site-reports/coverage-view-transitions.xml
-            npm run test-php:web-worker-offloading -- -- -- --coverage-clover=./single-site-reports/coverage-web-worker-offloading.xml
-            npm run test-php:webp-uploads -- -- -- --coverage-clover=./single-site-reports/coverage-webp-uploads.xml
+            for plugin in $(jq -r '.plugins[]' plugins.json); do
+              npm run "test-php:$plugin" -- -- -- --coverage-clover="./single-site-reports/coverage-$plugin.xml"
+            done
           else
             npm run test-php
           fi
       - name: Running multisite unit tests
         run: |
           if [ "${{ matrix.coverage }}" == "true" ]; then
-            npm run test-php-multisite:performance-lab -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-performance-lab.xml
-            npm run test-php-multisite:auto-sizes -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-auto-sizes.xml
-            npm run test-php-multisite:dominant-color-images -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-dominant-color-images.xml
-            npm run test-php-multisite:embed-optimizer -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-embed-optimizer.xml
-            npm run test-php-multisite:image-prioritizer -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-image-prioritizer.xml
-            npm run test-php-multisite:optimization-detective -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-optimization-detective.xml
-            npm run test-php-multisite:speculation-rules -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-speculation-rules.xml
-            npm run test-php-multisite:view-transitions -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-view-transitions.xml
-            npm run test-php-multisite:web-worker-offloading -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-web-worker-offloading.xml
-            npm run test-php-multisite:webp-uploads -- -- -- --coverage-clover=./multisite-reports/coverage-multisite-webp-uploads.xml
+            for plugin in $(jq -r '.plugins[]' plugins.json); do
+              npm run "test-php-multisite:$plugin" -- -- -- --coverage-clover="./multisite-reports/coverage-multisite-$plugin.xml"
+            done
           else
             npm run test-php-multisite
           fi


### PR DESCRIPTION
## Summary
- generate single-site coverage commands from `plugins.json`
- generate multisite coverage commands from the same source of truth
- preserve existing npm scripts and coverage report filenames

## Testing
- verified all 10 plugin slugs have matching single-site and multisite npm scripts
- verified generated commands and report filenames match the removed commands
- validated workflow YAML syntax
- ran `git diff --check`

Fixes #2594