### PR TITLE
Avoid npx when running build and test tooling

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
         run: npm run build
 
       - name: Install Playwright dependencies
-        run: npx playwright install chromium --with-deps
+        run: npm exec --no -- playwright install chromium --with-deps
 
       - name: Install WordPress
         run: npm run wp-env-test start

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+npm exec --no -- lint-staged

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -24,6 +24,6 @@
 		"wp-content/plugins/performance": "."
 	},
 	"lifecycleScripts": {
-		"afterStart": "npx wp-env --config=.wp-env.test.json run wordpress git config --global --replace-all safe.directory /var/www/html/wp-content/plugins/performance"
+		"afterStart": "npm exec --no -- wp-env --config=.wp-env.test.json run wordpress git config --global --replace-all safe.directory /var/www/html/wp-content/plugins/performance"
 	}
 }


### PR DESCRIPTION
## Summary

`npx` downloads a package (and its dependencies) from the registry and runs their install scripts when the package isn't found locally. Each such call in build/test tooling is a point where a compromised package could run code during a build. This replaces each `npx` call with `npm exec --no --`, which only runs an already-installed local binary and fails instead of installing when the package is missing.

This mirrors the fix already applied in WordPress/wordpress-develop#13021 for the same class of issue.

Fixes #2654

## Changes

- `.husky/pre-commit`: `npx lint-staged` → `npm exec --no -- lint-staged`
- `.wp-env.test.json`: `npx wp-env ...` → `npm exec --no -- wp-env ...`
- `.github/workflows/e2e-test.yml`: `npx playwright install chromium --with-deps` → `npm exec --no -- playwright install chromium --with-deps`

All three packages (`lint-staged`, `@wordpress/env`, `@playwright/test`) are already devDependencies in `package.json`, so this is behavior-neutral.

## Test plan

- [x] Searched the repo for all remaining `npx` usages outside `node_modules`/`package-lock.json` — none found.
- [x] Verified `npm exec --no -- lint-staged` resolves the local binary successfully.
- [x] Confirmed the pre-commit hook runs correctly with the updated command (observed during this PR's own commit).
- [x] CI: confirm the `e2e-test.yml` workflow still installs Playwright and runs e2e tests successfully.