### PR TITLE
Compare plugin versions when deciding whether to deploy

### DIFF
--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Setup PHP
+        # Required by the "Check if deployment is needed" step, which uses version_compare().
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: latest
+
       - name: Setup Node.js (.nvmrc)
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -96,9 +102,9 @@ jobs:
             exit 1
           fi
 
-          # Bail if the plugin is already up to date.
-          if [ "$PLUGIN_VERSION_WPORG" = "$PLUGIN_VERSION" ]; then
-            echo "::notice::The ${{ matrix.plugin }} plugin is already up to date on WordPress.org. Halting deployment."
+          # Bail if the version on WordPress.org is the same as or newer than the version being deployed.
+          if php -r 'exit( version_compare( $argv[1], $argv[2], ">=" ) ? 0 : 1 );' "$PLUGIN_VERSION_WPORG" "$PLUGIN_VERSION"; then
+            echo "::notice::The ${{ matrix.plugin }} plugin on WordPress.org is at version $PLUGIN_VERSION_WPORG, which is not older than the version being deployed ($PLUGIN_VERSION). Halting deployment."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

This is something I noticed while working on https://github.com/WordPress/performance/pull/2619. I wasn't comfortable using the regular workflow for deployments of all plugins when a tag was created because the "Check if deployment is needed" step only halts when the version on WordPress.org is string-equal to the version being built:

```bash
if [ "$PLUGIN_VERSION_WPORG" = "$PLUGIN_VERSION" ]; then
```

So if the version on WordPress.org is *newer* than the one in the branch, the versions are unequal, the check passes, and the deployment proceeds — overwriting a newer release with an older one. Being a string comparison, it is also blind to ordering generally: `1.10.0` and `1.9.0` are simply "not equal".

## Relevant technical choices

Swapped the equality test for `version_compare()`, halting whenever the WordPress.org version is `>=` the version being deployed:

```bash
if php -r 'exit( version_compare( $argv[1], $argv[2], ">=" ) ? 0 : 1 );' "$PLUGIN_VERSION_WPORG" "$PLUGIN_VERSION"; then
```

Verified against the cases that matter:

| WordPress.org | Being deployed | Result |
| --- | --- | --- |
| `1.2.0` | `1.2.0` | halt |
| `1.3.0` | `1.2.0` | halt (previously deployed) |
| `1.10.0` | `1.9.0` | halt (previously deployed) |
| `1.2.0` | `1.3.0` | deploy |
| `1.2.0-beta1` | `1.2.0` | deploy |

The `::notice::` now names both versions, so the job log says why it stopped rather than just asserting the plugin is up to date.

Also added a `setup-php` step, pinned to the same SHA already used by `php-lint.yml`, `plugin-check.yml`, and `copilot-setup-steps.yml`. PHP is preinstalled on the `ubuntu-latest` image, so `php -r` would work without it — but relying on that fails open: a missing `php` binary exits non-zero, the `if` reads as "versions differ", and the deployment proceeds. Setting PHP up explicitly turns that into a failed job instead. I used `php-version: latest` (as in `php-lint.yml`) since `version_compare()` behavior is stable across versions; happy to pin it to `'8.3'` to match `plugin-check.yml` if preferred.

## Testing instructions

The changed step can be exercised standalone:

```bash
for pair in "1.2.0 1.2.0" "1.3.0 1.2.0" "1.2.0 1.3.0" "1.10.0 1.9.0" "1.2.0-beta1 1.2.0"; do
  set -- $pair
  if php -r 'exit( version_compare( $argv[1], $argv[2], ">=" ) ? 0 : 1 );' "$1" "$2"; then
    echo "wporg=$1 build=$2 -> HALT"
  else
    echo "wporg=$1 build=$2 -> DEPLOY"
  fi
done
```

Note that the workflow itself only runs on release, so this path is not exercised by CI on this PR.

## Use of AI Tools

Claude Code wrote the change and this description, at my direction, after I spotted the faulty comparison and specified the `version_compare()` fix and the `setup-php` addition. I reviewed both the diff and the verification output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)