### PR TITLE
Bump @wordpress/env from 11.14.0 to 11.15.0 to fix Docker builds on EOL Debian bullseye

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@types/lodash": "4.17.25",
 				"@types/node": "^20.19.43",
 				"@wordpress/e2e-test-utils-playwright": "1.54.0",
-				"@wordpress/env": "^11.14.0",
+				"@wordpress/env": "^11.15.0",
 				"@wordpress/prettier-config": "^4.54.0",
 				"@wordpress/scripts": "^34.2.0",
 				"ajv": "8.20.0",
@@ -8995,9 +8995,9 @@
 			}
 		},
 		"node_modules/@wordpress/env": {
-			"version": "11.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.14.0.tgz",
-			"integrity": "sha512-Q/XUhGjFJtlfybw/mq+7H5MsF2u3zWH5YxNR5y473+CeIjZx20wt5Dx0RDHAJcG2ICTky4pJevNlIq/EFnUwIQ==",
+			"version": "11.15.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/env/-/env-11.15.0.tgz",
+			"integrity": "sha512-FZq3eMDXBlZVZU8jVSX/4XoexgiBM4ZBqk69Mh23pz+1MMeQ13l7g5v7zKAAnyA3F9eHd+1sWsUpQnuS1f1T6Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@types/lodash": "4.17.25",
 		"@types/node": "^20.19.43",
 		"@wordpress/e2e-test-utils-playwright": "1.54.0",
-		"@wordpress/env": "^11.14.0",
+		"@wordpress/env": "^11.15.0",
 		"@wordpress/prettier-config": "^4.54.0",
 		"@wordpress/scripts": "^34.2.0",
 		"ajv": "8.20.0",


### PR DESCRIPTION
## Summary

Unblocks CI: the PHP 7.4 and PHP 8.0 jobs in `Unit Testing for Plugins` currently fail on every PR touching PHP files.

Debian 11 (bullseye) [reached end of life on 2026-08-31](https://www.debian.org/News/2026/20260831), and its packages have since left the regular mirrors. Its `bullseye-security` release file expired a few days later, so the `apt-get -qy update` that wp-env runs while building the WordPress image exits with code 100 rather than merely warning:

```
#31 [wordpress 12/25] RUN apt-get -qy update
E: Release file for http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
   is expired (invalid since 2d 7h 21min 26s). Updates for this repository will not be applied.
#31 ERROR: process "/bin/sh -c apt-get -qy update" did not complete successfully: exit code: 100
```

Only the PHP 7.4 and 8.0 matrix entries are affected, because `wordpress:php7.4` and `wordpress:php8.0` are the bullseye-based images; PHP 8.1 and up are on bookworm. Example failing run: https://github.com/WordPress/performance/actions/runs/34437590947

## Relevant technical choices

wp-env fixed this upstream in WordPress/gutenberg#82478, which points the bullseye suite at `archive.debian.org` and drops the security and updates suites — the same treatment stretch and buster already received. `@wordpress/env` 11.15.0, published 2026-09-10, is the first release to carry it, so no local workaround is needed here; the bump is the entire fix.

Verified that the installed package ships the rewrite:

```
$ grep -c 'archive.debian.org/debian bullseye' node_modules/@wordpress/env/lib/runtime/docker/docker-config.js
1
```

Dependabot's `wordpress-packages` group would pick this up on its own eventually, but the cooldown window leaves CI red in the meantime.

Not verified locally against Docker — the PHP 7.4 and 8.0 jobs on this PR are the verification.

## Use of AI Tools

Claude Code diagnosed the failure, located the upstream fix, and prepared this bump and PR description. Reviewed by the PR author, who takes responsibility for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLEz4ouPNAMfSAE74CxYgY
