### PR TITLE
Fix broken artifact existence debug log

### DIFF
--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -193,8 +193,9 @@ jobs:
               throw new Error(`Invalid response from GitHub API: ${getArtifact.status}`);
             }
 
-            core.setOutput('exists', getArtifact.data.artifacts.length > 0);
-            core.debug(`Artifact for ${{ matrix.plugin }} exists: ${core.getInput('exists')} ? "true" : "false"`);
+            const exists = getArtifact.data.artifacts.length > 0;
+            core.setOutput('exists', exists);
+            core.debug(`Artifact for ${{ matrix.plugin }} exists: ${exists}`);
 
       - name: Download artifact
         if: steps.artifact-existence.outputs.exists == 'true'

--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -180,13 +180,17 @@ jobs:
       - name: Check artifact existence
         id: artifact-existence
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PLUGIN: ${{ matrix.plugin }}
         with:
           script: |
+            const plugin = process.env.PLUGIN;
+
             const getArtifact = await github.request('GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts{?name}', {
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: context.runId,
-              name: "${{ matrix.plugin }}"
+              name: plugin
             });
 
             if (getArtifact.status !== 200) {
@@ -195,7 +199,7 @@ jobs:
 
             const exists = getArtifact.data.artifacts.length > 0;
             core.setOutput('exists', exists);
-            core.debug(`Artifact for ${{ matrix.plugin }} exists: ${exists}`);
+            core.debug(`Artifact for ${plugin} exists: ${exists}`);
 
       - name: Download artifact
         if: steps.artifact-existence.outputs.exists == 'true'


### PR DESCRIPTION
## Summary

Fixes the misleading `core.debug` line in the `release-assets` job of `.github/workflows/deploy-plugins.yml`.

- Store artifact existence in a local `exists` boolean
- Reuse that value for `core.setOutput('exists', ...)` and the debug log
- Remove the incorrect `core.getInput('exists')` call and the non-evaluated ternary text inside the template literal

## Relevant technical choices

No behavior change for artifact download/upload. Downstream checks still use `steps.artifact-existence.outputs.exists == 'true'`.

## Testing

- Validated workflow YAML syntax
- Ran `git diff --check`
- Confirmed the broken debug pattern no longer appears in the repo

## Use of AI Tools

Used Cursor to locate the bug, I made changes and validated tests myself. I've also reviewed my code and take responsibility for the change.

Fixes #2597