### PR TITLE
Ignore stray closing P tags when tracking the open element stack

### DIFF
--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -377,6 +377,26 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 				return true;
 			}
 
+			/*
+			 * A closing P tag with no corresponding open P element is a stray end tag. This occurs with markup like
+			 * `<p><figure>&hellip;</figure></p>`, as output by `wpautop()` when a shortcode inside a paragraph expands
+			 * into a FIGURE, since the FIGURE has already implicitly closed the P per self::P_CLOSING_TAGS above. Such
+			 * an end tag does not close any open element. Instead, an empty P element is implied at this position, so
+			 * account for it in the sibling indices to keep the computed XPaths aligned with the DOM the browser
+			 * constructs.
+			 *
+			 * @link https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody:end-tag-p
+			 */
+			if ( 'P' === $tag_name && ! in_array( 'P', $this->open_stack_tags, true ) ) {
+				$level = count( $this->open_stack_tags );
+				if ( ! isset( $this->open_stack_indices[ $level ] ) ) {
+					$this->open_stack_indices[ $level ] = 0;
+				} else {
+					++$this->open_stack_indices[ $level ];
+				}
+				return true;
+			}
+
 			$popped_tag_name = array_pop( $this->open_stack_tags );
 			array_pop( $this->open_stack_attributes );
 			if ( $popped_tag_name !== $tag_name ) {

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -355,11 +355,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 			}
 			$this->open_stack_attributes[] = $attributes;
 
-			if ( ! isset( $this->open_stack_indices[ $level ] ) ) {
-				$this->open_stack_indices[ $level ] = 0;
-			} else {
-				++$this->open_stack_indices[ $level ];
-			}
+			$this->advance_open_stack_index( $level );
 
 			// Keep track of whether the next call to next_token() should start by
 			// immediately popping off the stack due to this tag being either self-closing
@@ -388,12 +384,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 			 * @link https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody:end-tag-p
 			 */
 			if ( 'P' === $tag_name && ! in_array( 'P', $this->open_stack_tags, true ) ) {
-				$level = count( $this->open_stack_tags );
-				if ( ! isset( $this->open_stack_indices[ $level ] ) ) {
-					$this->open_stack_indices[ $level ] = 0;
-				} else {
-					++$this->open_stack_indices[ $level ];
-				}
+				$this->advance_open_stack_index( count( $this->open_stack_tags ) );
 				return true;
 			}
 
