### PR TITLE
Optimization Detective: Handle stray closing P tags when P is not open

### DIFF
--- a/plugins/optimization-detective/class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/class-od-html-tag-processor.php
@@ -377,6 +377,22 @@ final class OD_HTML_Tag_Processor extends WP_HTML_Tag_Processor {
 				return true;
 			}
 
+			/*
+			 * A `</p>` encountered when no P is open is a stray end tag. Per the HTML spec this does not
+			 * close any open element; instead an empty P element is implied at this position. This happens
+			 * with `wpautop()` output like `<p><figure>…</figure></p>` where the FIGURE has already
+			 * implicitly closed the P (see self::P_CLOSING_TAGS above).
+			 */
+			if ( 'P' === $tag_name && 'P' !== end( $this->open_stack_tags ) ) {
+				$level = count( $this->open_stack_tags );
+				if ( ! isset( $this->open_stack_indices[ $level ] ) ) {
+					$this->open_stack_indices[ $level ] = 0;
+				} else {
+					++$this->open_stack_indices[ $level ];
+				}
+				return true;
+			}
+
 			$popped_tag_name = array_pop( $this->open_stack_tags );
 			array_pop( $this->open_stack_attributes );
 			if ( $popped_tag_name !== $tag_name ) {

--- a/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
+++ b/plugins/optimization-detective/tests/test-class-od-html-tag-processor.php
@@ -137,6 +137,35 @@ class Test_OD_HTML_Tag_Processor extends WP_UnitTestCase {
 					'/HTML/BODY/DIV[@id=\'page\']/*[3][self::SPAN]' => array( 'HTML', 'BODY', 'DIV', 'SPAN' ),
 				),
 			),
+			'multiple-figures-in-p-with-stray-p-closer' => array(
+				'document'          => '
+					<html>
+						<head></head>
+						<body>
+							<div id="page">
+								<p>
+									<figure><img src="foo.jpg"></figure>
+									<figure><img src="bar.jpg"></figure>
+								</p>
+								<footer id="footer">Footer</footer>
+							</div>
+						</body>
+					</html>
+				',
+				'open_tags'         => array( 'HTML', 'HEAD', 'BODY', 'DIV', 'P', 'FIGURE', 'IMG', 'FIGURE', 'IMG', 'FOOTER' ),
+				'xpath_breadcrumbs' => array(
+					'/HTML'                        => array( 'HTML' ),
+					'/HTML/HEAD'                   => array( 'HTML', 'HEAD' ),
+					'/HTML/BODY'                   => array( 'HTML', 'BODY' ),
+					'/HTML/BODY/DIV[@id=\'page\']' => array( 'HTML', 'BODY', 'DIV' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[1][self::P]' => array( 'HTML', 'BODY', 'DIV', 'P' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[2][self::FIGURE]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[2][self::FIGURE]/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE', 'IMG' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[3][self::FIGURE]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[3][self::FIGURE]/*[1][self::IMG]' => array( 'HTML', 'BODY', 'DIV', 'FIGURE', 'IMG' ),
+					'/HTML/BODY/DIV[@id=\'page\']/*[5][self::FOOTER[@id=\'footer\']]' => array( 'HTML', 'BODY', 'DIV', 'FOOTER' ),
+				),
+			),
 			'void-tags'                              => array(
 				'document'          => '
 					<html>


### PR DESCRIPTION
Fixes #2650

### Description

When `wpautop()` wraps multiple shortcodes (e.g. `<p><figure>...</figure><figure>...</figure></p>`), encountering the first `<figure>` causes `OD_HTML_Tag_Processor` to implicitly pop `P` off the open tag stack (since `FIGURE` is in `P_CLOSING_TAGS`).

When the trailing `</p>` tag is later encountered, `P` is no longer at the top of `->open_stack_tags`. Previously, `OD_HTML_Tag_Processor` called `array_pop( $this->open_stack_tags )`, popping a parent element (such as `<div class="entry-content">`) off the stack. This corrupted the open tag stack for the rest of the document, emitting warnings and producing incorrect `data-od-xpath` attributes on subsequent elements.

This PR updates `OD_HTML_Tag_Processor` to:
1. Detect when a `</p>` tag is encountered while `P` is not at the top of `->open_stack_tags`.
2. Increment `$this->open_stack_indices[ $level ]` to match browser DOM behavior (where an implied empty `<p>` element occupies a sibling slot).
3. Return `true` early without popping parent tags or emitting false warnings.

### Testing Instructions

1. Review `plugins/optimization-detective/class-od-html-tag-processor.php` and `plugins/optimization-detective/tests/test-class-od-html-tag-processor.php`.
2. Confirm that HTML containing `<p><figure>...</figure><figure>...</figure></p>` parses without warnings and computes accurate XPath breadcrumbs for subsequent elements.