### PR TITLE
Update props-bot-action to the latest trunk commit

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
       - name: Gather a list of contributors
-        uses: WordPress/props-bot-action@496473a3d11a263c17653aa9a00a98b8ed1479f8 # trunk
+        uses: WordPress/props-bot-action@8506b2615cdaaf57e4f3364eff8a38d0fbd16e1a # trunk
 
       - name: Remove the props-bot label
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0


### PR DESCRIPTION
Bumps the pinned `props-bot-action` reference to the current `trunk` HEAD (`8506b26`). The pin was on `496473a`; this picks up the changes merged since, keeping the props workflow current with upstream.