@@ -422,6 +413,25 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Advances the sibling index at the supplied depth to account for another element occurring there.
+	 *
+	 * This is called both when an open tag is pushed onto the stack and when an empty P element is implied by a stray
+	 * closing P tag, so that both arrive at the sibling indices used to compute XPaths in the same way.
+	 *
+	 * @since 1.0.0
+	 * @see self::get_xpath()
+	 *
+	 * @param non-negative-int $level Depth at which an element occurs.
+	 */
+	private function advance_open_stack_index( int $level ): void {
+		if ( ! isset( $this->open_stack_indices[ $level ] ) ) {
+			$this->open_stack_indices[ $level ] = 0;
+		} else {
+			++$this->open_stack_indices[ $level ];
+		}
 	}
 
 	/**

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -421,7 +421,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 	 * This is called both when an open tag is pushed onto the stack and when an empty P element is implied by a stray
 	 * closing P tag, so that both arrive at the sibling indices used to compute XPaths in the same way.
 	 *
-	 * @since 1.0.0
+	 * @since n.e.x.t
 	 * @see self::get_xpath()
 	 *
 	 * @param non-negative-int $level Depth at which an element occurs.

--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -377,7 +377,7 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 				return true;
 			}
 
-			/*
+			/**
 			 * A closing P tag with no corresponding open P element is a stray end tag. This occurs with markup like
 			 * `<p><figure>&hellip;</figure></p>`, as output by `wpautop()` when a shortcode inside a paragraph expands
 			 * into a FIGURE, since the FIGURE has already implicitly closed the P per self::P_CLOSING_TAGS above. Such

--- a/plugins/optimization-detective/tests/test-cases/stray-closing-p/buffer.html
+++ b/plugins/optimization-detective/tests/test-cases/stray-closing-p/buffer.html
@@ -1,0 +1,15 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+		<meta name="generator" content="optimization-detective 0.0.0">
+	</head>
+	<body>
+		<div id="page">
+			<!-- The following is as output by wpautop() when caption shortcodes inside a paragraph expand into FIGURE elements, which implicitly close the opening P tag and leave the closing P tag stray. -->
+			<p><figure class="wp-caption"><img src="https://example.com/bison1.jpg" alt="A bison" width="300" height="226"><figcaption>This is a bison.</figcaption></figure><br>
+			<figure class="wp-caption"><img src="https://example.com/bison2.jpg" alt="Another bison" width="300" height="226"><figcaption>This is another bison.</figcaption></figure></p>
+			<img src="https://example.com/hero.jpg" alt="Hero" width="1200" height="800">
+		</div>
+	</body>
+</html>

--- a/plugins/optimization-detective/tests/test-cases/stray-closing-p/expected.html
+++ b/plugins/optimization-detective/tests/test-cases/stray-closing-p/expected.html
@@ -1,0 +1,18 @@
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>...</title>
+		<meta data-od-replaced-content="optimization-detective 0.0.0" name="generator" content="optimization-detective 0.0.0; url_metric_groups={0:populated, 480:populated, 600:populated, 782:populated}">
+	<link data-od-added-tag rel="preconnect" href="https://inserted-at-finish-template-optimization-action.example.net/">
+</head>
+	<body>
+		<div id="page">
+			<!-- The following is as output by wpautop() when caption shortcodes inside a paragraph expand into FIGURE elements, which implicitly close the opening P tag and leave the closing P tag stray. -->
+			<p><figure class="wp-caption"><img data-od-xpath="/HTML/BODY/DIV[@id=&apos;page&apos;]/*[2][self::FIGURE]/*[1][self::IMG]" src="https://example.com/bison1.jpg" alt="A bison" width="300" height="226"><figcaption>This is a bison.</figcaption></figure><br>
+			<figure class="wp-caption"><img data-od-xpath="/HTML/BODY/DIV[@id=&apos;page&apos;]/*[4][self::FIGURE]/*[1][self::IMG]" src="https://example.com/bison2.jpg" alt="Another bison" width="300" height="226"><figcaption>This is another bison.</figcaption></figure></p>
+			<img data-od-added-fetchpriority data-od-xpath="/HTML/BODY/DIV[@id=&apos;page&apos;]/*[6][self::IMG]" fetchpriority="high" src="https://example.com/hero.jpg" alt="Hero" width="1200" height="800">
+		</div>
+	<script id="optimization-detective-detect-args" type="application/json">[]</script>
+<script type="module">/* detect loader */</script>
+</body>
+</html>

--- a/plugins/optimization-detective/tests/test-cases/stray-closing-p/set-up.php
+++ b/plugins/optimization-detective/tests/test-cases/stray-closing-p/set-up.php
@@ -1,0 +1,48 @@
+<?php
+return static function ( Test_OD_Optimization $test_case ): void {
+	add_filter( 'od_current_url_metrics_etag_data', '__return_empty_array' );
+
+	/*
+	 * These are the XPaths which a browser computes for the images in buffer.html. Note that the index for the
+	 * hero image accounts for the empty P element which the HTML spec implies at the position of the stray
+	 * closing P tag, the opening P tag having already been implicitly closed by the first FIGURE.
+	 */
+	$test_case->populate_url_metrics(
+		array(
+			array(
+				'xpath' => '/HTML/BODY/DIV[@id=\'page\']/*[2][self::FIGURE]/*[1][self::IMG]',
+				'isLCP' => false,
+			),
+			array(
+				'xpath' => '/HTML/BODY/DIV[@id=\'page\']/*[4][self::FIGURE]/*[1][self::IMG]',
+				'isLCP' => false,
+			),
+			array(
+				'xpath' => '/HTML/BODY/DIV[@id=\'page\']/*[6][self::IMG]',
+				'isLCP' => true,
+			),
+		),
+		false
+	);
+
+	add_action(
+		'od_register_tag_visitors',
+		static function ( OD_Tag_Visitor_Registry $registry ): void {
+			$registry->register(
+				'img-lcp',
+				static function ( OD_Tag_Visitor_Context $context ): bool {
+					if ( 'IMG' !== $context->processor->get_tag() ) {
+						return false;
+					}
+
+					// This only sets the attribute if the XPath computed for the tag matches the one stored in the URL Metrics.
+					$lcp_element = $context->url_metric_group_collection->get_common_lcp_element();
+					if ( null !== $lcp_element && $lcp_element->get_xpath() === $context->processor->get_xpath() ) {
+						$context->processor->set_attribute( 'fetchpriority', 'high' );
+					}
+					return true;
+				}
+			);
+		}
+	);
+};

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -349,6 +349,33 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 					'/HTML/BODY/DIV[@id=\'page\']/*[6][self::FOOTER]' => array( 'HTML', 'BODY', 'DIV', 'FOOTER' ),
 				),
 			),
