### PR TITLE
Add concurrency groups to cancel superseded workflow runs

### DIFF
--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -7,6 +7,12 @@ on:
       - synchronize
     branches:
       - trunk
+
+# Cancel previous workflow run groups that have not completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -12,7 +12,7 @@ on:
 concurrency:
   # Group workflow runs by workflow name, along with the head branch ref of the pull request
   # or otherwise the branch or tag ref.
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions: {}

--- a/.github/workflows/add-pr-labels.yml
+++ b/.github/workflows/add-pr-labels.yml
@@ -10,6 +10,8 @@ on:
 
 # Cancel previous workflow run groups that have not completed.
 concurrency:
+  # Group workflow runs by workflow name, along with the head branch ref of the pull request
+  # or otherwise the branch or tag ref.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -28,6 +28,8 @@ on:
 
 # Cancel previous workflow run groups that have not completed.
 concurrency:
+  # Group workflow runs by workflow name, along with the head branch ref of the pull request
+  # or otherwise the branch or tag ref.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,6 +26,11 @@ on:
       - reopened
       - synchronize
 
+# Cancel previous workflow run groups that have not completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -2,6 +2,11 @@ name: Spell Check
 
 on: [pull_request]
 
+# Cancel previous workflow run groups that have not completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -4,6 +4,8 @@ on: [pull_request]
 
 # Cancel previous workflow run groups that have not completed.
 concurrency:
+  # Group workflow runs by workflow name, along with the head branch ref of the pull request
+  # or otherwise the branch or tag ref.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
   cancel-in-progress: true
 


### PR DESCRIPTION
# Add concurrency configuration to remaining workflows

Adds `concurrency` with `cancel-in-progress: true` to the remaining GitHub Actions workflows that were missing it. This prevents duplicate workflow runs when multiple commits are pushed to the same pull request in quick succession, reducing unnecessary Actions usage and providing faster CI feedback.

## Summary

Fixes #2596 

## Relevant technical choices

* Added a `concurrency` block to:

  * `.github/workflows/e2e-test.yml`
  * `.github/workflows/spell-check.yml`
  * `.github/workflows/add-pr-labels.yml`
* Used the existing concurrency pattern already present in other workflows:

  ```yaml
  concurrency:
    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
    cancel-in-progress: true
  ```
* This ensures only the latest workflow run for a pull request remains active while superseded runs are automatically cancelled.

## Use of AI Tools

**AI assistance:** Yes

**Tool(s):** OpenCode

**Used for:** Assisting with the initial implementation and verifying consistency with existing workflow patterns. I reviewed, validated, and take responsibility for the final changes.
