### PR TITLE
Fix PHPStan issue for casting

### DIFF
--- a/plugins/webp-uploads/tests/test-load.php
+++ b/plugins/webp-uploads/tests/test-load.php
@@ -1433,8 +1433,8 @@ class Test_WebP_Uploads_Load extends TestCase {
 		$html = sprintf(
 			'<img src="%s" width="%d" height="%d" alt="">',
 			esc_url( $src ),
-			(int) $width,
-			(int) $height
+			$width,
+			$height
 		);
 
 		$filter_args = array();


### PR DESCRIPTION
## Summary

Fix PHPStan error:

```
Error: Casting to int something that's already int.
```

## Relevant technical choices

<!-- Please describe your changes. -->

## Use of AI Tools

<!--
You are free to use artificial intelligence (AI) tooling to contribute, but we ask that you disclose what tooling you are using and to what extent a pull request has been authored by AI. Are you using AI just as a code reviewer? Or, for the other extreme, are you using AI to write everything (e.g. "vibe coding")? It is your responsibility to review and take responsibility for what AI generates.

For more, see CONTRIBUTING.md which includes instructions for how to provide instructions to AI agents.

Moreover, see the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->

<!--
For maintainers only, please make sure:

- PR has a `[Type]` label.
- PR has a plugin-specific milestone, or the `no milestone` label if it does not apply to any specific plugin.
- PR has a changelog-friendly title, or the `skip changelog` label if it should not be mentioned in the plugin's changelog.
-->