+			'stray-closing-p-positions'              => array(
+				'document'          => '
+					<html>
+						<head></head>
+						<body>
+							<div id="page">
+								<!-- A stray closing P tag as the first child, where the implied empty P element takes the first slot. -->
+								<section></p><span>1</span></section>
+
+								<!-- Two stray closing P tags in a row imply two empty P elements. -->
+								<article></p></p><span>2</span></article>
+							</div>
+						</body>
+					</html>
+				',
+				'open_tags'         => array( 'HTML', 'HEAD', 'BODY', 'DIV', 'SECTION', 'SPAN', 'ARTICLE', 'SPAN' ),
+				'xpath_breadcrumbs' => array(
+					'/HTML'                        => array( 'HTML' ),
+					'/HTML/HEAD'                   => array( 'HTML', 'HEAD' ),
+					'/HTML/BODY'                   => array( 'HTML', 'BODY' ),
+					'/HTML/BODY/DIV[@id=\'page\']' => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[1][self::SECTION]' => array( 'HTML', 'BODY', 'DIV', 'SECTION' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[1][self::SECTION]/*[2][self::SPAN]' => array( 'HTML', 'BODY', 'DIV', 'SECTION', 'SPAN' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[2][self::ARTICLE]' => array( 'HTML', 'BODY', 'DIV', 'ARTICLE' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[2][self::ARTICLE]/*[3][self::SPAN]' => array( 'HTML', 'BODY', 'DIV', 'ARTICLE', 'SPAN' ),
+				),
+			),
 			'document-with-multiple-div-id-children' => array(
 				'document'          => '
 					<!DOCTYPE html>

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -317,6 +317,38 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 					'/HTML/BODY/DIV[@id=\'page\']/*[63][self::UL]' => array( 'HTML', 'BODY', 'DIV', 'UL' ),
 				),
 			),
