### PR TITLE
Dominant Color Images: Clean up redundant metadata generation in tests

### DIFF
--- a/plugins/dominant-color-images/tests/data/class-testcase.php
+++ b/plugins/dominant-color-images/tests/data/class-testcase.php
@@ -182,13 +182,12 @@ abstract class TestCase extends WP_UnitTestCase {
 		}
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
+		$metadata      = wp_get_attachment_metadata( $attachment_id );
 
-		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
-
-		$this->assertNotWPError( $dominant_color_data );
-		$this->assertContains( $dominant_color_data['dominant_color'], $expected_color );
-		$this->assertSame( $dominant_color_data['has_transparency'], $expected_transparency );
+		$this->assertIsArray( $metadata );
+		$this->assertArrayHasKey( 'dominant_color', $metadata );
+		$this->assertContains( $metadata['dominant_color'], $expected_color );
+		$this->assertSame( $metadata['has_transparency'], $expected_transparency );
 	}
 
 	/**
@@ -209,7 +208,6 @@ abstract class TestCase extends WP_UnitTestCase {
 			$this->markTestSkipped( "Mime type $mime_type is not supported." );
 		}
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
@@ -227,7 +225,6 @@ abstract class TestCase extends WP_UnitTestCase {
 		$image_path = TESTS_PLUGIN_DIR . '/tests/data/images/red.jpg';
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 
@@ -245,7 +242,6 @@ abstract class TestCase extends WP_UnitTestCase {
 	 */
 	public function test_get_dominant_color_none_images( string $image_path ): void {
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$dominant_color_data = dominant_color_get_dominant_color_data( $attachment_id );
 

--- a/plugins/dominant-color-images/tests/test-dominant-color.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color.php
@@ -26,7 +26,7 @@ class Test_Dominant_Color extends TestCase {
 		$this->assertEmpty( $dominant_color_metadata );
 
 		// Creating attachment.
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id           = self::factory()->attachment->create_upload_object( $image_path );
 		$dominant_color_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'dominant_color', $dominant_color_metadata );
 		$this->assertNotEmpty( $dominant_color_metadata['dominant_color'] );
@@ -76,7 +76,7 @@ class Test_Dominant_Color extends TestCase {
 		$transparency_metadata = dominant_color_metadata( array(), 1 );
 		$this->assertEmpty( $transparency_metadata );
 
-		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
+		$attachment_id         = self::factory()->attachment->create_upload_object( $image_path );
 		$transparency_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'has_transparency', $transparency_metadata );
 		$this->assertSame( $expected_transparency, $transparency_metadata['has_transparency'] );

--- a/plugins/dominant-color-images/tests/test-dominant-color.php
+++ b/plugins/dominant-color-images/tests/test-dominant-color.php
@@ -27,7 +27,6 @@ class Test_Dominant_Color extends TestCase {
 
 		// Creating attachment.
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$dominant_color_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'dominant_color', $dominant_color_metadata );
 		$this->assertNotEmpty( $dominant_color_metadata['dominant_color'] );
@@ -78,7 +77,6 @@ class Test_Dominant_Color extends TestCase {
 		$this->assertEmpty( $transparency_metadata );
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 		$transparency_metadata = dominant_color_metadata( array(), $attachment_id );
 		$this->assertArrayHasKey( 'has_transparency', $transparency_metadata );
 		$this->assertSame( $expected_transparency, $transparency_metadata['has_transparency'] );
@@ -130,7 +128,6 @@ class Test_Dominant_Color extends TestCase {
 		$this->skip_if_mime_type_unsupported( $image_path );
 
 		$attachment_id = self::factory()->attachment->create_upload_object( $image_path );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );
 		// Testing tag_add_adjust() with image being lazy load.
@@ -167,7 +164,6 @@ class Test_Dominant_Color extends TestCase {
 	 */
 	public function test_dominant_color_img_tag_add_dominant_color_requires_proper_quotes( string $image, bool $expected ): void {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/red.jpg' );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		$image_url = wp_get_attachment_image_url( $attachment_id );
 		$image     = sprintf( $image, $image_url );
@@ -211,7 +207,6 @@ class Test_Dominant_Color extends TestCase {
 	 */
 	public function test_dominant_color_img_tag_add_dominant_color_should_add_dominant_color_inline_style( string $filtered_image, string $expected ): void {
 		$attachment_id = self::factory()->attachment->create_upload_object( TESTS_PLUGIN_DIR . '/tests/data/images/red.jpg' );
-		wp_maybe_generate_attachment_metadata( get_post( $attachment_id ) );
 
 		list( $src, $width, $height ) = wp_get_attachment_image_src( $attachment_id );
 


### PR DESCRIPTION
### Description

Fixes #2524.

In `Dominant_Color_ImagesTestsTestCase`, `create_upload_object()` automatically invokes `wp_generate_attachment_metadata()`, which triggers the `dominant_color_metadata` filter and attaches dominant color data.

Subsequent calls to `wp_maybe_generate_attachment_metadata()` were redundant because metadata was already populated.

### Changes

- Removed redundant `wp_maybe_generate_attachment_metadata()` calls in `class-testcase.php` and `test-dominant-color.php`.
- Updated `test_get_dominant_color_valid()` to assert directly on the generated `_wp_attachment_metadata`, testing the end-to-end flow from upload to metadata storage.

### Testing Instructions

1. Run `composer test:dominant-color-images` or run PHPUnit on the dominant color images test suite.
2. Confirm all test assertions pass without regression.