### PR TITLE
Performance Lab: Remove broken security advisory link from changelog

### DIFF
--- a/plugins/performance-lab/readme.txt
+++ b/plugins/performance-lab/readme.txt
@@ -369,7 +369,7 @@ Contributions are always welcome! Learn more about how to get involved in the [C
 **Bug Fixes**
 
 * Images: Add dominant color styling before any existing inline style attributes. ([716](https://github.com/WordPress/performance/pull/716))
-* Infrastructure: Resolve low-severity security advisory [GHSA-66qq-69rw-6x63](https://github.com/WordPress/performance/security/advisories/GHSA-66qq-69rw-6x63).
+* Infrastructure: Resolve low-severity security advisory GHSA-66qq-69rw-6x63.
 
 = 2.2.0 =
 


### PR DESCRIPTION
### Description

Fixes #2643.

The Performance Lab plugin `readme.txt` changelog entry for version 2.3.0 contained a link to a private GitHub security advisory (`GHSA-66qq-69rw-6x63`) which returns a 404 error when clicked from the WordPress.org plugin directory Development page.

This PR removes the broken hyperlink while retaining the changelog description and advisory identifier.

### Testing Instructions

1. Review `plugins/performance-lab/readme.txt` in the v2.3.0 section.
2. Confirm the entry displays `Infrastructure: Resolve low-severity security advisory GHSA-66qq-69rw-6x63.` without the broken 404 URL.