+			'stray-closing-p'                        => array(
+				'document'          => '
+					<html>
+						<head></head>
+						<body>
+							<div id="page">
+								<!-- As output by wpautop() when caption shortcodes inside a paragraph expand into FIGURE elements, which implicitly close the P. The closing P tag is then stray. -->
+								<p><figure class="wp-caption"><img src="https://example.com/bison1.jpg" width="300" height="226" alt=""><figcaption>This is a bison.</figcaption></figure><br>
+								<figure class="wp-caption"><img src="https://example.com/bison2.jpg" width="300" height="226" alt=""><figcaption>This is another bison.</figcaption></figure></p>
+								<footer>The end!</footer>
+							</div>
+						</body>
+					</html>
+				',
+				'open_tags'         => array( 'HTML', 'HEAD', 'BODY', 'DIV', 'P', 'FIGURE', 'IMG', 'FIGCAPTION', 'BR', 'FIGURE', 'IMG', 'FIGCAPTION', 'FOOTER' ),
+				'xpath_breadcrumbs' => array(
+					'/HTML'                        => array( 'HTML' ),
+					'/HTML/HEAD'                   => array( 'HTML', 'HEAD' ),
+					'/HTML/BODY'                   => array( 'HTML', 'BODY' ),
+					'/HTML/BODY/DIV[@id=\'page\']' => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[1][self::P]' => array( 'HTML', 'BODY', 'DIV', 'P' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[2][self::FIGURE]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[2][self::FIGURE]/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE', 'IMG' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[2][self::FIGURE]/*[2][self::FIGCAPTION]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE', 'FIGCAPTION' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[3][self::BR]' => array( 'HTML', 'BODY', 'DIV', 'BR' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[4][self::FIGURE]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[4][self::FIGURE]/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE', 'IMG' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[4][self::FIGURE]/*[2][self::FIGCAPTION]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE', 'FIGCAPTION' ),
+					// Note the index 6 accounts for the empty P element which the HTML spec implies at the position of the stray closing P tag.
+					'/HTML/BODY/DIV[@id=\'page\']/*[6][self::FOOTER]' => array( 'HTML', 'BODY', 'DIV', 'FOOTER' ),
+				),
+			),
 			'document-with-multiple-div-id-children' => array(
 				'document'          => '
 					<!DOCTYPE html>


### PR DESCRIPTION
## Summary

Fixes #2650

`wpautop()` wraps two `[caption]` shortcodes that share a paragraph in a single `P`, and `do_shortcode()` then expands each into a `FIGURE`:

```html
<p><figure class="wp-caption">…</figure><br />
<figure class="wp-caption">…</figure></p>
```

`OD_HTML_Tag_Processor` already handles the first half correctly: `FIGURE` is in `self::P_CLOSING_TAGS`, so the opening `P` is implicitly closed. It got the second half wrong. The now-stray `</p>` fell through to the generic closer branch and popped unconditionally, taking the enclosing `DIV` off the stack.

Per the HTML spec, an end tag for `P` with no `P` element in scope closes nothing — a parse error is raised and an empty `P` element is implied at that position instead. Confirmed against `WP_HTML_Processor` on the same fragment:

```
spec:  DIV > P, DIV > FIGURE, DIV > FIGURE, DIV > P (implied), BODY > FOOTER
before: DIV > P, DIV > FIGURE, DIV > FIGURE,                   FOOTER  ← DIV consumed
```

### Why this matters beyond the log noise

The stack stayed one level short for the remainder of the document, so every XPath computed after the stray closer was wrong. On the homepage of my test site, 8 of the 12 `data-od-xpath` values lost the `MAIN` level entirely and picked up the wrong `ARTICLE` index:

```
before: …/*[1][self::DIV]/*[2][self::ARTICLE]/*[2][self::DIV]/*[1][self::FIGURE]/…
after:  …/*[1][self::DIV]/*[1][self::MAIN]/*[9][self::ARTICLE]/*[2][self::DIV]/*[1][self::FIGURE]/…
```

XPaths are the keys used to match URL Metrics back to elements, so no element after the stray closer could be matched and the optimizations depending on those matches silently did not apply.

## Relevant technical choices

**Advancing the sibling index is not cosmetic.** The browser's DOM does contain the implied empty `P`, so it occupies a sibling slot. Without the bump, a following sibling computes `*[3]` where the DOM has it at position 4, and the mismatch just moves rather than disappears. The new snapshot case pins this: the hero image after the stray closer resolves to `*[6][self::IMG]`, matching the XPath a browser reports, so the stored LCP element matches and `fetchpriority="high"` is applied. Before this change it computed `*[5]`, the lookup missed, and no attribute was added.

**The guard is deliberately narrow.** It fires only when there is no open `P` anywhere on the stack — a genuinely stray closer. Shapes such as `<p><em></p>`, where a closer should pop more than one element, keep their existing behavior; that broader divergence between our rudimentary stack tracking and the spec is #2622, and #1546 remains the wholesale alternative.

**Out of scope.** This fixes the input that was emitting notices, not the fact that notices raised inside the output buffer callback are swallowed. On PHP 8.5 those surface as:

```
Deprecated: ob_end_flush(): Producing output from user output handler {closure:od_buffer_output():56} is deprecated
Deprecated: ob_end_flush(): Producing output from user output handler {closure:Perflab_Server_Timing::start_output_buffer():277} is deprecated
```

because PHP 8.5 deprecates and discards output produced from within a user output handler — which is why the underlying notice was invisible in the browser and only reached `debug.log`. Adopting core's template enhancement output buffer, which installs its own error handler, addresses that: #2224 / #2516 for Optimization Detective, #2225 for Server-Timing.

## Testing

- New `stray-closing-p` case in `data_provider_sample_documents`, asserting `FOOTER` lands at `*[6]`.
- New `stray-closing-p` snapshot test case exercising the URL Metric match end to end.
- All 13 existing snapshots are unchanged — no `actual.html` was regenerated for any of them.
- `optimization-detective`: 358 tests, 12,323 assertions. `image-prioritizer`: 91 tests. `embed-optimizer`: 66 tests.
- `phpcs` and `phpstan` clean.
- On the test site the homepage goes from 4 tag stack warnings (plus the two deprecations) to zero, and all 12 image XPaths regain the `MAIN` level.

## Use of AI Tools

Claude Opus 5, via Claude Code, did the root-cause analysis, wrote the patch, and wrote the tests. I reviewed the diagnosis and the change, and take responsibility for it. The analysis was cross-checked against `WP_HTML_Processor` as the spec-compliant reference rather than taken on assertion.
