### PR TITLE
Enhanced Responsive Images: Fix cache priming running after block rendering

### DIFF
--- a/plugins/auto-sizes/hooks.php
+++ b/plugins/auto-sizes/hooks.php
@@ -29,7 +29,7 @@ add_action( 'wp_head', 'auto_sizes_render_generator' );
 /**
  * Filters related to the improved image sizes functionality.
  */
-add_filter( 'the_content', 'auto_sizes_prime_attachment_caches', 9 ); // This must run before 'do_blocks', which runs at priority 9.
+add_filter( 'the_content', 'auto_sizes_prime_attachment_caches', 8 ); // This must run before 'do_blocks', which runs at priority 9.
 add_filter( 'render_block_core/image', 'auto_sizes_filter_image_tag', 10, 3 );
 add_filter( 'render_block_core/cover', 'auto_sizes_filter_image_tag', 10, 3 );
 add_filter( 'render_block_core/post-featured-image', 'auto_sizes_filter_image_tag', 10, 3 );


### PR DESCRIPTION
## Summary

There is no existing issue for this, so reporting it here directly.

`auto_sizes_prime_attachment_caches` is registered on `the_content` at priority 9, which is the same priority core uses for `do_blocks`. Callbacks that share a priority run in registration order, and core registers `do_blocks` in `default-filters.php` while `wp-settings.php` loads, so it is always registered before any plugin. The priming callback therefore runs after `do_blocks` on every request, and the cache is never warmed in time to be useful.

The inline comment on that line already states the requirement correctly. Only the number disagrees with it.

## Relevant technical choices

Priority 8 was requested and agreed during review of #1625, in [this thread](https://github.com/WordPress/performance/pull/1625#discussion_r1852965772). The accompanying comment was applied, and the value 9 went in with it. This change restores 8.

At priority 8 the callback registers after core's own callbacks in that bucket, giving this order:

```
[8] apply_block_hooks_to_content_from_post_object
[8] WP_Embed::run_shortcode
[8] WP_Embed::autoembed
[8] auto_sizes_prime_attachment_caches
[9] do_blocks
```

This is the right position. It runs after block hooks have injected markup and after embeds are resolved, so those images are covered as well, and it still runs before `do_blocks`. Core itself uses priority 8 for this purpose, with the comment `// BEFORE do_blocks().`

`do_blocks` is registered at priority 9 in 6.9, 7.0 and 7.1. The plugin requires 6.9 and above.

### Measured effect

Query counts on a cold cache, single post, full `the_content` chain:

| Images | Before | After |
| --- | --- | --- |
| 1 | 3 | 3 |
| 2 | 5 | 3 |
| 5 | 11 | 3 |
| 10 | 21 | 3 |
| 20 | 41 | 3 |

Before is `2N + 1` for N images. After is flat. Posts with a single image are unchanged, because the function only primes when more than one attachment is found.

Rendered output is byte identical before and after at every size tested.

### Testing

Full `auto-sizes` suite, run before and after the change:

| Core | Mode | Result |
| --- | --- | --- |
| 6.9.4 | single site | 169 tests, 185 assertions, identical before and after |
| 6.9.4 | multisite | 169 tests, 185 assertions, identical before and after |
| 7.2-alpha | single site | 169 tests, 185 assertions, identical before and after |
| 7.2-alpha | multisite | 169 tests, 185 assertions, identical before and after |

PHPCS is clean and PHPStan reports no errors. No test in the repository asserts filter priority or query counts, so no test needed updating.

## Use of AI Tools

I used Claude Code on this one. It found the priority mismatch, traced the review history behind it, wrote and ran the measurement scripts and the test matrix above, and drafted this description. The code change itself is a single character. I reviewed the finding, the reasoning and every result before opening this, and I take responsibility for the contribution.